### PR TITLE
:book: Document KCP objects for different syncer deployment scenarios

### DIFF
--- a/docs/content/concepts/scenarios/README.md
+++ b/docs/content/concepts/scenarios/README.md
@@ -1,6 +1,6 @@
 # Document the KCP Workspace objects
 
-Document of the key KCP objects, with they Yaml, that are created and modified during the key steps of MC Syncer deployment:
+Document key KCP objects, with they Yaml, that are created and modified during the key steps of MC Syncer deployment:
 
 1. Creation of a KCP Workspace (`k ws create`)
 2. Creation of a KCP Syncer (`k kcp workload sync`)

--- a/docs/content/concepts/scenarios/README.md
+++ b/docs/content/concepts/scenarios/README.md
@@ -1,0 +1,13 @@
+# Document the KCP Workspace objects
+
+Document of the key KCP objects, with they Yaml, that are created and modified during the key steps of MC Syncer deployment:
+
+1. Creation of a KCP Workspace (`k ws create`)
+2. Creation of a KCP Syncer (`k kcp workload sync`)
+3. Deployment of the Syncer in the edge pcluster (`k apply -f`)
+4. Binding of the Syncer resources (`k kcp bind compute`)
+
+Two explanatory scenarios are considered:
+
+1. [A pcluster with compatible resource schemas, such as the Kind cluster](kind-scenario/README.md) example discussed in the [quickstart](https://docs.kcp.io/kcp/main/)
+2. [A pcluster with incompatible resource schemas, as the MicroShift cluster](jn-scenario/README.md) scenario discussed in [issue #2885](https://github.com/kcp-dev/kcp/issues/2885)

--- a/docs/content/concepts/scenarios/jn-scenario/README.md
+++ b/docs/content/concepts/scenarios/jn-scenario/README.md
@@ -1,0 +1,501 @@
+# List KCP Workspace objects (NVIDIA Jetson Nano MicroShift scenario)
+
+Table of content:
+
+- [List KCP Workspace objects (NVIDIA Jetson Nano MicroShift scenario)](#list-kcp-workspace-objects-nvidia-jetson-nano-microshift-scenario)
+  - [1. Start KCP](#1-start-kcp)
+  - [2. Check objects in the new `jn` KCP Workspace at the center (#1)](#2-check-objects-in-the-new-jn-kcp-workspace-at-the-center-1)
+  - [3. Create a syncer at the center](#3-create-a-syncer-at-the-center)
+  - [4. Check objects that were created in the `jn` KCP Workspace after running `kcp workload sync` at the center (#2)](#4-check-objects-that-were-created-in-the-jn-kcp-workspace-after-running-kcp-workload-sync-at-the-center-2)
+  - [5. Apply the syncer on the pcluster at the edge (NVIDIA Jetson Nano)](#5-apply-the-syncer-on-the-pcluster-at-the-edge-nvidia-jetson-nano)
+  - [6. Check objects that were created in the `jn` KCP Workspace at the center after running the syncer in the pcluster at the edge (#3)](#6-check-objects-that-were-created-in-the-jn-kcp-workspace-at-the-center-after-running-the-syncer-in-the-pcluster-at-the-edge-3)
+  - [7. Bind to `compute` at the center](#7-bind-to-compute-at-the-center)
+  - [8. Check objects that were created in the `jn` KCP Workspace after binding to `compute` at the center (#4)](#8-check-objects-that-were-created-in-the-jn-kcp-workspace-after-binding-to-compute-at-the-center-4)
+
+## 1. Start KCP
+
+Given KCP 0.11:
+
+```bash
+$ k version --short
+Client Version: v1.25.3
+Kustomize Version: v4.5.7
+Server Version: v1.24.3+kcp-v0.11.0
+```
+
+Start KCP with an external IP address binding:
+
+```bash
+$ kcp start --bind-address $(ifconfig | grep -A 1 'enp0s8' | tail -1 | awk '{print $2}')
+```
+
+Create a new KCP Workspace called `jn`:
+
+```bash
+$ k ws create jn --enter
+Workspace "jn" (type root:organization) created. Waiting for it to be ready...
+Workspace "jn" (type root:organization) is ready to use.
+Current workspace is "root:jn" (type root:organization).
+
+$ k ws tree
+.
+└── root
+    ├── compute
+    └── jn
+```
+
+## 2. Check objects in the new `jn` KCP Workspace at the center (#1)
+
+Given:
+
+```bash
+$ echo $KUBECONFIG
+~/.kcp/admin.kubeconfig
+
+$ k ws .
+Current workspace is "root:jn".
+```
+
+List key objects:
+
+```bash
+$ k get apiexports
+No resources found
+
+$ k get apibindings
+NAME                       AGE
+apiresource.kcp.io-9xqib   3m3s
+scheduling.kcp.io-1vgbc    3m3s
+tenancy.kcp.io-gn443       3m3s
+topology.kcp.io-1smay      3m2s
+workload.kcp.io-ak35l      3m3s
+
+$ k get synctargets
+No resources found
+
+$ k get locations
+No resources found
+
+$ k get placements
+No resources found
+```
+
+## 3. Create a syncer at the center
+
+Given:
+
+```bash
+$ echo $KUBECONFIG
+~/.kcp/admin.kubeconfig
+
+$ k ws .
+Current workspace is "root:jn".
+```
+
+Create the [syncer YAML](yamls/syncer-jn.yaml) and pull the schemas from the pcluster:
+
+```bash
+$ k kcp workload sync jn \
+    --syncer-image ghcr.io/kcp-dev/kcp/syncer:v0.11.0 \
+    --apiexports="" \
+    --resources=pods \
+    --resources=deployments.apps \
+    --resources=services \
+    --resources=ingresses.networking.k8s.io \
+    -o syncer-jn.yaml
+Creating synctarget "jn"
+Creating service account "kcp-syncer-jn-11hmg5wf"
+Creating cluster role "kcp-syncer-jn-11hmg5wf" to give service account "kcp-syncer-jn-11hmg5wf"
+```
+
+## 4. Check objects that were created in the `jn` KCP Workspace after running `kcp workload sync` at the center (#2)
+
+Given:
+
+```bash
+$ echo $KUBECONFIG
+~/.kcp/admin.kubeconfig
+
+$ k ws .
+Current workspace is "root:jn".
+```
+
+List key objects:
+
+```bash
+$ k get apiexports
+NAME         AGE
+kubernetes   5m42s
+
+$ k get apibindings
+NAME                       AGE
+apiresource.kcp.io-9xqib   22m
+kubernetes                 5m55s
+scheduling.kcp.io-1vgbc    22m
+tenancy.kcp.io-gn443       22m
+topology.kcp.io-1smay      22m
+workload.kcp.io-ak35l      22m
+
+$ k get synctargets
+NAME   AGE
+jn     6m15s
+
+$ k get locations
+NAME      RESOURCE      AVAILABLE   INSTANCES   LABELS   AGE
+default   synctargets   0           1                    6m26s
+
+$ k get placements
+No resources found
+```
+
+Objects yamls:
+
+- [APIExport `kubernetes`](yamls/2-apiexport-kubernetes.yaml) from `k get apiexport kubernetes -o yaml > 2-apiexport-kubernetes.yaml`
+- [APIBinding `kubernetes`](yamls/2-apibinding-kubernetes.yaml) from `k get apibinding kubernetes -o yaml > 2-apibinding-kubernetes.yaml`
+- [SyncTarget `jn`](yamls/2-synctarget-jn.yaml) from `k get synctarget jn -o yaml > 2-synctarget-jn.yaml`
+- [Location `default`](yamls/2-location-default.yaml) from `k get location default -o yaml > 2-location-default.yaml`
+
+## 5. Apply the syncer on the pcluster at the edge (NVIDIA Jetson Nano)
+
+```bash
+$ oc apply -f syncer-jn.yaml
+namespace/kcp-syncer-jn-11hmg5wf created
+serviceaccount/kcp-syncer-jn-11hmg5wf created
+secret/kcp-syncer-jn-11hmg5wf-token created
+clusterrole.rbac.authorization.k8s.io/kcp-syncer-jn-11hmg5wf created
+clusterrolebinding.rbac.authorization.k8s.io/kcp-syncer-jn-11hmg5wf created
+role.rbac.authorization.k8s.io/kcp-dns-jn-11hmg5wf created
+rolebinding.rbac.authorization.k8s.io/kcp-dns-jn-11hmg5wf created
+secret/kcp-syncer-jn-11hmg5wf created
+deployment.apps/kcp-syncer-jn-11hmg5wf created
+
+$ oc get pods -A
+NAMESPACE                       NAME                                      READY   STATUS    RESTARTS   AGE
+kcp-syncer-jn-11hmg5wf          kcp-syncer-jn-11hmg5wf-7c459c5b58-svl9l   1/1     Running   0          80s
+```
+
+## 6. Check objects that were created in the `jn` KCP Workspace at the center after running the syncer in the pcluster at the edge (#3)
+
+The `synctarget default` is not `available`.
+
+After running the syncer, [`kubernetes` `APIExport`](yamls/3-apiexport-kubernetes.yaml) contains the list of schemas pulled from the pcluster at the edge, running MicroShift 4.8:
+
+```yaml
+latestResourceSchemas:
+  - rev-788.deployments.apps
+  - rev-789.ingresses.networking.k8s.io
+  - rev-774.pods.core
+  - rev-770.services.core
+```
+
+Given:
+
+```bash
+$ echo $KUBECONFIG
+~/.kcp/admin.kubeconfig
+
+$ k ws .
+Current workspace is "root:jn".
+```
+
+List key objects:
+
+```bash
+$ k get apiexports
+NAME         AGE
+kubernetes   34m
+
+$ k get apibindings
+NAME                       AGE
+apiresource.kcp.io-9xqib   51m
+kubernetes                 34m
+scheduling.kcp.io-1vgbc    51m
+tenancy.kcp.io-gn443       51m
+topology.kcp.io-1smay      51m
+workload.kcp.io-ak35l      51m
+
+$ k get synctargets
+NAME   AGE
+jn     34m
+
+$ k get locations
+NAME      RESOURCE      AVAILABLE   INSTANCES   LABELS   AGE
+default   synctargets   1           1                    34m
+
+$ k get placements
+No resources found
+```
+
+Objects yamls:
+
+- [APIExport `kubernetes`](yamls/3-apiexport-kubernetes.yaml) from `k get apiexport kubernetes -o yaml > 3-apiexport-kubernetes.yaml`
+
+    Resource schemas added to the `spec`:
+
+    ```bash
+    $ diff 2-apiexport-kubernetes.yaml 3-apiexport-kubernetes.yaml
+    10c10
+    <   generation: 2
+    ---
+    >   generation: 5
+    12c12
+    <   resourceVersion: "748"
+    ---
+    >   resourceVersion: "801"
+    18a19,23
+    >   latestResourceSchemas:
+    >   - rev-788.deployments.apps
+    >   - rev-789.ingresses.networking.k8s.io
+    >   - rev-774.pods.core
+    >   - rev-770.services.core
+    ```
+
+- [APIBinding `kubernetes`](yamls/3-apibinding-kubernetes.yaml) from `k get apibinding kubernetes -o yaml > 3-apibinding-kubernetes.yaml`
+
+    Resources added to the list of `boundResources`:
+
+    ```bash
+    $ diff 2-apibinding-kubernetes.yaml 3-apibinding-kubernetes.yaml
+    15c15
+    <   resourceVersion: "751"
+    ---
+    >   resourceVersion: "819"
+    22a23,55
+    >   boundResources:
+    >   - group: ""
+    >     resource: services
+    >     schema:
+    >       UID: ddee1955-e64e-478b-9310-f934fac54910
+    >       identityHash: <id-hash>
+    >       name: rev-770.services.core
+    >     storageVersions:
+    >     - v1
+    >   - group: ""
+    >     resource: pods
+    >     schema:
+    >       UID: a5fe7c2d-adb9-4109-a4ee-8d703b27f2a9
+    >       identityHash: <id-hash>
+    >       name: rev-774.pods.core
+    >     storageVersions:
+    >     - v1
+    >   - group: apps
+    >     resource: deployments
+    >     schema:
+    >       UID: 309b6c26-5aa4-41d5-8afa-ce718ac1ea67
+    >       identityHash: <id-hash>
+    >       name: rev-788.deployments.apps
+    >     storageVersions:
+    >     - v1
+    >   - group: networking.k8s.io
+    >     resource: ingresses
+    >     schema:
+    >       UID: 6ab13f61-194b-4e0d-9816-b574cae3f875
+    >       identityHash: <id-hash>
+    >       name: rev-789.ingresses.networking.k8s.io
+    >     storageVersions:
+    >     - v1
+    30c63
+    <   - lastTransitionTime: "2023-03-20T18:37:20Z"
+    ---
+    >   - lastTransitionTime: "2023-03-20T19:08:23Z"
+    ```
+
+- [SyncTarget `jn`](yamls/3-synctarget-jn.yaml) from `k get synctarget jn -o yaml > 3-synctarget-jn.yaml`
+
+    Resources added to the list of `syncedResources`:
+
+    ```bash
+    $ diff 2-synctarget-jn.yaml 3-synctarget-jn.yaml
+    11c11
+    <   resourceVersion: "728"
+    ---
+    >   resourceVersion: "855"
+    19,23c19,20
+    <   - lastTransitionTime: "2023-03-20T18:37:20Z"
+    <     message: No heartbeat yet seen
+    <     reason: ErrorHeartbeat
+    <     severity: Warning
+    <     status: "False"
+    ---
+    >   - lastTransitionTime: "2023-03-20T19:08:14Z"
+    >     status: "True"
+    25,29c22,23
+    <   - lastTransitionTime: "2023-03-20T18:37:20Z"
+    <     message: No heartbeat yet seen
+    <     reason: ErrorHeartbeat
+    <     severity: Warning
+    <     status: "False"
+    ---
+    >   - lastTransitionTime: "2023-03-20T19:08:14Z"
+    >     status: "True"
+    30a25,51
+    >   - lastTransitionTime: "2023-03-20T19:08:16Z"
+    >     status: "True"
+    >     type: SyncerAuthorized
+    >   lastSyncerHeartbeatTime: "2023-03-20T19:14:14Z"
+    >   syncedResources:
+    >   - identityHash: <id-hash>
+    >     resource: services
+    >     state: Accepted
+    >     versions:
+    >     - v1
+    >   - identityHash: <id-hash>
+    >     resource: pods
+    >     state: Accepted
+    >     versions:
+    >     - v1
+    >   - group: networking.k8s.io
+    >     identityHash: <id-hash>
+    >     resource: ingresses
+    >     state: Accepted
+    >     versions:
+    >     - v1
+    >   - group: apps
+    >     identityHash: <id-hash>
+    >     resource: deployments
+    >     state: Accepted
+    >     versions:
+    >     - v1
+    ```
+
+- [Location `default`](yamls/3-location-default.yaml) from `k get location default -o yaml > 3-location-default.yaml`
+
+    Syncer instance is now available:
+
+    ```bash
+    $ diff 2-location-default.yaml 3-location-default.yaml
+    10c10
+    <   resourceVersion: "725"
+    ---
+    >   resourceVersion: "763"
+    19c19
+    <   availableInstances: 0
+    ---
+    >   availableInstances: 1
+    ```
+
+## 7. Bind to `compute` at the center
+
+Given:
+
+```bash
+$ echo $KUBECONFIG
+~/.kcp/admin.kubeconfig
+
+$ k ws .
+Current workspace is "root:jn".
+```
+
+```bash
+$ k kcp bind compute root:jn --apiexports=root:jn:kubernetes
+placement placement-268us406 created.
+Placement "placement-268us406" is ready.
+```
+
+Note that kcp DNS pod is also started at the edge:
+
+```bash
+$ oc get pods -A
+NAMESPACE                       NAME                                            READY   STATUS    RESTARTS   AGE
+kcp-syncer-jn-11hmg5wf          kcp-dns-jn-11hmg5wf-2oyxxkaf-6dc9cf88b7-2njwg   1/1     Running   0          26s
+kcp-syncer-jn-11hmg5wf          kcp-syncer-jn-11hmg5wf-7c459c5b58-svl9l         1/1     Running   0          35m
+```
+
+## 8. Check objects that were created in the `jn` KCP Workspace after binding to `compute` at the center (#4)
+
+A `placement` object is created:
+
+Given:
+
+```bash
+$ echo $KUBECONFIG
+~/.kcp/admin.kubeconfig
+
+$ k ws .
+Current workspace is "root:jn".
+```
+
+List key objects:
+
+```bash
+$ k get apiexports
+NAME         AGE
+kubernetes   69m
+
+$ k get apibindings
+NAME                       AGE
+apiresource.kcp.io-9xqib   86m
+kubernetes                 69m
+scheduling.kcp.io-1vgbc    86m
+tenancy.kcp.io-gn443       86m
+topology.kcp.io-1smay      86m
+workload.kcp.io-ak35l      86m
+
+$ k get synctargets
+NAME   AGE
+jn     69m
+
+$ k get locations
+NAME      RESOURCE      AVAILABLE   INSTANCES   LABELS   AGE
+default   synctargets   1           1                    69m
+
+$ k get placements
+NAME                 AGE
+placement-268us406   3m22s
+
+$ k get APIResourceImports
+NAME
+deployments.jn.v1.apps
+ingresses.jn.v1.networking.k8s.io
+pods.jn.v1.core
+services.jn.v1.core
+
+$ k get NegotiatedAPIResources
+NAME
+deployments.v1.apps
+ingresses.v1.networking.k8s.io
+pods.v1.core
+services.v1.core
+
+$ k get APIConversions
+No resources found
+```
+
+Objects yamls:
+
+- [APIExport `kubernetes`](yamls/4-apiexport-kubernetes.yaml) from `k get apiexport kubernetes -o yaml > 4-apiexport-kubernetes.yaml`
+
+    No difference.
+
+- [APIBinding `kubernetes`](yamls/4-apibinding-kubernetes.yaml) from `k get apibinding kubernetes -o yaml > 4-apibinding-kubernetes.yaml`
+
+    No difference.
+
+- [SyncTarget `jn`](yamls/4-synctarget-jn.yaml) from `k get synctarget jn -o yaml > 4-synctarget-jn.yaml`
+
+    No difference.
+
+- [Location `default`](yamls/4-location-default.yaml) from `k get location default -o yaml > 4-location-default.yaml`
+
+    No difference.
+
+- [Placement `placement-268us406`](yamls/4-placement.yaml) from `k get placement placement-268us406 -o yaml > 4-placement.yaml`
+
+    New object.
+
+- [APIResourceImport deployments.jn.v1.apps`](yamls/4-APIResourceImport-deployments.jn.v1.apps.yaml) from `k get APIResourceImport deployments.jn.v1.apps -o yaml > 4-APIResourceImport-deployments.jn.v1.apps.yaml`
+
+- [APIResourceImport ingresses.jn.v1.networking.k8s.io`](yamls/4-APIResourceImport-ingresses.jn.v1.networking.k8s.io.yaml) from `k get APIResourceImport ingresses.jn.v1.networking.k8s.io -o yaml > 4-APIResourceImport-ingresses.jn.v1.networking.k8s.io.yaml`
+
+- [APIResourceImport pods.jn.v1.core`](yamls/4-APIResourceImport-pods.jn.v1.core.yaml) from `k get APIResourceImport pods.jn.v1.core -o yaml > 4-APIResourceImport-pods.jn.v1.core.yaml`
+
+- [APIResourceImport services.jn.v1.core`](yamls/4-APIResourceImport-services.jn.v1.core.yaml) from `k get APIResourceImport services.jn.v1.core -o yaml > 4-APIResourceImport-services.jn.v1.core.yaml`
+
+- [NegotiatedAPIResource deployments.v1.apps`](yamls/4-NegotiatedAPIResource-deployments.v1.apps.yaml) from `k get NegotiatedAPIResource deployments.v1.apps -o yaml > 4-NegotiatedAPIResource-deployments.v1.apps.yaml`
+
+- [NegotiatedAPIResource ingresses.v1.networking.k8s.io`](yamls/4-NegotiatedAPIResource-ingresses.v1.networking.k8s.io.yaml) from `k get NegotiatedAPIResource ingresses.v1.networking.k8s.io -o yaml > 4-NegotiatedAPIResource-ingresses.v1.networking.k8s.io.yaml`
+
+- [NegotiatedAPIResource pods.v1.core`](yamls/4-NegotiatedAPIResource-pods.v1.core.yaml) from `k get NegotiatedAPIResource pods.v1.core -o yaml > 4-NegotiatedAPIResource-pods.v1.core.yaml`
+
+- [NegotiatedAPIResource services.v1.core`](yamls/4-NegotiatedAPIResource-services.v1.core.yaml) from `k get NegotiatedAPIResource services.v1.core -o yaml > 4-NegotiatedAPIResource-services.v1.core.yaml`
+

--- a/docs/content/concepts/scenarios/jn-scenario/README.md
+++ b/docs/content/concepts/scenarios/jn-scenario/README.md
@@ -80,6 +80,18 @@ $ k get placements
 No resources found
 ```
 
+Objects yamls:
+
+- [APIBinding `apiresource.kcp.io-9xqib`](yamls/1-apibinding-apiresource.kcp.io-9xqib.yaml) from `k get APIBinding apiresource.kcp.io-9xqib -o yaml > 1-apibinding-apiresource.kcp.io-9xqib.yaml`
+
+- [APIBinding `scheduling.kcp.io-1vgbc`](yamls/1-apibinding-scheduling.kcp.io-1vgbc.yaml) from `k get APIBinding scheduling.kcp.io-1vgbc -o yaml > 1-apibinding-scheduling.kcp.io-1vgbc.yaml`
+
+- [APIBinding `tenancy.kcp.io-gn443`](yamls/1-apibinding-tenancy.kcp.io-gn443.yaml) from `k get APIBinding tenancy.kcp.io-gn443 -o yaml > 1-apibinding-tenancy.kcp.io-gn443.yaml`
+
+- [APIBinding `topology.kcp.io-1smay`](yamls/1-apibinding-topology.kcp.io-1smay.yaml) from `k get APIBinding topology.kcp.io-1smay -o yaml > 1-apibinding-topology.kcp.io-1smay.yaml`
+
+- [APIBinding `workload.kcp.io-ak35l`](yamls/1-apibinding-workload.kcp.io-ak35l.yaml) from `k get APIBinding workload.kcp.io-ak35l -o yaml > 1-apibinding-workload.kcp.io-ak35l.yaml`
+
 ## 3. Create a syncer at the center
 
 Given:

--- a/docs/content/concepts/scenarios/jn-scenario/yamls/1-apibinding-apiresource.kcp.io-9xqib.yaml
+++ b/docs/content/concepts/scenarios/jn-scenario/yamls/1-apibinding-apiresource.kcp.io-9xqib.yaml
@@ -1,0 +1,59 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIBinding
+metadata:
+  annotations:
+    kcp.io/cluster: 49adf4fn8ks8x43u
+  creationTimestamp: "2023-03-20T18:20:24Z"
+  finalizers:
+  - apis.kcp.io/apibinding-finalizer
+  generation: 1
+  labels:
+    claimed.internal.apis.kcp.io/ahnWRDJw63QggF1foil1RXbW9P9PfRFOltnChg: LstvmbbzVDDOn90ZbhzSQO5U3DMCf88h1pZ
+    internal.apis.kcp.io/export: ahnWRDJw63QggF1foil1RXbW9P9PfRFOltnChg
+  name: apiresource.kcp.io-9xqib
+  resourceVersion: "703"
+  uid: b380da1b-44f8-404e-96d4-3021ef9f8e8e
+spec:
+  reference:
+    export:
+      name: apiresource.kcp.io
+      path: root
+status:
+  apiExportClusterName: root
+  boundResources:
+  - group: apiresource.kcp.io
+    resource: apiresourceimports
+    schema:
+      UID: 29ee7819-e850-4c79-9fc9-fcd3df50ec6c
+      identityHash: 5bfce2f1622b9059caac79b2629edc40815aaa5786dc2d3507206f709b3435c9
+      name: v220628-546034da.apiresourceimports.apiresource.kcp.io
+    storageVersions:
+    - v1alpha1
+  - group: apiresource.kcp.io
+    resource: negotiatedapiresources
+    schema:
+      UID: 7145a586-4e5d-4a79-9ec2-b4c1ea7fb4a8
+      identityHash: 5bfce2f1622b9059caac79b2629edc40815aaa5786dc2d3507206f709b3435c9
+      name: v220628-546034da.negotiatedapiresources.apiresource.kcp.io
+    storageVersions:
+    - v1alpha1
+  conditions:
+  - lastTransitionTime: "2023-03-20T18:20:25Z"
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2023-03-20T18:20:25Z"
+    status: "True"
+    type: APIExportValid
+  - lastTransitionTime: "2023-03-20T18:20:25Z"
+    status: "True"
+    type: BindingUpToDate
+  - lastTransitionTime: "2023-03-20T18:20:25Z"
+    status: "True"
+    type: InitialBindingCompleted
+  - lastTransitionTime: "2023-03-20T18:20:25Z"
+    status: "True"
+    type: PermissionClaimsApplied
+  - lastTransitionTime: "2023-03-20T18:20:25Z"
+    status: "True"
+    type: PermissionClaimsValid
+  phase: Bound

--- a/docs/content/concepts/scenarios/jn-scenario/yamls/1-apibinding-scheduling.kcp.io-1vgbc.yaml
+++ b/docs/content/concepts/scenarios/jn-scenario/yamls/1-apibinding-scheduling.kcp.io-1vgbc.yaml
@@ -1,0 +1,59 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIBinding
+metadata:
+  annotations:
+    kcp.io/cluster: 49adf4fn8ks8x43u
+  creationTimestamp: "2023-03-20T18:20:24Z"
+  finalizers:
+  - apis.kcp.io/apibinding-finalizer
+  generation: 1
+  labels:
+    claimed.internal.apis.kcp.io/8aZfSHUSG9wQttJSddiQz0e6FYRaCeqmEvcA3j: LstvmbbzVDDOn90ZbhzSQO5U3DMCf88h1pZ
+    internal.apis.kcp.io/export: 8aZfSHUSG9wQttJSddiQz0e6FYRaCeqmEvcA3j
+  name: scheduling.kcp.io-1vgbc
+  resourceVersion: "695"
+  uid: e805dcd9-63f3-4216-85f0-0b65c8b4168a
+spec:
+  reference:
+    export:
+      name: scheduling.kcp.io
+      path: root
+status:
+  apiExportClusterName: root
+  boundResources:
+  - group: scheduling.kcp.io
+    resource: locations
+    schema:
+      UID: 2061e191-c4c5-4c0b-8ee4-6fad5527f5e3
+      identityHash: 1e770024e464271c0907a46fa6154a498417a05ea50e67d5d492c6b07786c81d
+      name: v221006-eaaf199d.locations.scheduling.kcp.io
+    storageVersions:
+    - v1alpha1
+  - group: scheduling.kcp.io
+    resource: placements
+    schema:
+      UID: e41dc47d-b12f-42eb-9fd8-0cbf88389dea
+      identityHash: 1e770024e464271c0907a46fa6154a498417a05ea50e67d5d492c6b07786c81d
+      name: v221212-cf67ac73a.placements.scheduling.kcp.io
+    storageVersions:
+    - v1alpha1
+  conditions:
+  - lastTransitionTime: "2023-03-20T18:20:25Z"
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2023-03-20T18:20:25Z"
+    status: "True"
+    type: APIExportValid
+  - lastTransitionTime: "2023-03-20T18:20:25Z"
+    status: "True"
+    type: BindingUpToDate
+  - lastTransitionTime: "2023-03-20T18:20:25Z"
+    status: "True"
+    type: InitialBindingCompleted
+  - lastTransitionTime: "2023-03-20T18:20:24Z"
+    status: "True"
+    type: PermissionClaimsApplied
+  - lastTransitionTime: "2023-03-20T18:20:24Z"
+    status: "True"
+    type: PermissionClaimsValid
+  phase: Bound

--- a/docs/content/concepts/scenarios/jn-scenario/yamls/1-apibinding-tenancy.kcp.io-gn443.yam
+++ b/docs/content/concepts/scenarios/jn-scenario/yamls/1-apibinding-tenancy.kcp.io-gn443.yam
@@ -1,0 +1,67 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIBinding
+metadata:
+  annotations:
+    kcp.io/cluster: 49adf4fn8ks8x43u
+  creationTimestamp: "2023-03-20T18:20:24Z"
+  finalizers:
+  - apis.kcp.io/apibinding-finalizer
+  generation: 1
+  labels:
+    claimed.internal.apis.kcp.io/bmCdly9xXiUpEHe3ypvDwvXMTfoVZUE92mqAQf: LstvmbbzVDDOn90ZbhzSQO5U3DMCf88h1pZ
+    internal.apis.kcp.io/export: bmCdly9xXiUpEHe3ypvDwvXMTfoVZUE92mqAQf
+  name: tenancy.kcp.io-gn443
+  resourceVersion: "694"
+  uid: 486a3f11-ae8d-4fb4-ac22-be0d43bb8955
+spec:
+  reference:
+    export:
+      name: tenancy.kcp.io
+      path: root
+status:
+  apiExportClusterName: root
+  boundResources:
+  - group: tenancy.kcp.io
+    resource: clusterworkspaces
+    schema:
+      UID: 4c8fb1a4-16c9-40f5-9f99-832fd4209c49
+      identityHash: 58e0c91beecd0df4a83ba96f7b39bab6f2fbae9423198c00aa1b14fa611d5625
+      name: v221219-c92ed8152.clusterworkspaces.tenancy.kcp.io
+    storageVersions:
+    - v1alpha1
+  - group: tenancy.kcp.io
+    resource: workspacetypes
+    schema:
+      UID: 5a005041-76b7-45f0-a9d7-d22902f3d1b3
+      identityHash: 58e0c91beecd0df4a83ba96f7b39bab6f2fbae9423198c00aa1b14fa611d5625
+      name: v230110-89146c99.workspacetypes.tenancy.kcp.io
+    storageVersions:
+    - v1alpha1
+  - group: tenancy.kcp.io
+    resource: workspaces
+    schema:
+      UID: f695f3ec-6f4a-45c5-a765-045294138189
+      identityHash: 58e0c91beecd0df4a83ba96f7b39bab6f2fbae9423198c00aa1b14fa611d5625
+      name: v230116-832a4a55d.workspaces.tenancy.kcp.io
+    storageVersions:
+    - v1alpha1
+  conditions:
+  - lastTransitionTime: "2023-03-20T18:20:25Z"
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2023-03-20T18:20:25Z"
+    status: "True"
+    type: APIExportValid
+  - lastTransitionTime: "2023-03-20T18:20:25Z"
+    status: "True"
+    type: BindingUpToDate
+  - lastTransitionTime: "2023-03-20T18:20:25Z"
+    status: "True"
+    type: InitialBindingCompleted
+  - lastTransitionTime: "2023-03-20T18:20:24Z"
+    status: "True"
+    type: PermissionClaimsApplied
+  - lastTransitionTime: "2023-03-20T18:20:24Z"
+    status: "True"
+    type: PermissionClaimsValid
+  phase: Bound

--- a/docs/content/concepts/scenarios/jn-scenario/yamls/1-apibinding-topology.kcp.io-1smay.yaml
+++ b/docs/content/concepts/scenarios/jn-scenario/yamls/1-apibinding-topology.kcp.io-1smay.yaml
@@ -1,0 +1,59 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIBinding
+metadata:
+  annotations:
+    kcp.io/cluster: 49adf4fn8ks8x43u
+  creationTimestamp: "2023-03-20T18:20:25Z"
+  finalizers:
+  - apis.kcp.io/apibinding-finalizer
+  generation: 1
+  labels:
+    claimed.internal.apis.kcp.io/7QHLqjz8KlhjPddt8MECYq0OLDUNvLAO5v9x4x: LstvmbbzVDDOn90ZbhzSQO5U3DMCf88h1pZ
+    internal.apis.kcp.io/export: 7QHLqjz8KlhjPddt8MECYq0OLDUNvLAO5v9x4x
+  name: topology.kcp.io-1smay
+  resourceVersion: "704"
+  uid: 507d6d48-d1d8-4ec0-9897-56dab4d16ce4
+spec:
+  reference:
+    export:
+      name: topology.kcp.io
+      path: root
+status:
+  apiExportClusterName: root
+  boundResources:
+  - group: topology.kcp.io
+    resource: partitions
+    schema:
+      UID: 7e71bb77-e28f-4153-912d-dcf31a29ea2b
+      identityHash: 55303337649adc08e12ed03c2fb1c99f0102abe45b066471ed68f772818506c9
+      name: v221115-9b370eb8.partitions.topology.kcp.io
+    storageVersions:
+    - v1alpha1
+  - group: topology.kcp.io
+    resource: partitionsets
+    schema:
+      UID: 29e32771-d550-4000-9e1c-245a9e2a78d3
+      identityHash: 55303337649adc08e12ed03c2fb1c99f0102abe45b066471ed68f772818506c9
+      name: v230202-eee1a845.partitionsets.topology.kcp.io
+    storageVersions:
+    - v1alpha1
+  conditions:
+  - lastTransitionTime: "2023-03-20T18:20:25Z"
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2023-03-20T18:20:25Z"
+    status: "True"
+    type: APIExportValid
+  - lastTransitionTime: "2023-03-20T18:20:25Z"
+    status: "True"
+    type: BindingUpToDate
+  - lastTransitionTime: "2023-03-20T18:20:25Z"
+    status: "True"
+    type: InitialBindingCompleted
+  - lastTransitionTime: "2023-03-20T18:20:25Z"
+    status: "True"
+    type: PermissionClaimsApplied
+  - lastTransitionTime: "2023-03-20T18:20:25Z"
+    status: "True"
+    type: PermissionClaimsValid
+  phase: Bound

--- a/docs/content/concepts/scenarios/jn-scenario/yamls/1-apibinding-workload.kcp.io-ak35l.yaml
+++ b/docs/content/concepts/scenarios/jn-scenario/yamls/1-apibinding-workload.kcp.io-ak35l.yaml
@@ -1,0 +1,51 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIBinding
+metadata:
+  annotations:
+    kcp.io/cluster: 49adf4fn8ks8x43u
+  creationTimestamp: "2023-03-20T18:20:24Z"
+  finalizers:
+  - apis.kcp.io/apibinding-finalizer
+  generation: 1
+  labels:
+    claimed.internal.apis.kcp.io/dVu53medKhDTkZGOwOJZA2llRa3TUeGHwzWm9: LstvmbbzVDDOn90ZbhzSQO5U3DMCf88h1pZ
+    internal.apis.kcp.io/export: dVu53medKhDTkZGOwOJZA2llRa3TUeGHwzWm9
+  name: workload.kcp.io-ak35l
+  resourceVersion: "701"
+  uid: fe0e4d6b-cc05-4413-aff9-303f8d0511d1
+spec:
+  reference:
+    export:
+      name: workload.kcp.io
+      path: root
+status:
+  apiExportClusterName: root
+  boundResources:
+  - group: workload.kcp.io
+    resource: synctargets
+    schema:
+      UID: b04de63e-a290-4d17-8fc4-ec8f59b2f1af
+      identityHash: d8b380917662ba269c5428943831c7e5c4677254efe87b9456933eb71fafe1cb
+      name: v230109-773b219c.synctargets.workload.kcp.io
+    storageVersions:
+    - v1alpha1
+  conditions:
+  - lastTransitionTime: "2023-03-20T18:20:25Z"
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2023-03-20T18:20:25Z"
+    status: "True"
+    type: APIExportValid
+  - lastTransitionTime: "2023-03-20T18:20:25Z"
+    status: "True"
+    type: BindingUpToDate
+  - lastTransitionTime: "2023-03-20T18:20:25Z"
+    status: "True"
+    type: InitialBindingCompleted
+  - lastTransitionTime: "2023-03-20T18:20:24Z"
+    status: "True"
+    type: PermissionClaimsApplied
+  - lastTransitionTime: "2023-03-20T18:20:24Z"
+    status: "True"
+    type: PermissionClaimsValid
+  phase: Bound

--- a/docs/content/concepts/scenarios/jn-scenario/yamls/2-apibinding-kubernetes.yaml
+++ b/docs/content/concepts/scenarios/jn-scenario/yamls/2-apibinding-kubernetes.yaml
@@ -1,0 +1,42 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIBinding
+metadata:
+  annotations:
+    extra.apis.kcp.io/compute.workload.kcp.io: "true"
+    kcp.io/cluster: 49adf4fn8ks8x43u
+  creationTimestamp: "2023-03-20T18:37:20Z"
+  finalizers:
+  - apis.kcp.io/apibinding-finalizer
+  generation: 1
+  labels:
+    claimed.internal.apis.kcp.io/40Zi0j9PsQDYRFZUfMx8bfzH69sqffiovtyuvN: LstvmbbzVDDOn90ZbhzSQO5U3DMCf88h1pZ
+    internal.apis.kcp.io/export: 40Zi0j9PsQDYRFZUfMx8bfzH69sqffiovtyuvN
+  name: kubernetes
+  resourceVersion: "751"
+  uid: bf4cb1a5-c734-4a88-a1a4-b1d630289b9d
+spec:
+  reference:
+    export:
+      name: kubernetes
+status:
+  apiExportClusterName: 49adf4fn8ks8x43u
+  conditions:
+  - lastTransitionTime: "2023-03-20T18:37:20Z"
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2023-03-20T18:37:20Z"
+    status: "True"
+    type: APIExportValid
+  - lastTransitionTime: "2023-03-20T18:37:20Z"
+    status: "True"
+    type: BindingUpToDate
+  - lastTransitionTime: "2023-03-20T18:37:20Z"
+    status: "True"
+    type: InitialBindingCompleted
+  - lastTransitionTime: "2023-03-20T18:37:20Z"
+    status: "True"
+    type: PermissionClaimsApplied
+  - lastTransitionTime: "2023-03-20T18:37:20Z"
+    status: "True"
+    type: PermissionClaimsValid
+  phase: Bound

--- a/docs/content/concepts/scenarios/jn-scenario/yamls/2-apiexport-kubernetes.yaml
+++ b/docs/content/concepts/scenarios/jn-scenario/yamls/2-apiexport-kubernetes.yaml
@@ -1,0 +1,29 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIExport
+metadata:
+  annotations:
+    extra.apis.kcp.io/compute.workload.kcp.io: "true"
+    kcp.io/cluster: 49adf4fn8ks8x43u
+    kcp.io/path: root:jn
+    workload.kcp.io/skip-default-object-creation: "true"
+  creationTimestamp: "2023-03-20T18:37:20Z"
+  generation: 2
+  name: kubernetes
+  resourceVersion: "748"
+  uid: 9af84401-21f1-400e-b570-6cd38fb8713b
+spec:
+  identity:
+    secretRef:
+      name: kubernetes
+      namespace: kcp-system
+status:
+  conditions:
+  - lastTransitionTime: "2023-03-20T18:37:20Z"
+    status: "True"
+    type: IdentityValid
+  - lastTransitionTime: "2023-03-20T18:37:20Z"
+    status: "True"
+    type: VirtualWorkspaceURLsReady
+  identityHash: <id-hash>
+  virtualWorkspaces:
+  - url: https://<kcp-url>:6443/services/apiexport/49adf4fn8ks8x43u/kubernetes

--- a/docs/content/concepts/scenarios/jn-scenario/yamls/2-apiexport-kubernetes.yaml
+++ b/docs/content/concepts/scenarios/jn-scenario/yamls/2-apiexport-kubernetes.yaml
@@ -24,6 +24,6 @@ status:
   - lastTransitionTime: "2023-03-20T18:37:20Z"
     status: "True"
     type: VirtualWorkspaceURLsReady
-  identityHash: <id-hash>
+  identityHash: b20e9ad1d17024e51df7cd1af743cf403e385c3e890c9e1b16034ee604de7b0e
   virtualWorkspaces:
   - url: https://<kcp-url>:6443/services/apiexport/49adf4fn8ks8x43u/kubernetes

--- a/docs/content/concepts/scenarios/jn-scenario/yamls/2-location-default.yaml
+++ b/docs/content/concepts/scenarios/jn-scenario/yamls/2-location-default.yaml
@@ -1,0 +1,20 @@
+apiVersion: scheduling.kcp.io/v1alpha1
+kind: Location
+metadata:
+  annotations:
+    kcp.io/cluster: 49adf4fn8ks8x43u
+    kcp.io/path: root:jn
+  creationTimestamp: "2023-03-20T18:37:20Z"
+  generation: 1
+  name: default
+  resourceVersion: "725"
+  uid: 39d5688a-704e-436d-8300-24fd851d00dd
+spec:
+  instanceSelector: {}
+  resource:
+    group: workload.kcp.io
+    resource: synctargets
+    version: v1alpha1
+status:
+  availableInstances: 0
+  instances: 1

--- a/docs/content/concepts/scenarios/jn-scenario/yamls/2-synctarget-jn.yaml
+++ b/docs/content/concepts/scenarios/jn-scenario/yamls/2-synctarget-jn.yaml
@@ -1,0 +1,33 @@
+apiVersion: workload.kcp.io/v1alpha1
+kind: SyncTarget
+metadata:
+  annotations:
+    kcp.io/cluster: 49adf4fn8ks8x43u
+  creationTimestamp: "2023-03-20T18:37:20Z"
+  generation: 1
+  labels:
+    internal.workload.kcp.io/key: 8GswqbXhDhJDayJn7uG56ILV6BjJYgcKLWUGSH
+  name: jn
+  resourceVersion: "728"
+  uid: 72de24eb-7d49-4aca-be22-63f95548a816
+spec:
+  supportedAPIExports:
+  - export: kubernetes
+  unschedulable: false
+status:
+  conditions:
+  - lastTransitionTime: "2023-03-20T18:37:20Z"
+    message: No heartbeat yet seen
+    reason: ErrorHeartbeat
+    severity: Warning
+    status: "False"
+    type: Ready
+  - lastTransitionTime: "2023-03-20T18:37:20Z"
+    message: No heartbeat yet seen
+    reason: ErrorHeartbeat
+    severity: Warning
+    status: "False"
+    type: HeartbeatHealthy
+  virtualWorkspaces:
+  - syncerURL: https://<kcp-url>:6443/services/syncer/49adf4fn8ks8x43u/jn/72de24eb-7d49-4aca-be22-63f95548a816
+    upsyncerURL: https://<kcp-url>:6443/services/upsyncer/49adf4fn8ks8x43u/jn/72de24eb-7d49-4aca-be22-63f95548a816

--- a/docs/content/concepts/scenarios/jn-scenario/yamls/3-apibinding-kubernetes.yaml
+++ b/docs/content/concepts/scenarios/jn-scenario/yamls/3-apibinding-kubernetes.yaml
@@ -1,0 +1,75 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIBinding
+metadata:
+  annotations:
+    extra.apis.kcp.io/compute.workload.kcp.io: "true"
+    kcp.io/cluster: 49adf4fn8ks8x43u
+  creationTimestamp: "2023-03-20T18:37:20Z"
+  finalizers:
+  - apis.kcp.io/apibinding-finalizer
+  generation: 1
+  labels:
+    claimed.internal.apis.kcp.io/40Zi0j9PsQDYRFZUfMx8bfzH69sqffiovtyuvN: LstvmbbzVDDOn90ZbhzSQO5U3DMCf88h1pZ
+    internal.apis.kcp.io/export: 40Zi0j9PsQDYRFZUfMx8bfzH69sqffiovtyuvN
+  name: kubernetes
+  resourceVersion: "819"
+  uid: bf4cb1a5-c734-4a88-a1a4-b1d630289b9d
+spec:
+  reference:
+    export:
+      name: kubernetes
+status:
+  apiExportClusterName: 49adf4fn8ks8x43u
+  boundResources:
+  - group: ""
+    resource: services
+    schema:
+      UID: ddee1955-e64e-478b-9310-f934fac54910
+      identityHash: <id-hash>
+      name: rev-770.services.core
+    storageVersions:
+    - v1
+  - group: ""
+    resource: pods
+    schema:
+      UID: a5fe7c2d-adb9-4109-a4ee-8d703b27f2a9
+      identityHash: <id-hash>
+      name: rev-774.pods.core
+    storageVersions:
+    - v1
+  - group: apps
+    resource: deployments
+    schema:
+      UID: 309b6c26-5aa4-41d5-8afa-ce718ac1ea67
+      identityHash: <id-hash>
+      name: rev-788.deployments.apps
+    storageVersions:
+    - v1
+  - group: networking.k8s.io
+    resource: ingresses
+    schema:
+      UID: 6ab13f61-194b-4e0d-9816-b574cae3f875
+      identityHash: <id-hash>
+      name: rev-789.ingresses.networking.k8s.io
+    storageVersions:
+    - v1
+  conditions:
+  - lastTransitionTime: "2023-03-20T18:37:20Z"
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2023-03-20T18:37:20Z"
+    status: "True"
+    type: APIExportValid
+  - lastTransitionTime: "2023-03-20T19:08:23Z"
+    status: "True"
+    type: BindingUpToDate
+  - lastTransitionTime: "2023-03-20T18:37:20Z"
+    status: "True"
+    type: InitialBindingCompleted
+  - lastTransitionTime: "2023-03-20T18:37:20Z"
+    status: "True"
+    type: PermissionClaimsApplied
+  - lastTransitionTime: "2023-03-20T18:37:20Z"
+    status: "True"
+    type: PermissionClaimsValid
+  phase: Bound

--- a/docs/content/concepts/scenarios/jn-scenario/yamls/3-apibinding-kubernetes.yaml
+++ b/docs/content/concepts/scenarios/jn-scenario/yamls/3-apibinding-kubernetes.yaml
@@ -25,7 +25,7 @@ status:
     resource: services
     schema:
       UID: ddee1955-e64e-478b-9310-f934fac54910
-      identityHash: <id-hash>
+      identityHash: b20e9ad1d17024e51df7cd1af743cf403e385c3e890c9e1b16034ee604de7b0e
       name: rev-770.services.core
     storageVersions:
     - v1
@@ -33,7 +33,7 @@ status:
     resource: pods
     schema:
       UID: a5fe7c2d-adb9-4109-a4ee-8d703b27f2a9
-      identityHash: <id-hash>
+      identityHash: b20e9ad1d17024e51df7cd1af743cf403e385c3e890c9e1b16034ee604de7b0e
       name: rev-774.pods.core
     storageVersions:
     - v1
@@ -41,7 +41,7 @@ status:
     resource: deployments
     schema:
       UID: 309b6c26-5aa4-41d5-8afa-ce718ac1ea67
-      identityHash: <id-hash>
+      identityHash: b20e9ad1d17024e51df7cd1af743cf403e385c3e890c9e1b16034ee604de7b0e
       name: rev-788.deployments.apps
     storageVersions:
     - v1
@@ -49,7 +49,7 @@ status:
     resource: ingresses
     schema:
       UID: 6ab13f61-194b-4e0d-9816-b574cae3f875
-      identityHash: <id-hash>
+      identityHash: b20e9ad1d17024e51df7cd1af743cf403e385c3e890c9e1b16034ee604de7b0e
       name: rev-789.ingresses.networking.k8s.io
     storageVersions:
     - v1

--- a/docs/content/concepts/scenarios/jn-scenario/yamls/3-apiexport-kubernetes.yaml
+++ b/docs/content/concepts/scenarios/jn-scenario/yamls/3-apiexport-kubernetes.yaml
@@ -1,0 +1,34 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIExport
+metadata:
+  annotations:
+    extra.apis.kcp.io/compute.workload.kcp.io: "true"
+    kcp.io/cluster: 49adf4fn8ks8x43u
+    kcp.io/path: root:jn
+    workload.kcp.io/skip-default-object-creation: "true"
+  creationTimestamp: "2023-03-20T18:37:20Z"
+  generation: 5
+  name: kubernetes
+  resourceVersion: "801"
+  uid: 9af84401-21f1-400e-b570-6cd38fb8713b
+spec:
+  identity:
+    secretRef:
+      name: kubernetes
+      namespace: kcp-system
+  latestResourceSchemas:
+  - rev-788.deployments.apps
+  - rev-789.ingresses.networking.k8s.io
+  - rev-774.pods.core
+  - rev-770.services.core
+status:
+  conditions:
+  - lastTransitionTime: "2023-03-20T18:37:20Z"
+    status: "True"
+    type: IdentityValid
+  - lastTransitionTime: "2023-03-20T18:37:20Z"
+    status: "True"
+    type: VirtualWorkspaceURLsReady
+  identityHash: <id-hash>
+  virtualWorkspaces:
+  - url: https://<kcp-url>:6443/services/apiexport/49adf4fn8ks8x43u/kubernetes

--- a/docs/content/concepts/scenarios/jn-scenario/yamls/3-apiexport-kubernetes.yaml
+++ b/docs/content/concepts/scenarios/jn-scenario/yamls/3-apiexport-kubernetes.yaml
@@ -29,6 +29,6 @@ status:
   - lastTransitionTime: "2023-03-20T18:37:20Z"
     status: "True"
     type: VirtualWorkspaceURLsReady
-  identityHash: <id-hash>
+  identityHash: b20e9ad1d17024e51df7cd1af743cf403e385c3e890c9e1b16034ee604de7b0e
   virtualWorkspaces:
   - url: https://<kcp-url>:6443/services/apiexport/49adf4fn8ks8x43u/kubernetes

--- a/docs/content/concepts/scenarios/jn-scenario/yamls/3-location-default.yaml
+++ b/docs/content/concepts/scenarios/jn-scenario/yamls/3-location-default.yaml
@@ -1,0 +1,20 @@
+apiVersion: scheduling.kcp.io/v1alpha1
+kind: Location
+metadata:
+  annotations:
+    kcp.io/cluster: 49adf4fn8ks8x43u
+    kcp.io/path: root:jn
+  creationTimestamp: "2023-03-20T18:37:20Z"
+  generation: 1
+  name: default
+  resourceVersion: "763"
+  uid: 39d5688a-704e-436d-8300-24fd851d00dd
+spec:
+  instanceSelector: {}
+  resource:
+    group: workload.kcp.io
+    resource: synctargets
+    version: v1alpha1
+status:
+  availableInstances: 1
+  instances: 1

--- a/docs/content/concepts/scenarios/jn-scenario/yamls/3-synctarget-jn.yaml
+++ b/docs/content/concepts/scenarios/jn-scenario/yamls/3-synctarget-jn.yaml
@@ -27,24 +27,24 @@ status:
     type: SyncerAuthorized
   lastSyncerHeartbeatTime: "2023-03-20T19:14:14Z"
   syncedResources:
-  - identityHash: <id-hash>
+  - identityHash: b20e9ad1d17024e51df7cd1af743cf403e385c3e890c9e1b16034ee604de7b0e
     resource: services
     state: Accepted
     versions:
     - v1
-  - identityHash: <id-hash>
+  - identityHash: b20e9ad1d17024e51df7cd1af743cf403e385c3e890c9e1b16034ee604de7b0e
     resource: pods
     state: Accepted
     versions:
     - v1
   - group: networking.k8s.io
-    identityHash: <id-hash>
+    identityHash: b20e9ad1d17024e51df7cd1af743cf403e385c3e890c9e1b16034ee604de7b0e
     resource: ingresses
     state: Accepted
     versions:
     - v1
   - group: apps
-    identityHash: <id-hash>
+    identityHash: b20e9ad1d17024e51df7cd1af743cf403e385c3e890c9e1b16034ee604de7b0e
     resource: deployments
     state: Accepted
     versions:

--- a/docs/content/concepts/scenarios/jn-scenario/yamls/3-synctarget-jn.yaml
+++ b/docs/content/concepts/scenarios/jn-scenario/yamls/3-synctarget-jn.yaml
@@ -1,0 +1,54 @@
+apiVersion: workload.kcp.io/v1alpha1
+kind: SyncTarget
+metadata:
+  annotations:
+    kcp.io/cluster: 49adf4fn8ks8x43u
+  creationTimestamp: "2023-03-20T18:37:20Z"
+  generation: 1
+  labels:
+    internal.workload.kcp.io/key: 8GswqbXhDhJDayJn7uG56ILV6BjJYgcKLWUGSH
+  name: jn
+  resourceVersion: "855"
+  uid: 72de24eb-7d49-4aca-be22-63f95548a816
+spec:
+  supportedAPIExports:
+  - export: kubernetes
+  unschedulable: false
+status:
+  conditions:
+  - lastTransitionTime: "2023-03-20T19:08:14Z"
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2023-03-20T19:08:14Z"
+    status: "True"
+    type: HeartbeatHealthy
+  - lastTransitionTime: "2023-03-20T19:08:16Z"
+    status: "True"
+    type: SyncerAuthorized
+  lastSyncerHeartbeatTime: "2023-03-20T19:14:14Z"
+  syncedResources:
+  - identityHash: <id-hash>
+    resource: services
+    state: Accepted
+    versions:
+    - v1
+  - identityHash: <id-hash>
+    resource: pods
+    state: Accepted
+    versions:
+    - v1
+  - group: networking.k8s.io
+    identityHash: <id-hash>
+    resource: ingresses
+    state: Accepted
+    versions:
+    - v1
+  - group: apps
+    identityHash: <id-hash>
+    resource: deployments
+    state: Accepted
+    versions:
+    - v1
+  virtualWorkspaces:
+  - syncerURL: https://<kcp-url>:6443/services/syncer/49adf4fn8ks8x43u/jn/72de24eb-7d49-4aca-be22-63f95548a816
+    upsyncerURL: https://<kcp-url>:6443/services/upsyncer/49adf4fn8ks8x43u/jn/72de24eb-7d49-4aca-be22-63f95548a816

--- a/docs/content/concepts/scenarios/jn-scenario/yamls/4-APIResourceImport-deployments.jn.v1.apps.yaml
+++ b/docs/content/concepts/scenarios/jn-scenario/yamls/4-APIResourceImport-deployments.jn.v1.apps.yaml
@@ -1,0 +1,6589 @@
+apiVersion: apiresource.kcp.io/v1alpha1
+kind: APIResourceImport
+metadata:
+  annotations:
+    apiresource.kcp.io/apiVersion: apps/v1
+    kcp.io/cluster: 49adf4fn8ks8x43u
+  creationTimestamp: "2023-03-20T19:08:21Z"
+  generation: 1
+  name: deployments.jn.v1.apps
+  ownerReferences:
+  - apiVersion: workload.kcp.io/v1alpha1
+    controller: true
+    kind: SyncTarget
+    name: jn
+    uid: 72de24eb-7d49-4aca-be22-63f95548a816
+  resourceVersion: "793"
+  uid: febdcb4d-6273-419c-9360-b4e5b561b0d4
+spec:
+  categories:
+  - all
+  groupVersion:
+    group: apps
+    version: v1
+  kind: Deployment
+  listKind: DeploymentList
+  location: jn
+  openAPIV3Schema:
+    description: Deployment enables declarative updates for Pods and ReplicaSets.
+    properties:
+      apiVersion:
+        description: 'APIVersion defines the versioned schema of this representation
+          of an object. Servers should convert recognized schemas to the latest internal
+          value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+        type: string
+      kind:
+        description: 'Kind is a string value representing the REST resource this object
+          represents. Servers may infer this from the endpoint the client submits
+          requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+        type: string
+      metadata:
+        type: object
+      spec:
+        description: Specification of the desired behavior of the Deployment.
+        properties:
+          minReadySeconds:
+            description: Minimum number of seconds for which a newly created pod should
+              be ready without any of its container crashing, for it to be considered
+              available. Defaults to 0 (pod will be considered available as soon as
+              it is ready)
+            format: int32
+            type: integer
+          paused:
+            description: Indicates that the deployment is paused.
+            type: boolean
+          progressDeadlineSeconds:
+            description: The maximum time in seconds for a deployment to make progress
+              before it is considered to be failed. The deployment controller will
+              continue to process failed deployments and a condition with a ProgressDeadlineExceeded
+              reason will be surfaced in the deployment status. Note that progress
+              will not be estimated during the time a deployment is paused. Defaults
+              to 600s.
+            format: int32
+            type: integer
+          replicas:
+            description: Number of desired pods. This is a pointer to distinguish
+              between explicit zero and not specified. Defaults to 1.
+            format: int32
+            type: integer
+          revisionHistoryLimit:
+            description: The number of old ReplicaSets to retain to allow rollback.
+              This is a pointer to distinguish between explicit zero and not specified.
+              Defaults to 10.
+            format: int32
+            type: integer
+          selector:
+            description: Label selector for pods. Existing ReplicaSets whose pods
+              are selected by this will be the ones affected by this deployment. It
+              must match the pod template's labels.
+            properties:
+              matchExpressions:
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
+                items:
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
+                  properties:
+                    key:
+                      description: key is the label key that the selector applies
+                        to.
+                      type: string
+                    operator:
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      type: string
+                    values:
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - key
+                  - operator
+                  type: object
+                type: array
+              matchLabels:
+                additionalProperties:
+                  type: string
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
+                type: object
+            type: object
+          strategy:
+            description: The deployment strategy to use to replace existing pods with
+              new ones.
+            properties:
+              rollingUpdate:
+                description: Rolling update config params. Present only if DeploymentStrategyType
+                  = RollingUpdate.
+                properties:
+                  maxSurge:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'The maximum number of pods that can be scheduled
+                      above the desired number of pods. Value can be an absolute number
+                      (ex: 5) or a percentage of desired pods (ex: 10%). This can
+                      not be 0 if MaxUnavailable is 0. Absolute number is calculated
+                      from percentage by rounding up. Defaults to 25%. Example: when
+                      this is set to 30%, the new ReplicaSet can be scaled up immediately
+                      when the rolling update starts, such that the total number of
+                      old and new pods do not exceed 130% of desired pods. Once old
+                      pods have been killed, new ReplicaSet can be scaled up further,
+                      ensuring that total number of pods running at any time during
+                      the update is at most 130% of desired pods.'
+                    x-kubernetes-int-or-string: true
+                  maxUnavailable:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'The maximum number of pods that can be unavailable
+                      during the update. Value can be an absolute number (ex: 5) or
+                      a percentage of desired pods (ex: 10%). Absolute number is calculated
+                      from percentage by rounding down. This can not be 0 if MaxSurge
+                      is 0. Defaults to 25%. Example: when this is set to 30%, the
+                      old ReplicaSet can be scaled down to 70% of desired pods immediately
+                      when the rolling update starts. Once new pods are ready, old
+                      ReplicaSet can be scaled down further, followed by scaling up
+                      the new ReplicaSet, ensuring that the total number of pods available
+                      at all times during the update is at least 70% of desired pods.'
+                    x-kubernetes-int-or-string: true
+                type: object
+              type:
+                description: Type of deployment. Can be "Recreate" or "RollingUpdate".
+                  Default is RollingUpdate.
+                type: string
+            type: object
+          template:
+            description: Template describes the pods that will be created.
+            properties:
+              metadata:
+                description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              spec:
+                description: 'Specification of the desired behavior of the pod. More
+                  info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                properties:
+                  activeDeadlineSeconds:
+                    description: Optional duration in seconds the pod may be active
+                      on the node relative to StartTime before the system will actively
+                      try to mark it failed and kill associated containers. Value
+                      must be a positive integer.
+                    format: int64
+                    type: integer
+                  affinity:
+                    description: If specified, the pod's scheduling constraints
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for
+                          the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node matches the corresponding matchExpressions;
+                              the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches
+                                all objects with implicit weight 0 (i.e. it's a no-op).
+                                A null preferred scheduling term matches no objects
+                                (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators
+                                              are In, NotIn, Exists, DoesNotExist.
+                                              Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators
+                                              are In, NotIn, Exists, DoesNotExist.
+                                              Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the
+                                    corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - weight
+                              - preference
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by
+                              this field are not met at scheduling time, the pod will
+                              not be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from
+                              its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term
+                                    matches no objects. The requirements of them are
+                                    ANDed. The TopologySelectorTerm type implements
+                                    a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators
+                                              are In, NotIn, Exists, DoesNotExist.
+                                              Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators
+                                              are In, NotIn, Exists, DoesNotExist.
+                                              Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g.
+                          co-locate this pod in the same node, zone, etc. as some
+                          other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node has pods which matches the corresponding
+                              podAffinityTerm; the node(s) with the highest sum are
+                              the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces. This
+                                        field is alpha-level and is only honored when
+                                        PodAffinityNamespaceSelector feature is enabled.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the
+                                    corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - weight
+                              - podAffinityTerm
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by
+                              this field are not met at scheduling time, the pod will
+                              not be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to a pod label update),
+                              the system may or may not try to eventually evict the
+                              pod from its node. When there are multiple elements,
+                              the lists of nodes corresponding to each podAffinityTerm
+                              are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located
+                                is defined as running on a node whose value of the
+                                label with key <topologyKey> matches that of any node
+                                on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces. This field is alpha-level
+                                    and is only honored when PodAffinityNamespaceSelector
+                                    feature is enabled.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules
+                          (e.g. avoid putting this pod in the same node, zone, etc.
+                          as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the anti-affinity expressions
+                              specified by this field, but it may choose a node that
+                              violates one or more of the expressions. The node that
+                              is most preferred is the one with the greatest sum of
+                              weights, i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              anti-affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node has pods which matches the corresponding
+                              podAffinityTerm; the node(s) with the highest sum are
+                              the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces. This
+                                        field is alpha-level and is only honored when
+                                        PodAffinityNamespaceSelector feature is enabled.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the
+                                    corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - weight
+                              - podAffinityTerm
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified
+                              by this field are not met at scheduling time, the pod
+                              will not be scheduled onto the node. If the anti-affinity
+                              requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod
+                              label update), the system may or may not try to eventually
+                              evict the pod from its node. When there are multiple
+                              elements, the lists of nodes corresponding to each podAffinityTerm
+                              are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located
+                                is defined as running on a node whose value of the
+                                label with key <topologyKey> matches that of any node
+                                on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces. This field is alpha-level
+                                    and is only honored when PodAffinityNamespaceSelector
+                                    feature is enabled.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  automountServiceAccountToken:
+                    description: AutomountServiceAccountToken indicates whether a
+                      service account token should be automatically mounted.
+                    type: boolean
+                  containers:
+                    description: List of containers belonging to the pod. Containers
+                      cannot currently be added or removed. There must be at least
+                      one container in a Pod. Cannot be updated.
+                    items:
+                      description: A single application container that you want to
+                        run within a pod.
+                      properties:
+                        args:
+                          description: 'Arguments to the entrypoint. The docker image''s
+                            CMD is used if this is not provided. Variable references
+                            $(VAR_NAME) are expanded using the container''s environment.
+                            If a variable cannot be resolved, the reference in the
+                            input string will be unchanged. The $(VAR_NAME) syntax
+                            can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                            references will never be expanded, regardless of whether
+                            the variable exists or not. Cannot be updated. More info:
+                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: 'Entrypoint array. Not executed within a shell.
+                            The docker image''s ENTRYPOINT is used if this is not
+                            provided. Variable references $(VAR_NAME) are expanded
+                            using the container''s environment. If a variable cannot
+                            be resolved, the reference in the input string will be
+                            unchanged. The $(VAR_NAME) syntax can be escaped with
+                            a double $$, ie: $$(VAR_NAME). Escaped references will
+                            never be expanded, regardless of whether the variable
+                            exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the
+                            container. Cannot be updated.
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previous defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  The $(VAR_NAME) syntax can be escaped with a double
+                                  $$, ie: $$(VAR_NAME). Escaped references will never
+                                  be expanded, regardless of whether the variable
+                                  exists or not. Defaults to "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's
+                                  value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container. The keys defined within a source must
+                            be a C_IDENTIFIER. All invalid keys will be reported as
+                            an event when the container is starting. When a key exists
+                            in multiple sources, the value associated with the last
+                            source will take precedence. Values defined by an Env
+                            with a duplicate key will take precedence. Cannot be updated.
+                          items:
+                            description: EnvFromSource represents the source of a
+                              set of ConfigMaps
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must
+                                      be defined
+                                    type: boolean
+                                type: object
+                              prefix:
+                                description: An optional identifier to prepend to
+                                  each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be
+                                      defined
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                            This field is optional to allow higher level config management
+                            to default or override container images in workload controllers
+                            like Deployments and StatefulSets.'
+                          type: string
+                        imagePullPolicy:
+                          description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                            Defaults to Always if :latest tag is specified, or IfNotPresent
+                            otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                          type: string
+                        lifecycle:
+                          description: Actions that the management system should take
+                            in response to container lifecycle events. Cannot be updated.
+                          properties:
+                            postStart:
+                              description: 'PostStart is called immediately after
+                                a container is created. If the handler fails, the
+                                container is terminated and restarted according to
+                                its restart policy. Other management of the container
+                                blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            preStop:
+                              description: 'PreStop is called immediately before a
+                                container is terminated due to an API request or management
+                                event such as liveness/startup probe failure, preemption,
+                                resource contention, etc. The handler is not called
+                                if the container crashes or exits. The reason for
+                                termination is passed to the handler. The Pod''s termination
+                                grace period countdown begins before the PreStop hooked
+                                is executed. Regardless of the outcome of the handler,
+                                the container will eventually terminate within the
+                                Pod''s termination grace period. Other management
+                                of the container blocks until the hook completes or
+                                until the termination grace period is reached. More
+                                info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                          type: object
+                        livenessProbe:
+                          description: 'Periodic probe of container liveness. Container
+                            will be restarted if the probe fails. Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                an alpha field and requires enabling ProbeTerminationGracePeriod
+                                feature gate.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: Name of the container specified as a DNS_LABEL.
+                            Each container in a pod must have a unique name (DNS_LABEL).
+                            Cannot be updated.
+                          type: string
+                        ports:
+                          description: List of ports to expose from the container.
+                            Exposing a port here gives the system additional information
+                            about the network connections a container uses, but is
+                            primarily informational. Not specifying a port here DOES
+                            NOT prevent that port from being exposed. Any port which
+                            is listening on the default "0.0.0.0" address inside a
+                            container will be accessible from the network. Cannot
+                            be updated.
+                          items:
+                            description: ContainerPort represents a network port in
+                              a single container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's
+                                  IP address. This must be a valid port number, 0
+                                  < x < 65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port
+                                  to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host.
+                                  If specified, this must be a valid port number,
+                                  0 < x < 65536. If HostNetwork is specified, this
+                                  must match ContainerPort. Most containers do not
+                                  need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a
+                                  pod must have a unique name. Name for the port that
+                                  can be referred to by services.
+                                type: string
+                              protocol:
+                                default: TCP
+                                description: Protocol for port. Must be UDP, TCP,
+                                  or SCTP. Defaults to "TCP".
+                                type: string
+                            required:
+                            - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - containerPort
+                          - protocol
+                          x-kubernetes-list-type: map
+                        readinessProbe:
+                          description: 'Periodic probe of container service readiness.
+                            Container will be removed from service endpoints if the
+                            probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                an alpha field and requires enabling ProbeTerminationGracePeriod
+                                feature gate.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          description: 'Compute Resources required by this container.
+                            Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        securityContext:
+                          description: 'Security options the pod should run with.
+                            More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                            More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                          properties:
+                            allowPrivilegeEscalation:
+                              description: 'AllowPrivilegeEscalation controls whether
+                                a process can gain more privileges than its parent
+                                process. This bool directly controls if the no_new_privs
+                                flag will be set on the container process. AllowPrivilegeEscalation
+                                is true always when the container is: 1) run as Privileged
+                                2) has CAP_SYS_ADMIN'
+                              type: boolean
+                            capabilities:
+                              description: The capabilities to add/drop when running
+                                containers. Defaults to the default set of capabilities
+                                granted by the container runtime.
+                              properties:
+                                add:
+                                  description: Added capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                                drop:
+                                  description: Removed capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            privileged:
+                              description: Run container in privileged mode. Processes
+                                in privileged containers are essentially equivalent
+                                to root on the host. Defaults to false.
+                              type: boolean
+                            procMount:
+                              description: procMount denotes the type of proc mount
+                                to use for the containers. The default is DefaultProcMount
+                                which uses the container runtime defaults for readonly
+                                paths and masked paths. This requires the ProcMountType
+                                feature flag to be enabled.
+                              type: string
+                            readOnlyRootFilesystem:
+                              description: Whether this container has a read-only
+                                root filesystem. Default is false.
+                              type: boolean
+                            runAsGroup:
+                              description: The GID to run the entrypoint of the container
+                                process. Uses runtime default if unset. May also be
+                                set in PodSecurityContext.  If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              description: Indicates that the container must run as
+                                a non-root user. If true, the Kubelet will validate
+                                the image at runtime to ensure that it does not run
+                                as UID 0 (root) and fail to start the container if
+                                it does. If unset or false, no such validation will
+                                be performed. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                              type: boolean
+                            runAsUser:
+                              description: The UID to run the entrypoint of the container
+                                process. Defaults to user specified in image metadata
+                                if unspecified. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              description: The SELinux context to be applied to the
+                                container. If unspecified, the container runtime will
+                                allocate a random SELinux context for each container.  May
+                                also be set in PodSecurityContext.  If set in both
+                                SecurityContext and PodSecurityContext, the value
+                                specified in SecurityContext takes precedence.
+                              properties:
+                                level:
+                                  description: Level is SELinux level label that applies
+                                    to the container.
+                                  type: string
+                                role:
+                                  description: Role is a SELinux role label that applies
+                                    to the container.
+                                  type: string
+                                type:
+                                  description: Type is a SELinux type label that applies
+                                    to the container.
+                                  type: string
+                                user:
+                                  description: User is a SELinux user label that applies
+                                    to the container.
+                                  type: string
+                              type: object
+                            seccompProfile:
+                              description: The seccomp options to use by this container.
+                                If seccomp options are provided at both the pod &
+                                container level, the container options override the
+                                pod options.
+                              properties:
+                                localhostProfile:
+                                  description: localhostProfile indicates a profile
+                                    defined in a file on the node should be used.
+                                    The profile must be preconfigured on the node
+                                    to work. Must be a descending path, relative to
+                                    the kubelet's configured seccomp profile location.
+                                    Must only be set if type is "Localhost".
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                    Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            windowsOptions:
+                              description: The Windows specific settings applied to
+                                all containers. If unspecified, the options from the
+                                PodSecurityContext will be used. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
+                              properties:
+                                gmsaCredentialSpec:
+                                  description: GMSACredentialSpec is where the GMSA
+                                    admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                    inlines the contents of the GMSA credential spec
+                                    named by the GMSACredentialSpecName field.
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  description: GMSACredentialSpecName is the name
+                                    of the GMSA credential spec to use.
+                                  type: string
+                                runAsUserName:
+                                  description: The UserName in Windows to run the
+                                    entrypoint of the container process. Defaults
+                                    to the user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  type: string
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: 'StartupProbe indicates that the Pod has successfully
+                            initialized. If specified, no other probes are executed
+                            until this completes successfully. If this probe fails,
+                            the Pod will be restarted, just as if the livenessProbe
+                            failed. This can be used to provide different probe parameters
+                            at the beginning of a Pod''s lifecycle, when it might
+                            take a long time to load data or warm a cache, than during
+                            steady-state operation. This cannot be updated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                an alpha field and requires enabling ProbeTerminationGracePeriod
+                                feature gate.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        stdin:
+                          description: Whether this container should allocate a buffer
+                            for stdin in the container runtime. If this is not set,
+                            reads from stdin in the container will always result in
+                            EOF. Default is false.
+                          type: boolean
+                        stdinOnce:
+                          description: Whether the container runtime should close
+                            the stdin channel after it has been opened by a single
+                            attach. When stdin is true the stdin stream will remain
+                            open across multiple attach sessions. If stdinOnce is
+                            set to true, stdin is opened on container start, is empty
+                            until the first client attaches to stdin, and then remains
+                            open and accepts data until the client disconnects, at
+                            which time stdin is closed and remains closed until the
+                            container is restarted. If this flag is false, a container
+                            processes that reads from stdin will never receive an
+                            EOF. Default is false
+                          type: boolean
+                        terminationMessagePath:
+                          description: 'Optional: Path at which the file to which
+                            the container''s termination message will be written is
+                            mounted into the container''s filesystem. Message written
+                            is intended to be brief final status, such as an assertion
+                            failure message. Will be truncated by the node if greater
+                            than 4096 bytes. The total message length across all containers
+                            will be limited to 12kb. Defaults to /dev/termination-log.
+                            Cannot be updated.'
+                          type: string
+                        terminationMessagePolicy:
+                          description: Indicate how the termination message should
+                            be populated. File will use the contents of terminationMessagePath
+                            to populate the container status message on both success
+                            and failure. FallbackToLogsOnError will use the last chunk
+                            of container log output if the termination message file
+                            is empty and the container exited with an error. The log
+                            output is limited to 2048 bytes or 80 lines, whichever
+                            is smaller. Defaults to File. Cannot be updated.
+                          type: string
+                        tty:
+                          description: Whether this container should allocate a TTY
+                            for itself, also requires 'stdin' to be true. Default
+                            is false.
+                          type: boolean
+                        volumeDevices:
+                          description: volumeDevices is the list of block devices
+                            to be used by the container.
+                          items:
+                            description: volumeDevice describes a mapping of a raw
+                              block device within a container.
+                            properties:
+                              devicePath:
+                                description: devicePath is the path inside of the
+                                  container that the device will be mapped to.
+                                type: string
+                              name:
+                                description: name must match the name of a persistentVolumeClaim
+                                  in the pod
+                                type: string
+                            required:
+                            - devicePath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - devicePath
+                          x-kubernetes-list-type: map
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                            Cannot be updated.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write
+                                  otherwise (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the
+                                  container's volume should be mounted. Defaults to
+                                  "" (volume's root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from
+                                  which the container's volume should be mounted.
+                                  Behaves similarly to SubPath but environment variable
+                                  references $(VAR_NAME) are expanded using the container's
+                                  environment. Defaults to "" (volume's root). SubPathExpr
+                                  and SubPath are mutually exclusive.
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - mountPath
+                          x-kubernetes-list-type: map
+                        workingDir:
+                          description: Container's working directory. If not specified,
+                            the container runtime's default will be used, which might
+                            be configured in the container image. Cannot be updated.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  dnsConfig:
+                    description: Specifies the DNS parameters of a pod. Parameters
+                      specified here will be merged to the generated DNS configuration
+                      based on DNSPolicy.
+                    properties:
+                      nameservers:
+                        description: A list of DNS name server IP addresses. This
+                          will be appended to the base nameservers generated from
+                          DNSPolicy. Duplicated nameservers will be removed.
+                        items:
+                          type: string
+                        type: array
+                      options:
+                        description: A list of DNS resolver options. This will be
+                          merged with the base options generated from DNSPolicy. Duplicated
+                          entries will be removed. Resolution options given in Options
+                          will override those that appear in the base DNSPolicy.
+                        items:
+                          description: PodDNSConfigOption defines DNS resolver options
+                            of a pod.
+                          properties:
+                            name:
+                              description: Required.
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                      searches:
+                        description: A list of DNS search domains for host-name lookup.
+                          This will be appended to the base search paths generated
+                          from DNSPolicy. Duplicated search paths will be removed.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  dnsPolicy:
+                    description: Set DNS policy for the pod. Defaults to "ClusterFirst".
+                      Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst',
+                      'Default' or 'None'. DNS parameters given in DNSConfig will
+                      be merged with the policy selected with DNSPolicy. To have DNS
+                      options set along with hostNetwork, you have to specify DNS
+                      policy explicitly to 'ClusterFirstWithHostNet'.
+                    type: string
+                  enableServiceLinks:
+                    description: 'EnableServiceLinks indicates whether information
+                      about services should be injected into pod''s environment variables,
+                      matching the syntax of Docker links. Optional: Defaults to true.'
+                    type: boolean
+                  ephemeralContainers:
+                    description: List of ephemeral containers run in this pod. Ephemeral
+                      containers may be run in an existing pod to perform user-initiated
+                      actions such as debugging. This list cannot be specified when
+                      creating a pod, and it cannot be modified by updating the pod
+                      spec. In order to add an ephemeral container to an existing
+                      pod, use the pod's ephemeralcontainers subresource. This field
+                      is alpha-level and is only honored by servers that enable the
+                      EphemeralContainers feature.
+                    items:
+                      description: An EphemeralContainer is a container that may be
+                        added temporarily to an existing pod for user-initiated activities
+                        such as debugging. Ephemeral containers have no resource or
+                        scheduling guarantees, and they will not be restarted when
+                        they exit or when a pod is removed or restarted. If an ephemeral
+                        container causes a pod to exceed its resource allocation,
+                        the pod may be evicted. Ephemeral containers may not be added
+                        by directly updating the pod spec. They must be added via
+                        the pod's ephemeralcontainers subresource, and they will appear
+                        in the pod spec once added. This is an alpha feature enabled
+                        by the EphemeralContainers feature flag.
+                      properties:
+                        args:
+                          description: 'Arguments to the entrypoint. The docker image''s
+                            CMD is used if this is not provided. Variable references
+                            $(VAR_NAME) are expanded using the container''s environment.
+                            If a variable cannot be resolved, the reference in the
+                            input string will be unchanged. The $(VAR_NAME) syntax
+                            can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                            references will never be expanded, regardless of whether
+                            the variable exists or not. Cannot be updated. More info:
+                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: 'Entrypoint array. Not executed within a shell.
+                            The docker image''s ENTRYPOINT is used if this is not
+                            provided. Variable references $(VAR_NAME) are expanded
+                            using the container''s environment. If a variable cannot
+                            be resolved, the reference in the input string will be
+                            unchanged. The $(VAR_NAME) syntax can be escaped with
+                            a double $$, ie: $$(VAR_NAME). Escaped references will
+                            never be expanded, regardless of whether the variable
+                            exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the
+                            container. Cannot be updated.
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previous defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  The $(VAR_NAME) syntax can be escaped with a double
+                                  $$, ie: $$(VAR_NAME). Escaped references will never
+                                  be expanded, regardless of whether the variable
+                                  exists or not. Defaults to "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's
+                                  value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container. The keys defined within a source must
+                            be a C_IDENTIFIER. All invalid keys will be reported as
+                            an event when the container is starting. When a key exists
+                            in multiple sources, the value associated with the last
+                            source will take precedence. Values defined by an Env
+                            with a duplicate key will take precedence. Cannot be updated.
+                          items:
+                            description: EnvFromSource represents the source of a
+                              set of ConfigMaps
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must
+                                      be defined
+                                    type: boolean
+                                type: object
+                              prefix:
+                                description: An optional identifier to prepend to
+                                  each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be
+                                      defined
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                          type: string
+                        imagePullPolicy:
+                          description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                            Defaults to Always if :latest tag is specified, or IfNotPresent
+                            otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                          type: string
+                        lifecycle:
+                          description: Lifecycle is not allowed for ephemeral containers.
+                          properties:
+                            postStart:
+                              description: 'PostStart is called immediately after
+                                a container is created. If the handler fails, the
+                                container is terminated and restarted according to
+                                its restart policy. Other management of the container
+                                blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            preStop:
+                              description: 'PreStop is called immediately before a
+                                container is terminated due to an API request or management
+                                event such as liveness/startup probe failure, preemption,
+                                resource contention, etc. The handler is not called
+                                if the container crashes or exits. The reason for
+                                termination is passed to the handler. The Pod''s termination
+                                grace period countdown begins before the PreStop hooked
+                                is executed. Regardless of the outcome of the handler,
+                                the container will eventually terminate within the
+                                Pod''s termination grace period. Other management
+                                of the container blocks until the hook completes or
+                                until the termination grace period is reached. More
+                                info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                          type: object
+                        livenessProbe:
+                          description: Probes are not allowed for ephemeral containers.
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                an alpha field and requires enabling ProbeTerminationGracePeriod
+                                feature gate.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: Name of the ephemeral container specified as
+                            a DNS_LABEL. This name must be unique among all containers,
+                            init containers and ephemeral containers.
+                          type: string
+                        ports:
+                          description: Ports are not allowed for ephemeral containers.
+                          items:
+                            description: ContainerPort represents a network port in
+                              a single container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's
+                                  IP address. This must be a valid port number, 0
+                                  < x < 65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port
+                                  to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host.
+                                  If specified, this must be a valid port number,
+                                  0 < x < 65536. If HostNetwork is specified, this
+                                  must match ContainerPort. Most containers do not
+                                  need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a
+                                  pod must have a unique name. Name for the port that
+                                  can be referred to by services.
+                                type: string
+                              protocol:
+                                default: TCP
+                                description: Protocol for port. Must be UDP, TCP,
+                                  or SCTP. Defaults to "TCP".
+                                type: string
+                            required:
+                            - containerPort
+                            type: object
+                          type: array
+                        readinessProbe:
+                          description: Probes are not allowed for ephemeral containers.
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                an alpha field and requires enabling ProbeTerminationGracePeriod
+                                feature gate.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          description: Resources are not allowed for ephemeral containers.
+                            Ephemeral containers use spare resources already allocated
+                            to the pod.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        securityContext:
+                          description: SecurityContext is not allowed for ephemeral
+                            containers.
+                          properties:
+                            allowPrivilegeEscalation:
+                              description: 'AllowPrivilegeEscalation controls whether
+                                a process can gain more privileges than its parent
+                                process. This bool directly controls if the no_new_privs
+                                flag will be set on the container process. AllowPrivilegeEscalation
+                                is true always when the container is: 1) run as Privileged
+                                2) has CAP_SYS_ADMIN'
+                              type: boolean
+                            capabilities:
+                              description: The capabilities to add/drop when running
+                                containers. Defaults to the default set of capabilities
+                                granted by the container runtime.
+                              properties:
+                                add:
+                                  description: Added capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                                drop:
+                                  description: Removed capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            privileged:
+                              description: Run container in privileged mode. Processes
+                                in privileged containers are essentially equivalent
+                                to root on the host. Defaults to false.
+                              type: boolean
+                            procMount:
+                              description: procMount denotes the type of proc mount
+                                to use for the containers. The default is DefaultProcMount
+                                which uses the container runtime defaults for readonly
+                                paths and masked paths. This requires the ProcMountType
+                                feature flag to be enabled.
+                              type: string
+                            readOnlyRootFilesystem:
+                              description: Whether this container has a read-only
+                                root filesystem. Default is false.
+                              type: boolean
+                            runAsGroup:
+                              description: The GID to run the entrypoint of the container
+                                process. Uses runtime default if unset. May also be
+                                set in PodSecurityContext.  If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              description: Indicates that the container must run as
+                                a non-root user. If true, the Kubelet will validate
+                                the image at runtime to ensure that it does not run
+                                as UID 0 (root) and fail to start the container if
+                                it does. If unset or false, no such validation will
+                                be performed. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                              type: boolean
+                            runAsUser:
+                              description: The UID to run the entrypoint of the container
+                                process. Defaults to user specified in image metadata
+                                if unspecified. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              description: The SELinux context to be applied to the
+                                container. If unspecified, the container runtime will
+                                allocate a random SELinux context for each container.  May
+                                also be set in PodSecurityContext.  If set in both
+                                SecurityContext and PodSecurityContext, the value
+                                specified in SecurityContext takes precedence.
+                              properties:
+                                level:
+                                  description: Level is SELinux level label that applies
+                                    to the container.
+                                  type: string
+                                role:
+                                  description: Role is a SELinux role label that applies
+                                    to the container.
+                                  type: string
+                                type:
+                                  description: Type is a SELinux type label that applies
+                                    to the container.
+                                  type: string
+                                user:
+                                  description: User is a SELinux user label that applies
+                                    to the container.
+                                  type: string
+                              type: object
+                            seccompProfile:
+                              description: The seccomp options to use by this container.
+                                If seccomp options are provided at both the pod &
+                                container level, the container options override the
+                                pod options.
+                              properties:
+                                localhostProfile:
+                                  description: localhostProfile indicates a profile
+                                    defined in a file on the node should be used.
+                                    The profile must be preconfigured on the node
+                                    to work. Must be a descending path, relative to
+                                    the kubelet's configured seccomp profile location.
+                                    Must only be set if type is "Localhost".
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                    Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            windowsOptions:
+                              description: The Windows specific settings applied to
+                                all containers. If unspecified, the options from the
+                                PodSecurityContext will be used. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
+                              properties:
+                                gmsaCredentialSpec:
+                                  description: GMSACredentialSpec is where the GMSA
+                                    admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                    inlines the contents of the GMSA credential spec
+                                    named by the GMSACredentialSpecName field.
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  description: GMSACredentialSpecName is the name
+                                    of the GMSA credential spec to use.
+                                  type: string
+                                runAsUserName:
+                                  description: The UserName in Windows to run the
+                                    entrypoint of the container process. Defaults
+                                    to the user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  type: string
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: Probes are not allowed for ephemeral containers.
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                an alpha field and requires enabling ProbeTerminationGracePeriod
+                                feature gate.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        stdin:
+                          description: Whether this container should allocate a buffer
+                            for stdin in the container runtime. If this is not set,
+                            reads from stdin in the container will always result in
+                            EOF. Default is false.
+                          type: boolean
+                        stdinOnce:
+                          description: Whether the container runtime should close
+                            the stdin channel after it has been opened by a single
+                            attach. When stdin is true the stdin stream will remain
+                            open across multiple attach sessions. If stdinOnce is
+                            set to true, stdin is opened on container start, is empty
+                            until the first client attaches to stdin, and then remains
+                            open and accepts data until the client disconnects, at
+                            which time stdin is closed and remains closed until the
+                            container is restarted. If this flag is false, a container
+                            processes that reads from stdin will never receive an
+                            EOF. Default is false
+                          type: boolean
+                        targetContainerName:
+                          description: If set, the name of the container from PodSpec
+                            that this ephemeral container targets. The ephemeral container
+                            will be run in the namespaces (IPC, PID, etc) of this
+                            container. If not set then the ephemeral container is
+                            run in whatever namespaces are shared for the pod. Note
+                            that the container runtime must support this feature.
+                          type: string
+                        terminationMessagePath:
+                          description: 'Optional: Path at which the file to which
+                            the container''s termination message will be written is
+                            mounted into the container''s filesystem. Message written
+                            is intended to be brief final status, such as an assertion
+                            failure message. Will be truncated by the node if greater
+                            than 4096 bytes. The total message length across all containers
+                            will be limited to 12kb. Defaults to /dev/termination-log.
+                            Cannot be updated.'
+                          type: string
+                        terminationMessagePolicy:
+                          description: Indicate how the termination message should
+                            be populated. File will use the contents of terminationMessagePath
+                            to populate the container status message on both success
+                            and failure. FallbackToLogsOnError will use the last chunk
+                            of container log output if the termination message file
+                            is empty and the container exited with an error. The log
+                            output is limited to 2048 bytes or 80 lines, whichever
+                            is smaller. Defaults to File. Cannot be updated.
+                          type: string
+                        tty:
+                          description: Whether this container should allocate a TTY
+                            for itself, also requires 'stdin' to be true. Default
+                            is false.
+                          type: boolean
+                        volumeDevices:
+                          description: volumeDevices is the list of block devices
+                            to be used by the container.
+                          items:
+                            description: volumeDevice describes a mapping of a raw
+                              block device within a container.
+                            properties:
+                              devicePath:
+                                description: devicePath is the path inside of the
+                                  container that the device will be mapped to.
+                                type: string
+                              name:
+                                description: name must match the name of a persistentVolumeClaim
+                                  in the pod
+                                type: string
+                            required:
+                            - devicePath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - devicePath
+                          x-kubernetes-list-type: map
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                            Cannot be updated.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write
+                                  otherwise (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the
+                                  container's volume should be mounted. Defaults to
+                                  "" (volume's root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from
+                                  which the container's volume should be mounted.
+                                  Behaves similarly to SubPath but environment variable
+                                  references $(VAR_NAME) are expanded using the container's
+                                  environment. Defaults to "" (volume's root). SubPathExpr
+                                  and SubPath are mutually exclusive.
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - mountPath
+                          x-kubernetes-list-type: map
+                        workingDir:
+                          description: Container's working directory. If not specified,
+                            the container runtime's default will be used, which might
+                            be configured in the container image. Cannot be updated.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  hostAliases:
+                    description: HostAliases is an optional list of hosts and IPs
+                      that will be injected into the pod's hosts file if specified.
+                      This is only valid for non-hostNetwork pods.
+                    items:
+                      description: HostAlias holds the mapping between IP and hostnames
+                        that will be injected as an entry in the pod's hosts file.
+                      properties:
+                        hostnames:
+                          description: Hostnames for the above IP address.
+                          items:
+                            type: string
+                          type: array
+                        ip:
+                          description: IP address of the host file entry.
+                          type: string
+                      required:
+                      - ip
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - ip
+                    x-kubernetes-list-type: map
+                  hostIPC:
+                    description: 'Use the host''s ipc namespace. Optional: Default
+                      to false.'
+                    type: boolean
+                  hostNetwork:
+                    description: Host networking requested for this pod. Use the host's
+                      network namespace. If this option is set, the ports that will
+                      be used must be specified. Default to false.
+                    type: boolean
+                  hostPID:
+                    description: 'Use the host''s pid namespace. Optional: Default
+                      to false.'
+                    type: boolean
+                  hostname:
+                    description: Specifies the hostname of the Pod If not specified,
+                      the pod's hostname will be set to a system-defined value.
+                    type: string
+                  imagePullSecrets:
+                    description: 'ImagePullSecrets is an optional list of references
+                      to secrets in the same namespace to use for pulling any of the
+                      images used by this PodSpec. If specified, these secrets will
+                      be passed to individual puller implementations for them to use.
+                      For example, in the case of docker, only DockerConfig type secrets
+                      are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                    items:
+                      description: LocalObjectReference contains enough information
+                        to let you locate the referenced object inside the same namespace.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  initContainers:
+                    description: 'List of initialization containers belonging to the
+                      pod. Init containers are executed in order prior to containers
+                      being started. If any init container fails, the pod is considered
+                      to have failed and is handled according to its restartPolicy.
+                      The name for an init container or normal container must be unique
+                      among all containers. Init containers may not have Lifecycle
+                      actions, Readiness probes, Liveness probes, or Startup probes.
+                      The resourceRequirements of an init container are taken into
+                      account during scheduling by finding the highest request/limit
+                      for each resource type, and then using the max of of that value
+                      or the sum of the normal containers. Limits are applied to init
+                      containers in a similar fashion. Init containers cannot currently
+                      be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                    items:
+                      description: A single application container that you want to
+                        run within a pod.
+                      properties:
+                        args:
+                          description: 'Arguments to the entrypoint. The docker image''s
+                            CMD is used if this is not provided. Variable references
+                            $(VAR_NAME) are expanded using the container''s environment.
+                            If a variable cannot be resolved, the reference in the
+                            input string will be unchanged. The $(VAR_NAME) syntax
+                            can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                            references will never be expanded, regardless of whether
+                            the variable exists or not. Cannot be updated. More info:
+                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: 'Entrypoint array. Not executed within a shell.
+                            The docker image''s ENTRYPOINT is used if this is not
+                            provided. Variable references $(VAR_NAME) are expanded
+                            using the container''s environment. If a variable cannot
+                            be resolved, the reference in the input string will be
+                            unchanged. The $(VAR_NAME) syntax can be escaped with
+                            a double $$, ie: $$(VAR_NAME). Escaped references will
+                            never be expanded, regardless of whether the variable
+                            exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the
+                            container. Cannot be updated.
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previous defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  The $(VAR_NAME) syntax can be escaped with a double
+                                  $$, ie: $$(VAR_NAME). Escaped references will never
+                                  be expanded, regardless of whether the variable
+                                  exists or not. Defaults to "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's
+                                  value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container. The keys defined within a source must
+                            be a C_IDENTIFIER. All invalid keys will be reported as
+                            an event when the container is starting. When a key exists
+                            in multiple sources, the value associated with the last
+                            source will take precedence. Values defined by an Env
+                            with a duplicate key will take precedence. Cannot be updated.
+                          items:
+                            description: EnvFromSource represents the source of a
+                              set of ConfigMaps
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must
+                                      be defined
+                                    type: boolean
+                                type: object
+                              prefix:
+                                description: An optional identifier to prepend to
+                                  each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be
+                                      defined
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                            This field is optional to allow higher level config management
+                            to default or override container images in workload controllers
+                            like Deployments and StatefulSets.'
+                          type: string
+                        imagePullPolicy:
+                          description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                            Defaults to Always if :latest tag is specified, or IfNotPresent
+                            otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                          type: string
+                        lifecycle:
+                          description: Actions that the management system should take
+                            in response to container lifecycle events. Cannot be updated.
+                          properties:
+                            postStart:
+                              description: 'PostStart is called immediately after
+                                a container is created. If the handler fails, the
+                                container is terminated and restarted according to
+                                its restart policy. Other management of the container
+                                blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            preStop:
+                              description: 'PreStop is called immediately before a
+                                container is terminated due to an API request or management
+                                event such as liveness/startup probe failure, preemption,
+                                resource contention, etc. The handler is not called
+                                if the container crashes or exits. The reason for
+                                termination is passed to the handler. The Pod''s termination
+                                grace period countdown begins before the PreStop hooked
+                                is executed. Regardless of the outcome of the handler,
+                                the container will eventually terminate within the
+                                Pod''s termination grace period. Other management
+                                of the container blocks until the hook completes or
+                                until the termination grace period is reached. More
+                                info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                          type: object
+                        livenessProbe:
+                          description: 'Periodic probe of container liveness. Container
+                            will be restarted if the probe fails. Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                an alpha field and requires enabling ProbeTerminationGracePeriod
+                                feature gate.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: Name of the container specified as a DNS_LABEL.
+                            Each container in a pod must have a unique name (DNS_LABEL).
+                            Cannot be updated.
+                          type: string
+                        ports:
+                          description: List of ports to expose from the container.
+                            Exposing a port here gives the system additional information
+                            about the network connections a container uses, but is
+                            primarily informational. Not specifying a port here DOES
+                            NOT prevent that port from being exposed. Any port which
+                            is listening on the default "0.0.0.0" address inside a
+                            container will be accessible from the network. Cannot
+                            be updated.
+                          items:
+                            description: ContainerPort represents a network port in
+                              a single container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's
+                                  IP address. This must be a valid port number, 0
+                                  < x < 65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port
+                                  to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host.
+                                  If specified, this must be a valid port number,
+                                  0 < x < 65536. If HostNetwork is specified, this
+                                  must match ContainerPort. Most containers do not
+                                  need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a
+                                  pod must have a unique name. Name for the port that
+                                  can be referred to by services.
+                                type: string
+                              protocol:
+                                default: TCP
+                                description: Protocol for port. Must be UDP, TCP,
+                                  or SCTP. Defaults to "TCP".
+                                type: string
+                            required:
+                            - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - containerPort
+                          - protocol
+                          x-kubernetes-list-type: map
+                        readinessProbe:
+                          description: 'Periodic probe of container service readiness.
+                            Container will be removed from service endpoints if the
+                            probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                an alpha field and requires enabling ProbeTerminationGracePeriod
+                                feature gate.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          description: 'Compute Resources required by this container.
+                            Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        securityContext:
+                          description: 'Security options the pod should run with.
+                            More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                            More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                          properties:
+                            allowPrivilegeEscalation:
+                              description: 'AllowPrivilegeEscalation controls whether
+                                a process can gain more privileges than its parent
+                                process. This bool directly controls if the no_new_privs
+                                flag will be set on the container process. AllowPrivilegeEscalation
+                                is true always when the container is: 1) run as Privileged
+                                2) has CAP_SYS_ADMIN'
+                              type: boolean
+                            capabilities:
+                              description: The capabilities to add/drop when running
+                                containers. Defaults to the default set of capabilities
+                                granted by the container runtime.
+                              properties:
+                                add:
+                                  description: Added capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                                drop:
+                                  description: Removed capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            privileged:
+                              description: Run container in privileged mode. Processes
+                                in privileged containers are essentially equivalent
+                                to root on the host. Defaults to false.
+                              type: boolean
+                            procMount:
+                              description: procMount denotes the type of proc mount
+                                to use for the containers. The default is DefaultProcMount
+                                which uses the container runtime defaults for readonly
+                                paths and masked paths. This requires the ProcMountType
+                                feature flag to be enabled.
+                              type: string
+                            readOnlyRootFilesystem:
+                              description: Whether this container has a read-only
+                                root filesystem. Default is false.
+                              type: boolean
+                            runAsGroup:
+                              description: The GID to run the entrypoint of the container
+                                process. Uses runtime default if unset. May also be
+                                set in PodSecurityContext.  If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              description: Indicates that the container must run as
+                                a non-root user. If true, the Kubelet will validate
+                                the image at runtime to ensure that it does not run
+                                as UID 0 (root) and fail to start the container if
+                                it does. If unset or false, no such validation will
+                                be performed. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                              type: boolean
+                            runAsUser:
+                              description: The UID to run the entrypoint of the container
+                                process. Defaults to user specified in image metadata
+                                if unspecified. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              description: The SELinux context to be applied to the
+                                container. If unspecified, the container runtime will
+                                allocate a random SELinux context for each container.  May
+                                also be set in PodSecurityContext.  If set in both
+                                SecurityContext and PodSecurityContext, the value
+                                specified in SecurityContext takes precedence.
+                              properties:
+                                level:
+                                  description: Level is SELinux level label that applies
+                                    to the container.
+                                  type: string
+                                role:
+                                  description: Role is a SELinux role label that applies
+                                    to the container.
+                                  type: string
+                                type:
+                                  description: Type is a SELinux type label that applies
+                                    to the container.
+                                  type: string
+                                user:
+                                  description: User is a SELinux user label that applies
+                                    to the container.
+                                  type: string
+                              type: object
+                            seccompProfile:
+                              description: The seccomp options to use by this container.
+                                If seccomp options are provided at both the pod &
+                                container level, the container options override the
+                                pod options.
+                              properties:
+                                localhostProfile:
+                                  description: localhostProfile indicates a profile
+                                    defined in a file on the node should be used.
+                                    The profile must be preconfigured on the node
+                                    to work. Must be a descending path, relative to
+                                    the kubelet's configured seccomp profile location.
+                                    Must only be set if type is "Localhost".
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                    Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            windowsOptions:
+                              description: The Windows specific settings applied to
+                                all containers. If unspecified, the options from the
+                                PodSecurityContext will be used. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
+                              properties:
+                                gmsaCredentialSpec:
+                                  description: GMSACredentialSpec is where the GMSA
+                                    admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                    inlines the contents of the GMSA credential spec
+                                    named by the GMSACredentialSpecName field.
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  description: GMSACredentialSpecName is the name
+                                    of the GMSA credential spec to use.
+                                  type: string
+                                runAsUserName:
+                                  description: The UserName in Windows to run the
+                                    entrypoint of the container process. Defaults
+                                    to the user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  type: string
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: 'StartupProbe indicates that the Pod has successfully
+                            initialized. If specified, no other probes are executed
+                            until this completes successfully. If this probe fails,
+                            the Pod will be restarted, just as if the livenessProbe
+                            failed. This can be used to provide different probe parameters
+                            at the beginning of a Pod''s lifecycle, when it might
+                            take a long time to load data or warm a cache, than during
+                            steady-state operation. This cannot be updated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                an alpha field and requires enabling ProbeTerminationGracePeriod
+                                feature gate.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        stdin:
+                          description: Whether this container should allocate a buffer
+                            for stdin in the container runtime. If this is not set,
+                            reads from stdin in the container will always result in
+                            EOF. Default is false.
+                          type: boolean
+                        stdinOnce:
+                          description: Whether the container runtime should close
+                            the stdin channel after it has been opened by a single
+                            attach. When stdin is true the stdin stream will remain
+                            open across multiple attach sessions. If stdinOnce is
+                            set to true, stdin is opened on container start, is empty
+                            until the first client attaches to stdin, and then remains
+                            open and accepts data until the client disconnects, at
+                            which time stdin is closed and remains closed until the
+                            container is restarted. If this flag is false, a container
+                            processes that reads from stdin will never receive an
+                            EOF. Default is false
+                          type: boolean
+                        terminationMessagePath:
+                          description: 'Optional: Path at which the file to which
+                            the container''s termination message will be written is
+                            mounted into the container''s filesystem. Message written
+                            is intended to be brief final status, such as an assertion
+                            failure message. Will be truncated by the node if greater
+                            than 4096 bytes. The total message length across all containers
+                            will be limited to 12kb. Defaults to /dev/termination-log.
+                            Cannot be updated.'
+                          type: string
+                        terminationMessagePolicy:
+                          description: Indicate how the termination message should
+                            be populated. File will use the contents of terminationMessagePath
+                            to populate the container status message on both success
+                            and failure. FallbackToLogsOnError will use the last chunk
+                            of container log output if the termination message file
+                            is empty and the container exited with an error. The log
+                            output is limited to 2048 bytes or 80 lines, whichever
+                            is smaller. Defaults to File. Cannot be updated.
+                          type: string
+                        tty:
+                          description: Whether this container should allocate a TTY
+                            for itself, also requires 'stdin' to be true. Default
+                            is false.
+                          type: boolean
+                        volumeDevices:
+                          description: volumeDevices is the list of block devices
+                            to be used by the container.
+                          items:
+                            description: volumeDevice describes a mapping of a raw
+                              block device within a container.
+                            properties:
+                              devicePath:
+                                description: devicePath is the path inside of the
+                                  container that the device will be mapped to.
+                                type: string
+                              name:
+                                description: name must match the name of a persistentVolumeClaim
+                                  in the pod
+                                type: string
+                            required:
+                            - devicePath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - devicePath
+                          x-kubernetes-list-type: map
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                            Cannot be updated.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write
+                                  otherwise (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the
+                                  container's volume should be mounted. Defaults to
+                                  "" (volume's root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from
+                                  which the container's volume should be mounted.
+                                  Behaves similarly to SubPath but environment variable
+                                  references $(VAR_NAME) are expanded using the container's
+                                  environment. Defaults to "" (volume's root). SubPathExpr
+                                  and SubPath are mutually exclusive.
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - mountPath
+                          x-kubernetes-list-type: map
+                        workingDir:
+                          description: Container's working directory. If not specified,
+                            the container runtime's default will be used, which might
+                            be configured in the container image. Cannot be updated.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  nodeName:
+                    description: NodeName is a request to schedule this pod onto a
+                      specific node. If it is non-empty, the scheduler simply schedules
+                      this pod onto that node, assuming that it fits resource requirements.
+                    type: string
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'NodeSelector is a selector which must be true for
+                      the pod to fit on a node. Selector which must match a node''s
+                      labels for the pod to be scheduled on that node. More info:
+                      https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                    type: object
+                  overhead:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Overhead represents the resource overhead associated
+                      with running a pod for a given RuntimeClass. This field will
+                      be autopopulated at admission time by the RuntimeClass admission
+                      controller. If the RuntimeClass admission controller is enabled,
+                      overhead must not be set in Pod create requests. The RuntimeClass
+                      admission controller will reject Pod create requests which have
+                      the overhead already set. If RuntimeClass is configured and
+                      selected in the PodSpec, Overhead will be set to the value defined
+                      in the corresponding RuntimeClass, otherwise it will remain
+                      unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md
+                      This field is alpha-level as of Kubernetes v1.16, and is only
+                      honored by servers that enable the PodOverhead feature.'
+                    type: object
+                  preemptionPolicy:
+                    description: PreemptionPolicy is the Policy for preempting pods
+                      with lower priority. One of Never, PreemptLowerPriority. Defaults
+                      to PreemptLowerPriority if unset. This field is beta-level,
+                      gated by the NonPreemptingPriority feature-gate.
+                    type: string
+                  priority:
+                    description: The priority value. Various system components use
+                      this field to find the priority of the pod. When Priority Admission
+                      Controller is enabled, it prevents users from setting this field.
+                      The admission controller populates this field from PriorityClassName.
+                      The higher the value, the higher the priority.
+                    format: int32
+                    type: integer
+                  priorityClassName:
+                    description: If specified, indicates the pod's priority. "system-node-critical"
+                      and "system-cluster-critical" are two special keywords which
+                      indicate the highest priorities with the former being the highest
+                      priority. Any other name must be defined by creating a PriorityClass
+                      object with that name. If not specified, the pod priority will
+                      be default or zero if there is no default.
+                    type: string
+                  readinessGates:
+                    description: 'If specified, all readiness gates will be evaluated
+                      for pod readiness. A pod is ready when all its containers are
+                      ready AND all conditions specified in the readiness gates have
+                      status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md'
+                    items:
+                      description: PodReadinessGate contains the reference to a pod
+                        condition
+                      properties:
+                        conditionType:
+                          description: ConditionType refers to a condition in the
+                            pod's condition list with matching type.
+                          type: string
+                      required:
+                      - conditionType
+                      type: object
+                    type: array
+                  restartPolicy:
+                    description: 'Restart policy for all containers within the pod.
+                      One of Always, OnFailure, Never. Default to Always. More info:
+                      https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
+                    type: string
+                  runtimeClassName:
+                    description: 'RuntimeClassName refers to a RuntimeClass object
+                      in the node.k8s.io group, which should be used to run this pod.  If
+                      no RuntimeClass resource matches the named class, the pod will
+                      not be run. If unset or empty, the "legacy" RuntimeClass will
+                      be used, which is an implicit class with an empty definition
+                      that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
+                      This is a beta feature as of Kubernetes v1.14.'
+                    type: string
+                  schedulerName:
+                    description: If specified, the pod will be dispatched by specified
+                      scheduler. If not specified, the pod will be dispatched by default
+                      scheduler.
+                    type: string
+                  securityContext:
+                    description: 'SecurityContext holds pod-level security attributes
+                      and common container settings. Optional: Defaults to empty.  See
+                      type description for default values of each field.'
+                    properties:
+                      fsGroup:
+                        description: |-
+                          A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
+                          1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
+                          If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                        format: int64
+                        type: integer
+                      fsGroupChangePolicy:
+                        description: 'fsGroupChangePolicy defines behavior of changing
+                          ownership and permission of the volume before being exposed
+                          inside Pod. This field will only apply to volume types which
+                          support fsGroup based ownership(and permissions). It will
+                          have no effect on ephemeral volume types such as: secret,
+                          configmaps and emptydir. Valid values are "OnRootMismatch"
+                          and "Always". If not specified, "Always" is used.'
+                        type: string
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence for that container.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in SecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in SecurityContext.  If set
+                          in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence for that container.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to all containers.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          SecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence
+                          for that container.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: The seccomp options to use by the containers
+                          in this pod.
+                        properties:
+                          localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used. The profile must
+                              be preconfigured on the node to work. Must be a descending
+                              path, relative to the kubelet's configured seccomp profile
+                              location. Must only be set if type is "Localhost".
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                              Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      supplementalGroups:
+                        description: A list of groups applied to the first process
+                          run in each container, in addition to the container's primary
+                          GID.  If unspecified, no groups will be added to any container.
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      sysctls:
+                        description: Sysctls hold a list of namespaced sysctls used
+                          for the pod. Pods with unsupported sysctls (by the container
+                          runtime) might fail to launch.
+                        items:
+                          description: Sysctl defines a kernel parameter to be set
+                          properties:
+                            name:
+                              description: Name of a property to set
+                              type: string
+                            value:
+                              description: Value of a property to set
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options within a container's
+                          SecurityContext will be used. If set in both SecurityContext
+                          and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  serviceAccount:
+                    description: 'DeprecatedServiceAccount is a depreciated alias
+                      for ServiceAccountName. Deprecated: Use serviceAccountName instead.'
+                    type: string
+                  serviceAccountName:
+                    description: 'ServiceAccountName is the name of the ServiceAccount
+                      to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                    type: string
+                  setHostnameAsFQDN:
+                    description: If true the pod's hostname will be configured as
+                      the pod's FQDN, rather than the leaf name (the default). In
+                      Linux containers, this means setting the FQDN in the hostname
+                      field of the kernel (the nodename field of struct utsname).
+                      In Windows containers, this means setting the registry value
+                      of hostname for the registry key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters
+                      to FQDN. If a pod does not have FQDN, this has no effect. Default
+                      to false.
+                    type: boolean
+                  shareProcessNamespace:
+                    description: 'Share a single process namespace between all of
+                      the containers in a pod. When this is set containers will be
+                      able to view and signal processes from other containers in the
+                      same pod, and the first process in each container will not be
+                      assigned PID 1. HostPID and ShareProcessNamespace cannot both
+                      be set. Optional: Default to false.'
+                    type: boolean
+                  subdomain:
+                    description: If specified, the fully qualified Pod hostname will
+                      be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+                      If not specified, the pod will not have a domainname at all.
+                    type: string
+                  terminationGracePeriodSeconds:
+                    description: Optional duration in seconds the pod needs to terminate
+                      gracefully. May be decreased in delete request. Value must be
+                      non-negative integer. The value zero indicates stop immediately
+                      via the kill signal (no opportunity to shut down). If this value
+                      is nil, the default grace period will be used instead. The grace
+                      period is the duration in seconds after the processes running
+                      in the pod are sent a termination signal and the time when the
+                      processes are forcibly halted with a kill signal. Set this value
+                      longer than the expected cleanup time for your process. Defaults
+                      to 30 seconds.
+                    format: int64
+                    type: integer
+                  tolerations:
+                    description: If specified, the pod's tolerations.
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using
+                        the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match.
+                            Empty means match all taint effects. When specified, allowed
+                            values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to
+                            the value. Valid operators are Exists and Equal. Defaults
+                            to Equal. Exists is equivalent to wildcard for value,
+                            so that a pod can tolerate all taints of a particular
+                            category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of
+                            time the toleration (which must be of effect NoExecute,
+                            otherwise this field is ignored) tolerates the taint.
+                            By default, it is not set, which means tolerate the taint
+                            forever (do not evict). Zero and negative values will
+                            be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  topologySpreadConstraints:
+                    description: TopologySpreadConstraints describes how a group of
+                      pods ought to spread across topology domains. Scheduler will
+                      schedule pods in a way which abides by the constraints. All
+                      topologySpreadConstraints are ANDed.
+                    items:
+                      description: TopologySpreadConstraint specifies how to spread
+                        matching pods among the given topology.
+                      properties:
+                        labelSelector:
+                          description: LabelSelector is used to find matching pods.
+                            Pods that match this label selector are counted to determine
+                            the number of pods in their corresponding topology domain.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        maxSkew:
+                          description: 'MaxSkew describes the degree to which pods
+                            may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                            it is the maximum permitted difference between the number
+                            of matching pods in the target topology and the global
+                            minimum. For example, in a 3-zone cluster, MaxSkew is
+                            set to 1, and pods with the same labelSelector spread
+                            as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
+                            - if MaxSkew is 1, incoming pod can only be scheduled
+                            to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(2-0) on zone1(zone2) violate
+                            MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
+                            onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                            it is used to give higher precedence to topologies that
+                            satisfy it. It''s a required field. Default value is 1
+                            and 0 is not allowed.'
+                          format: int32
+                          type: integer
+                        topologyKey:
+                          description: TopologyKey is the key of node labels. Nodes
+                            that have a label with this key and identical values are
+                            considered to be in the same topology. We consider each
+                            <key, value> as a "bucket", and try to put balanced number
+                            of pods into each bucket. It's a required field.
+                          type: string
+                        whenUnsatisfiable:
+                          description: |-
+                            WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                              but giving higher precedence to topologies that would help reduce the
+                              skew.
+                            A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assigment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
+                          type: string
+                      required:
+                      - maxSkew
+                      - topologyKey
+                      - whenUnsatisfiable
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - topologyKey
+                    - whenUnsatisfiable
+                    x-kubernetes-list-type: map
+                  volumes:
+                    description: 'List of volumes that can be mounted by containers
+                      belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                    items:
+                      description: Volume represents a named volume in a pod that
+                        may be accessed by any container in the pod.
+                      properties:
+                        awsElasticBlockStore:
+                          description: 'AWSElasticBlockStore represents an AWS Disk
+                            resource that is attached to a kubelet''s host machine
+                            and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                          properties:
+                            fsType:
+                              description: 'Filesystem type of the volume that you
+                                want to mount. Tip: Ensure that the filesystem type
+                                is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              type: string
+                            partition:
+                              description: 'The partition in the volume that you want
+                                to mount. If omitted, the default is to mount by volume
+                                name. Examples: For volume /dev/sda1, you specify
+                                the partition as "1". Similarly, the volume partition
+                                for /dev/sda is "0" (or you can leave the property
+                                empty).'
+                              format: int32
+                              type: integer
+                            readOnly:
+                              description: 'Specify "true" to force and set the ReadOnly
+                                property in VolumeMounts to "true". If omitted, the
+                                default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              type: boolean
+                            volumeID:
+                              description: 'Unique ID of the persistent disk resource
+                                in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        azureDisk:
+                          description: AzureDisk represents an Azure Data Disk mount
+                            on the host and bind mount to the pod.
+                          properties:
+                            cachingMode:
+                              description: 'Host Caching mode: None, Read Only, Read
+                                Write.'
+                              type: string
+                            diskName:
+                              description: The Name of the data disk in the blob storage
+                              type: string
+                            diskURI:
+                              description: The URI the data disk in the blob storage
+                              type: string
+                            fsType:
+                              description: Filesystem type to mount. Must be a filesystem
+                                type supported by the host operating system. Ex. "ext4",
+                                "xfs", "ntfs". Implicitly inferred to be "ext4" if
+                                unspecified.
+                              type: string
+                            kind:
+                              description: 'Expected values Shared: multiple blob
+                                disks per storage account  Dedicated: single blob
+                                disk per storage account  Managed: azure managed data
+                                disk (only in managed availability set). defaults
+                                to shared'
+                              type: string
+                            readOnly:
+                              description: Defaults to false (read/write). ReadOnly
+                                here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                          required:
+                          - diskName
+                          - diskURI
+                          type: object
+                        azureFile:
+                          description: AzureFile represents an Azure File Service
+                            mount on the host and bind mount to the pod.
+                          properties:
+                            readOnly:
+                              description: Defaults to false (read/write). ReadOnly
+                                here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretName:
+                              description: the name of secret that contains Azure
+                                Storage Account Name and Key
+                              type: string
+                            shareName:
+                              description: Share Name
+                              type: string
+                          required:
+                          - secretName
+                          - shareName
+                          type: object
+                        cephfs:
+                          description: CephFS represents a Ceph FS mount on the host
+                            that shares a pod's lifetime
+                          properties:
+                            monitors:
+                              description: 'Required: Monitors is a collection of
+                                Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              items:
+                                type: string
+                              type: array
+                            path:
+                              description: 'Optional: Used as the mounted root, rather
+                                than the full Ceph tree, default is /'
+                              type: string
+                            readOnly:
+                              description: 'Optional: Defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              type: boolean
+                            secretFile:
+                              description: 'Optional: SecretFile is the path to key
+                                ring for User, default is /etc/ceph/user.secret More
+                                info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              type: string
+                            secretRef:
+                              description: 'Optional: SecretRef is reference to the
+                                authentication secret for User, default is empty.
+                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            user:
+                              description: 'Optional: User is the rados user name,
+                                default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              type: string
+                          required:
+                          - monitors
+                          type: object
+                        cinder:
+                          description: 'Cinder represents a cinder volume attached
+                            and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                          properties:
+                            fsType:
+                              description: 'Filesystem type to mount. Must be a filesystem
+                                type supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              type: string
+                            readOnly:
+                              description: 'Optional: Defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              type: boolean
+                            secretRef:
+                              description: 'Optional: points to a secret object containing
+                                parameters used to connect to OpenStack.'
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            volumeID:
+                              description: 'volume id used to identify the volume
+                                in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        configMap:
+                          description: ConfigMap represents a configMap that should
+                            populate this volume
+                          properties:
+                            defaultMode:
+                              description: 'Optional: mode bits used to set permissions
+                                on created files by default. Must be an octal value
+                                between 0000 and 0777 or a decimal value between 0
+                                and 511. YAML accepts both octal and decimal values,
+                                JSON requires decimal values for mode bits. Defaults
+                                to 0644. Directories within the path are not affected
+                                by this setting. This might be in conflict with other
+                                options that affect the file mode, like fsGroup, and
+                                the result can be other mode bits set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: If unspecified, each key-value pair in
+                                the Data field of the referenced ConfigMap will be
+                                projected into the volume as a file whose name is
+                                the key and content is the value. If specified, the
+                                listed keys will be projected into the specified paths,
+                                and unlisted keys will not be present. If a key is
+                                specified which is not present in the ConfigMap, the
+                                volume setup will error unless it is marked optional.
+                                Paths must be relative and may not contain the '..'
+                                path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a
+                                  volume.
+                                properties:
+                                  key:
+                                    description: The key to project.
+                                    type: string
+                                  mode:
+                                    description: 'Optional: mode bits used to set
+                                      permissions on this file. Must be an octal value
+                                      between 0000 and 0777 or a decimal value between
+                                      0 and 511. YAML accepts both octal and decimal
+                                      values, JSON requires decimal values for mode
+                                      bits. If not specified, the volume defaultMode
+                                      will be used. This might be in conflict with
+                                      other options that affect the file mode, like
+                                      fsGroup, and the result can be other mode bits
+                                      set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: The relative path of the file to
+                                      map the key to. May not be an absolute path.
+                                      May not contain the path element '..'. May not
+                                      start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its keys
+                                must be defined
+                              type: boolean
+                          type: object
+                        csi:
+                          description: CSI (Container Storage Interface) represents
+                            ephemeral storage that is handled by certain external
+                            CSI drivers (Beta feature).
+                          properties:
+                            driver:
+                              description: Driver is the name of the CSI driver that
+                                handles this volume. Consult with your admin for the
+                                correct name as registered in the cluster.
+                              type: string
+                            fsType:
+                              description: Filesystem type to mount. Ex. "ext4", "xfs",
+                                "ntfs". If not provided, the empty value is passed
+                                to the associated CSI driver which will determine
+                                the default filesystem to apply.
+                              type: string
+                            nodePublishSecretRef:
+                              description: NodePublishSecretRef is a reference to
+                                the secret object containing sensitive information
+                                to pass to the CSI driver to complete the CSI NodePublishVolume
+                                and NodeUnpublishVolume calls. This field is optional,
+                                and  may be empty if no secret is required. If the
+                                secret object contains more than one secret, all secret
+                                references are passed.
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            readOnly:
+                              description: Specifies a read-only configuration for
+                                the volume. Defaults to false (read/write).
+                              type: boolean
+                            volumeAttributes:
+                              additionalProperties:
+                                type: string
+                              description: VolumeAttributes stores driver-specific
+                                properties that are passed to the CSI driver. Consult
+                                your driver's documentation for supported values.
+                              type: object
+                          required:
+                          - driver
+                          type: object
+                        downwardAPI:
+                          description: DownwardAPI represents downward API about the
+                            pod that should populate this volume
+                          properties:
+                            defaultMode:
+                              description: 'Optional: mode bits to use on created
+                                files by default. Must be a Optional: mode bits used
+                                to set permissions on created files by default. Must
+                                be an octal value between 0000 and 0777 or a decimal
+                                value between 0 and 511. YAML accepts both octal and
+                                decimal values, JSON requires decimal values for mode
+                                bits. Defaults to 0644. Directories within the path
+                                are not affected by this setting. This might be in
+                                conflict with other options that affect the file mode,
+                                like fsGroup, and the result can be other mode bits
+                                set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: Items is a list of downward API volume
+                                file
+                              items:
+                                description: DownwardAPIVolumeFile represents information
+                                  to create the file containing the pod field
+                                properties:
+                                  fieldRef:
+                                    description: 'Required: Selects a field of the
+                                      pod: only annotations, labels, name and namespace
+                                      are supported.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  mode:
+                                    description: 'Optional: mode bits used to set
+                                      permissions on this file, must be an octal value
+                                      between 0000 and 0777 or a decimal value between
+                                      0 and 511. YAML accepts both octal and decimal
+                                      values, JSON requires decimal values for mode
+                                      bits. If not specified, the volume defaultMode
+                                      will be used. This might be in conflict with
+                                      other options that affect the file mode, like
+                                      fsGroup, and the result can be other mode bits
+                                      set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: 'Required: Path is  the relative
+                                      path name of the file to be created. Must not
+                                      be absolute or contain the ''..'' path. Must
+                                      be utf-8 encoded. The first item of the relative
+                                      path must not start with ''..'''
+                                    type: string
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, requests.cpu and requests.memory)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                required:
+                                - path
+                                type: object
+                              type: array
+                          type: object
+                        emptyDir:
+                          description: 'EmptyDir represents a temporary directory
+                            that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                          properties:
+                            medium:
+                              description: 'What type of storage medium should back
+                                this directory. The default is "" which means to use
+                                the node''s default medium. Must be an empty string
+                                (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              type: string
+                            sizeLimit:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: 'Total amount of local storage required
+                                for this EmptyDir volume. The size limit is also applicable
+                                for memory medium. The maximum usage on memory medium
+                                EmptyDir would be the minimum value between the SizeLimit
+                                specified here and the sum of memory limits of all
+                                containers in a pod. The default is nil which means
+                                that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          type: object
+                        ephemeral:
+                          description: |-
+                            Ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+
+                            Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+                               tracking are needed,
+                            c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+                               a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                               information on the connection between this volume type
+                               and PersistentVolumeClaim).
+
+                            Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+
+                            Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+
+                            A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+
+                            This is a beta feature and only available when the GenericEphemeralVolume feature gate is enabled.
+                          properties:
+                            volumeClaimTemplate:
+                              description: |-
+                                Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+
+                                An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+
+                                This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+
+                                Required, must not be nil.
+                              properties:
+                                metadata:
+                                  description: May contain labels and annotations
+                                    that will be copied into the PVC when creating
+                                    it. No other fields are allowed and will be rejected
+                                    during validation.
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                spec:
+                                  description: The specification for the PersistentVolumeClaim.
+                                    The entire content is copied unchanged into the
+                                    PVC that gets created from this template. The
+                                    same fields as in a PersistentVolumeClaim are
+                                    also valid here.
+                                  properties:
+                                    accessModes:
+                                      description: 'AccessModes contains the desired
+                                        access modes the volume should have. More
+                                        info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                      items:
+                                        type: string
+                                      type: array
+                                    dataSource:
+                                      description: 'This field can be used to specify
+                                        either: * An existing VolumeSnapshot object
+                                        (snapshot.storage.k8s.io/VolumeSnapshot) *
+                                        An existing PVC (PersistentVolumeClaim) *
+                                        An existing custom resource that implements
+                                        data population (Alpha) In order to use custom
+                                        resource types that implement data population,
+                                        the AnyVolumeDataSource feature gate must
+                                        be enabled. If the provisioner or an external
+                                        controller can support the specified data
+                                        source, it will create a new volume based
+                                        on the contents of the specified data source.'
+                                      properties:
+                                        apiGroup:
+                                          description: APIGroup is the group for the
+                                            resource being referenced. If APIGroup
+                                            is not specified, the specified Kind must
+                                            be in the core API group. For any other
+                                            third-party types, APIGroup is required.
+                                          type: string
+                                        kind:
+                                          description: Kind is the type of resource
+                                            being referenced
+                                          type: string
+                                        name:
+                                          description: Name is the name of resource
+                                            being referenced
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                    resources:
+                                      description: 'Resources represents the minimum
+                                        resources the volume should have. More info:
+                                        https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Limits describes the maximum
+                                            amount of compute resources allowed. More
+                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Requests describes the minimum
+                                            amount of compute resources required.
+                                            If Requests is omitted for a container,
+                                            it defaults to Limits if that is explicitly
+                                            specified, otherwise to an implementation-defined
+                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                      type: object
+                                    selector:
+                                      description: A label query over volumes to consider
+                                        for binding.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    storageClassName:
+                                      description: 'Name of the StorageClass required
+                                        by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                      type: string
+                                    volumeMode:
+                                      description: volumeMode defines what type of
+                                        volume is required by the claim. Value of
+                                        Filesystem is implied when not included in
+                                        claim spec.
+                                      type: string
+                                    volumeName:
+                                      description: VolumeName is the binding reference
+                                        to the PersistentVolume backing this claim.
+                                      type: string
+                                  type: object
+                              required:
+                              - spec
+                              type: object
+                          type: object
+                        fc:
+                          description: FC represents a Fibre Channel resource that
+                            is attached to a kubelet's host machine and then exposed
+                            to the pod.
+                          properties:
+                            fsType:
+                              description: Filesystem type to mount. Must be a filesystem
+                                type supported by the host operating system. Ex. "ext4",
+                                "xfs", "ntfs". Implicitly inferred to be "ext4" if
+                                unspecified.
+                              type: string
+                            lun:
+                              description: 'Optional: FC target lun number'
+                              format: int32
+                              type: integer
+                            readOnly:
+                              description: 'Optional: Defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                              type: boolean
+                            targetWWNs:
+                              description: 'Optional: FC target worldwide names (WWNs)'
+                              items:
+                                type: string
+                              type: array
+                            wwids:
+                              description: 'Optional: FC volume world wide identifiers
+                                (wwids) Either wwids or combination of targetWWNs
+                                and lun must be set, but not both simultaneously.'
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        flexVolume:
+                          description: FlexVolume represents a generic volume resource
+                            that is provisioned/attached using an exec based plugin.
+                          properties:
+                            driver:
+                              description: Driver is the name of the driver to use
+                                for this volume.
+                              type: string
+                            fsType:
+                              description: Filesystem type to mount. Must be a filesystem
+                                type supported by the host operating system. Ex. "ext4",
+                                "xfs", "ntfs". The default filesystem depends on FlexVolume
+                                script.
+                              type: string
+                            options:
+                              additionalProperties:
+                                type: string
+                              description: 'Optional: Extra command options if any.'
+                              type: object
+                            readOnly:
+                              description: 'Optional: Defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                              type: boolean
+                            secretRef:
+                              description: 'Optional: SecretRef is reference to the
+                                secret object containing sensitive information to
+                                pass to the plugin scripts. This may be empty if no
+                                secret object is specified. If the secret object contains
+                                more than one secret, all secrets are passed to the
+                                plugin scripts.'
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                          required:
+                          - driver
+                          type: object
+                        flocker:
+                          description: Flocker represents a Flocker volume attached
+                            to a kubelet's host machine. This depends on the Flocker
+                            control service being running
+                          properties:
+                            datasetName:
+                              description: Name of the dataset stored as metadata
+                                -> name on the dataset for Flocker should be considered
+                                as deprecated
+                              type: string
+                            datasetUUID:
+                              description: UUID of the dataset. This is unique identifier
+                                of a Flocker dataset
+                              type: string
+                          type: object
+                        gcePersistentDisk:
+                          description: 'GCEPersistentDisk represents a GCE Disk resource
+                            that is attached to a kubelet''s host machine and then
+                            exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                          properties:
+                            fsType:
+                              description: 'Filesystem type of the volume that you
+                                want to mount. Tip: Ensure that the filesystem type
+                                is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              type: string
+                            partition:
+                              description: 'The partition in the volume that you want
+                                to mount. If omitted, the default is to mount by volume
+                                name. Examples: For volume /dev/sda1, you specify
+                                the partition as "1". Similarly, the volume partition
+                                for /dev/sda is "0" (or you can leave the property
+                                empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              format: int32
+                              type: integer
+                            pdName:
+                              description: 'Unique name of the PD resource in GCE.
+                                Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              type: string
+                            readOnly:
+                              description: 'ReadOnly here will force the ReadOnly
+                                setting in VolumeMounts. Defaults to false. More info:
+                                https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              type: boolean
+                          required:
+                          - pdName
+                          type: object
+                        gitRepo:
+                          description: 'GitRepo represents a git repository at a particular
+                            revision. DEPRECATED: GitRepo is deprecated. To provision
+                            a container with a git repo, mount an EmptyDir into an
+                            InitContainer that clones the repo using git, then mount
+                            the EmptyDir into the Pod''s container.'
+                          properties:
+                            directory:
+                              description: Target directory name. Must not contain
+                                or start with '..'.  If '.' is supplied, the volume
+                                directory will be the git repository.  Otherwise,
+                                if specified, the volume will contain the git repository
+                                in the subdirectory with the given name.
+                              type: string
+                            repository:
+                              description: Repository URL
+                              type: string
+                            revision:
+                              description: Commit hash for the specified revision.
+                              type: string
+                          required:
+                          - repository
+                          type: object
+                        glusterfs:
+                          description: 'Glusterfs represents a Glusterfs mount on
+                            the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                          properties:
+                            endpoints:
+                              description: 'EndpointsName is the endpoint name that
+                                details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                              type: string
+                            path:
+                              description: 'Path is the Glusterfs volume path. More
+                                info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                              type: string
+                            readOnly:
+                              description: 'ReadOnly here will force the Glusterfs
+                                volume to be mounted with read-only permissions. Defaults
+                                to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                              type: boolean
+                          required:
+                          - endpoints
+                          - path
+                          type: object
+                        hostPath:
+                          description: 'HostPath represents a pre-existing file or
+                            directory on the host machine that is directly exposed
+                            to the container. This is generally used for system agents
+                            or other privileged things that are allowed to see the
+                            host machine. Most containers will NOT need this. More
+                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                          properties:
+                            path:
+                              description: 'Path of the directory on the host. If
+                                the path is a symlink, it will follow the link to
+                                the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                              type: string
+                            type:
+                              description: 'Type for HostPath Volume Defaults to ""
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        iscsi:
+                          description: 'ISCSI represents an ISCSI Disk resource that
+                            is attached to a kubelet''s host machine and then exposed
+                            to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                          properties:
+                            chapAuthDiscovery:
+                              description: whether support iSCSI Discovery CHAP authentication
+                              type: boolean
+                            chapAuthSession:
+                              description: whether support iSCSI Session CHAP authentication
+                              type: boolean
+                            fsType:
+                              description: 'Filesystem type of the volume that you
+                                want to mount. Tip: Ensure that the filesystem type
+                                is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                              type: string
+                            initiatorName:
+                              description: Custom iSCSI Initiator Name. If initiatorName
+                                is specified with iscsiInterface simultaneously, new
+                                iSCSI interface <target portal>:<volume name> will
+                                be created for the connection.
+                              type: string
+                            iqn:
+                              description: Target iSCSI Qualified Name.
+                              type: string
+                            iscsiInterface:
+                              description: iSCSI Interface Name that uses an iSCSI
+                                transport. Defaults to 'default' (tcp).
+                              type: string
+                            lun:
+                              description: iSCSI Target Lun number.
+                              format: int32
+                              type: integer
+                            portals:
+                              description: iSCSI Target Portal List. The portal is
+                                either an IP or ip_addr:port if the port is other
+                                than default (typically TCP ports 860 and 3260).
+                              items:
+                                type: string
+                              type: array
+                            readOnly:
+                              description: ReadOnly here will force the ReadOnly setting
+                                in VolumeMounts. Defaults to false.
+                              type: boolean
+                            secretRef:
+                              description: CHAP Secret for iSCSI target and initiator
+                                authentication
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            targetPortal:
+                              description: iSCSI Target Portal. The Portal is either
+                                an IP or ip_addr:port if the port is other than default
+                                (typically TCP ports 860 and 3260).
+                              type: string
+                          required:
+                          - targetPortal
+                          - iqn
+                          - lun
+                          type: object
+                        name:
+                          description: 'Volume''s name. Must be a DNS_LABEL and unique
+                            within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        nfs:
+                          description: 'NFS represents an NFS mount on the host that
+                            shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                          properties:
+                            path:
+                              description: 'Path that is exported by the NFS server.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              type: string
+                            readOnly:
+                              description: 'ReadOnly here will force the NFS export
+                                to be mounted with read-only permissions. Defaults
+                                to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              type: boolean
+                            server:
+                              description: 'Server is the hostname or IP address of
+                                the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              type: string
+                          required:
+                          - server
+                          - path
+                          type: object
+                        persistentVolumeClaim:
+                          description: 'PersistentVolumeClaimVolumeSource represents
+                            a reference to a PersistentVolumeClaim in the same namespace.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          properties:
+                            claimName:
+                              description: 'ClaimName is the name of a PersistentVolumeClaim
+                                in the same namespace as the pod using this volume.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              type: string
+                            readOnly:
+                              description: Will force the ReadOnly setting in VolumeMounts.
+                                Default false.
+                              type: boolean
+                          required:
+                          - claimName
+                          type: object
+                        photonPersistentDisk:
+                          description: PhotonPersistentDisk represents a PhotonController
+                            persistent disk attached and mounted on kubelets host
+                            machine
+                          properties:
+                            fsType:
+                              description: Filesystem type to mount. Must be a filesystem
+                                type supported by the host operating system. Ex. "ext4",
+                                "xfs", "ntfs". Implicitly inferred to be "ext4" if
+                                unspecified.
+                              type: string
+                            pdID:
+                              description: ID that identifies Photon Controller persistent
+                                disk
+                              type: string
+                          required:
+                          - pdID
+                          type: object
+                        portworxVolume:
+                          description: PortworxVolume represents a portworx volume
+                            attached and mounted on kubelets host machine
+                          properties:
+                            fsType:
+                              description: FSType represents the filesystem type to
+                                mount Must be a filesystem type supported by the host
+                                operating system. Ex. "ext4", "xfs". Implicitly inferred
+                                to be "ext4" if unspecified.
+                              type: string
+                            readOnly:
+                              description: Defaults to false (read/write). ReadOnly
+                                here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            volumeID:
+                              description: VolumeID uniquely identifies a Portworx
+                                volume
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        projected:
+                          description: Items for all in one resources secrets, configmaps,
+                            and downward API
+                          properties:
+                            defaultMode:
+                              description: Mode bits used to set permissions on created
+                                files by default. Must be an octal value between 0000
+                                and 0777 or a decimal value between 0 and 511. YAML
+                                accepts both octal and decimal values, JSON requires
+                                decimal values for mode bits. Directories within the
+                                path are not affected by this setting. This might
+                                be in conflict with other options that affect the
+                                file mode, like fsGroup, and the result can be other
+                                mode bits set.
+                              format: int32
+                              type: integer
+                            sources:
+                              description: list of volume projections
+                              items:
+                                description: Projection that may be projected along
+                                  with other supported volume types
+                                properties:
+                                  configMap:
+                                    description: information about the configMap data
+                                      to project
+                                    properties:
+                                      items:
+                                        description: If unspecified, each key-value
+                                          pair in the Data field of the referenced
+                                          ConfigMap will be projected into the volume
+                                          as a file whose name is the key and content
+                                          is the value. If specified, the listed keys
+                                          will be projected into the specified paths,
+                                          and unlisted keys will not be present. If
+                                          a key is specified which is not present
+                                          in the ConfigMap, the volume setup will
+                                          error unless it is marked optional. Paths
+                                          must be relative and may not contain the
+                                          '..' path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: The key to project.
+                                              type: string
+                                            mode:
+                                              description: 'Optional: mode bits used
+                                                to set permissions on this file. Must
+                                                be an octal value between 0000 and
+                                                0777 or a decimal value between 0
+                                                and 511. YAML accepts both octal and
+                                                decimal values, JSON requires decimal
+                                                values for mode bits. If not specified,
+                                                the volume defaultMode will be used.
+                                                This might be in conflict with other
+                                                options that affect the file mode,
+                                                like fsGroup, and the result can be
+                                                other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: The relative path of the
+                                                file to map the key to. May not be
+                                                an absolute path. May not contain
+                                                the path element '..'. May not start
+                                                with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its keys must be defined
+                                        type: boolean
+                                    type: object
+                                  downwardAPI:
+                                    description: information about the downwardAPI
+                                      data to project
+                                    properties:
+                                      items:
+                                        description: Items is a list of DownwardAPIVolume
+                                          file
+                                        items:
+                                          description: DownwardAPIVolumeFile represents
+                                            information to create the file containing
+                                            the pod field
+                                          properties:
+                                            fieldRef:
+                                              description: 'Required: Selects a field
+                                                of the pod: only annotations, labels,
+                                                name and namespace are supported.'
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                            mode:
+                                              description: 'Optional: mode bits used
+                                                to set permissions on this file, must
+                                                be an octal value between 0000 and
+                                                0777 or a decimal value between 0
+                                                and 511. YAML accepts both octal and
+                                                decimal values, JSON requires decimal
+                                                values for mode bits. If not specified,
+                                                the volume defaultMode will be used.
+                                                This might be in conflict with other
+                                                options that affect the file mode,
+                                                like fsGroup, and the result can be
+                                                other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: 'Required: Path is  the
+                                                relative path name of the file to
+                                                be created. Must not be absolute or
+                                                contain the ''..'' path. Must be utf-8
+                                                encoded. The first item of the relative
+                                                path must not start with ''..'''
+                                              type: string
+                                            resourceFieldRef:
+                                              description: 'Selects a resource of
+                                                the container: only resources limits
+                                                and requests (limits.cpu, limits.memory,
+                                                requests.cpu and requests.memory)
+                                                are currently supported.'
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                          required:
+                                          - path
+                                          type: object
+                                        type: array
+                                    type: object
+                                  secret:
+                                    description: information about the secret data
+                                      to project
+                                    properties:
+                                      items:
+                                        description: If unspecified, each key-value
+                                          pair in the Data field of the referenced
+                                          Secret will be projected into the volume
+                                          as a file whose name is the key and content
+                                          is the value. If specified, the listed keys
+                                          will be projected into the specified paths,
+                                          and unlisted keys will not be present. If
+                                          a key is specified which is not present
+                                          in the Secret, the volume setup will error
+                                          unless it is marked optional. Paths must
+                                          be relative and may not contain the '..'
+                                          path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: The key to project.
+                                              type: string
+                                            mode:
+                                              description: 'Optional: mode bits used
+                                                to set permissions on this file. Must
+                                                be an octal value between 0000 and
+                                                0777 or a decimal value between 0
+                                                and 511. YAML accepts both octal and
+                                                decimal values, JSON requires decimal
+                                                values for mode bits. If not specified,
+                                                the volume defaultMode will be used.
+                                                This might be in conflict with other
+                                                options that affect the file mode,
+                                                like fsGroup, and the result can be
+                                                other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: The relative path of the
+                                                file to map the key to. May not be
+                                                an absolute path. May not contain
+                                                the path element '..'. May not start
+                                                with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    type: object
+                                  serviceAccountToken:
+                                    description: information about the serviceAccountToken
+                                      data to project
+                                    properties:
+                                      audience:
+                                        description: Audience is the intended audience
+                                          of the token. A recipient of a token must
+                                          identify itself with an identifier specified
+                                          in the audience of the token, and otherwise
+                                          should reject the token. The audience defaults
+                                          to the identifier of the apiserver.
+                                        type: string
+                                      expirationSeconds:
+                                        description: ExpirationSeconds is the requested
+                                          duration of validity of the service account
+                                          token. As the token approaches expiration,
+                                          the kubelet volume plugin will proactively
+                                          rotate the service account token. The kubelet
+                                          will start trying to rotate the token if
+                                          the token is older than 80 percent of its
+                                          time to live or if the token is older than
+                                          24 hours.Defaults to 1 hour and must be
+                                          at least 10 minutes.
+                                        format: int64
+                                        type: integer
+                                      path:
+                                        description: Path is the path relative to
+                                          the mount point of the file to project the
+                                          token into.
+                                        type: string
+                                    required:
+                                    - path
+                                    type: object
+                                type: object
+                              type: array
+                          type: object
+                        quobyte:
+                          description: Quobyte represents a Quobyte mount on the host
+                            that shares a pod's lifetime
+                          properties:
+                            group:
+                              description: Group to map volume access to Default is
+                                no group
+                              type: string
+                            readOnly:
+                              description: ReadOnly here will force the Quobyte volume
+                                to be mounted with read-only permissions. Defaults
+                                to false.
+                              type: boolean
+                            registry:
+                              description: Registry represents a single or multiple
+                                Quobyte Registry services specified as a string as
+                                host:port pair (multiple entries are separated with
+                                commas) which acts as the central registry for volumes
+                              type: string
+                            tenant:
+                              description: Tenant owning the given Quobyte volume
+                                in the Backend Used with dynamically provisioned Quobyte
+                                volumes, value is set by the plugin
+                              type: string
+                            user:
+                              description: User to map volume access to Defaults to
+                                serivceaccount user
+                              type: string
+                            volume:
+                              description: Volume is a string that references an already
+                                created Quobyte volume by name.
+                              type: string
+                          required:
+                          - registry
+                          - volume
+                          type: object
+                        rbd:
+                          description: 'RBD represents a Rados Block Device mount
+                            on the host that shares a pod''s lifetime. More info:
+                            https://examples.k8s.io/volumes/rbd/README.md'
+                          properties:
+                            fsType:
+                              description: 'Filesystem type of the volume that you
+                                want to mount. Tip: Ensure that the filesystem type
+                                is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                              type: string
+                            image:
+                              description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: string
+                            keyring:
+                              description: 'Keyring is the path to key ring for RBDUser.
+                                Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: string
+                            monitors:
+                              description: 'A collection of Ceph monitors. More info:
+                                https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              items:
+                                type: string
+                              type: array
+                            pool:
+                              description: 'The rados pool name. Default is rbd. More
+                                info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: string
+                            readOnly:
+                              description: 'ReadOnly here will force the ReadOnly
+                                setting in VolumeMounts. Defaults to false. More info:
+                                https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: boolean
+                            secretRef:
+                              description: 'SecretRef is name of the authentication
+                                secret for RBDUser. If provided overrides keyring.
+                                Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            user:
+                              description: 'The rados user name. Default is admin.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: string
+                          required:
+                          - monitors
+                          - image
+                          type: object
+                        scaleIO:
+                          description: ScaleIO represents a ScaleIO persistent volume
+                            attached and mounted on Kubernetes nodes.
+                          properties:
+                            fsType:
+                              description: Filesystem type to mount. Must be a filesystem
+                                type supported by the host operating system. Ex. "ext4",
+                                "xfs", "ntfs". Default is "xfs".
+                              type: string
+                            gateway:
+                              description: The host address of the ScaleIO API Gateway.
+                              type: string
+                            protectionDomain:
+                              description: The name of the ScaleIO Protection Domain
+                                for the configured storage.
+                              type: string
+                            readOnly:
+                              description: Defaults to false (read/write). ReadOnly
+                                here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretRef:
+                              description: SecretRef references to the secret for
+                                ScaleIO user and other sensitive information. If this
+                                is not provided, Login operation will fail.
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            sslEnabled:
+                              description: Flag to enable/disable SSL communication
+                                with Gateway, default false
+                              type: boolean
+                            storageMode:
+                              description: Indicates whether the storage for a volume
+                                should be ThickProvisioned or ThinProvisioned. Default
+                                is ThinProvisioned.
+                              type: string
+                            storagePool:
+                              description: The ScaleIO Storage Pool associated with
+                                the protection domain.
+                              type: string
+                            system:
+                              description: The name of the storage system as configured
+                                in ScaleIO.
+                              type: string
+                            volumeName:
+                              description: The name of a volume already created in
+                                the ScaleIO system that is associated with this volume
+                                source.
+                              type: string
+                          required:
+                          - gateway
+                          - system
+                          - secretRef
+                          type: object
+                        secret:
+                          description: 'Secret represents a secret that should populate
+                            this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                          properties:
+                            defaultMode:
+                              description: 'Optional: mode bits used to set permissions
+                                on created files by default. Must be an octal value
+                                between 0000 and 0777 or a decimal value between 0
+                                and 511. YAML accepts both octal and decimal values,
+                                JSON requires decimal values for mode bits. Defaults
+                                to 0644. Directories within the path are not affected
+                                by this setting. This might be in conflict with other
+                                options that affect the file mode, like fsGroup, and
+                                the result can be other mode bits set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: If unspecified, each key-value pair in
+                                the Data field of the referenced Secret will be projected
+                                into the volume as a file whose name is the key and
+                                content is the value. If specified, the listed keys
+                                will be projected into the specified paths, and unlisted
+                                keys will not be present. If a key is specified which
+                                is not present in the Secret, the volume setup will
+                                error unless it is marked optional. Paths must be
+                                relative and may not contain the '..' path or start
+                                with '..'.
+                              items:
+                                description: Maps a string key to a path within a
+                                  volume.
+                                properties:
+                                  key:
+                                    description: The key to project.
+                                    type: string
+                                  mode:
+                                    description: 'Optional: mode bits used to set
+                                      permissions on this file. Must be an octal value
+                                      between 0000 and 0777 or a decimal value between
+                                      0 and 511. YAML accepts both octal and decimal
+                                      values, JSON requires decimal values for mode
+                                      bits. If not specified, the volume defaultMode
+                                      will be used. This might be in conflict with
+                                      other options that affect the file mode, like
+                                      fsGroup, and the result can be other mode bits
+                                      set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: The relative path of the file to
+                                      map the key to. May not be an absolute path.
+                                      May not contain the path element '..'. May not
+                                      start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                            optional:
+                              description: Specify whether the Secret or its keys
+                                must be defined
+                              type: boolean
+                            secretName:
+                              description: 'Name of the secret in the pod''s namespace
+                                to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              type: string
+                          type: object
+                        storageos:
+                          description: StorageOS represents a StorageOS volume attached
+                            and mounted on Kubernetes nodes.
+                          properties:
+                            fsType:
+                              description: Filesystem type to mount. Must be a filesystem
+                                type supported by the host operating system. Ex. "ext4",
+                                "xfs", "ntfs". Implicitly inferred to be "ext4" if
+                                unspecified.
+                              type: string
+                            readOnly:
+                              description: Defaults to false (read/write). ReadOnly
+                                here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretRef:
+                              description: SecretRef specifies the secret to use for
+                                obtaining the StorageOS API credentials.  If not specified,
+                                default values will be attempted.
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            volumeName:
+                              description: VolumeName is the human-readable name of
+                                the StorageOS volume.  Volume names are only unique
+                                within a namespace.
+                              type: string
+                            volumeNamespace:
+                              description: VolumeNamespace specifies the scope of
+                                the volume within StorageOS.  If no namespace is specified
+                                then the Pod's namespace will be used.  This allows
+                                the Kubernetes name scoping to be mirrored within
+                                StorageOS for tighter integration. Set VolumeName
+                                to any name to override the default behaviour. Set
+                                to "default" if you are not using namespaces within
+                                StorageOS. Namespaces that do not pre-exist within
+                                StorageOS will be created.
+                              type: string
+                          type: object
+                        vsphereVolume:
+                          description: VsphereVolume represents a vSphere volume attached
+                            and mounted on kubelets host machine
+                          properties:
+                            fsType:
+                              description: Filesystem type to mount. Must be a filesystem
+                                type supported by the host operating system. Ex. "ext4",
+                                "xfs", "ntfs". Implicitly inferred to be "ext4" if
+                                unspecified.
+                              type: string
+                            storagePolicyID:
+                              description: Storage Policy Based Management (SPBM)
+                                profile ID associated with the StoragePolicyName.
+                              type: string
+                            storagePolicyName:
+                              description: Storage Policy Based Management (SPBM)
+                                profile name.
+                              type: string
+                            volumePath:
+                              description: Path that identifies vSphere volume vmdk
+                              type: string
+                          required:
+                          - volumePath
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                required:
+                - containers
+                type: object
+            type: object
+        required:
+        - selector
+        - template
+        type: object
+      status:
+        description: Most recently observed status of the Deployment.
+        properties:
+          availableReplicas:
+            description: Total number of available pods (ready for at least minReadySeconds)
+              targeted by this deployment.
+            format: int32
+            type: integer
+          collisionCount:
+            description: Count of hash collisions for the Deployment. The Deployment
+              controller uses this field as a collision avoidance mechanism when it
+              needs to create the name for the newest ReplicaSet.
+            format: int32
+            type: integer
+          conditions:
+            description: Represents the latest available observations of a deployment's
+              current state.
+            items:
+              description: DeploymentCondition describes the state of a deployment
+                at a certain point.
+              properties:
+                lastTransitionTime:
+                  description: Last time the condition transitioned from one status
+                    to another.
+                  format: date-time
+                  type: string
+                lastUpdateTime:
+                  description: The last time this condition was updated.
+                  format: date-time
+                  type: string
+                message:
+                  description: A human readable message indicating details about the
+                    transition.
+                  type: string
+                reason:
+                  description: The reason for the condition's last transition.
+                  type: string
+                status:
+                  description: Status of the condition, one of True, False, Unknown.
+                  type: string
+                type:
+                  description: Type of deployment condition.
+                  type: string
+              required:
+              - status
+              - type
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - type
+            x-kubernetes-list-type: map
+          observedGeneration:
+            description: The generation observed by the deployment controller.
+            format: int64
+            type: integer
+          readyReplicas:
+            description: Total number of ready pods targeted by this deployment.
+            format: int32
+            type: integer
+          replicas:
+            description: Total number of non-terminated pods targeted by this deployment
+              (their labels match the selector).
+            format: int32
+            type: integer
+          unavailableReplicas:
+            description: Total number of unavailable pods targeted by this deployment.
+              This is the total number of pods that are still required for the deployment
+              to have 100% available capacity. They may either be pods that are running
+              but not yet available or pods that still have not been created.
+            format: int32
+            type: integer
+          updatedReplicas:
+            description: Total number of non-terminated pods targeted by this deployment
+              that have the desired template spec.
+            format: int32
+            type: integer
+        type: object
+    type: object
+  plural: deployments
+  schemaUpdateStrategy: UpdateUnpublished
+  scope: Namespaced
+  shortNames:
+  - deploy
+  singular: deployment
+  subResources:
+  - name: scale
+  - name: status
+status:
+  conditions:
+  - lastTransitionTime: "2023-03-20T19:08:21Z"
+    status: "True"
+    type: Compatible

--- a/docs/content/concepts/scenarios/jn-scenario/yamls/4-APIResourceImport-ingresses.jn.v1.networking.k8s.io.yaml
+++ b/docs/content/concepts/scenarios/jn-scenario/yamls/4-APIResourceImport-ingresses.jn.v1.networking.k8s.io.yaml
@@ -1,0 +1,351 @@
+apiVersion: apiresource.kcp.io/v1alpha1
+kind: APIResourceImport
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kcp-dev/kubernetes/pull/4
+    apiresource.kcp.io/apiVersion: networking.k8s.io/v1
+    kcp.io/cluster: 49adf4fn8ks8x43u
+  creationTimestamp: "2023-03-20T19:08:21Z"
+  generation: 1
+  name: ingresses.jn.v1.networking.k8s.io
+  ownerReferences:
+  - apiVersion: workload.kcp.io/v1alpha1
+    controller: true
+    kind: SyncTarget
+    name: jn
+    uid: 72de24eb-7d49-4aca-be22-63f95548a816
+  resourceVersion: "790"
+  uid: 2198a159-efca-4c15-84b1-70f3154c4542
+spec:
+  groupVersion:
+    group: networking.k8s.io
+    version: v1
+  kind: Ingress
+  listKind: IngressList
+  location: jn
+  openAPIV3Schema:
+    description: Ingress is a collection of rules that allow inbound connections to
+      reach the endpoints defined by a backend. An Ingress can be configured to give
+      services externally-reachable urls, load balance traffic, terminate SSL, offer
+      name based virtual hosting etc.
+    properties:
+      apiVersion:
+        description: 'APIVersion defines the versioned schema of this representation
+          of an object. Servers should convert recognized schemas to the latest internal
+          value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+        type: string
+      kind:
+        description: 'Kind is a string value representing the REST resource this object
+          represents. Servers may infer this from the endpoint the client submits
+          requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+        type: string
+      metadata:
+        type: object
+      spec:
+        description: 'Spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+        properties:
+          defaultBackend:
+            description: DefaultBackend is the backend that should handle requests
+              that don't match any rule. If Rules are not specified, DefaultBackend
+              must be specified. If DefaultBackend is not set, the handling of requests
+              that do not match any of the rules will be up to the Ingress controller.
+            properties:
+              resource:
+                description: Resource is an ObjectRef to another Kubernetes resource
+                  in the namespace of the Ingress object. If resource is specified,
+                  a service.Name and service.Port must not be specified. This is a
+                  mutually exclusive setting with "Service".
+                properties:
+                  apiGroup:
+                    description: APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in
+                      the core API group. For any other third-party types, APIGroup
+                      is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              service:
+                description: Service references a Service as a Backend. This is a
+                  mutually exclusive setting with "Resource".
+                properties:
+                  name:
+                    description: Name is the referenced service. The service must
+                      exist in the same namespace as the Ingress object.
+                    type: string
+                  port:
+                    description: Port of the referenced service. A port name or port
+                      number is required for a IngressServiceBackend.
+                    properties:
+                      name:
+                        description: Name is the name of the port on the Service.
+                          This is a mutually exclusive setting with "Number".
+                        type: string
+                      number:
+                        description: Number is the numerical port number (e.g. 80)
+                          on the Service. This is a mutually exclusive setting with
+                          "Name".
+                        format: int32
+                        type: integer
+                    type: object
+                required:
+                - name
+                type: object
+            type: object
+          ingressClassName:
+            description: IngressClassName is the name of the IngressClass cluster
+              resource. The associated IngressClass defines which controller will
+              implement the resource. This replaces the deprecated `kubernetes.io/ingress.class`
+              annotation. For backwards compatibility, when that annotation is set,
+              it must be given precedence over this field. The controller may emit
+              a warning if the field and annotation have different values. Implementations
+              of this API should ignore Ingresses without a class specified. An IngressClass
+              resource may be marked as default, which can be used to set a default
+              value for this field. For more information, refer to the IngressClass
+              documentation.
+            type: string
+          rules:
+            description: A list of host rules used to configure the Ingress. If unspecified,
+              or no rule matches, all traffic is sent to the default backend.
+            items:
+              description: IngressRule represents the rules mapping the paths under
+                a specified host to the related backend services. Incoming requests
+                are first evaluated for a host match, then routed to the backend associated
+                with the matching IngressRuleValue.
+              properties:
+                host:
+                  description: "Host is the fully qualified domain name of a network
+                    host, as defined by RFC 3986. Note the following deviations from
+                    the \"host\" part of the URI as defined in RFC 3986: 1. IPs are
+                    not allowed. Currently an IngressRuleValue can only apply to\n
+                    \  the IP in the Spec of the parent Ingress.\n2. The `:` delimiter
+                    is not respected because ports are not allowed.\n\t  Currently
+                    the port of an Ingress is implicitly :80 for http and\n\t  :443
+                    for https.\nBoth these may change in the future. Incoming requests
+                    are matched against the host before the IngressRuleValue. If the
+                    host is unspecified, the Ingress routes all traffic based on the
+                    specified IngressRuleValue.\n\nHost can be \"precise\" which is
+                    a domain name without the terminating dot of a network host (e.g.
+                    \"foo.bar.com\") or \"wildcard\", which is a domain name prefixed
+                    with a single wildcard label (e.g. \"*.foo.com\"). The wildcard
+                    character '*' must appear by itself as the first DNS label and
+                    matches only a single label. You cannot have a wildcard label
+                    by itself (e.g. Host == \"*\"). Requests will be matched against
+                    the Host field in the following way: 1. If Host is precise, the
+                    request matches this rule if the http host header is equal to
+                    Host. 2. If Host is a wildcard, then the request matches this
+                    rule if the http host header is to equal to the suffix (removing
+                    the first label) of the wildcard rule."
+                  type: string
+                http:
+                  description: 'HTTPIngressRuleValue is a list of http selectors pointing
+                    to backends. In the example: http://<host>/<path>?<searchpart>
+                    -> backend where where parts of the url correspond to RFC 3986,
+                    this resource will be used to match against everything after the
+                    last ''/'' and before the first ''?'' or ''#''.'
+                  properties:
+                    paths:
+                      description: A collection of paths that map requests to backends.
+                      items:
+                        description: HTTPIngressPath associates a path with a backend.
+                          Incoming urls matching the path are forwarded to the backend.
+                        properties:
+                          backend:
+                            description: Backend defines the referenced service endpoint
+                              to which the traffic will be forwarded to.
+                            properties:
+                              resource:
+                                description: Resource is an ObjectRef to another Kubernetes
+                                  resource in the namespace of the Ingress object.
+                                  If resource is specified, a service.Name and service.Port
+                                  must not be specified. This is a mutually exclusive
+                                  setting with "Service".
+                                properties:
+                                  apiGroup:
+                                    description: APIGroup is the group for the resource
+                                      being referenced. If APIGroup is not specified,
+                                      the specified Kind must be in the core API group.
+                                      For any other third-party types, APIGroup is
+                                      required.
+                                    type: string
+                                  kind:
+                                    description: Kind is the type of resource being
+                                      referenced
+                                    type: string
+                                  name:
+                                    description: Name is the name of resource being
+                                      referenced
+                                    type: string
+                                required:
+                                - kind
+                                - name
+                                type: object
+                              service:
+                                description: Service references a Service as a Backend.
+                                  This is a mutually exclusive setting with "Resource".
+                                properties:
+                                  name:
+                                    description: Name is the referenced service. The
+                                      service must exist in the same namespace as
+                                      the Ingress object.
+                                    type: string
+                                  port:
+                                    description: Port of the referenced service. A
+                                      port name or port number is required for a IngressServiceBackend.
+                                    properties:
+                                      name:
+                                        description: Name is the name of the port
+                                          on the Service. This is a mutually exclusive
+                                          setting with "Number".
+                                        type: string
+                                      number:
+                                        description: Number is the numerical port
+                                          number (e.g. 80) on the Service. This is
+                                          a mutually exclusive setting with "Name".
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                            type: object
+                          path:
+                            description: Path is matched against the path of an incoming
+                              request. Currently it can contain characters disallowed
+                              from the conventional "path" part of a URL as defined
+                              by RFC 3986. Paths must begin with a '/'. When unspecified,
+                              all paths from incoming requests are matched.
+                            type: string
+                          pathType:
+                            description: |-
+                              PathType determines the interpretation of the Path matching. PathType can be one of the following values: * Exact: Matches the URL path exactly. * Prefix: Matches based on a URL path prefix split by '/'. Matching is
+                                done on a path element by element basis. A path element refers is the
+                                list of labels in the path split by the '/' separator. A request is a
+                                match for path p if every p is an element-wise prefix of p of the
+                                request path. Note that if the last element of the path is a substring
+                                of the last element in request path, it is not a match (e.g. /foo/bar
+                                matches /foo/bar/baz, but does not match /foo/barbaz).
+                              * ImplementationSpecific: Interpretation of the Path matching is up to
+                                the IngressClass. Implementations can treat this as a separate PathType
+                                or treat it identically to Prefix or Exact path types.
+                              Implementations are required to support all path types.
+                            type: string
+                        required:
+                        - backend
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  required:
+                  - paths
+                  type: object
+              type: object
+            type: array
+            x-kubernetes-list-type: atomic
+          tls:
+            description: TLS configuration. Currently the Ingress only supports a
+              single TLS port, 443. If multiple members of this list specify different
+              hosts, they will be multiplexed on the same port according to the hostname
+              specified through the SNI TLS extension, if the ingress controller fulfilling
+              the ingress supports SNI.
+            items:
+              description: IngressTLS describes the transport layer security associated
+                with an Ingress.
+              properties:
+                hosts:
+                  description: Hosts are a list of hosts included in the TLS certificate.
+                    The values in this list must match the name/s used in the tlsSecret.
+                    Defaults to the wildcard host setting for the loadbalancer controller
+                    fulfilling this Ingress, if left unspecified.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: atomic
+                secretName:
+                  description: SecretName is the name of the secret used to terminate
+                    TLS traffic on port 443. Field is left optional to allow TLS routing
+                    based on SNI hostname alone. If the SNI host in a listener conflicts
+                    with the "Host" header field used by an IngressRule, the SNI host
+                    is used for termination and value of the Host header is used for
+                    routing.
+                  type: string
+              type: object
+            type: array
+            x-kubernetes-list-type: atomic
+        type: object
+      status:
+        description: 'Status is the current state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+        properties:
+          loadBalancer:
+            description: LoadBalancer contains the current status of the load-balancer.
+            properties:
+              ingress:
+                description: Ingress is a list containing ingress points for the load-balancer.
+                  Traffic intended for the service should be sent to these ingress
+                  points.
+                items:
+                  description: 'LoadBalancerIngress represents the status of a load-balancer
+                    ingress point: traffic intended for the service should be sent
+                    to an ingress point.'
+                  properties:
+                    hostname:
+                      description: Hostname is set for load-balancer ingress points
+                        that are DNS based (typically AWS load-balancers)
+                      type: string
+                    ip:
+                      description: IP is set for load-balancer ingress points that
+                        are IP based (typically GCE or OpenStack load-balancers)
+                      type: string
+                    ports:
+                      description: Ports is a list of records of service ports If
+                        used, every port defined in the service should have an entry
+                        in it
+                      items:
+                        properties:
+                          error:
+                            description: |-
+                              Error is to record the problem with the service port The format of the error shall comply with the following rules: - built-in error values shall be specified in this file and those shall use
+                                CamelCase names
+                              - cloud provider specific error values must have names that comply with the
+                                format foo.example.com/CamelCase.
+                            type: string
+                          port:
+                            description: Port is the port number of the service port
+                              of which status is recorded here
+                            format: int32
+                            type: integer
+                          protocol:
+                            description: 'Protocol is the protocol of the service
+                              port of which status is recorded here The supported
+                              values are: "TCP", "UDP", "SCTP"'
+                            type: string
+                        required:
+                        - port
+                        - protocol
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  type: object
+                type: array
+            type: object
+        type: object
+    type: object
+  plural: ingresses
+  schemaUpdateStrategy: UpdateUnpublished
+  scope: Namespaced
+  shortNames:
+  - ing
+  singular: ingress
+  subResources:
+  - name: status
+status:
+  conditions:
+  - lastTransitionTime: "2023-03-20T19:08:21Z"
+    status: "True"
+    type: Compatible

--- a/docs/content/concepts/scenarios/jn-scenario/yamls/4-APIResourceImport-pods.jn.v1.core.yaml
+++ b/docs/content/concepts/scenarios/jn-scenario/yamls/4-APIResourceImport-pods.jn.v1.core.yaml
@@ -1,0 +1,6593 @@
+apiVersion: apiresource.kcp.io/v1alpha1
+kind: APIResourceImport
+metadata:
+  annotations:
+    apiresource.kcp.io/apiVersion: v1
+    kcp.io/cluster: 49adf4fn8ks8x43u
+  creationTimestamp: "2023-03-20T19:08:21Z"
+  generation: 1
+  name: pods.jn.v1.core
+  ownerReferences:
+  - apiVersion: workload.kcp.io/v1alpha1
+    controller: true
+    kind: SyncTarget
+    name: jn
+    uid: 72de24eb-7d49-4aca-be22-63f95548a816
+  resourceVersion: "783"
+  uid: 2bfc2ba1-dfec-4168-9178-278b54cdf419
+spec:
+  categories:
+  - all
+  groupVersion:
+    version: v1
+  kind: Pod
+  listKind: PodList
+  location: jn
+  openAPIV3Schema:
+    description: Pod is a collection of containers that can run on a host. This resource
+      is created by clients and scheduled onto hosts.
+    properties:
+      apiVersion:
+        description: 'APIVersion defines the versioned schema of this representation
+          of an object. Servers should convert recognized schemas to the latest internal
+          value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+        type: string
+      kind:
+        description: 'Kind is a string value representing the REST resource this object
+          represents. Servers may infer this from the endpoint the client submits
+          requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+        type: string
+      metadata:
+        type: object
+      spec:
+        description: 'Specification of the desired behavior of the pod. More info:
+          https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+        properties:
+          activeDeadlineSeconds:
+            description: Optional duration in seconds the pod may be active on the
+              node relative to StartTime before the system will actively try to mark
+              it failed and kill associated containers. Value must be a positive integer.
+            format: int64
+            type: integer
+          affinity:
+            description: If specified, the pod's scheduling constraints
+            properties:
+              nodeAffinity:
+                description: Describes node affinity scheduling rules for the pod.
+                properties:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    description: The scheduler will prefer to schedule pods to nodes
+                      that satisfy the affinity expressions specified by this field,
+                      but it may choose a node that violates one or more of the expressions.
+                      The node that is most preferred is the one with the greatest
+                      sum of weights, i.e. for each node that meets all of the scheduling
+                      requirements (resource request, requiredDuringScheduling affinity
+                      expressions, etc.), compute a sum by iterating through the elements
+                      of this field and adding "weight" to the sum if the node matches
+                      the corresponding matchExpressions; the node(s) with the highest
+                      sum are the most preferred.
+                    items:
+                      description: An empty preferred scheduling term matches all
+                        objects with implicit weight 0 (i.e. it's a no-op). A null
+                        preferred scheduling term matches no objects (i.e. is also
+                        a no-op).
+                      properties:
+                        preference:
+                          description: A node selector term, associated with the corresponding
+                            weight.
+                          properties:
+                            matchExpressions:
+                              description: A list of node selector requirements by
+                                node's labels.
+                              items:
+                                description: A node selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: The label key that the selector applies
+                                      to.
+                                    type: string
+                                  operator:
+                                    description: Represents a key's relationship to
+                                      a set of values. Valid operators are In, NotIn,
+                                      Exists, DoesNotExist. Gt, and Lt.
+                                    type: string
+                                  values:
+                                    description: An array of string values. If the
+                                      operator is In or NotIn, the values array must
+                                      be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator
+                                      is Gt or Lt, the values array must have a single
+                                      element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchFields:
+                              description: A list of node selector requirements by
+                                node's fields.
+                              items:
+                                description: A node selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: The label key that the selector applies
+                                      to.
+                                    type: string
+                                  operator:
+                                    description: Represents a key's relationship to
+                                      a set of values. Valid operators are In, NotIn,
+                                      Exists, DoesNotExist. Gt, and Lt.
+                                    type: string
+                                  values:
+                                    description: An array of string values. If the
+                                      operator is In or NotIn, the values array must
+                                      be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator
+                                      is Gt or Lt, the values array must have a single
+                                      element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                          type: object
+                        weight:
+                          description: Weight associated with matching the corresponding
+                            nodeSelectorTerm, in the range 1-100.
+                          format: int32
+                          type: integer
+                      required:
+                      - weight
+                      - preference
+                      type: object
+                    type: array
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    description: If the affinity requirements specified by this field
+                      are not met at scheduling time, the pod will not be scheduled
+                      onto the node. If the affinity requirements specified by this
+                      field cease to be met at some point during pod execution (e.g.
+                      due to an update), the system may or may not try to eventually
+                      evict the pod from its node.
+                    properties:
+                      nodeSelectorTerms:
+                        description: Required. A list of node selector terms. The
+                          terms are ORed.
+                        items:
+                          description: A null or empty node selector term matches
+                            no objects. The requirements of them are ANDed. The TopologySelectorTerm
+                            type implements a subset of the NodeSelectorTerm.
+                          properties:
+                            matchExpressions:
+                              description: A list of node selector requirements by
+                                node's labels.
+                              items:
+                                description: A node selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: The label key that the selector applies
+                                      to.
+                                    type: string
+                                  operator:
+                                    description: Represents a key's relationship to
+                                      a set of values. Valid operators are In, NotIn,
+                                      Exists, DoesNotExist. Gt, and Lt.
+                                    type: string
+                                  values:
+                                    description: An array of string values. If the
+                                      operator is In or NotIn, the values array must
+                                      be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator
+                                      is Gt or Lt, the values array must have a single
+                                      element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchFields:
+                              description: A list of node selector requirements by
+                                node's fields.
+                              items:
+                                description: A node selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: The label key that the selector applies
+                                      to.
+                                    type: string
+                                  operator:
+                                    description: Represents a key's relationship to
+                                      a set of values. Valid operators are In, NotIn,
+                                      Exists, DoesNotExist. Gt, and Lt.
+                                    type: string
+                                  values:
+                                    description: An array of string values. If the
+                                      operator is In or NotIn, the values array must
+                                      be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator
+                                      is Gt or Lt, the values array must have a single
+                                      element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                          type: object
+                        type: array
+                    required:
+                    - nodeSelectorTerms
+                    type: object
+                type: object
+              podAffinity:
+                description: Describes pod affinity scheduling rules (e.g. co-locate
+                  this pod in the same node, zone, etc. as some other pod(s)).
+                properties:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    description: The scheduler will prefer to schedule pods to nodes
+                      that satisfy the affinity expressions specified by this field,
+                      but it may choose a node that violates one or more of the expressions.
+                      The node that is most preferred is the one with the greatest
+                      sum of weights, i.e. for each node that meets all of the scheduling
+                      requirements (resource request, requiredDuringScheduling affinity
+                      expressions, etc.), compute a sum by iterating through the elements
+                      of this field and adding "weight" to the sum if the node has
+                      pods which matches the corresponding podAffinityTerm; the node(s)
+                      with the highest sum are the most preferred.
+                    items:
+                      description: The weights of all of the matched WeightedPodAffinityTerm
+                        fields are added per-node to find the most preferred node(s)
+                      properties:
+                        podAffinityTerm:
+                          description: Required. A pod affinity term, associated with
+                            the corresponding weight.
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field. null selector
+                                and null or empty namespaces list means "this pod's
+                                namespace". An empty selector ({}) matches all namespaces.
+                                This field is alpha-level and is only honored when
+                                PodAffinityNamespaceSelector feature is enabled.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector. null or
+                                empty namespaces list and null namespaceSelector means
+                                "this pod's namespace"
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        weight:
+                          description: weight associated with matching the corresponding
+                            podAffinityTerm, in the range 1-100.
+                          format: int32
+                          type: integer
+                      required:
+                      - weight
+                      - podAffinityTerm
+                      type: object
+                    type: array
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    description: If the affinity requirements specified by this field
+                      are not met at scheduling time, the pod will not be scheduled
+                      onto the node. If the affinity requirements specified by this
+                      field cease to be met at some point during pod execution (e.g.
+                      due to a pod label update), the system may or may not try to
+                      eventually evict the pod from its node. When there are multiple
+                      elements, the lists of nodes corresponding to each podAffinityTerm
+                      are intersected, i.e. all terms must be satisfied.
+                    items:
+                      description: Defines a set of pods (namely those matching the
+                        labelSelector relative to the given namespace(s)) that this
+                        pod should be co-located (affinity) or not co-located (anti-affinity)
+                        with, where co-located is defined as running on a node whose
+                        value of the label with key <topologyKey> matches that of
+                        any node on which a pod of the set of pods is running
+                      properties:
+                        labelSelector:
+                          description: A label query over a set of resources, in this
+                            case pods.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        namespaceSelector:
+                          description: A label query over the set of namespaces that
+                            the term applies to. The term is applied to the union
+                            of the namespaces selected by this field and the ones
+                            listed in the namespaces field. null selector and null
+                            or empty namespaces list means "this pod's namespace".
+                            An empty selector ({}) matches all namespaces. This field
+                            is alpha-level and is only honored when PodAffinityNamespaceSelector
+                            feature is enabled.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        namespaces:
+                          description: namespaces specifies a static list of namespace
+                            names that the term applies to. The term is applied to
+                            the union of the namespaces listed in this field and the
+                            ones selected by namespaceSelector. null or empty namespaces
+                            list and null namespaceSelector means "this pod's namespace"
+                          items:
+                            type: string
+                          type: array
+                        topologyKey:
+                          description: This pod should be co-located (affinity) or
+                            not co-located (anti-affinity) with the pods matching
+                            the labelSelector in the specified namespaces, where co-located
+                            is defined as running on a node whose value of the label
+                            with key topologyKey matches that of any node on which
+                            any of the selected pods is running. Empty topologyKey
+                            is not allowed.
+                          type: string
+                      required:
+                      - topologyKey
+                      type: object
+                    type: array
+                type: object
+              podAntiAffinity:
+                description: Describes pod anti-affinity scheduling rules (e.g. avoid
+                  putting this pod in the same node, zone, etc. as some other pod(s)).
+                properties:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    description: The scheduler will prefer to schedule pods to nodes
+                      that satisfy the anti-affinity expressions specified by this
+                      field, but it may choose a node that violates one or more of
+                      the expressions. The node that is most preferred is the one
+                      with the greatest sum of weights, i.e. for each node that meets
+                      all of the scheduling requirements (resource request, requiredDuringScheduling
+                      anti-affinity expressions, etc.), compute a sum by iterating
+                      through the elements of this field and adding "weight" to the
+                      sum if the node has pods which matches the corresponding podAffinityTerm;
+                      the node(s) with the highest sum are the most preferred.
+                    items:
+                      description: The weights of all of the matched WeightedPodAffinityTerm
+                        fields are added per-node to find the most preferred node(s)
+                      properties:
+                        podAffinityTerm:
+                          description: Required. A pod affinity term, associated with
+                            the corresponding weight.
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field. null selector
+                                and null or empty namespaces list means "this pod's
+                                namespace". An empty selector ({}) matches all namespaces.
+                                This field is alpha-level and is only honored when
+                                PodAffinityNamespaceSelector feature is enabled.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector. null or
+                                empty namespaces list and null namespaceSelector means
+                                "this pod's namespace"
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        weight:
+                          description: weight associated with matching the corresponding
+                            podAffinityTerm, in the range 1-100.
+                          format: int32
+                          type: integer
+                      required:
+                      - weight
+                      - podAffinityTerm
+                      type: object
+                    type: array
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    description: If the anti-affinity requirements specified by this
+                      field are not met at scheduling time, the pod will not be scheduled
+                      onto the node. If the anti-affinity requirements specified by
+                      this field cease to be met at some point during pod execution
+                      (e.g. due to a pod label update), the system may or may not
+                      try to eventually evict the pod from its node. When there are
+                      multiple elements, the lists of nodes corresponding to each
+                      podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                    items:
+                      description: Defines a set of pods (namely those matching the
+                        labelSelector relative to the given namespace(s)) that this
+                        pod should be co-located (affinity) or not co-located (anti-affinity)
+                        with, where co-located is defined as running on a node whose
+                        value of the label with key <topologyKey> matches that of
+                        any node on which a pod of the set of pods is running
+                      properties:
+                        labelSelector:
+                          description: A label query over a set of resources, in this
+                            case pods.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        namespaceSelector:
+                          description: A label query over the set of namespaces that
+                            the term applies to. The term is applied to the union
+                            of the namespaces selected by this field and the ones
+                            listed in the namespaces field. null selector and null
+                            or empty namespaces list means "this pod's namespace".
+                            An empty selector ({}) matches all namespaces. This field
+                            is alpha-level and is only honored when PodAffinityNamespaceSelector
+                            feature is enabled.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        namespaces:
+                          description: namespaces specifies a static list of namespace
+                            names that the term applies to. The term is applied to
+                            the union of the namespaces listed in this field and the
+                            ones selected by namespaceSelector. null or empty namespaces
+                            list and null namespaceSelector means "this pod's namespace"
+                          items:
+                            type: string
+                          type: array
+                        topologyKey:
+                          description: This pod should be co-located (affinity) or
+                            not co-located (anti-affinity) with the pods matching
+                            the labelSelector in the specified namespaces, where co-located
+                            is defined as running on a node whose value of the label
+                            with key topologyKey matches that of any node on which
+                            any of the selected pods is running. Empty topologyKey
+                            is not allowed.
+                          type: string
+                      required:
+                      - topologyKey
+                      type: object
+                    type: array
+                type: object
+            type: object
+          automountServiceAccountToken:
+            description: AutomountServiceAccountToken indicates whether a service
+              account token should be automatically mounted.
+            type: boolean
+          containers:
+            description: List of containers belonging to the pod. Containers cannot
+              currently be added or removed. There must be at least one container
+              in a Pod. Cannot be updated.
+            items:
+              description: A single application container that you want to run within
+                a pod.
+              properties:
+                args:
+                  description: 'Arguments to the entrypoint. The docker image''s CMD
+                    is used if this is not provided. Variable references $(VAR_NAME)
+                    are expanded using the container''s environment. If a variable
+                    cannot be resolved, the reference in the input string will be
+                    unchanged. The $(VAR_NAME) syntax can be escaped with a double
+                    $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                    regardless of whether the variable exists or not. Cannot be updated.
+                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                command:
+                  description: 'Entrypoint array. Not executed within a shell. The
+                    docker image''s ENTRYPOINT is used if this is not provided. Variable
+                    references $(VAR_NAME) are expanded using the container''s environment.
+                    If a variable cannot be resolved, the reference in the input string
+                    will be unchanged. The $(VAR_NAME) syntax can be escaped with
+                    a double $$, ie: $$(VAR_NAME). Escaped references will never be
+                    expanded, regardless of whether the variable exists or not. Cannot
+                    be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                env:
+                  description: List of environment variables to set in the container.
+                    Cannot be updated.
+                  items:
+                    description: EnvVar represents an environment variable present
+                      in a Container.
+                    properties:
+                      name:
+                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        type: string
+                      value:
+                        description: 'Variable references $(VAR_NAME) are expanded
+                          using the previous defined environment variables in the
+                          container and any service environment variables. If a variable
+                          cannot be resolved, the reference in the input string will
+                          be unchanged. The $(VAR_NAME) syntax can be escaped with
+                          a double $$, ie: $$(VAR_NAME). Escaped references will never
+                          be expanded, regardless of whether the variable exists or
+                          not. Defaults to "".'
+                        type: string
+                      valueFrom:
+                        description: Source for the environment variable's value.
+                          Cannot be used if value is not empty.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          fieldRef:
+                            description: 'Selects a field of the pod: supports metadata.name,
+                              metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                              spec.nodeName, spec.serviceAccountName, status.hostIP,
+                              status.podIP, status.podIPs.'
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                            - fieldPath
+                            type: object
+                          resourceFieldRef:
+                            description: 'Selects a resource of the container: only
+                              resources limits and requests (limits.cpu, limits.memory,
+                              limits.ephemeral-storage, requests.cpu, requests.memory
+                              and requests.ephemeral-storage) are currently supported.'
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Specifies the output format of the exposed
+                                  resources, defaults to "1"
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                            - resource
+                            type: object
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - name
+                  x-kubernetes-list-type: map
+                envFrom:
+                  description: List of sources to populate environment variables in
+                    the container. The keys defined within a source must be a C_IDENTIFIER.
+                    All invalid keys will be reported as an event when the container
+                    is starting. When a key exists in multiple sources, the value
+                    associated with the last source will take precedence. Values defined
+                    by an Env with a duplicate key will take precedence. Cannot be
+                    updated.
+                  items:
+                    description: EnvFromSource represents the source of a set of ConfigMaps
+                    properties:
+                      configMapRef:
+                        description: The ConfigMap to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the ConfigMap must be defined
+                            type: boolean
+                        type: object
+                      prefix:
+                        description: An optional identifier to prepend to each key
+                          in the ConfigMap. Must be a C_IDENTIFIER.
+                        type: string
+                      secretRef:
+                        description: The Secret to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret must be defined
+                            type: boolean
+                        type: object
+                    type: object
+                  type: array
+                image:
+                  description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                    This field is optional to allow higher level config management
+                    to default or override container images in workload controllers
+                    like Deployments and StatefulSets.'
+                  type: string
+                imagePullPolicy:
+                  description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                    Defaults to Always if :latest tag is specified, or IfNotPresent
+                    otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                  type: string
+                lifecycle:
+                  description: Actions that the management system should take in response
+                    to container lifecycle events. Cannot be updated.
+                  properties:
+                    postStart:
+                      description: 'PostStart is called immediately after a container
+                        is created. If the handler fails, the container is terminated
+                        and restarted according to its restart policy. Other management
+                        of the container blocks until the hook completes. More info:
+                        https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: TCPSocket specifies an action involving a TCP
+                            port. TCP hooks not yet supported
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                    preStop:
+                      description: 'PreStop is called immediately before a container
+                        is terminated due to an API request or management event such
+                        as liveness/startup probe failure, preemption, resource contention,
+                        etc. The handler is not called if the container crashes or
+                        exits. The reason for termination is passed to the handler.
+                        The Pod''s termination grace period countdown begins before
+                        the PreStop hooked is executed. Regardless of the outcome
+                        of the handler, the container will eventually terminate within
+                        the Pod''s termination grace period. Other management of the
+                        container blocks until the hook completes or until the termination
+                        grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: TCPSocket specifies an action involving a TCP
+                            port. TCP hooks not yet supported
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                  type: object
+                livenessProbe:
+                  description: 'Periodic probe of container liveness. Container will
+                    be restarted if the probe fails. Cannot be updated. More info:
+                    https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: One and only one of the following should be specified.
+                        Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: Scheme to use for connecting to the host. Defaults
+                            to HTTP.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                        TCP hooks not yet supported
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is an alpha field and requires enabling ProbeTerminationGracePeriod
+                        feature gate.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                name:
+                  description: Name of the container specified as a DNS_LABEL. Each
+                    container in a pod must have a unique name (DNS_LABEL). Cannot
+                    be updated.
+                  type: string
+                ports:
+                  description: List of ports to expose from the container. Exposing
+                    a port here gives the system additional information about the
+                    network connections a container uses, but is primarily informational.
+                    Not specifying a port here DOES NOT prevent that port from being
+                    exposed. Any port which is listening on the default "0.0.0.0"
+                    address inside a container will be accessible from the network.
+                    Cannot be updated.
+                  items:
+                    description: ContainerPort represents a network port in a single
+                      container.
+                    properties:
+                      containerPort:
+                        description: Number of port to expose on the pod's IP address.
+                          This must be a valid port number, 0 < x < 65536.
+                        format: int32
+                        type: integer
+                      hostIP:
+                        description: What host IP to bind the external port to.
+                        type: string
+                      hostPort:
+                        description: Number of port to expose on the host. If specified,
+                          this must be a valid port number, 0 < x < 65536. If HostNetwork
+                          is specified, this must match ContainerPort. Most containers
+                          do not need this.
+                        format: int32
+                        type: integer
+                      name:
+                        description: If specified, this must be an IANA_SVC_NAME and
+                          unique within the pod. Each named port in a pod must have
+                          a unique name. Name for the port that can be referred to
+                          by services.
+                        type: string
+                      protocol:
+                        default: TCP
+                        description: Protocol for port. Must be UDP, TCP, or SCTP.
+                          Defaults to "TCP".
+                        type: string
+                    required:
+                    - containerPort
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - containerPort
+                  - protocol
+                  x-kubernetes-list-type: map
+                readinessProbe:
+                  description: 'Periodic probe of container service readiness. Container
+                    will be removed from service endpoints if the probe fails. Cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: One and only one of the following should be specified.
+                        Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: Scheme to use for connecting to the host. Defaults
+                            to HTTP.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                        TCP hooks not yet supported
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is an alpha field and requires enabling ProbeTerminationGracePeriod
+                        feature gate.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                resources:
+                  description: 'Compute Resources required by this container. Cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                  type: object
+                securityContext:
+                  description: 'Security options the pod should run with. More info:
+                    https://kubernetes.io/docs/concepts/policy/security-context/ More
+                    info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                  properties:
+                    allowPrivilegeEscalation:
+                      description: 'AllowPrivilegeEscalation controls whether a process
+                        can gain more privileges than its parent process. This bool
+                        directly controls if the no_new_privs flag will be set on
+                        the container process. AllowPrivilegeEscalation is true always
+                        when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                      type: boolean
+                    capabilities:
+                      description: The capabilities to add/drop when running containers.
+                        Defaults to the default set of capabilities granted by the
+                        container runtime.
+                      properties:
+                        add:
+                          description: Added capabilities
+                          items:
+                            type: string
+                          type: array
+                        drop:
+                          description: Removed capabilities
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    privileged:
+                      description: Run container in privileged mode. Processes in
+                        privileged containers are essentially equivalent to root on
+                        the host. Defaults to false.
+                      type: boolean
+                    procMount:
+                      description: procMount denotes the type of proc mount to use
+                        for the containers. The default is DefaultProcMount which
+                        uses the container runtime defaults for readonly paths and
+                        masked paths. This requires the ProcMountType feature flag
+                        to be enabled.
+                      type: string
+                    readOnlyRootFilesystem:
+                      description: Whether this container has a read-only root filesystem.
+                        Default is false.
+                      type: boolean
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container
+                        process. Uses runtime default if unset. May also be set in
+                        PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to
+                        start the container if it does. If unset or false, no such
+                        validation will be performed. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container
+                        process. Defaults to user specified in image metadata if unspecified.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: The SELinux context to be applied to the container.
+                        If unspecified, the container runtime will allocate a random
+                        SELinux context for each container.  May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
+                      type: object
+                    seccompProfile:
+                      description: The seccomp options to use by this container. If
+                        seccomp options are provided at both the pod & container level,
+                        the container options override the pod options.
+                      properties:
+                        localhostProfile:
+                          description: localhostProfile indicates a profile defined
+                            in a file on the node should be used. The profile must
+                            be preconfigured on the node to work. Must be a descending
+                            path, relative to the kubelet's configured seccomp profile
+                            location. Must only be set if type is "Localhost".
+                          type: string
+                        type:
+                          description: |-
+                            type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                            Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    windowsOptions:
+                      description: The Windows specific settings applied to all containers.
+                        If unspecified, the options from the PodSecurityContext will
+                        be used. If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence.
+                      properties:
+                        gmsaCredentialSpec:
+                          description: GMSACredentialSpec is where the GMSA admission
+                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                            inlines the contents of the GMSA credential spec named
+                            by the GMSACredentialSpecName field.
+                          type: string
+                        gmsaCredentialSpecName:
+                          description: GMSACredentialSpecName is the name of the GMSA
+                            credential spec to use.
+                          type: string
+                        runAsUserName:
+                          description: The UserName in Windows to run the entrypoint
+                            of the container process. Defaults to the user specified
+                            in image metadata if unspecified. May also be set in PodSecurityContext.
+                            If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence.
+                          type: string
+                      type: object
+                  type: object
+                startupProbe:
+                  description: 'StartupProbe indicates that the Pod has successfully
+                    initialized. If specified, no other probes are executed until
+                    this completes successfully. If this probe fails, the Pod will
+                    be restarted, just as if the livenessProbe failed. This can be
+                    used to provide different probe parameters at the beginning of
+                    a Pod''s lifecycle, when it might take a long time to load data
+                    or warm a cache, than during steady-state operation. This cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: One and only one of the following should be specified.
+                        Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: Scheme to use for connecting to the host. Defaults
+                            to HTTP.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                        TCP hooks not yet supported
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is an alpha field and requires enabling ProbeTerminationGracePeriod
+                        feature gate.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                stdin:
+                  description: Whether this container should allocate a buffer for
+                    stdin in the container runtime. If this is not set, reads from
+                    stdin in the container will always result in EOF. Default is false.
+                  type: boolean
+                stdinOnce:
+                  description: Whether the container runtime should close the stdin
+                    channel after it has been opened by a single attach. When stdin
+                    is true the stdin stream will remain open across multiple attach
+                    sessions. If stdinOnce is set to true, stdin is opened on container
+                    start, is empty until the first client attaches to stdin, and
+                    then remains open and accepts data until the client disconnects,
+                    at which time stdin is closed and remains closed until the container
+                    is restarted. If this flag is false, a container processes that
+                    reads from stdin will never receive an EOF. Default is false
+                  type: boolean
+                terminationMessagePath:
+                  description: 'Optional: Path at which the file to which the container''s
+                    termination message will be written is mounted into the container''s
+                    filesystem. Message written is intended to be brief final status,
+                    such as an assertion failure message. Will be truncated by the
+                    node if greater than 4096 bytes. The total message length across
+                    all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                    Cannot be updated.'
+                  type: string
+                terminationMessagePolicy:
+                  description: Indicate how the termination message should be populated.
+                    File will use the contents of terminationMessagePath to populate
+                    the container status message on both success and failure. FallbackToLogsOnError
+                    will use the last chunk of container log output if the termination
+                    message file is empty and the container exited with an error.
+                    The log output is limited to 2048 bytes or 80 lines, whichever
+                    is smaller. Defaults to File. Cannot be updated.
+                  type: string
+                tty:
+                  description: Whether this container should allocate a TTY for itself,
+                    also requires 'stdin' to be true. Default is false.
+                  type: boolean
+                volumeDevices:
+                  description: volumeDevices is the list of block devices to be used
+                    by the container.
+                  items:
+                    description: volumeDevice describes a mapping of a raw block device
+                      within a container.
+                    properties:
+                      devicePath:
+                        description: devicePath is the path inside of the container
+                          that the device will be mapped to.
+                        type: string
+                      name:
+                        description: name must match the name of a persistentVolumeClaim
+                          in the pod
+                        type: string
+                    required:
+                    - devicePath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - devicePath
+                  x-kubernetes-list-type: map
+                volumeMounts:
+                  description: Pod volumes to mount into the container's filesystem.
+                    Cannot be updated.
+                  items:
+                    description: VolumeMount describes a mounting of a Volume within
+                      a container.
+                    properties:
+                      mountPath:
+                        description: Path within the container at which the volume
+                          should be mounted.  Must not contain ':'.
+                        type: string
+                      mountPropagation:
+                        description: mountPropagation determines how mounts are propagated
+                          from the host to container and the other way around. When
+                          not set, MountPropagationNone is used. This field is beta
+                          in 1.10.
+                        type: string
+                      name:
+                        description: This must match the Name of a Volume.
+                        type: string
+                      readOnly:
+                        description: Mounted read-only if true, read-write otherwise
+                          (false or unspecified). Defaults to false.
+                        type: boolean
+                      subPath:
+                        description: Path within the volume from which the container's
+                          volume should be mounted. Defaults to "" (volume's root).
+                        type: string
+                      subPathExpr:
+                        description: Expanded path within the volume from which the
+                          container's volume should be mounted. Behaves similarly
+                          to SubPath but environment variable references $(VAR_NAME)
+                          are expanded using the container's environment. Defaults
+                          to "" (volume's root). SubPathExpr and SubPath are mutually
+                          exclusive.
+                        type: string
+                    required:
+                    - mountPath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - mountPath
+                  x-kubernetes-list-type: map
+                workingDir:
+                  description: Container's working directory. If not specified, the
+                    container runtime's default will be used, which might be configured
+                    in the container image. Cannot be updated.
+                  type: string
+              required:
+              - name
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - name
+            x-kubernetes-list-type: map
+          dnsConfig:
+            description: Specifies the DNS parameters of a pod. Parameters specified
+              here will be merged to the generated DNS configuration based on DNSPolicy.
+            properties:
+              nameservers:
+                description: A list of DNS name server IP addresses. This will be
+                  appended to the base nameservers generated from DNSPolicy. Duplicated
+                  nameservers will be removed.
+                items:
+                  type: string
+                type: array
+              options:
+                description: A list of DNS resolver options. This will be merged with
+                  the base options generated from DNSPolicy. Duplicated entries will
+                  be removed. Resolution options given in Options will override those
+                  that appear in the base DNSPolicy.
+                items:
+                  description: PodDNSConfigOption defines DNS resolver options of
+                    a pod.
+                  properties:
+                    name:
+                      description: Required.
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
+              searches:
+                description: A list of DNS search domains for host-name lookup. This
+                  will be appended to the base search paths generated from DNSPolicy.
+                  Duplicated search paths will be removed.
+                items:
+                  type: string
+                type: array
+            type: object
+          dnsPolicy:
+            description: Set DNS policy for the pod. Defaults to "ClusterFirst". Valid
+              values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
+              DNS parameters given in DNSConfig will be merged with the policy selected
+              with DNSPolicy. To have DNS options set along with hostNetwork, you
+              have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+            type: string
+          enableServiceLinks:
+            description: 'EnableServiceLinks indicates whether information about services
+              should be injected into pod''s environment variables, matching the syntax
+              of Docker links. Optional: Defaults to true.'
+            type: boolean
+          ephemeralContainers:
+            description: List of ephemeral containers run in this pod. Ephemeral containers
+              may be run in an existing pod to perform user-initiated actions such
+              as debugging. This list cannot be specified when creating a pod, and
+              it cannot be modified by updating the pod spec. In order to add an ephemeral
+              container to an existing pod, use the pod's ephemeralcontainers subresource.
+              This field is alpha-level and is only honored by servers that enable
+              the EphemeralContainers feature.
+            items:
+              description: An EphemeralContainer is a container that may be added
+                temporarily to an existing pod for user-initiated activities such
+                as debugging. Ephemeral containers have no resource or scheduling
+                guarantees, and they will not be restarted when they exit or when
+                a pod is removed or restarted. If an ephemeral container causes a
+                pod to exceed its resource allocation, the pod may be evicted. Ephemeral
+                containers may not be added by directly updating the pod spec. They
+                must be added via the pod's ephemeralcontainers subresource, and they
+                will appear in the pod spec once added. This is an alpha feature enabled
+                by the EphemeralContainers feature flag.
+              properties:
+                args:
+                  description: 'Arguments to the entrypoint. The docker image''s CMD
+                    is used if this is not provided. Variable references $(VAR_NAME)
+                    are expanded using the container''s environment. If a variable
+                    cannot be resolved, the reference in the input string will be
+                    unchanged. The $(VAR_NAME) syntax can be escaped with a double
+                    $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                    regardless of whether the variable exists or not. Cannot be updated.
+                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                command:
+                  description: 'Entrypoint array. Not executed within a shell. The
+                    docker image''s ENTRYPOINT is used if this is not provided. Variable
+                    references $(VAR_NAME) are expanded using the container''s environment.
+                    If a variable cannot be resolved, the reference in the input string
+                    will be unchanged. The $(VAR_NAME) syntax can be escaped with
+                    a double $$, ie: $$(VAR_NAME). Escaped references will never be
+                    expanded, regardless of whether the variable exists or not. Cannot
+                    be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                env:
+                  description: List of environment variables to set in the container.
+                    Cannot be updated.
+                  items:
+                    description: EnvVar represents an environment variable present
+                      in a Container.
+                    properties:
+                      name:
+                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        type: string
+                      value:
+                        description: 'Variable references $(VAR_NAME) are expanded
+                          using the previous defined environment variables in the
+                          container and any service environment variables. If a variable
+                          cannot be resolved, the reference in the input string will
+                          be unchanged. The $(VAR_NAME) syntax can be escaped with
+                          a double $$, ie: $$(VAR_NAME). Escaped references will never
+                          be expanded, regardless of whether the variable exists or
+                          not. Defaults to "".'
+                        type: string
+                      valueFrom:
+                        description: Source for the environment variable's value.
+                          Cannot be used if value is not empty.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          fieldRef:
+                            description: 'Selects a field of the pod: supports metadata.name,
+                              metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                              spec.nodeName, spec.serviceAccountName, status.hostIP,
+                              status.podIP, status.podIPs.'
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                            - fieldPath
+                            type: object
+                          resourceFieldRef:
+                            description: 'Selects a resource of the container: only
+                              resources limits and requests (limits.cpu, limits.memory,
+                              limits.ephemeral-storage, requests.cpu, requests.memory
+                              and requests.ephemeral-storage) are currently supported.'
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Specifies the output format of the exposed
+                                  resources, defaults to "1"
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                            - resource
+                            type: object
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - name
+                  x-kubernetes-list-type: map
+                envFrom:
+                  description: List of sources to populate environment variables in
+                    the container. The keys defined within a source must be a C_IDENTIFIER.
+                    All invalid keys will be reported as an event when the container
+                    is starting. When a key exists in multiple sources, the value
+                    associated with the last source will take precedence. Values defined
+                    by an Env with a duplicate key will take precedence. Cannot be
+                    updated.
+                  items:
+                    description: EnvFromSource represents the source of a set of ConfigMaps
+                    properties:
+                      configMapRef:
+                        description: The ConfigMap to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the ConfigMap must be defined
+                            type: boolean
+                        type: object
+                      prefix:
+                        description: An optional identifier to prepend to each key
+                          in the ConfigMap. Must be a C_IDENTIFIER.
+                        type: string
+                      secretRef:
+                        description: The Secret to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret must be defined
+                            type: boolean
+                        type: object
+                    type: object
+                  type: array
+                image:
+                  description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                  type: string
+                imagePullPolicy:
+                  description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                    Defaults to Always if :latest tag is specified, or IfNotPresent
+                    otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                  type: string
+                lifecycle:
+                  description: Lifecycle is not allowed for ephemeral containers.
+                  properties:
+                    postStart:
+                      description: 'PostStart is called immediately after a container
+                        is created. If the handler fails, the container is terminated
+                        and restarted according to its restart policy. Other management
+                        of the container blocks until the hook completes. More info:
+                        https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: TCPSocket specifies an action involving a TCP
+                            port. TCP hooks not yet supported
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                    preStop:
+                      description: 'PreStop is called immediately before a container
+                        is terminated due to an API request or management event such
+                        as liveness/startup probe failure, preemption, resource contention,
+                        etc. The handler is not called if the container crashes or
+                        exits. The reason for termination is passed to the handler.
+                        The Pod''s termination grace period countdown begins before
+                        the PreStop hooked is executed. Regardless of the outcome
+                        of the handler, the container will eventually terminate within
+                        the Pod''s termination grace period. Other management of the
+                        container blocks until the hook completes or until the termination
+                        grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: TCPSocket specifies an action involving a TCP
+                            port. TCP hooks not yet supported
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                  type: object
+                livenessProbe:
+                  description: Probes are not allowed for ephemeral containers.
+                  properties:
+                    exec:
+                      description: One and only one of the following should be specified.
+                        Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: Scheme to use for connecting to the host. Defaults
+                            to HTTP.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                        TCP hooks not yet supported
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is an alpha field and requires enabling ProbeTerminationGracePeriod
+                        feature gate.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                name:
+                  description: Name of the ephemeral container specified as a DNS_LABEL.
+                    This name must be unique among all containers, init containers
+                    and ephemeral containers.
+                  type: string
+                ports:
+                  description: Ports are not allowed for ephemeral containers.
+                  items:
+                    description: ContainerPort represents a network port in a single
+                      container.
+                    properties:
+                      containerPort:
+                        description: Number of port to expose on the pod's IP address.
+                          This must be a valid port number, 0 < x < 65536.
+                        format: int32
+                        type: integer
+                      hostIP:
+                        description: What host IP to bind the external port to.
+                        type: string
+                      hostPort:
+                        description: Number of port to expose on the host. If specified,
+                          this must be a valid port number, 0 < x < 65536. If HostNetwork
+                          is specified, this must match ContainerPort. Most containers
+                          do not need this.
+                        format: int32
+                        type: integer
+                      name:
+                        description: If specified, this must be an IANA_SVC_NAME and
+                          unique within the pod. Each named port in a pod must have
+                          a unique name. Name for the port that can be referred to
+                          by services.
+                        type: string
+                      protocol:
+                        default: TCP
+                        description: Protocol for port. Must be UDP, TCP, or SCTP.
+                          Defaults to "TCP".
+                        type: string
+                    required:
+                    - containerPort
+                    type: object
+                  type: array
+                readinessProbe:
+                  description: Probes are not allowed for ephemeral containers.
+                  properties:
+                    exec:
+                      description: One and only one of the following should be specified.
+                        Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: Scheme to use for connecting to the host. Defaults
+                            to HTTP.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                        TCP hooks not yet supported
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is an alpha field and requires enabling ProbeTerminationGracePeriod
+                        feature gate.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                resources:
+                  description: Resources are not allowed for ephemeral containers.
+                    Ephemeral containers use spare resources already allocated to
+                    the pod.
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                  type: object
+                securityContext:
+                  description: SecurityContext is not allowed for ephemeral containers.
+                  properties:
+                    allowPrivilegeEscalation:
+                      description: 'AllowPrivilegeEscalation controls whether a process
+                        can gain more privileges than its parent process. This bool
+                        directly controls if the no_new_privs flag will be set on
+                        the container process. AllowPrivilegeEscalation is true always
+                        when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                      type: boolean
+                    capabilities:
+                      description: The capabilities to add/drop when running containers.
+                        Defaults to the default set of capabilities granted by the
+                        container runtime.
+                      properties:
+                        add:
+                          description: Added capabilities
+                          items:
+                            type: string
+                          type: array
+                        drop:
+                          description: Removed capabilities
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    privileged:
+                      description: Run container in privileged mode. Processes in
+                        privileged containers are essentially equivalent to root on
+                        the host. Defaults to false.
+                      type: boolean
+                    procMount:
+                      description: procMount denotes the type of proc mount to use
+                        for the containers. The default is DefaultProcMount which
+                        uses the container runtime defaults for readonly paths and
+                        masked paths. This requires the ProcMountType feature flag
+                        to be enabled.
+                      type: string
+                    readOnlyRootFilesystem:
+                      description: Whether this container has a read-only root filesystem.
+                        Default is false.
+                      type: boolean
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container
+                        process. Uses runtime default if unset. May also be set in
+                        PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to
+                        start the container if it does. If unset or false, no such
+                        validation will be performed. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container
+                        process. Defaults to user specified in image metadata if unspecified.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: The SELinux context to be applied to the container.
+                        If unspecified, the container runtime will allocate a random
+                        SELinux context for each container.  May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
+                      type: object
+                    seccompProfile:
+                      description: The seccomp options to use by this container. If
+                        seccomp options are provided at both the pod & container level,
+                        the container options override the pod options.
+                      properties:
+                        localhostProfile:
+                          description: localhostProfile indicates a profile defined
+                            in a file on the node should be used. The profile must
+                            be preconfigured on the node to work. Must be a descending
+                            path, relative to the kubelet's configured seccomp profile
+                            location. Must only be set if type is "Localhost".
+                          type: string
+                        type:
+                          description: |-
+                            type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                            Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    windowsOptions:
+                      description: The Windows specific settings applied to all containers.
+                        If unspecified, the options from the PodSecurityContext will
+                        be used. If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence.
+                      properties:
+                        gmsaCredentialSpec:
+                          description: GMSACredentialSpec is where the GMSA admission
+                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                            inlines the contents of the GMSA credential spec named
+                            by the GMSACredentialSpecName field.
+                          type: string
+                        gmsaCredentialSpecName:
+                          description: GMSACredentialSpecName is the name of the GMSA
+                            credential spec to use.
+                          type: string
+                        runAsUserName:
+                          description: The UserName in Windows to run the entrypoint
+                            of the container process. Defaults to the user specified
+                            in image metadata if unspecified. May also be set in PodSecurityContext.
+                            If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence.
+                          type: string
+                      type: object
+                  type: object
+                startupProbe:
+                  description: Probes are not allowed for ephemeral containers.
+                  properties:
+                    exec:
+                      description: One and only one of the following should be specified.
+                        Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: Scheme to use for connecting to the host. Defaults
+                            to HTTP.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                        TCP hooks not yet supported
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is an alpha field and requires enabling ProbeTerminationGracePeriod
+                        feature gate.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                stdin:
+                  description: Whether this container should allocate a buffer for
+                    stdin in the container runtime. If this is not set, reads from
+                    stdin in the container will always result in EOF. Default is false.
+                  type: boolean
+                stdinOnce:
+                  description: Whether the container runtime should close the stdin
+                    channel after it has been opened by a single attach. When stdin
+                    is true the stdin stream will remain open across multiple attach
+                    sessions. If stdinOnce is set to true, stdin is opened on container
+                    start, is empty until the first client attaches to stdin, and
+                    then remains open and accepts data until the client disconnects,
+                    at which time stdin is closed and remains closed until the container
+                    is restarted. If this flag is false, a container processes that
+                    reads from stdin will never receive an EOF. Default is false
+                  type: boolean
+                targetContainerName:
+                  description: If set, the name of the container from PodSpec that
+                    this ephemeral container targets. The ephemeral container will
+                    be run in the namespaces (IPC, PID, etc) of this container. If
+                    not set then the ephemeral container is run in whatever namespaces
+                    are shared for the pod. Note that the container runtime must support
+                    this feature.
+                  type: string
+                terminationMessagePath:
+                  description: 'Optional: Path at which the file to which the container''s
+                    termination message will be written is mounted into the container''s
+                    filesystem. Message written is intended to be brief final status,
+                    such as an assertion failure message. Will be truncated by the
+                    node if greater than 4096 bytes. The total message length across
+                    all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                    Cannot be updated.'
+                  type: string
+                terminationMessagePolicy:
+                  description: Indicate how the termination message should be populated.
+                    File will use the contents of terminationMessagePath to populate
+                    the container status message on both success and failure. FallbackToLogsOnError
+                    will use the last chunk of container log output if the termination
+                    message file is empty and the container exited with an error.
+                    The log output is limited to 2048 bytes or 80 lines, whichever
+                    is smaller. Defaults to File. Cannot be updated.
+                  type: string
+                tty:
+                  description: Whether this container should allocate a TTY for itself,
+                    also requires 'stdin' to be true. Default is false.
+                  type: boolean
+                volumeDevices:
+                  description: volumeDevices is the list of block devices to be used
+                    by the container.
+                  items:
+                    description: volumeDevice describes a mapping of a raw block device
+                      within a container.
+                    properties:
+                      devicePath:
+                        description: devicePath is the path inside of the container
+                          that the device will be mapped to.
+                        type: string
+                      name:
+                        description: name must match the name of a persistentVolumeClaim
+                          in the pod
+                        type: string
+                    required:
+                    - devicePath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - devicePath
+                  x-kubernetes-list-type: map
+                volumeMounts:
+                  description: Pod volumes to mount into the container's filesystem.
+                    Cannot be updated.
+                  items:
+                    description: VolumeMount describes a mounting of a Volume within
+                      a container.
+                    properties:
+                      mountPath:
+                        description: Path within the container at which the volume
+                          should be mounted.  Must not contain ':'.
+                        type: string
+                      mountPropagation:
+                        description: mountPropagation determines how mounts are propagated
+                          from the host to container and the other way around. When
+                          not set, MountPropagationNone is used. This field is beta
+                          in 1.10.
+                        type: string
+                      name:
+                        description: This must match the Name of a Volume.
+                        type: string
+                      readOnly:
+                        description: Mounted read-only if true, read-write otherwise
+                          (false or unspecified). Defaults to false.
+                        type: boolean
+                      subPath:
+                        description: Path within the volume from which the container's
+                          volume should be mounted. Defaults to "" (volume's root).
+                        type: string
+                      subPathExpr:
+                        description: Expanded path within the volume from which the
+                          container's volume should be mounted. Behaves similarly
+                          to SubPath but environment variable references $(VAR_NAME)
+                          are expanded using the container's environment. Defaults
+                          to "" (volume's root). SubPathExpr and SubPath are mutually
+                          exclusive.
+                        type: string
+                    required:
+                    - mountPath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - mountPath
+                  x-kubernetes-list-type: map
+                workingDir:
+                  description: Container's working directory. If not specified, the
+                    container runtime's default will be used, which might be configured
+                    in the container image. Cannot be updated.
+                  type: string
+              required:
+              - name
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - name
+            x-kubernetes-list-type: map
+          hostAliases:
+            description: HostAliases is an optional list of hosts and IPs that will
+              be injected into the pod's hosts file if specified. This is only valid
+              for non-hostNetwork pods.
+            items:
+              description: HostAlias holds the mapping between IP and hostnames that
+                will be injected as an entry in the pod's hosts file.
+              properties:
+                hostnames:
+                  description: Hostnames for the above IP address.
+                  items:
+                    type: string
+                  type: array
+                ip:
+                  description: IP address of the host file entry.
+                  type: string
+              required:
+              - ip
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - ip
+            x-kubernetes-list-type: map
+          hostIPC:
+            description: 'Use the host''s ipc namespace. Optional: Default to false.'
+            type: boolean
+          hostNetwork:
+            description: Host networking requested for this pod. Use the host's network
+              namespace. If this option is set, the ports that will be used must be
+              specified. Default to false.
+            type: boolean
+          hostPID:
+            description: 'Use the host''s pid namespace. Optional: Default to false.'
+            type: boolean
+          hostname:
+            description: Specifies the hostname of the Pod If not specified, the pod's
+              hostname will be set to a system-defined value.
+            type: string
+          imagePullSecrets:
+            description: 'ImagePullSecrets is an optional list of references to secrets
+              in the same namespace to use for pulling any of the images used by this
+              PodSpec. If specified, these secrets will be passed to individual puller
+              implementations for them to use. For example, in the case of docker,
+              only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+            items:
+              description: LocalObjectReference contains enough information to let
+                you locate the referenced object inside the same namespace.
+              properties:
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+              required:
+              - name
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - name
+            x-kubernetes-list-type: map
+          initContainers:
+            description: 'List of initialization containers belonging to the pod.
+              Init containers are executed in order prior to containers being started.
+              If any init container fails, the pod is considered to have failed and
+              is handled according to its restartPolicy. The name for an init container
+              or normal container must be unique among all containers. Init containers
+              may not have Lifecycle actions, Readiness probes, Liveness probes, or
+              Startup probes. The resourceRequirements of an init container are taken
+              into account during scheduling by finding the highest request/limit
+              for each resource type, and then using the max of of that value or the
+              sum of the normal containers. Limits are applied to init containers
+              in a similar fashion. Init containers cannot currently be added or removed.
+              Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+            items:
+              description: A single application container that you want to run within
+                a pod.
+              properties:
+                args:
+                  description: 'Arguments to the entrypoint. The docker image''s CMD
+                    is used if this is not provided. Variable references $(VAR_NAME)
+                    are expanded using the container''s environment. If a variable
+                    cannot be resolved, the reference in the input string will be
+                    unchanged. The $(VAR_NAME) syntax can be escaped with a double
+                    $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                    regardless of whether the variable exists or not. Cannot be updated.
+                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                command:
+                  description: 'Entrypoint array. Not executed within a shell. The
+                    docker image''s ENTRYPOINT is used if this is not provided. Variable
+                    references $(VAR_NAME) are expanded using the container''s environment.
+                    If a variable cannot be resolved, the reference in the input string
+                    will be unchanged. The $(VAR_NAME) syntax can be escaped with
+                    a double $$, ie: $$(VAR_NAME). Escaped references will never be
+                    expanded, regardless of whether the variable exists or not. Cannot
+                    be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                env:
+                  description: List of environment variables to set in the container.
+                    Cannot be updated.
+                  items:
+                    description: EnvVar represents an environment variable present
+                      in a Container.
+                    properties:
+                      name:
+                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        type: string
+                      value:
+                        description: 'Variable references $(VAR_NAME) are expanded
+                          using the previous defined environment variables in the
+                          container and any service environment variables. If a variable
+                          cannot be resolved, the reference in the input string will
+                          be unchanged. The $(VAR_NAME) syntax can be escaped with
+                          a double $$, ie: $$(VAR_NAME). Escaped references will never
+                          be expanded, regardless of whether the variable exists or
+                          not. Defaults to "".'
+                        type: string
+                      valueFrom:
+                        description: Source for the environment variable's value.
+                          Cannot be used if value is not empty.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          fieldRef:
+                            description: 'Selects a field of the pod: supports metadata.name,
+                              metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                              spec.nodeName, spec.serviceAccountName, status.hostIP,
+                              status.podIP, status.podIPs.'
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                            - fieldPath
+                            type: object
+                          resourceFieldRef:
+                            description: 'Selects a resource of the container: only
+                              resources limits and requests (limits.cpu, limits.memory,
+                              limits.ephemeral-storage, requests.cpu, requests.memory
+                              and requests.ephemeral-storage) are currently supported.'
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Specifies the output format of the exposed
+                                  resources, defaults to "1"
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                            - resource
+                            type: object
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - name
+                  x-kubernetes-list-type: map
+                envFrom:
+                  description: List of sources to populate environment variables in
+                    the container. The keys defined within a source must be a C_IDENTIFIER.
+                    All invalid keys will be reported as an event when the container
+                    is starting. When a key exists in multiple sources, the value
+                    associated with the last source will take precedence. Values defined
+                    by an Env with a duplicate key will take precedence. Cannot be
+                    updated.
+                  items:
+                    description: EnvFromSource represents the source of a set of ConfigMaps
+                    properties:
+                      configMapRef:
+                        description: The ConfigMap to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the ConfigMap must be defined
+                            type: boolean
+                        type: object
+                      prefix:
+                        description: An optional identifier to prepend to each key
+                          in the ConfigMap. Must be a C_IDENTIFIER.
+                        type: string
+                      secretRef:
+                        description: The Secret to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret must be defined
+                            type: boolean
+                        type: object
+                    type: object
+                  type: array
+                image:
+                  description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                    This field is optional to allow higher level config management
+                    to default or override container images in workload controllers
+                    like Deployments and StatefulSets.'
+                  type: string
+                imagePullPolicy:
+                  description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                    Defaults to Always if :latest tag is specified, or IfNotPresent
+                    otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                  type: string
+                lifecycle:
+                  description: Actions that the management system should take in response
+                    to container lifecycle events. Cannot be updated.
+                  properties:
+                    postStart:
+                      description: 'PostStart is called immediately after a container
+                        is created. If the handler fails, the container is terminated
+                        and restarted according to its restart policy. Other management
+                        of the container blocks until the hook completes. More info:
+                        https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: TCPSocket specifies an action involving a TCP
+                            port. TCP hooks not yet supported
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                    preStop:
+                      description: 'PreStop is called immediately before a container
+                        is terminated due to an API request or management event such
+                        as liveness/startup probe failure, preemption, resource contention,
+                        etc. The handler is not called if the container crashes or
+                        exits. The reason for termination is passed to the handler.
+                        The Pod''s termination grace period countdown begins before
+                        the PreStop hooked is executed. Regardless of the outcome
+                        of the handler, the container will eventually terminate within
+                        the Pod''s termination grace period. Other management of the
+                        container blocks until the hook completes or until the termination
+                        grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: TCPSocket specifies an action involving a TCP
+                            port. TCP hooks not yet supported
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                  type: object
+                livenessProbe:
+                  description: 'Periodic probe of container liveness. Container will
+                    be restarted if the probe fails. Cannot be updated. More info:
+                    https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: One and only one of the following should be specified.
+                        Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: Scheme to use for connecting to the host. Defaults
+                            to HTTP.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                        TCP hooks not yet supported
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is an alpha field and requires enabling ProbeTerminationGracePeriod
+                        feature gate.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                name:
+                  description: Name of the container specified as a DNS_LABEL. Each
+                    container in a pod must have a unique name (DNS_LABEL). Cannot
+                    be updated.
+                  type: string
+                ports:
+                  description: List of ports to expose from the container. Exposing
+                    a port here gives the system additional information about the
+                    network connections a container uses, but is primarily informational.
+                    Not specifying a port here DOES NOT prevent that port from being
+                    exposed. Any port which is listening on the default "0.0.0.0"
+                    address inside a container will be accessible from the network.
+                    Cannot be updated.
+                  items:
+                    description: ContainerPort represents a network port in a single
+                      container.
+                    properties:
+                      containerPort:
+                        description: Number of port to expose on the pod's IP address.
+                          This must be a valid port number, 0 < x < 65536.
+                        format: int32
+                        type: integer
+                      hostIP:
+                        description: What host IP to bind the external port to.
+                        type: string
+                      hostPort:
+                        description: Number of port to expose on the host. If specified,
+                          this must be a valid port number, 0 < x < 65536. If HostNetwork
+                          is specified, this must match ContainerPort. Most containers
+                          do not need this.
+                        format: int32
+                        type: integer
+                      name:
+                        description: If specified, this must be an IANA_SVC_NAME and
+                          unique within the pod. Each named port in a pod must have
+                          a unique name. Name for the port that can be referred to
+                          by services.
+                        type: string
+                      protocol:
+                        default: TCP
+                        description: Protocol for port. Must be UDP, TCP, or SCTP.
+                          Defaults to "TCP".
+                        type: string
+                    required:
+                    - containerPort
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - containerPort
+                  - protocol
+                  x-kubernetes-list-type: map
+                readinessProbe:
+                  description: 'Periodic probe of container service readiness. Container
+                    will be removed from service endpoints if the probe fails. Cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: One and only one of the following should be specified.
+                        Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: Scheme to use for connecting to the host. Defaults
+                            to HTTP.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                        TCP hooks not yet supported
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is an alpha field and requires enabling ProbeTerminationGracePeriod
+                        feature gate.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                resources:
+                  description: 'Compute Resources required by this container. Cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                  type: object
+                securityContext:
+                  description: 'Security options the pod should run with. More info:
+                    https://kubernetes.io/docs/concepts/policy/security-context/ More
+                    info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                  properties:
+                    allowPrivilegeEscalation:
+                      description: 'AllowPrivilegeEscalation controls whether a process
+                        can gain more privileges than its parent process. This bool
+                        directly controls if the no_new_privs flag will be set on
+                        the container process. AllowPrivilegeEscalation is true always
+                        when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                      type: boolean
+                    capabilities:
+                      description: The capabilities to add/drop when running containers.
+                        Defaults to the default set of capabilities granted by the
+                        container runtime.
+                      properties:
+                        add:
+                          description: Added capabilities
+                          items:
+                            type: string
+                          type: array
+                        drop:
+                          description: Removed capabilities
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    privileged:
+                      description: Run container in privileged mode. Processes in
+                        privileged containers are essentially equivalent to root on
+                        the host. Defaults to false.
+                      type: boolean
+                    procMount:
+                      description: procMount denotes the type of proc mount to use
+                        for the containers. The default is DefaultProcMount which
+                        uses the container runtime defaults for readonly paths and
+                        masked paths. This requires the ProcMountType feature flag
+                        to be enabled.
+                      type: string
+                    readOnlyRootFilesystem:
+                      description: Whether this container has a read-only root filesystem.
+                        Default is false.
+                      type: boolean
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container
+                        process. Uses runtime default if unset. May also be set in
+                        PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to
+                        start the container if it does. If unset or false, no such
+                        validation will be performed. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container
+                        process. Defaults to user specified in image metadata if unspecified.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: The SELinux context to be applied to the container.
+                        If unspecified, the container runtime will allocate a random
+                        SELinux context for each container.  May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
+                      type: object
+                    seccompProfile:
+                      description: The seccomp options to use by this container. If
+                        seccomp options are provided at both the pod & container level,
+                        the container options override the pod options.
+                      properties:
+                        localhostProfile:
+                          description: localhostProfile indicates a profile defined
+                            in a file on the node should be used. The profile must
+                            be preconfigured on the node to work. Must be a descending
+                            path, relative to the kubelet's configured seccomp profile
+                            location. Must only be set if type is "Localhost".
+                          type: string
+                        type:
+                          description: |-
+                            type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                            Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    windowsOptions:
+                      description: The Windows specific settings applied to all containers.
+                        If unspecified, the options from the PodSecurityContext will
+                        be used. If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence.
+                      properties:
+                        gmsaCredentialSpec:
+                          description: GMSACredentialSpec is where the GMSA admission
+                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                            inlines the contents of the GMSA credential spec named
+                            by the GMSACredentialSpecName field.
+                          type: string
+                        gmsaCredentialSpecName:
+                          description: GMSACredentialSpecName is the name of the GMSA
+                            credential spec to use.
+                          type: string
+                        runAsUserName:
+                          description: The UserName in Windows to run the entrypoint
+                            of the container process. Defaults to the user specified
+                            in image metadata if unspecified. May also be set in PodSecurityContext.
+                            If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence.
+                          type: string
+                      type: object
+                  type: object
+                startupProbe:
+                  description: 'StartupProbe indicates that the Pod has successfully
+                    initialized. If specified, no other probes are executed until
+                    this completes successfully. If this probe fails, the Pod will
+                    be restarted, just as if the livenessProbe failed. This can be
+                    used to provide different probe parameters at the beginning of
+                    a Pod''s lifecycle, when it might take a long time to load data
+                    or warm a cache, than during steady-state operation. This cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: One and only one of the following should be specified.
+                        Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: Scheme to use for connecting to the host. Defaults
+                            to HTTP.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                        TCP hooks not yet supported
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is an alpha field and requires enabling ProbeTerminationGracePeriod
+                        feature gate.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                stdin:
+                  description: Whether this container should allocate a buffer for
+                    stdin in the container runtime. If this is not set, reads from
+                    stdin in the container will always result in EOF. Default is false.
+                  type: boolean
+                stdinOnce:
+                  description: Whether the container runtime should close the stdin
+                    channel after it has been opened by a single attach. When stdin
+                    is true the stdin stream will remain open across multiple attach
+                    sessions. If stdinOnce is set to true, stdin is opened on container
+                    start, is empty until the first client attaches to stdin, and
+                    then remains open and accepts data until the client disconnects,
+                    at which time stdin is closed and remains closed until the container
+                    is restarted. If this flag is false, a container processes that
+                    reads from stdin will never receive an EOF. Default is false
+                  type: boolean
+                terminationMessagePath:
+                  description: 'Optional: Path at which the file to which the container''s
+                    termination message will be written is mounted into the container''s
+                    filesystem. Message written is intended to be brief final status,
+                    such as an assertion failure message. Will be truncated by the
+                    node if greater than 4096 bytes. The total message length across
+                    all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                    Cannot be updated.'
+                  type: string
+                terminationMessagePolicy:
+                  description: Indicate how the termination message should be populated.
+                    File will use the contents of terminationMessagePath to populate
+                    the container status message on both success and failure. FallbackToLogsOnError
+                    will use the last chunk of container log output if the termination
+                    message file is empty and the container exited with an error.
+                    The log output is limited to 2048 bytes or 80 lines, whichever
+                    is smaller. Defaults to File. Cannot be updated.
+                  type: string
+                tty:
+                  description: Whether this container should allocate a TTY for itself,
+                    also requires 'stdin' to be true. Default is false.
+                  type: boolean
+                volumeDevices:
+                  description: volumeDevices is the list of block devices to be used
+                    by the container.
+                  items:
+                    description: volumeDevice describes a mapping of a raw block device
+                      within a container.
+                    properties:
+                      devicePath:
+                        description: devicePath is the path inside of the container
+                          that the device will be mapped to.
+                        type: string
+                      name:
+                        description: name must match the name of a persistentVolumeClaim
+                          in the pod
+                        type: string
+                    required:
+                    - devicePath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - devicePath
+                  x-kubernetes-list-type: map
+                volumeMounts:
+                  description: Pod volumes to mount into the container's filesystem.
+                    Cannot be updated.
+                  items:
+                    description: VolumeMount describes a mounting of a Volume within
+                      a container.
+                    properties:
+                      mountPath:
+                        description: Path within the container at which the volume
+                          should be mounted.  Must not contain ':'.
+                        type: string
+                      mountPropagation:
+                        description: mountPropagation determines how mounts are propagated
+                          from the host to container and the other way around. When
+                          not set, MountPropagationNone is used. This field is beta
+                          in 1.10.
+                        type: string
+                      name:
+                        description: This must match the Name of a Volume.
+                        type: string
+                      readOnly:
+                        description: Mounted read-only if true, read-write otherwise
+                          (false or unspecified). Defaults to false.
+                        type: boolean
+                      subPath:
+                        description: Path within the volume from which the container's
+                          volume should be mounted. Defaults to "" (volume's root).
+                        type: string
+                      subPathExpr:
+                        description: Expanded path within the volume from which the
+                          container's volume should be mounted. Behaves similarly
+                          to SubPath but environment variable references $(VAR_NAME)
+                          are expanded using the container's environment. Defaults
+                          to "" (volume's root). SubPathExpr and SubPath are mutually
+                          exclusive.
+                        type: string
+                    required:
+                    - mountPath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - mountPath
+                  x-kubernetes-list-type: map
+                workingDir:
+                  description: Container's working directory. If not specified, the
+                    container runtime's default will be used, which might be configured
+                    in the container image. Cannot be updated.
+                  type: string
+              required:
+              - name
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - name
+            x-kubernetes-list-type: map
+          nodeName:
+            description: NodeName is a request to schedule this pod onto a specific
+              node. If it is non-empty, the scheduler simply schedules this pod onto
+              that node, assuming that it fits resource requirements.
+            type: string
+          nodeSelector:
+            additionalProperties:
+              type: string
+            description: 'NodeSelector is a selector which must be true for the pod
+              to fit on a node. Selector which must match a node''s labels for the
+              pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+            type: object
+          overhead:
+            additionalProperties:
+              anyOf:
+              - type: integer
+              - type: string
+              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+              x-kubernetes-int-or-string: true
+            description: 'Overhead represents the resource overhead associated with
+              running a pod for a given RuntimeClass. This field will be autopopulated
+              at admission time by the RuntimeClass admission controller. If the RuntimeClass
+              admission controller is enabled, overhead must not be set in Pod create
+              requests. The RuntimeClass admission controller will reject Pod create
+              requests which have the overhead already set. If RuntimeClass is configured
+              and selected in the PodSpec, Overhead will be set to the value defined
+              in the corresponding RuntimeClass, otherwise it will remain unset and
+              treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md
+              This field is alpha-level as of Kubernetes v1.16, and is only honored
+              by servers that enable the PodOverhead feature.'
+            type: object
+          preemptionPolicy:
+            description: PreemptionPolicy is the Policy for preempting pods with lower
+              priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority
+              if unset. This field is beta-level, gated by the NonPreemptingPriority
+              feature-gate.
+            type: string
+          priority:
+            description: The priority value. Various system components use this field
+              to find the priority of the pod. When Priority Admission Controller
+              is enabled, it prevents users from setting this field. The admission
+              controller populates this field from PriorityClassName. The higher the
+              value, the higher the priority.
+            format: int32
+            type: integer
+          priorityClassName:
+            description: If specified, indicates the pod's priority. "system-node-critical"
+              and "system-cluster-critical" are two special keywords which indicate
+              the highest priorities with the former being the highest priority. Any
+              other name must be defined by creating a PriorityClass object with that
+              name. If not specified, the pod priority will be default or zero if
+              there is no default.
+            type: string
+          readinessGates:
+            description: 'If specified, all readiness gates will be evaluated for
+              pod readiness. A pod is ready when all its containers are ready AND
+              all conditions specified in the readiness gates have status equal to
+              "True" More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md'
+            items:
+              description: PodReadinessGate contains the reference to a pod condition
+              properties:
+                conditionType:
+                  description: ConditionType refers to a condition in the pod's condition
+                    list with matching type.
+                  type: string
+              required:
+              - conditionType
+              type: object
+            type: array
+          restartPolicy:
+            description: 'Restart policy for all containers within the pod. One of
+              Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
+            type: string
+          runtimeClassName:
+            description: 'RuntimeClassName refers to a RuntimeClass object in the
+              node.k8s.io group, which should be used to run this pod.  If no RuntimeClass
+              resource matches the named class, the pod will not be run. If unset
+              or empty, the "legacy" RuntimeClass will be used, which is an implicit
+              class with an empty definition that uses the default runtime handler.
+              More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
+              This is a beta feature as of Kubernetes v1.14.'
+            type: string
+          schedulerName:
+            description: If specified, the pod will be dispatched by specified scheduler.
+              If not specified, the pod will be dispatched by default scheduler.
+            type: string
+          securityContext:
+            description: 'SecurityContext holds pod-level security attributes and
+              common container settings. Optional: Defaults to empty.  See type description
+              for default values of each field.'
+            properties:
+              fsGroup:
+                description: |-
+                  A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
+                  1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
+                  If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                format: int64
+                type: integer
+              fsGroupChangePolicy:
+                description: 'fsGroupChangePolicy defines behavior of changing ownership
+                  and permission of the volume before being exposed inside Pod. This
+                  field will only apply to volume types which support fsGroup based
+                  ownership(and permissions). It will have no effect on ephemeral
+                  volume types such as: secret, configmaps and emptydir. Valid values
+                  are "OnRootMismatch" and "Always". If not specified, "Always" is
+                  used.'
+                type: string
+              runAsGroup:
+                description: The GID to run the entrypoint of the container process.
+                  Uses runtime default if unset. May also be set in SecurityContext.  If
+                  set in both SecurityContext and PodSecurityContext, the value specified
+                  in SecurityContext takes precedence for that container.
+                format: int64
+                type: integer
+              runAsNonRoot:
+                description: Indicates that the container must run as a non-root user.
+                  If true, the Kubelet will validate the image at runtime to ensure
+                  that it does not run as UID 0 (root) and fail to start the container
+                  if it does. If unset or false, no such validation will be performed.
+                  May also be set in SecurityContext.  If set in both SecurityContext
+                  and PodSecurityContext, the value specified in SecurityContext takes
+                  precedence.
+                type: boolean
+              runAsUser:
+                description: The UID to run the entrypoint of the container process.
+                  Defaults to user specified in image metadata if unspecified. May
+                  also be set in SecurityContext.  If set in both SecurityContext
+                  and PodSecurityContext, the value specified in SecurityContext takes
+                  precedence for that container.
+                format: int64
+                type: integer
+              seLinuxOptions:
+                description: The SELinux context to be applied to all containers.
+                  If unspecified, the container runtime will allocate a random SELinux
+                  context for each container.  May also be set in SecurityContext.  If
+                  set in both SecurityContext and PodSecurityContext, the value specified
+                  in SecurityContext takes precedence for that container.
+                properties:
+                  level:
+                    description: Level is SELinux level label that applies to the
+                      container.
+                    type: string
+                  role:
+                    description: Role is a SELinux role label that applies to the
+                      container.
+                    type: string
+                  type:
+                    description: Type is a SELinux type label that applies to the
+                      container.
+                    type: string
+                  user:
+                    description: User is a SELinux user label that applies to the
+                      container.
+                    type: string
+                type: object
+              seccompProfile:
+                description: The seccomp options to use by the containers in this
+                  pod.
+                properties:
+                  localhostProfile:
+                    description: localhostProfile indicates a profile defined in a
+                      file on the node should be used. The profile must be preconfigured
+                      on the node to work. Must be a descending path, relative to
+                      the kubelet's configured seccomp profile location. Must only
+                      be set if type is "Localhost".
+                    type: string
+                  type:
+                    description: |-
+                      type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                      Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                    type: string
+                required:
+                - type
+                type: object
+              supplementalGroups:
+                description: A list of groups applied to the first process run in
+                  each container, in addition to the container's primary GID.  If
+                  unspecified, no groups will be added to any container.
+                items:
+                  format: int64
+                  type: integer
+                type: array
+              sysctls:
+                description: Sysctls hold a list of namespaced sysctls used for the
+                  pod. Pods with unsupported sysctls (by the container runtime) might
+                  fail to launch.
+                items:
+                  description: Sysctl defines a kernel parameter to be set
+                  properties:
+                    name:
+                      description: Name of a property to set
+                      type: string
+                    value:
+                      description: Value of a property to set
+                      type: string
+                  required:
+                  - name
+                  - value
+                  type: object
+                type: array
+              windowsOptions:
+                description: The Windows specific settings applied to all containers.
+                  If unspecified, the options within a container's SecurityContext
+                  will be used. If set in both SecurityContext and PodSecurityContext,
+                  the value specified in SecurityContext takes precedence.
+                properties:
+                  gmsaCredentialSpec:
+                    description: GMSACredentialSpec is where the GMSA admission webhook
+                      (https://github.com/kubernetes-sigs/windows-gmsa) inlines the
+                      contents of the GMSA credential spec named by the GMSACredentialSpecName
+                      field.
+                    type: string
+                  gmsaCredentialSpecName:
+                    description: GMSACredentialSpecName is the name of the GMSA credential
+                      spec to use.
+                    type: string
+                  runAsUserName:
+                    description: The UserName in Windows to run the entrypoint of
+                      the container process. Defaults to the user specified in image
+                      metadata if unspecified. May also be set in PodSecurityContext.
+                      If set in both SecurityContext and PodSecurityContext, the value
+                      specified in SecurityContext takes precedence.
+                    type: string
+                type: object
+            type: object
+          serviceAccount:
+            description: 'DeprecatedServiceAccount is a depreciated alias for ServiceAccountName.
+              Deprecated: Use serviceAccountName instead.'
+            type: string
+          serviceAccountName:
+            description: 'ServiceAccountName is the name of the ServiceAccount to
+              use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+            type: string
+          setHostnameAsFQDN:
+            description: If true the pod's hostname will be configured as the pod's
+              FQDN, rather than the leaf name (the default). In Linux containers,
+              this means setting the FQDN in the hostname field of the kernel (the
+              nodename field of struct utsname). In Windows containers, this means
+              setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters
+              to FQDN. If a pod does not have FQDN, this has no effect. Default to
+              false.
+            type: boolean
+          shareProcessNamespace:
+            description: 'Share a single process namespace between all of the containers
+              in a pod. When this is set containers will be able to view and signal
+              processes from other containers in the same pod, and the first process
+              in each container will not be assigned PID 1. HostPID and ShareProcessNamespace
+              cannot both be set. Optional: Default to false.'
+            type: boolean
+          subdomain:
+            description: If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod
+              namespace>.svc.<cluster domain>". If not specified, the pod will not
+              have a domainname at all.
+            type: string
+          terminationGracePeriodSeconds:
+            description: Optional duration in seconds the pod needs to terminate gracefully.
+              May be decreased in delete request. Value must be non-negative integer.
+              The value zero indicates stop immediately via the kill signal (no opportunity
+              to shut down). If this value is nil, the default grace period will be
+              used instead. The grace period is the duration in seconds after the
+              processes running in the pod are sent a termination signal and the time
+              when the processes are forcibly halted with a kill signal. Set this
+              value longer than the expected cleanup time for your process. Defaults
+              to 30 seconds.
+            format: int64
+            type: integer
+          tolerations:
+            description: If specified, the pod's tolerations.
+            items:
+              description: The pod this Toleration is attached to tolerates any taint
+                that matches the triple <key,value,effect> using the matching operator
+                <operator>.
+              properties:
+                effect:
+                  description: Effect indicates the taint effect to match. Empty means
+                    match all taint effects. When specified, allowed values are NoSchedule,
+                    PreferNoSchedule and NoExecute.
+                  type: string
+                key:
+                  description: Key is the taint key that the toleration applies to.
+                    Empty means match all taint keys. If the key is empty, operator
+                    must be Exists; this combination means to match all values and
+                    all keys.
+                  type: string
+                operator:
+                  description: Operator represents a key's relationship to the value.
+                    Valid operators are Exists and Equal. Defaults to Equal. Exists
+                    is equivalent to wildcard for value, so that a pod can tolerate
+                    all taints of a particular category.
+                  type: string
+                tolerationSeconds:
+                  description: TolerationSeconds represents the period of time the
+                    toleration (which must be of effect NoExecute, otherwise this
+                    field is ignored) tolerates the taint. By default, it is not set,
+                    which means tolerate the taint forever (do not evict). Zero and
+                    negative values will be treated as 0 (evict immediately) by the
+                    system.
+                  format: int64
+                  type: integer
+                value:
+                  description: Value is the taint value the toleration matches to.
+                    If the operator is Exists, the value should be empty, otherwise
+                    just a regular string.
+                  type: string
+              type: object
+            type: array
+          topologySpreadConstraints:
+            description: TopologySpreadConstraints describes how a group of pods ought
+              to spread across topology domains. Scheduler will schedule pods in a
+              way which abides by the constraints. All topologySpreadConstraints are
+              ANDed.
+            items:
+              description: TopologySpreadConstraint specifies how to spread matching
+                pods among the given topology.
+              properties:
+                labelSelector:
+                  description: LabelSelector is used to find matching pods. Pods that
+                    match this label selector are counted to determine the number
+                    of pods in their corresponding topology domain.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                maxSkew:
+                  description: 'MaxSkew describes the degree to which pods may be
+                    unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                    it is the maximum permitted difference between the number of matching
+                    pods in the target topology and the global minimum. For example,
+                    in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                    labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
+                    - if MaxSkew is 1, incoming pod can only be scheduled to zone3
+                    to become 1/1/1; scheduling it onto zone1(zone2) would make the
+                    ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew
+                    is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                    it is used to give higher precedence to topologies that satisfy
+                    it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                  format: int32
+                  type: integer
+                topologyKey:
+                  description: TopologyKey is the key of node labels. Nodes that have
+                    a label with this key and identical values are considered to be
+                    in the same topology. We consider each <key, value> as a "bucket",
+                    and try to put balanced number of pods into each bucket. It's
+                    a required field.
+                  type: string
+                whenUnsatisfiable:
+                  description: |-
+                    WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                      but giving higher precedence to topologies that would help reduce the
+                      skew.
+                    A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assigment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
+                  type: string
+              required:
+              - maxSkew
+              - topologyKey
+              - whenUnsatisfiable
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - topologyKey
+            - whenUnsatisfiable
+            x-kubernetes-list-type: map
+          volumes:
+            description: 'List of volumes that can be mounted by containers belonging
+              to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+            items:
+              description: Volume represents a named volume in a pod that may be accessed
+                by any container in the pod.
+              properties:
+                awsElasticBlockStore:
+                  description: 'AWSElasticBlockStore represents an AWS Disk resource
+                    that is attached to a kubelet''s host machine and then exposed
+                    to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                  properties:
+                    fsType:
+                      description: 'Filesystem type of the volume that you want to
+                        mount. Tip: Ensure that the filesystem type is supported by
+                        the host operating system. Examples: "ext4", "xfs", "ntfs".
+                        Implicitly inferred to be "ext4" if unspecified. More info:
+                        https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                      type: string
+                    partition:
+                      description: 'The partition in the volume that you want to mount.
+                        If omitted, the default is to mount by volume name. Examples:
+                        For volume /dev/sda1, you specify the partition as "1". Similarly,
+                        the volume partition for /dev/sda is "0" (or you can leave
+                        the property empty).'
+                      format: int32
+                      type: integer
+                    readOnly:
+                      description: 'Specify "true" to force and set the ReadOnly property
+                        in VolumeMounts to "true". If omitted, the default is "false".
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                      type: boolean
+                    volumeID:
+                      description: 'Unique ID of the persistent disk resource in AWS
+                        (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                      type: string
+                  required:
+                  - volumeID
+                  type: object
+                azureDisk:
+                  description: AzureDisk represents an Azure Data Disk mount on the
+                    host and bind mount to the pod.
+                  properties:
+                    cachingMode:
+                      description: 'Host Caching mode: None, Read Only, Read Write.'
+                      type: string
+                    diskName:
+                      description: The Name of the data disk in the blob storage
+                      type: string
+                    diskURI:
+                      description: The URI the data disk in the blob storage
+                      type: string
+                    fsType:
+                      description: Filesystem type to mount. Must be a filesystem
+                        type supported by the host operating system. Ex. "ext4", "xfs",
+                        "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                      type: string
+                    kind:
+                      description: 'Expected values Shared: multiple blob disks per
+                        storage account  Dedicated: single blob disk per storage account  Managed:
+                        azure managed data disk (only in managed availability set).
+                        defaults to shared'
+                      type: string
+                    readOnly:
+                      description: Defaults to false (read/write). ReadOnly here will
+                        force the ReadOnly setting in VolumeMounts.
+                      type: boolean
+                  required:
+                  - diskName
+                  - diskURI
+                  type: object
+                azureFile:
+                  description: AzureFile represents an Azure File Service mount on
+                    the host and bind mount to the pod.
+                  properties:
+                    readOnly:
+                      description: Defaults to false (read/write). ReadOnly here will
+                        force the ReadOnly setting in VolumeMounts.
+                      type: boolean
+                    secretName:
+                      description: the name of secret that contains Azure Storage
+                        Account Name and Key
+                      type: string
+                    shareName:
+                      description: Share Name
+                      type: string
+                  required:
+                  - secretName
+                  - shareName
+                  type: object
+                cephfs:
+                  description: CephFS represents a Ceph FS mount on the host that
+                    shares a pod's lifetime
+                  properties:
+                    monitors:
+                      description: 'Required: Monitors is a collection of Ceph monitors
+                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                      items:
+                        type: string
+                      type: array
+                    path:
+                      description: 'Optional: Used as the mounted root, rather than
+                        the full Ceph tree, default is /'
+                      type: string
+                    readOnly:
+                      description: 'Optional: Defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts. More
+                        info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                      type: boolean
+                    secretFile:
+                      description: 'Optional: SecretFile is the path to key ring for
+                        User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                      type: string
+                    secretRef:
+                      description: 'Optional: SecretRef is reference to the authentication
+                        secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    user:
+                      description: 'Optional: User is the rados user name, default
+                        is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                      type: string
+                  required:
+                  - monitors
+                  type: object
+                cinder:
+                  description: 'Cinder represents a cinder volume attached and mounted
+                    on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                  properties:
+                    fsType:
+                      description: 'Filesystem type to mount. Must be a filesystem
+                        type supported by the host operating system. Examples: "ext4",
+                        "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                      type: string
+                    readOnly:
+                      description: 'Optional: Defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts. More
+                        info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                      type: boolean
+                    secretRef:
+                      description: 'Optional: points to a secret object containing
+                        parameters used to connect to OpenStack.'
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    volumeID:
+                      description: 'volume id used to identify the volume in cinder.
+                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                      type: string
+                  required:
+                  - volumeID
+                  type: object
+                configMap:
+                  description: ConfigMap represents a configMap that should populate
+                    this volume
+                  properties:
+                    defaultMode:
+                      description: 'Optional: mode bits used to set permissions on
+                        created files by default. Must be an octal value between 0000
+                        and 0777 or a decimal value between 0 and 511. YAML accepts
+                        both octal and decimal values, JSON requires decimal values
+                        for mode bits. Defaults to 0644. Directories within the path
+                        are not affected by this setting. This might be in conflict
+                        with other options that affect the file mode, like fsGroup,
+                        and the result can be other mode bits set.'
+                      format: int32
+                      type: integer
+                    items:
+                      description: If unspecified, each key-value pair in the Data
+                        field of the referenced ConfigMap will be projected into the
+                        volume as a file whose name is the key and content is the
+                        value. If specified, the listed keys will be projected into
+                        the specified paths, and unlisted keys will not be present.
+                        If a key is specified which is not present in the ConfigMap,
+                        the volume setup will error unless it is marked optional.
+                        Paths must be relative and may not contain the '..' path or
+                        start with '..'.
+                      items:
+                        description: Maps a string key to a path within a volume.
+                        properties:
+                          key:
+                            description: The key to project.
+                            type: string
+                          mode:
+                            description: 'Optional: mode bits used to set permissions
+                              on this file. Must be an octal value between 0000 and
+                              0777 or a decimal value between 0 and 511. YAML accepts
+                              both octal and decimal values, JSON requires decimal
+                              values for mode bits. If not specified, the volume defaultMode
+                              will be used. This might be in conflict with other options
+                              that affect the file mode, like fsGroup, and the result
+                              can be other mode bits set.'
+                            format: int32
+                            type: integer
+                          path:
+                            description: The relative path of the file to map the
+                              key to. May not be an absolute path. May not contain
+                              the path element '..'. May not start with the string
+                              '..'.
+                            type: string
+                        required:
+                        - key
+                        - path
+                        type: object
+                      type: array
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    optional:
+                      description: Specify whether the ConfigMap or its keys must
+                        be defined
+                      type: boolean
+                  type: object
+                csi:
+                  description: CSI (Container Storage Interface) represents ephemeral
+                    storage that is handled by certain external CSI drivers (Beta
+                    feature).
+                  properties:
+                    driver:
+                      description: Driver is the name of the CSI driver that handles
+                        this volume. Consult with your admin for the correct name
+                        as registered in the cluster.
+                      type: string
+                    fsType:
+                      description: Filesystem type to mount. Ex. "ext4", "xfs", "ntfs".
+                        If not provided, the empty value is passed to the associated
+                        CSI driver which will determine the default filesystem to
+                        apply.
+                      type: string
+                    nodePublishSecretRef:
+                      description: NodePublishSecretRef is a reference to the secret
+                        object containing sensitive information to pass to the CSI
+                        driver to complete the CSI NodePublishVolume and NodeUnpublishVolume
+                        calls. This field is optional, and  may be empty if no secret
+                        is required. If the secret object contains more than one secret,
+                        all secret references are passed.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    readOnly:
+                      description: Specifies a read-only configuration for the volume.
+                        Defaults to false (read/write).
+                      type: boolean
+                    volumeAttributes:
+                      additionalProperties:
+                        type: string
+                      description: VolumeAttributes stores driver-specific properties
+                        that are passed to the CSI driver. Consult your driver's documentation
+                        for supported values.
+                      type: object
+                  required:
+                  - driver
+                  type: object
+                downwardAPI:
+                  description: DownwardAPI represents downward API about the pod that
+                    should populate this volume
+                  properties:
+                    defaultMode:
+                      description: 'Optional: mode bits to use on created files by
+                        default. Must be a Optional: mode bits used to set permissions
+                        on created files by default. Must be an octal value between
+                        0000 and 0777 or a decimal value between 0 and 511. YAML accepts
+                        both octal and decimal values, JSON requires decimal values
+                        for mode bits. Defaults to 0644. Directories within the path
+                        are not affected by this setting. This might be in conflict
+                        with other options that affect the file mode, like fsGroup,
+                        and the result can be other mode bits set.'
+                      format: int32
+                      type: integer
+                    items:
+                      description: Items is a list of downward API volume file
+                      items:
+                        description: DownwardAPIVolumeFile represents information
+                          to create the file containing the pod field
+                        properties:
+                          fieldRef:
+                            description: 'Required: Selects a field of the pod: only
+                              annotations, labels, name and namespace are supported.'
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                            - fieldPath
+                            type: object
+                          mode:
+                            description: 'Optional: mode bits used to set permissions
+                              on this file, must be an octal value between 0000 and
+                              0777 or a decimal value between 0 and 511. YAML accepts
+                              both octal and decimal values, JSON requires decimal
+                              values for mode bits. If not specified, the volume defaultMode
+                              will be used. This might be in conflict with other options
+                              that affect the file mode, like fsGroup, and the result
+                              can be other mode bits set.'
+                            format: int32
+                            type: integer
+                          path:
+                            description: 'Required: Path is  the relative path name
+                              of the file to be created. Must not be absolute or contain
+                              the ''..'' path. Must be utf-8 encoded. The first item
+                              of the relative path must not start with ''..'''
+                            type: string
+                          resourceFieldRef:
+                            description: 'Selects a resource of the container: only
+                              resources limits and requests (limits.cpu, limits.memory,
+                              requests.cpu and requests.memory) are currently supported.'
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Specifies the output format of the exposed
+                                  resources, defaults to "1"
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                            - resource
+                            type: object
+                        required:
+                        - path
+                        type: object
+                      type: array
+                  type: object
+                emptyDir:
+                  description: 'EmptyDir represents a temporary directory that shares
+                    a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                  properties:
+                    medium:
+                      description: 'What type of storage medium should back this directory.
+                        The default is "" which means to use the node''s default medium.
+                        Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                      type: string
+                    sizeLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: 'Total amount of local storage required for this
+                        EmptyDir volume. The size limit is also applicable for memory
+                        medium. The maximum usage on memory medium EmptyDir would
+                        be the minimum value between the SizeLimit specified here
+                        and the sum of memory limits of all containers in a pod. The
+                        default is nil which means that the limit is undefined. More
+                        info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  type: object
+                ephemeral:
+                  description: |-
+                    Ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+
+                    Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+                       tracking are needed,
+                    c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+                       a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                       information on the connection between this volume type
+                       and PersistentVolumeClaim).
+
+                    Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+
+                    Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+
+                    A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+
+                    This is a beta feature and only available when the GenericEphemeralVolume feature gate is enabled.
+                  properties:
+                    volumeClaimTemplate:
+                      description: |-
+                        Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+
+                        An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+
+                        This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+
+                        Required, must not be nil.
+                      properties:
+                        metadata:
+                          description: May contain labels and annotations that will
+                            be copied into the PVC when creating it. No other fields
+                            are allowed and will be rejected during validation.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        spec:
+                          description: The specification for the PersistentVolumeClaim.
+                            The entire content is copied unchanged into the PVC that
+                            gets created from this template. The same fields as in
+                            a PersistentVolumeClaim are also valid here.
+                          properties:
+                            accessModes:
+                              description: 'AccessModes contains the desired access
+                                modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                              items:
+                                type: string
+                              type: array
+                            dataSource:
+                              description: 'This field can be used to specify either:
+                                * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                * An existing PVC (PersistentVolumeClaim) * An existing
+                                custom resource that implements data population (Alpha)
+                                In order to use custom resource types that implement
+                                data population, the AnyVolumeDataSource feature gate
+                                must be enabled. If the provisioner or an external
+                                controller can support the specified data source,
+                                it will create a new volume based on the contents
+                                of the specified data source.'
+                              properties:
+                                apiGroup:
+                                  description: APIGroup is the group for the resource
+                                    being referenced. If APIGroup is not specified,
+                                    the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being
+                                    referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being
+                                    referenced
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            resources:
+                              description: 'Resources represents the minimum resources
+                                the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                              type: object
+                            selector:
+                              description: A label query over volumes to consider
+                                for binding.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            storageClassName:
+                              description: 'Name of the StorageClass required by the
+                                claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                              type: string
+                            volumeMode:
+                              description: volumeMode defines what type of volume
+                                is required by the claim. Value of Filesystem is implied
+                                when not included in claim spec.
+                              type: string
+                            volumeName:
+                              description: VolumeName is the binding reference to
+                                the PersistentVolume backing this claim.
+                              type: string
+                          type: object
+                      required:
+                      - spec
+                      type: object
+                  type: object
+                fc:
+                  description: FC represents a Fibre Channel resource that is attached
+                    to a kubelet's host machine and then exposed to the pod.
+                  properties:
+                    fsType:
+                      description: Filesystem type to mount. Must be a filesystem
+                        type supported by the host operating system. Ex. "ext4", "xfs",
+                        "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                      type: string
+                    lun:
+                      description: 'Optional: FC target lun number'
+                      format: int32
+                      type: integer
+                    readOnly:
+                      description: 'Optional: Defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts.'
+                      type: boolean
+                    targetWWNs:
+                      description: 'Optional: FC target worldwide names (WWNs)'
+                      items:
+                        type: string
+                      type: array
+                    wwids:
+                      description: 'Optional: FC volume world wide identifiers (wwids)
+                        Either wwids or combination of targetWWNs and lun must be
+                        set, but not both simultaneously.'
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                flexVolume:
+                  description: FlexVolume represents a generic volume resource that
+                    is provisioned/attached using an exec based plugin.
+                  properties:
+                    driver:
+                      description: Driver is the name of the driver to use for this
+                        volume.
+                      type: string
+                    fsType:
+                      description: Filesystem type to mount. Must be a filesystem
+                        type supported by the host operating system. Ex. "ext4", "xfs",
+                        "ntfs". The default filesystem depends on FlexVolume script.
+                      type: string
+                    options:
+                      additionalProperties:
+                        type: string
+                      description: 'Optional: Extra command options if any.'
+                      type: object
+                    readOnly:
+                      description: 'Optional: Defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts.'
+                      type: boolean
+                    secretRef:
+                      description: 'Optional: SecretRef is reference to the secret
+                        object containing sensitive information to pass to the plugin
+                        scripts. This may be empty if no secret object is specified.
+                        If the secret object contains more than one secret, all secrets
+                        are passed to the plugin scripts.'
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                  required:
+                  - driver
+                  type: object
+                flocker:
+                  description: Flocker represents a Flocker volume attached to a kubelet's
+                    host machine. This depends on the Flocker control service being
+                    running
+                  properties:
+                    datasetName:
+                      description: Name of the dataset stored as metadata -> name
+                        on the dataset for Flocker should be considered as deprecated
+                      type: string
+                    datasetUUID:
+                      description: UUID of the dataset. This is unique identifier
+                        of a Flocker dataset
+                      type: string
+                  type: object
+                gcePersistentDisk:
+                  description: 'GCEPersistentDisk represents a GCE Disk resource that
+                    is attached to a kubelet''s host machine and then exposed to the
+                    pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                  properties:
+                    fsType:
+                      description: 'Filesystem type of the volume that you want to
+                        mount. Tip: Ensure that the filesystem type is supported by
+                        the host operating system. Examples: "ext4", "xfs", "ntfs".
+                        Implicitly inferred to be "ext4" if unspecified. More info:
+                        https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                      type: string
+                    partition:
+                      description: 'The partition in the volume that you want to mount.
+                        If omitted, the default is to mount by volume name. Examples:
+                        For volume /dev/sda1, you specify the partition as "1". Similarly,
+                        the volume partition for /dev/sda is "0" (or you can leave
+                        the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                      format: int32
+                      type: integer
+                    pdName:
+                      description: 'Unique name of the PD resource in GCE. Used to
+                        identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                      type: string
+                    readOnly:
+                      description: 'ReadOnly here will force the ReadOnly setting
+                        in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                      type: boolean
+                  required:
+                  - pdName
+                  type: object
+                gitRepo:
+                  description: 'GitRepo represents a git repository at a particular
+                    revision. DEPRECATED: GitRepo is deprecated. To provision a container
+                    with a git repo, mount an EmptyDir into an InitContainer that
+                    clones the repo using git, then mount the EmptyDir into the Pod''s
+                    container.'
+                  properties:
+                    directory:
+                      description: Target directory name. Must not contain or start
+                        with '..'.  If '.' is supplied, the volume directory will
+                        be the git repository.  Otherwise, if specified, the volume
+                        will contain the git repository in the subdirectory with the
+                        given name.
+                      type: string
+                    repository:
+                      description: Repository URL
+                      type: string
+                    revision:
+                      description: Commit hash for the specified revision.
+                      type: string
+                  required:
+                  - repository
+                  type: object
+                glusterfs:
+                  description: 'Glusterfs represents a Glusterfs mount on the host
+                    that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                  properties:
+                    endpoints:
+                      description: 'EndpointsName is the endpoint name that details
+                        Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                      type: string
+                    path:
+                      description: 'Path is the Glusterfs volume path. More info:
+                        https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                      type: string
+                    readOnly:
+                      description: 'ReadOnly here will force the Glusterfs volume
+                        to be mounted with read-only permissions. Defaults to false.
+                        More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                      type: boolean
+                  required:
+                  - endpoints
+                  - path
+                  type: object
+                hostPath:
+                  description: 'HostPath represents a pre-existing file or directory
+                    on the host machine that is directly exposed to the container.
+                    This is generally used for system agents or other privileged things
+                    that are allowed to see the host machine. Most containers will
+                    NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                  properties:
+                    path:
+                      description: 'Path of the directory on the host. If the path
+                        is a symlink, it will follow the link to the real path. More
+                        info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                      type: string
+                    type:
+                      description: 'Type for HostPath Volume Defaults to "" More info:
+                        https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                      type: string
+                  required:
+                  - path
+                  type: object
+                iscsi:
+                  description: 'ISCSI represents an ISCSI Disk resource that is attached
+                    to a kubelet''s host machine and then exposed to the pod. More
+                    info: https://examples.k8s.io/volumes/iscsi/README.md'
+                  properties:
+                    chapAuthDiscovery:
+                      description: whether support iSCSI Discovery CHAP authentication
+                      type: boolean
+                    chapAuthSession:
+                      description: whether support iSCSI Session CHAP authentication
+                      type: boolean
+                    fsType:
+                      description: 'Filesystem type of the volume that you want to
+                        mount. Tip: Ensure that the filesystem type is supported by
+                        the host operating system. Examples: "ext4", "xfs", "ntfs".
+                        Implicitly inferred to be "ext4" if unspecified. More info:
+                        https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                      type: string
+                    initiatorName:
+                      description: Custom iSCSI Initiator Name. If initiatorName is
+                        specified with iscsiInterface simultaneously, new iSCSI interface
+                        <target portal>:<volume name> will be created for the connection.
+                      type: string
+                    iqn:
+                      description: Target iSCSI Qualified Name.
+                      type: string
+                    iscsiInterface:
+                      description: iSCSI Interface Name that uses an iSCSI transport.
+                        Defaults to 'default' (tcp).
+                      type: string
+                    lun:
+                      description: iSCSI Target Lun number.
+                      format: int32
+                      type: integer
+                    portals:
+                      description: iSCSI Target Portal List. The portal is either
+                        an IP or ip_addr:port if the port is other than default (typically
+                        TCP ports 860 and 3260).
+                      items:
+                        type: string
+                      type: array
+                    readOnly:
+                      description: ReadOnly here will force the ReadOnly setting in
+                        VolumeMounts. Defaults to false.
+                      type: boolean
+                    secretRef:
+                      description: CHAP Secret for iSCSI target and initiator authentication
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    targetPortal:
+                      description: iSCSI Target Portal. The Portal is either an IP
+                        or ip_addr:port if the port is other than default (typically
+                        TCP ports 860 and 3260).
+                      type: string
+                  required:
+                  - targetPortal
+                  - iqn
+                  - lun
+                  type: object
+                name:
+                  description: 'Volume''s name. Must be a DNS_LABEL and unique within
+                    the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                nfs:
+                  description: 'NFS represents an NFS mount on the host that shares
+                    a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                  properties:
+                    path:
+                      description: 'Path that is exported by the NFS server. More
+                        info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                      type: string
+                    readOnly:
+                      description: 'ReadOnly here will force the NFS export to be
+                        mounted with read-only permissions. Defaults to false. More
+                        info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                      type: boolean
+                    server:
+                      description: 'Server is the hostname or IP address of the NFS
+                        server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                      type: string
+                  required:
+                  - server
+                  - path
+                  type: object
+                persistentVolumeClaim:
+                  description: 'PersistentVolumeClaimVolumeSource represents a reference
+                    to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                  properties:
+                    claimName:
+                      description: 'ClaimName is the name of a PersistentVolumeClaim
+                        in the same namespace as the pod using this volume. More info:
+                        https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                      type: string
+                    readOnly:
+                      description: Will force the ReadOnly setting in VolumeMounts.
+                        Default false.
+                      type: boolean
+                  required:
+                  - claimName
+                  type: object
+                photonPersistentDisk:
+                  description: PhotonPersistentDisk represents a PhotonController
+                    persistent disk attached and mounted on kubelets host machine
+                  properties:
+                    fsType:
+                      description: Filesystem type to mount. Must be a filesystem
+                        type supported by the host operating system. Ex. "ext4", "xfs",
+                        "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                      type: string
+                    pdID:
+                      description: ID that identifies Photon Controller persistent
+                        disk
+                      type: string
+                  required:
+                  - pdID
+                  type: object
+                portworxVolume:
+                  description: PortworxVolume represents a portworx volume attached
+                    and mounted on kubelets host machine
+                  properties:
+                    fsType:
+                      description: FSType represents the filesystem type to mount
+                        Must be a filesystem type supported by the host operating
+                        system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
+                        if unspecified.
+                      type: string
+                    readOnly:
+                      description: Defaults to false (read/write). ReadOnly here will
+                        force the ReadOnly setting in VolumeMounts.
+                      type: boolean
+                    volumeID:
+                      description: VolumeID uniquely identifies a Portworx volume
+                      type: string
+                  required:
+                  - volumeID
+                  type: object
+                projected:
+                  description: Items for all in one resources secrets, configmaps,
+                    and downward API
+                  properties:
+                    defaultMode:
+                      description: Mode bits used to set permissions on created files
+                        by default. Must be an octal value between 0000 and 0777 or
+                        a decimal value between 0 and 511. YAML accepts both octal
+                        and decimal values, JSON requires decimal values for mode
+                        bits. Directories within the path are not affected by this
+                        setting. This might be in conflict with other options that
+                        affect the file mode, like fsGroup, and the result can be
+                        other mode bits set.
+                      format: int32
+                      type: integer
+                    sources:
+                      description: list of volume projections
+                      items:
+                        description: Projection that may be projected along with other
+                          supported volume types
+                        properties:
+                          configMap:
+                            description: information about the configMap data to project
+                            properties:
+                              items:
+                                description: If unspecified, each key-value pair in
+                                  the Data field of the referenced ConfigMap will
+                                  be projected into the volume as a file whose name
+                                  is the key and content is the value. If specified,
+                                  the listed keys will be projected into the specified
+                                  paths, and unlisted keys will not be present. If
+                                  a key is specified which is not present in the ConfigMap,
+                                  the volume setup will error unless it is marked
+                                  optional. Paths must be relative and may not contain
+                                  the '..' path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: The key to project.
+                                      type: string
+                                    mode:
+                                      description: 'Optional: mode bits used to set
+                                        permissions on this file. Must be an octal
+                                        value between 0000 and 0777 or a decimal value
+                                        between 0 and 511. YAML accepts both octal
+                                        and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: The relative path of the file to
+                                        map the key to. May not be an absolute path.
+                                        May not contain the path element '..'. May
+                                        not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its
+                                  keys must be defined
+                                type: boolean
+                            type: object
+                          downwardAPI:
+                            description: information about the downwardAPI data to
+                              project
+                            properties:
+                              items:
+                                description: Items is a list of DownwardAPIVolume
+                                  file
+                                items:
+                                  description: DownwardAPIVolumeFile represents information
+                                    to create the file containing the pod field
+                                  properties:
+                                    fieldRef:
+                                      description: 'Required: Selects a field of the
+                                        pod: only annotations, labels, name and namespace
+                                        are supported.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    mode:
+                                      description: 'Optional: mode bits used to set
+                                        permissions on this file, must be an octal
+                                        value between 0000 and 0777 or a decimal value
+                                        between 0 and 511. YAML accepts both octal
+                                        and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: 'Required: Path is  the relative
+                                        path name of the file to be created. Must
+                                        not be absolute or contain the ''..'' path.
+                                        Must be utf-8 encoded. The first item of the
+                                        relative path must not start with ''..'''
+                                      type: string
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, requests.cpu and requests.memory)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                  required:
+                                  - path
+                                  type: object
+                                type: array
+                            type: object
+                          secret:
+                            description: information about the secret data to project
+                            properties:
+                              items:
+                                description: If unspecified, each key-value pair in
+                                  the Data field of the referenced Secret will be
+                                  projected into the volume as a file whose name is
+                                  the key and content is the value. If specified,
+                                  the listed keys will be projected into the specified
+                                  paths, and unlisted keys will not be present. If
+                                  a key is specified which is not present in the Secret,
+                                  the volume setup will error unless it is marked
+                                  optional. Paths must be relative and may not contain
+                                  the '..' path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: The key to project.
+                                      type: string
+                                    mode:
+                                      description: 'Optional: mode bits used to set
+                                        permissions on this file. Must be an octal
+                                        value between 0000 and 0777 or a decimal value
+                                        between 0 and 511. YAML accepts both octal
+                                        and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: The relative path of the file to
+                                        map the key to. May not be an absolute path.
+                                        May not contain the path element '..'. May
+                                        not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            type: object
+                          serviceAccountToken:
+                            description: information about the serviceAccountToken
+                              data to project
+                            properties:
+                              audience:
+                                description: Audience is the intended audience of
+                                  the token. A recipient of a token must identify
+                                  itself with an identifier specified in the audience
+                                  of the token, and otherwise should reject the token.
+                                  The audience defaults to the identifier of the apiserver.
+                                type: string
+                              expirationSeconds:
+                                description: ExpirationSeconds is the requested duration
+                                  of validity of the service account token. As the
+                                  token approaches expiration, the kubelet volume
+                                  plugin will proactively rotate the service account
+                                  token. The kubelet will start trying to rotate the
+                                  token if the token is older than 80 percent of its
+                                  time to live or if the token is older than 24 hours.Defaults
+                                  to 1 hour and must be at least 10 minutes.
+                                format: int64
+                                type: integer
+                              path:
+                                description: Path is the path relative to the mount
+                                  point of the file to project the token into.
+                                type: string
+                            required:
+                            - path
+                            type: object
+                        type: object
+                      type: array
+                  type: object
+                quobyte:
+                  description: Quobyte represents a Quobyte mount on the host that
+                    shares a pod's lifetime
+                  properties:
+                    group:
+                      description: Group to map volume access to Default is no group
+                      type: string
+                    readOnly:
+                      description: ReadOnly here will force the Quobyte volume to
+                        be mounted with read-only permissions. Defaults to false.
+                      type: boolean
+                    registry:
+                      description: Registry represents a single or multiple Quobyte
+                        Registry services specified as a string as host:port pair
+                        (multiple entries are separated with commas) which acts as
+                        the central registry for volumes
+                      type: string
+                    tenant:
+                      description: Tenant owning the given Quobyte volume in the Backend
+                        Used with dynamically provisioned Quobyte volumes, value is
+                        set by the plugin
+                      type: string
+                    user:
+                      description: User to map volume access to Defaults to serivceaccount
+                        user
+                      type: string
+                    volume:
+                      description: Volume is a string that references an already created
+                        Quobyte volume by name.
+                      type: string
+                  required:
+                  - registry
+                  - volume
+                  type: object
+                rbd:
+                  description: 'RBD represents a Rados Block Device mount on the host
+                    that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                  properties:
+                    fsType:
+                      description: 'Filesystem type of the volume that you want to
+                        mount. Tip: Ensure that the filesystem type is supported by
+                        the host operating system. Examples: "ext4", "xfs", "ntfs".
+                        Implicitly inferred to be "ext4" if unspecified. More info:
+                        https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                      type: string
+                    image:
+                      description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      type: string
+                    keyring:
+                      description: 'Keyring is the path to key ring for RBDUser. Default
+                        is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      type: string
+                    monitors:
+                      description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      items:
+                        type: string
+                      type: array
+                    pool:
+                      description: 'The rados pool name. Default is rbd. More info:
+                        https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      type: string
+                    readOnly:
+                      description: 'ReadOnly here will force the ReadOnly setting
+                        in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      type: boolean
+                    secretRef:
+                      description: 'SecretRef is name of the authentication secret
+                        for RBDUser. If provided overrides keyring. Default is nil.
+                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    user:
+                      description: 'The rados user name. Default is admin. More info:
+                        https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      type: string
+                  required:
+                  - monitors
+                  - image
+                  type: object
+                scaleIO:
+                  description: ScaleIO represents a ScaleIO persistent volume attached
+                    and mounted on Kubernetes nodes.
+                  properties:
+                    fsType:
+                      description: Filesystem type to mount. Must be a filesystem
+                        type supported by the host operating system. Ex. "ext4", "xfs",
+                        "ntfs". Default is "xfs".
+                      type: string
+                    gateway:
+                      description: The host address of the ScaleIO API Gateway.
+                      type: string
+                    protectionDomain:
+                      description: The name of the ScaleIO Protection Domain for the
+                        configured storage.
+                      type: string
+                    readOnly:
+                      description: Defaults to false (read/write). ReadOnly here will
+                        force the ReadOnly setting in VolumeMounts.
+                      type: boolean
+                    secretRef:
+                      description: SecretRef references to the secret for ScaleIO
+                        user and other sensitive information. If this is not provided,
+                        Login operation will fail.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    sslEnabled:
+                      description: Flag to enable/disable SSL communication with Gateway,
+                        default false
+                      type: boolean
+                    storageMode:
+                      description: Indicates whether the storage for a volume should
+                        be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                      type: string
+                    storagePool:
+                      description: The ScaleIO Storage Pool associated with the protection
+                        domain.
+                      type: string
+                    system:
+                      description: The name of the storage system as configured in
+                        ScaleIO.
+                      type: string
+                    volumeName:
+                      description: The name of a volume already created in the ScaleIO
+                        system that is associated with this volume source.
+                      type: string
+                  required:
+                  - gateway
+                  - system
+                  - secretRef
+                  type: object
+                secret:
+                  description: 'Secret represents a secret that should populate this
+                    volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                  properties:
+                    defaultMode:
+                      description: 'Optional: mode bits used to set permissions on
+                        created files by default. Must be an octal value between 0000
+                        and 0777 or a decimal value between 0 and 511. YAML accepts
+                        both octal and decimal values, JSON requires decimal values
+                        for mode bits. Defaults to 0644. Directories within the path
+                        are not affected by this setting. This might be in conflict
+                        with other options that affect the file mode, like fsGroup,
+                        and the result can be other mode bits set.'
+                      format: int32
+                      type: integer
+                    items:
+                      description: If unspecified, each key-value pair in the Data
+                        field of the referenced Secret will be projected into the
+                        volume as a file whose name is the key and content is the
+                        value. If specified, the listed keys will be projected into
+                        the specified paths, and unlisted keys will not be present.
+                        If a key is specified which is not present in the Secret,
+                        the volume setup will error unless it is marked optional.
+                        Paths must be relative and may not contain the '..' path or
+                        start with '..'.
+                      items:
+                        description: Maps a string key to a path within a volume.
+                        properties:
+                          key:
+                            description: The key to project.
+                            type: string
+                          mode:
+                            description: 'Optional: mode bits used to set permissions
+                              on this file. Must be an octal value between 0000 and
+                              0777 or a decimal value between 0 and 511. YAML accepts
+                              both octal and decimal values, JSON requires decimal
+                              values for mode bits. If not specified, the volume defaultMode
+                              will be used. This might be in conflict with other options
+                              that affect the file mode, like fsGroup, and the result
+                              can be other mode bits set.'
+                            format: int32
+                            type: integer
+                          path:
+                            description: The relative path of the file to map the
+                              key to. May not be an absolute path. May not contain
+                              the path element '..'. May not start with the string
+                              '..'.
+                            type: string
+                        required:
+                        - key
+                        - path
+                        type: object
+                      type: array
+                    optional:
+                      description: Specify whether the Secret or its keys must be
+                        defined
+                      type: boolean
+                    secretName:
+                      description: 'Name of the secret in the pod''s namespace to
+                        use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                      type: string
+                  type: object
+                storageos:
+                  description: StorageOS represents a StorageOS volume attached and
+                    mounted on Kubernetes nodes.
+                  properties:
+                    fsType:
+                      description: Filesystem type to mount. Must be a filesystem
+                        type supported by the host operating system. Ex. "ext4", "xfs",
+                        "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                      type: string
+                    readOnly:
+                      description: Defaults to false (read/write). ReadOnly here will
+                        force the ReadOnly setting in VolumeMounts.
+                      type: boolean
+                    secretRef:
+                      description: SecretRef specifies the secret to use for obtaining
+                        the StorageOS API credentials.  If not specified, default
+                        values will be attempted.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    volumeName:
+                      description: VolumeName is the human-readable name of the StorageOS
+                        volume.  Volume names are only unique within a namespace.
+                      type: string
+                    volumeNamespace:
+                      description: VolumeNamespace specifies the scope of the volume
+                        within StorageOS.  If no namespace is specified then the Pod's
+                        namespace will be used.  This allows the Kubernetes name scoping
+                        to be mirrored within StorageOS for tighter integration. Set
+                        VolumeName to any name to override the default behaviour.
+                        Set to "default" if you are not using namespaces within StorageOS.
+                        Namespaces that do not pre-exist within StorageOS will be
+                        created.
+                      type: string
+                  type: object
+                vsphereVolume:
+                  description: VsphereVolume represents a vSphere volume attached
+                    and mounted on kubelets host machine
+                  properties:
+                    fsType:
+                      description: Filesystem type to mount. Must be a filesystem
+                        type supported by the host operating system. Ex. "ext4", "xfs",
+                        "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                      type: string
+                    storagePolicyID:
+                      description: Storage Policy Based Management (SPBM) profile
+                        ID associated with the StoragePolicyName.
+                      type: string
+                    storagePolicyName:
+                      description: Storage Policy Based Management (SPBM) profile
+                        name.
+                      type: string
+                    volumePath:
+                      description: Path that identifies vSphere volume vmdk
+                      type: string
+                  required:
+                  - volumePath
+                  type: object
+              required:
+              - name
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - name
+            x-kubernetes-list-type: map
+        required:
+        - containers
+        type: object
+      status:
+        description: 'Most recently observed status of the pod. This data may not
+          be up to date. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+        properties:
+          conditions:
+            description: 'Current service state of pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions'
+            items:
+              description: PodCondition contains details for the current condition
+                of this pod.
+              properties:
+                lastProbeTime:
+                  description: Last time we probed the condition.
+                  format: date-time
+                  type: string
+                lastTransitionTime:
+                  description: Last time the condition transitioned from one status
+                    to another.
+                  format: date-time
+                  type: string
+                message:
+                  description: Human-readable message indicating details about last
+                    transition.
+                  type: string
+                reason:
+                  description: Unique, one-word, CamelCase reason for the condition's
+                    last transition.
+                  type: string
+                status:
+                  description: 'Status is the status of the condition. Can be True,
+                    False, Unknown. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions'
+                  type: string
+                type:
+                  description: 'Type is the type of the condition. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions'
+                  type: string
+              required:
+              - status
+              - type
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - type
+            x-kubernetes-list-type: map
+          containerStatuses:
+            description: 'The list has one entry per container in the manifest. Each
+              entry is currently the output of `docker inspect`. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status'
+            items:
+              description: ContainerStatus contains details for the current status
+                of this container.
+              properties:
+                containerID:
+                  description: Container's ID in the format 'docker://<container_id>'.
+                  type: string
+                image:
+                  description: 'The image the container is running. More info: https://kubernetes.io/docs/concepts/containers/images'
+                  type: string
+                imageID:
+                  description: ImageID of the container's image.
+                  type: string
+                lastState:
+                  description: Details about the container's last termination condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format 'docker://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+                name:
+                  description: This must be a DNS_LABEL. Each container in a pod must
+                    have a unique name. Cannot be updated.
+                  type: string
+                ready:
+                  description: Specifies whether the container has passed its readiness
+                    probe.
+                  type: boolean
+                restartCount:
+                  description: The number of times the container has been restarted,
+                    currently based on the number of dead containers that have not
+                    yet been removed. Note that this is calculated from dead containers.
+                    But those containers are subject to garbage collection. This value
+                    will get capped at 5 by GC.
+                  format: int32
+                  type: integer
+                started:
+                  description: Specifies whether the container has passed its startup
+                    probe. Initialized as false, becomes true after startupProbe is
+                    considered successful. Resets to false when the container is restarted,
+                    or if kubelet loses state temporarily. Is always true when no
+                    startupProbe is defined.
+                  type: boolean
+                state:
+                  description: Details about the container's current condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format 'docker://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+              required:
+              - name
+              - ready
+              - restartCount
+              - image
+              - imageID
+              type: object
+            type: array
+          ephemeralContainerStatuses:
+            description: Status for any ephemeral containers that have run in this
+              pod. This field is alpha-level and is only populated by servers that
+              enable the EphemeralContainers feature.
+            items:
+              description: ContainerStatus contains details for the current status
+                of this container.
+              properties:
+                containerID:
+                  description: Container's ID in the format 'docker://<container_id>'.
+                  type: string
+                image:
+                  description: 'The image the container is running. More info: https://kubernetes.io/docs/concepts/containers/images'
+                  type: string
+                imageID:
+                  description: ImageID of the container's image.
+                  type: string
+                lastState:
+                  description: Details about the container's last termination condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format 'docker://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+                name:
+                  description: This must be a DNS_LABEL. Each container in a pod must
+                    have a unique name. Cannot be updated.
+                  type: string
+                ready:
+                  description: Specifies whether the container has passed its readiness
+                    probe.
+                  type: boolean
+                restartCount:
+                  description: The number of times the container has been restarted,
+                    currently based on the number of dead containers that have not
+                    yet been removed. Note that this is calculated from dead containers.
+                    But those containers are subject to garbage collection. This value
+                    will get capped at 5 by GC.
+                  format: int32
+                  type: integer
+                started:
+                  description: Specifies whether the container has passed its startup
+                    probe. Initialized as false, becomes true after startupProbe is
+                    considered successful. Resets to false when the container is restarted,
+                    or if kubelet loses state temporarily. Is always true when no
+                    startupProbe is defined.
+                  type: boolean
+                state:
+                  description: Details about the container's current condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format 'docker://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+              required:
+              - name
+              - ready
+              - restartCount
+              - image
+              - imageID
+              type: object
+            type: array
+          hostIP:
+            description: IP address of the host to which the pod is assigned. Empty
+              if not yet scheduled.
+            type: string
+          initContainerStatuses:
+            description: 'The list has one entry per init container in the manifest.
+              The most recent successful init container will have ready = true, the
+              most recently started container will have startTime set. More info:
+              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status'
+            items:
+              description: ContainerStatus contains details for the current status
+                of this container.
+              properties:
+                containerID:
+                  description: Container's ID in the format 'docker://<container_id>'.
+                  type: string
+                image:
+                  description: 'The image the container is running. More info: https://kubernetes.io/docs/concepts/containers/images'
+                  type: string
+                imageID:
+                  description: ImageID of the container's image.
+                  type: string
+                lastState:
+                  description: Details about the container's last termination condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format 'docker://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+                name:
+                  description: This must be a DNS_LABEL. Each container in a pod must
+                    have a unique name. Cannot be updated.
+                  type: string
+                ready:
+                  description: Specifies whether the container has passed its readiness
+                    probe.
+                  type: boolean
+                restartCount:
+                  description: The number of times the container has been restarted,
+                    currently based on the number of dead containers that have not
+                    yet been removed. Note that this is calculated from dead containers.
+                    But those containers are subject to garbage collection. This value
+                    will get capped at 5 by GC.
+                  format: int32
+                  type: integer
+                started:
+                  description: Specifies whether the container has passed its startup
+                    probe. Initialized as false, becomes true after startupProbe is
+                    considered successful. Resets to false when the container is restarted,
+                    or if kubelet loses state temporarily. Is always true when no
+                    startupProbe is defined.
+                  type: boolean
+                state:
+                  description: Details about the container's current condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format 'docker://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+              required:
+              - name
+              - ready
+              - restartCount
+              - image
+              - imageID
+              type: object
+            type: array
+          message:
+            description: A human readable message indicating details about why the
+              pod is in this condition.
+            type: string
+          nominatedNodeName:
+            description: nominatedNodeName is set only when this pod preempts other
+              pods on the node, but it cannot be scheduled right away as preemption
+              victims receive their graceful termination periods. This field does
+              not guarantee that the pod will be scheduled on this node. Scheduler
+              may decide to place the pod elsewhere if other nodes become available
+              sooner. Scheduler may also decide to give the resources on this node
+              to a higher priority pod that is created after preemption. As a result,
+              this field may be different than PodSpec.nodeName when the pod is scheduled.
+            type: string
+          phase:
+            description: |-
+              The phase of a Pod is a simple, high-level summary of where the Pod is in its lifecycle. The conditions array, the reason and message fields, and the individual container status arrays contain more detail about the pod's status. There are five possible phase values:
+
+              Pending: The pod has been accepted by the Kubernetes system, but one or more of the container images has not been created. This includes time before being scheduled as well as time spent downloading images over the network, which could take a while. Running: The pod has been bound to a node, and all of the containers have been created. At least one container is still running, or is in the process of starting or restarting. Succeeded: All containers in the pod have terminated in success, and will not be restarted. Failed: All containers in the pod have terminated, and at least one container has terminated in failure. The container either exited with non-zero status or was terminated by the system. Unknown: For some reason the state of the pod could not be obtained, typically due to an error in communicating with the host of the pod.
+
+              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-phase
+            type: string
+          podIP:
+            description: IP address allocated to the pod. Routable at least within
+              the cluster. Empty if not yet allocated.
+            type: string
+          podIPs:
+            description: podIPs holds the IP addresses allocated to the pod. If this
+              field is specified, the 0th entry must match the podIP field. Pods may
+              be allocated at most 1 value for each of IPv4 and IPv6. This list is
+              empty if no IPs have been allocated yet.
+            items:
+              description: |-
+                IP address information for entries in the (plural) PodIPs field. Each entry includes:
+                   IP: An IP address allocated to the pod. Routable at least within the cluster.
+              properties:
+                ip:
+                  description: ip is an IP address (IPv4 or IPv6) assigned to the
+                    pod
+                  type: string
+              required:
+              - ip
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - ip
+            x-kubernetes-list-type: map
+          qosClass:
+            description: 'The Quality of Service (QOS) classification assigned to
+              the pod based on resource requirements See PodQOSClass type for available
+              QOS classes More info: https://git.k8s.io/community/contributors/design-proposals/node/resource-qos.md'
+            type: string
+          reason:
+            description: A brief CamelCase message indicating details about why the
+              pod is in this state. e.g. 'Evicted'
+            type: string
+          startTime:
+            description: RFC 3339 date and time at which the object was acknowledged
+              by the Kubelet. This is before the Kubelet pulled the container image(s)
+              for the pod.
+            format: date-time
+            type: string
+        type: object
+    type: object
+  plural: pods
+  schemaUpdateStrategy: UpdateUnpublished
+  scope: Namespaced
+  shortNames:
+  - po
+  singular: pod
+  subResources:
+  - name: status
+status:
+  conditions:
+  - lastTransitionTime: "2023-03-20T19:08:21Z"
+    status: "True"
+    type: Compatible

--- a/docs/content/concepts/scenarios/jn-scenario/yamls/4-APIResourceImport-services.jn.v1.core.yaml
+++ b/docs/content/concepts/scenarios/jn-scenario/yamls/4-APIResourceImport-services.jn.v1.core.yaml
@@ -1,0 +1,438 @@
+apiVersion: apiresource.kcp.io/v1alpha1
+kind: APIResourceImport
+metadata:
+  annotations:
+    apiresource.kcp.io/apiVersion: v1
+    kcp.io/cluster: 49adf4fn8ks8x43u
+  creationTimestamp: "2023-03-20T19:08:21Z"
+  generation: 1
+  name: services.jn.v1.core
+  ownerReferences:
+  - apiVersion: workload.kcp.io/v1alpha1
+    controller: true
+    kind: SyncTarget
+    name: jn
+    uid: 72de24eb-7d49-4aca-be22-63f95548a816
+  resourceVersion: "771"
+  uid: 34638d12-4421-4b05-83f9-d770f5109aa0
+spec:
+  categories:
+  - all
+  groupVersion:
+    version: v1
+  kind: Service
+  listKind: ServiceList
+  location: jn
+  openAPIV3Schema:
+    description: Service is a named abstraction of software service (for example,
+      mysql) consisting of local port (for example 3306) that the proxy listens on,
+      and the selector that determines which pods will answer requests sent through
+      the proxy.
+    properties:
+      apiVersion:
+        description: 'APIVersion defines the versioned schema of this representation
+          of an object. Servers should convert recognized schemas to the latest internal
+          value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+        type: string
+      kind:
+        description: 'Kind is a string value representing the REST resource this object
+          represents. Servers may infer this from the endpoint the client submits
+          requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+        type: string
+      metadata:
+        type: object
+      spec:
+        description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        properties:
+          allocateLoadBalancerNodePorts:
+            description: allocateLoadBalancerNodePorts defines if NodePorts will be
+              automatically allocated for services with type LoadBalancer.  Default
+              is "true". It may be set to "false" if the cluster load-balancer does
+              not rely on NodePorts. allocateLoadBalancerNodePorts may only be set
+              for services with type LoadBalancer and will be cleared if the type
+              is changed to any other type. This field is alpha-level and is only
+              honored by servers that enable the ServiceLBNodePortControl feature.
+            type: boolean
+          clusterIP:
+            description: 'clusterIP is the IP address of the service and is usually
+              assigned randomly. If an address is specified manually, is in-range
+              (as per system configuration), and is not in use, it will be allocated
+              to the service; otherwise creation of the service will fail. This field
+              may not be changed through updates unless the type field is also being
+              changed to ExternalName (which requires this field to be blank) or the
+              type field is being changed from ExternalName (in which case this field
+              may optionally be specified, as describe above).  Valid values are "None",
+              empty string (""), or a valid IP address. Setting this to "None" makes
+              a "headless service" (no virtual IP), which is useful when direct endpoint
+              connections are preferred and proxying is not required.  Only applies
+              to types ClusterIP, NodePort, and LoadBalancer. If this field is specified
+              when creating a Service of type ExternalName, creation will fail. This
+              field will be wiped when updating a Service to type ExternalName. More
+              info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+            type: string
+          clusterIPs:
+            description: |-
+              ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address.  Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value.
+
+              Unless the "IPv6DualStack" feature gate is enabled, this field is limited to one value, which must be the same as the clusterIP field.  If the feature gate is enabled, this field may hold a maximum of two entries (dual-stack IPs, in either order).  These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+            items:
+              type: string
+            type: array
+            x-kubernetes-list-type: atomic
+          externalIPs:
+            description: externalIPs is a list of IP addresses for which nodes in
+              the cluster will also accept traffic for this service.  These IPs are
+              not managed by Kubernetes.  The user is responsible for ensuring that
+              traffic arrives at a node with this IP.  A common example is external
+              load-balancers that are not part of the Kubernetes system.
+            items:
+              type: string
+            type: array
+          externalName:
+            description: externalName is the external reference that discovery mechanisms
+              will return as an alias for this service (e.g. a DNS CNAME record).
+              No proxying will be involved.  Must be a lowercase RFC-1123 hostname
+              (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
+            type: string
+          externalTrafficPolicy:
+            description: externalTrafficPolicy denotes if this Service desires to
+              route external traffic to node-local or cluster-wide endpoints. "Local"
+              preserves the client source IP and avoids a second hop for LoadBalancer
+              and Nodeport type services, but risks potentially imbalanced traffic
+              spreading. "Cluster" obscures the client source IP and may cause a second
+              hop to another node, but should have good overall load-spreading.
+            type: string
+          healthCheckNodePort:
+            description: healthCheckNodePort specifies the healthcheck nodePort for
+              the service. This only applies when type is set to LoadBalancer and
+              externalTrafficPolicy is set to Local. If a value is specified, is in-range,
+              and is not in use, it will be used.  If not specified, a value will
+              be automatically allocated.  External systems (e.g. load-balancers)
+              can use this port to determine if a given node holds endpoints for this
+              service or not.  If this field is specified when creating a Service
+              which does not need it, creation will fail. This field will be wiped
+              when updating a Service to no longer need it (e.g. changing type).
+            format: int32
+            type: integer
+          internalTrafficPolicy:
+            description: InternalTrafficPolicy specifies if the cluster internal traffic
+              should be routed to all endpoints or node-local endpoints only. "Cluster"
+              routes internal traffic to a Service to all endpoints. "Local" routes
+              traffic to node-local endpoints only, traffic is dropped if no node-local
+              endpoints are ready. The default value is "Cluster".
+            type: string
+          ipFamilies:
+            description: |-
+              IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service, and is gated by the "IPv6DualStack" feature gate.  This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail.  This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service.  Valid values are "IPv4" and "IPv6".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to "headless" services.  This field will be wiped when updating a Service to type ExternalName.
+
+              This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field.
+            items:
+              type: string
+            type: array
+            x-kubernetes-list-type: atomic
+          ipFamilyPolicy:
+            description: IPFamilyPolicy represents the dual-stack-ness requested or
+              required by this Service, and is gated by the "IPv6DualStack" feature
+              gate.  If there is no value provided, then this field will be set to
+              SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack"
+              (two IP families on dual-stack configured clusters or a single IP family
+              on single-stack clusters), or "RequireDualStack" (two IP families on
+              dual-stack configured clusters, otherwise fail). The ipFamilies and
+              clusterIPs fields depend on the value of this field.  This field will
+              be wiped when updating a service to type ExternalName.
+            type: string
+          loadBalancerClass:
+            description: loadBalancerClass is the class of the load balancer implementation
+              this Service belongs to. If specified, the value of this field must
+              be a label-style identifier, with an optional prefix, e.g. "internal-vip"
+              or "example.com/internal-vip". Unprefixed names are reserved for end-users.
+              This field can only be set when the Service type is 'LoadBalancer'.
+              If not set, the default load balancer implementation is used, today
+              this is typically done through the cloud provider integration, but should
+              apply for any default implementation. If set, it is assumed that a load
+              balancer implementation is watching for Services with a matching class.
+              Any default load balancer implementation (e.g. cloud providers) should
+              ignore Services that set this field. This field can only be set when
+              creating or updating a Service to type 'LoadBalancer'. Once set, it
+              can not be changed. This field will be wiped when a service is updated
+              to a non 'LoadBalancer' type.
+            type: string
+          loadBalancerIP:
+            description: 'Only applies to Service Type: LoadBalancer LoadBalancer
+              will get created with the IP specified in this field. This feature depends
+              on whether the underlying cloud-provider supports specifying the loadBalancerIP
+              when a load balancer is created. This field will be ignored if the cloud-provider
+              does not support the feature.'
+            type: string
+          loadBalancerSourceRanges:
+            description: 'If specified and supported by the platform, this will restrict
+              traffic through the cloud-provider load-balancer will be restricted
+              to the specified client IPs. This field will be ignored if the cloud-provider
+              does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+            items:
+              type: string
+            type: array
+          ports:
+            description: 'The list of ports that are exposed by this service. More
+              info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+            items:
+              description: ServicePort contains information on service's port.
+              properties:
+                appProtocol:
+                  description: The application protocol for this port. This field
+                    follows standard Kubernetes label syntax. Un-prefixed names are
+                    reserved for IANA standard service names (as per RFC-6335 and
+                    http://www.iana.org/assignments/service-names). Non-standard protocols
+                    should use prefixed names such as mycompany.com/my-custom-protocol.
+                    This is a beta field that is guarded by the ServiceAppProtocol
+                    feature gate and enabled by default.
+                  type: string
+                name:
+                  description: The name of this port within the service. This must
+                    be a DNS_LABEL. All ports within a ServiceSpec must have unique
+                    names. When considering the endpoints for a Service, this must
+                    match the 'name' field in the EndpointPort. Optional if only one
+                    ServicePort is defined on this service.
+                  type: string
+                nodePort:
+                  description: 'The port on each node on which this service is exposed
+                    when type is NodePort or LoadBalancer.  Usually assigned by the
+                    system. If a value is specified, in-range, and not in use it will
+                    be used, otherwise the operation will fail.  If not specified,
+                    a port will be allocated if this Service requires one.  If this
+                    field is specified when creating a Service which does not need
+                    it, creation will fail. This field will be wiped when updating
+                    a Service to no longer need it (e.g. changing type from NodePort
+                    to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                  format: int32
+                  type: integer
+                port:
+                  description: The port that will be exposed by this service.
+                  format: int32
+                  type: integer
+                protocol:
+                  default: TCP
+                  description: The IP protocol for this port. Supports "TCP", "UDP",
+                    and "SCTP". Default is TCP.
+                  type: string
+                targetPort:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: 'Number or name of the port to access on the pods targeted
+                    by the service. Number must be in the range 1 to 65535. Name must
+                    be an IANA_SVC_NAME. If this is a string, it will be looked up
+                    as a named port in the target Pod''s container ports. If this
+                    is not specified, the value of the ''port'' field is used (an
+                    identity map). This field is ignored for services with clusterIP=None,
+                    and should be omitted or set equal to the ''port'' field. More
+                    info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                  x-kubernetes-int-or-string: true
+              required:
+              - port
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - port
+            - protocol
+            x-kubernetes-list-type: map
+          publishNotReadyAddresses:
+            description: publishNotReadyAddresses indicates that any agent which deals
+              with endpoints for this Service should disregard any indications of
+              ready/not-ready. The primary use case for setting this field is for
+              a StatefulSet's Headless Service to propagate SRV DNS records for its
+              Pods for the purpose of peer discovery. The Kubernetes controllers that
+              generate Endpoints and EndpointSlice resources for Services interpret
+              this to mean that all endpoints are considered "ready" even if the Pods
+              themselves are not. Agents which consume only Kubernetes generated endpoints
+              through the Endpoints or EndpointSlice resources can safely assume this
+              behavior.
+            type: boolean
+          selector:
+            additionalProperties:
+              type: string
+            description: 'Route service traffic to pods with label keys and values
+              matching this selector. If empty or not present, the service is assumed
+              to have an external process managing its endpoints, which Kubernetes
+              will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer.
+              Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+            type: object
+          sessionAffinity:
+            description: 'Supports "ClientIP" and "None". Used to maintain session
+              affinity. Enable client IP based session affinity. Must be ClientIP
+              or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+            type: string
+          sessionAffinityConfig:
+            description: sessionAffinityConfig contains the configurations of session
+              affinity.
+            properties:
+              clientIP:
+                description: clientIP contains the configurations of Client IP based
+                  session affinity.
+                properties:
+                  timeoutSeconds:
+                    description: timeoutSeconds specifies the seconds of ClientIP
+                      type session sticky time. The value must be >0 && <=86400(for
+                      1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for
+                      3 hours).
+                    format: int32
+                    type: integer
+                type: object
+            type: object
+          topologyKeys:
+            description: topologyKeys is a preference-order list of topology keys
+              which implementations of services should use to preferentially sort
+              endpoints when accessing this Service, it can not be used at the same
+              time as externalTrafficPolicy=Local. Topology keys must be valid label
+              keys and at most 16 keys may be specified. Endpoints are chosen based
+              on the first topology key with available backends. If this field is
+              specified and all entries have no backends that match the topology of
+              the client, the service has no backends for that client and connections
+              should fail. The special value "*" may be used to mean "any topology".
+              This catch-all value, if used, only makes sense as the last value in
+              the list. If this is not specified or empty, no topology constraints
+              will be applied. This field is alpha-level and is only honored by servers
+              that enable the ServiceTopology feature. This field is deprecated and
+              will be removed in a future version.
+            items:
+              type: string
+            type: array
+          type:
+            description: 'type determines how the Service is exposed. Defaults to
+              ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and
+              LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for
+              load-balancing to endpoints. Endpoints are determined by the selector
+              or if that is not specified, by manual construction of an Endpoints
+              object or EndpointSlice objects. If clusterIP is "None", no virtual
+              IP is allocated and the endpoints are published as a set of endpoints
+              rather than a virtual IP. "NodePort" builds on ClusterIP and allocates
+              a port on every node which routes to the same endpoints as the clusterIP.
+              "LoadBalancer" builds on NodePort and creates an external load-balancer
+              (if supported in the current cloud) which routes to the same endpoints
+              as the clusterIP. "ExternalName" aliases this service to the specified
+              externalName. Several other fields do not apply to ExternalName services.
+              More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+            type: string
+        type: object
+      status:
+        description: 'Most recently observed status of the service. Populated by the
+          system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+        properties:
+          conditions:
+            description: Current service state
+            items:
+              description: Condition contains details for one aspect of the current
+                state of this API Resource.
+              properties:
+                lastTransitionTime:
+                  description: lastTransitionTime is the last time the condition transitioned
+                    from one status to another. This should be when the underlying
+                    condition changed.  If that is not known, then using the time
+                    when the API field changed is acceptable.
+                  format: date-time
+                  type: string
+                message:
+                  description: message is a human readable message indicating details
+                    about the transition. This may be an empty string.
+                  type: string
+                observedGeneration:
+                  description: observedGeneration represents the .metadata.generation
+                    that the condition was set based upon. For instance, if .metadata.generation
+                    is currently 12, but the .status.conditions[x].observedGeneration
+                    is 9, the condition is out of date with respect to the current
+                    state of the instance.
+                  format: int64
+                  type: integer
+                reason:
+                  description: reason contains a programmatic identifier indicating
+                    the reason for the condition's last transition. Producers of specific
+                    condition types may define expected values and meanings for this
+                    field, and whether the values are considered a guaranteed API.
+                    The value should be a CamelCase string. This field may not be
+                    empty.
+                  type: string
+                status:
+                  description: status of the condition, one of True, False, Unknown.
+                  type: string
+                type:
+                  description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                  type: string
+              required:
+              - lastTransitionTime
+              - message
+              - reason
+              - status
+              - type
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - type
+            x-kubernetes-list-type: map
+          loadBalancer:
+            description: LoadBalancer contains the current status of the load-balancer,
+              if one is present.
+            properties:
+              ingress:
+                description: Ingress is a list containing ingress points for the load-balancer.
+                  Traffic intended for the service should be sent to these ingress
+                  points.
+                items:
+                  description: 'LoadBalancerIngress represents the status of a load-balancer
+                    ingress point: traffic intended for the service should be sent
+                    to an ingress point.'
+                  properties:
+                    hostname:
+                      description: Hostname is set for load-balancer ingress points
+                        that are DNS based (typically AWS load-balancers)
+                      type: string
+                    ip:
+                      description: IP is set for load-balancer ingress points that
+                        are IP based (typically GCE or OpenStack load-balancers)
+                      type: string
+                    ports:
+                      description: Ports is a list of records of service ports If
+                        used, every port defined in the service should have an entry
+                        in it
+                      items:
+                        properties:
+                          error:
+                            description: |-
+                              Error is to record the problem with the service port The format of the error shall comply with the following rules: - built-in error values shall be specified in this file and those shall use
+                                CamelCase names
+                              - cloud provider specific error values must have names that comply with the
+                                format foo.example.com/CamelCase.
+                            type: string
+                          port:
+                            description: Port is the port number of the service port
+                              of which status is recorded here
+                            format: int32
+                            type: integer
+                          protocol:
+                            description: 'Protocol is the protocol of the service
+                              port of which status is recorded here The supported
+                              values are: "TCP", "UDP", "SCTP"'
+                            type: string
+                        required:
+                        - port
+                        - protocol
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  type: object
+                type: array
+            type: object
+        type: object
+    type: object
+  plural: services
+  schemaUpdateStrategy: UpdateUnpublished
+  scope: Namespaced
+  shortNames:
+  - svc
+  singular: service
+  subResources:
+  - name: status
+status:
+  conditions:
+  - lastTransitionTime: "2023-03-20T19:08:21Z"
+    status: "True"
+    type: Compatible

--- a/docs/content/concepts/scenarios/jn-scenario/yamls/4-NegotiatedAPIResource-deployments.v1.apps.yaml
+++ b/docs/content/concepts/scenarios/jn-scenario/yamls/4-NegotiatedAPIResource-deployments.v1.apps.yaml
@@ -1,0 +1,6576 @@
+apiVersion: apiresource.kcp.io/v1alpha1
+kind: NegotiatedAPIResource
+metadata:
+  annotations:
+    apiresource.kcp.io/apiVersion: apps/v1
+    kcp.io/cluster: 49adf4fn8ks8x43u
+  creationTimestamp: "2023-03-20T19:08:21Z"
+  generation: 1
+  name: deployments.v1.apps
+  resourceVersion: "788"
+  uid: 52e8939a-bf9b-4a7d-8b8f-f1f4a2483446
+spec:
+  categories:
+  - all
+  groupVersion:
+    group: apps
+    version: v1
+  kind: Deployment
+  listKind: DeploymentList
+  openAPIV3Schema:
+    description: Deployment enables declarative updates for Pods and ReplicaSets.
+    properties:
+      apiVersion:
+        description: 'APIVersion defines the versioned schema of this representation
+          of an object. Servers should convert recognized schemas to the latest internal
+          value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+        type: string
+      kind:
+        description: 'Kind is a string value representing the REST resource this object
+          represents. Servers may infer this from the endpoint the client submits
+          requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+        type: string
+      metadata:
+        type: object
+      spec:
+        description: Specification of the desired behavior of the Deployment.
+        properties:
+          minReadySeconds:
+            description: Minimum number of seconds for which a newly created pod should
+              be ready without any of its container crashing, for it to be considered
+              available. Defaults to 0 (pod will be considered available as soon as
+              it is ready)
+            format: int32
+            type: integer
+          paused:
+            description: Indicates that the deployment is paused.
+            type: boolean
+          progressDeadlineSeconds:
+            description: The maximum time in seconds for a deployment to make progress
+              before it is considered to be failed. The deployment controller will
+              continue to process failed deployments and a condition with a ProgressDeadlineExceeded
+              reason will be surfaced in the deployment status. Note that progress
+              will not be estimated during the time a deployment is paused. Defaults
+              to 600s.
+            format: int32
+            type: integer
+          replicas:
+            description: Number of desired pods. This is a pointer to distinguish
+              between explicit zero and not specified. Defaults to 1.
+            format: int32
+            type: integer
+          revisionHistoryLimit:
+            description: The number of old ReplicaSets to retain to allow rollback.
+              This is a pointer to distinguish between explicit zero and not specified.
+              Defaults to 10.
+            format: int32
+            type: integer
+          selector:
+            description: Label selector for pods. Existing ReplicaSets whose pods
+              are selected by this will be the ones affected by this deployment. It
+              must match the pod template's labels.
+            properties:
+              matchExpressions:
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
+                items:
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
+                  properties:
+                    key:
+                      description: key is the label key that the selector applies
+                        to.
+                      type: string
+                    operator:
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      type: string
+                    values:
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - key
+                  - operator
+                  type: object
+                type: array
+              matchLabels:
+                additionalProperties:
+                  type: string
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
+                type: object
+            type: object
+          strategy:
+            description: The deployment strategy to use to replace existing pods with
+              new ones.
+            properties:
+              rollingUpdate:
+                description: Rolling update config params. Present only if DeploymentStrategyType
+                  = RollingUpdate.
+                properties:
+                  maxSurge:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'The maximum number of pods that can be scheduled
+                      above the desired number of pods. Value can be an absolute number
+                      (ex: 5) or a percentage of desired pods (ex: 10%). This can
+                      not be 0 if MaxUnavailable is 0. Absolute number is calculated
+                      from percentage by rounding up. Defaults to 25%. Example: when
+                      this is set to 30%, the new ReplicaSet can be scaled up immediately
+                      when the rolling update starts, such that the total number of
+                      old and new pods do not exceed 130% of desired pods. Once old
+                      pods have been killed, new ReplicaSet can be scaled up further,
+                      ensuring that total number of pods running at any time during
+                      the update is at most 130% of desired pods.'
+                    x-kubernetes-int-or-string: true
+                  maxUnavailable:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'The maximum number of pods that can be unavailable
+                      during the update. Value can be an absolute number (ex: 5) or
+                      a percentage of desired pods (ex: 10%). Absolute number is calculated
+                      from percentage by rounding down. This can not be 0 if MaxSurge
+                      is 0. Defaults to 25%. Example: when this is set to 30%, the
+                      old ReplicaSet can be scaled down to 70% of desired pods immediately
+                      when the rolling update starts. Once new pods are ready, old
+                      ReplicaSet can be scaled down further, followed by scaling up
+                      the new ReplicaSet, ensuring that the total number of pods available
+                      at all times during the update is at least 70% of desired pods.'
+                    x-kubernetes-int-or-string: true
+                type: object
+              type:
+                description: Type of deployment. Can be "Recreate" or "RollingUpdate".
+                  Default is RollingUpdate.
+                type: string
+            type: object
+          template:
+            description: Template describes the pods that will be created.
+            properties:
+              metadata:
+                description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              spec:
+                description: 'Specification of the desired behavior of the pod. More
+                  info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                properties:
+                  activeDeadlineSeconds:
+                    description: Optional duration in seconds the pod may be active
+                      on the node relative to StartTime before the system will actively
+                      try to mark it failed and kill associated containers. Value
+                      must be a positive integer.
+                    format: int64
+                    type: integer
+                  affinity:
+                    description: If specified, the pod's scheduling constraints
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for
+                          the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node matches the corresponding matchExpressions;
+                              the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches
+                                all objects with implicit weight 0 (i.e. it's a no-op).
+                                A null preferred scheduling term matches no objects
+                                (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators
+                                              are In, NotIn, Exists, DoesNotExist.
+                                              Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators
+                                              are In, NotIn, Exists, DoesNotExist.
+                                              Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the
+                                    corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - weight
+                              - preference
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by
+                              this field are not met at scheduling time, the pod will
+                              not be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from
+                              its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term
+                                    matches no objects. The requirements of them are
+                                    ANDed. The TopologySelectorTerm type implements
+                                    a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators
+                                              are In, NotIn, Exists, DoesNotExist.
+                                              Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators
+                                              are In, NotIn, Exists, DoesNotExist.
+                                              Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g.
+                          co-locate this pod in the same node, zone, etc. as some
+                          other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node has pods which matches the corresponding
+                              podAffinityTerm; the node(s) with the highest sum are
+                              the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces. This
+                                        field is alpha-level and is only honored when
+                                        PodAffinityNamespaceSelector feature is enabled.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the
+                                    corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - weight
+                              - podAffinityTerm
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by
+                              this field are not met at scheduling time, the pod will
+                              not be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to a pod label update),
+                              the system may or may not try to eventually evict the
+                              pod from its node. When there are multiple elements,
+                              the lists of nodes corresponding to each podAffinityTerm
+                              are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located
+                                is defined as running on a node whose value of the
+                                label with key <topologyKey> matches that of any node
+                                on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces. This field is alpha-level
+                                    and is only honored when PodAffinityNamespaceSelector
+                                    feature is enabled.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules
+                          (e.g. avoid putting this pod in the same node, zone, etc.
+                          as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the anti-affinity expressions
+                              specified by this field, but it may choose a node that
+                              violates one or more of the expressions. The node that
+                              is most preferred is the one with the greatest sum of
+                              weights, i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              anti-affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node has pods which matches the corresponding
+                              podAffinityTerm; the node(s) with the highest sum are
+                              the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces. This
+                                        field is alpha-level and is only honored when
+                                        PodAffinityNamespaceSelector feature is enabled.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the
+                                    corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - weight
+                              - podAffinityTerm
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified
+                              by this field are not met at scheduling time, the pod
+                              will not be scheduled onto the node. If the anti-affinity
+                              requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod
+                              label update), the system may or may not try to eventually
+                              evict the pod from its node. When there are multiple
+                              elements, the lists of nodes corresponding to each podAffinityTerm
+                              are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located
+                                is defined as running on a node whose value of the
+                                label with key <topologyKey> matches that of any node
+                                on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces. This field is alpha-level
+                                    and is only honored when PodAffinityNamespaceSelector
+                                    feature is enabled.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  automountServiceAccountToken:
+                    description: AutomountServiceAccountToken indicates whether a
+                      service account token should be automatically mounted.
+                    type: boolean
+                  containers:
+                    description: List of containers belonging to the pod. Containers
+                      cannot currently be added or removed. There must be at least
+                      one container in a Pod. Cannot be updated.
+                    items:
+                      description: A single application container that you want to
+                        run within a pod.
+                      properties:
+                        args:
+                          description: 'Arguments to the entrypoint. The docker image''s
+                            CMD is used if this is not provided. Variable references
+                            $(VAR_NAME) are expanded using the container''s environment.
+                            If a variable cannot be resolved, the reference in the
+                            input string will be unchanged. The $(VAR_NAME) syntax
+                            can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                            references will never be expanded, regardless of whether
+                            the variable exists or not. Cannot be updated. More info:
+                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: 'Entrypoint array. Not executed within a shell.
+                            The docker image''s ENTRYPOINT is used if this is not
+                            provided. Variable references $(VAR_NAME) are expanded
+                            using the container''s environment. If a variable cannot
+                            be resolved, the reference in the input string will be
+                            unchanged. The $(VAR_NAME) syntax can be escaped with
+                            a double $$, ie: $$(VAR_NAME). Escaped references will
+                            never be expanded, regardless of whether the variable
+                            exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the
+                            container. Cannot be updated.
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previous defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  The $(VAR_NAME) syntax can be escaped with a double
+                                  $$, ie: $$(VAR_NAME). Escaped references will never
+                                  be expanded, regardless of whether the variable
+                                  exists or not. Defaults to "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's
+                                  value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container. The keys defined within a source must
+                            be a C_IDENTIFIER. All invalid keys will be reported as
+                            an event when the container is starting. When a key exists
+                            in multiple sources, the value associated with the last
+                            source will take precedence. Values defined by an Env
+                            with a duplicate key will take precedence. Cannot be updated.
+                          items:
+                            description: EnvFromSource represents the source of a
+                              set of ConfigMaps
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must
+                                      be defined
+                                    type: boolean
+                                type: object
+                              prefix:
+                                description: An optional identifier to prepend to
+                                  each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be
+                                      defined
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                            This field is optional to allow higher level config management
+                            to default or override container images in workload controllers
+                            like Deployments and StatefulSets.'
+                          type: string
+                        imagePullPolicy:
+                          description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                            Defaults to Always if :latest tag is specified, or IfNotPresent
+                            otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                          type: string
+                        lifecycle:
+                          description: Actions that the management system should take
+                            in response to container lifecycle events. Cannot be updated.
+                          properties:
+                            postStart:
+                              description: 'PostStart is called immediately after
+                                a container is created. If the handler fails, the
+                                container is terminated and restarted according to
+                                its restart policy. Other management of the container
+                                blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            preStop:
+                              description: 'PreStop is called immediately before a
+                                container is terminated due to an API request or management
+                                event such as liveness/startup probe failure, preemption,
+                                resource contention, etc. The handler is not called
+                                if the container crashes or exits. The reason for
+                                termination is passed to the handler. The Pod''s termination
+                                grace period countdown begins before the PreStop hooked
+                                is executed. Regardless of the outcome of the handler,
+                                the container will eventually terminate within the
+                                Pod''s termination grace period. Other management
+                                of the container blocks until the hook completes or
+                                until the termination grace period is reached. More
+                                info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                          type: object
+                        livenessProbe:
+                          description: 'Periodic probe of container liveness. Container
+                            will be restarted if the probe fails. Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                an alpha field and requires enabling ProbeTerminationGracePeriod
+                                feature gate.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: Name of the container specified as a DNS_LABEL.
+                            Each container in a pod must have a unique name (DNS_LABEL).
+                            Cannot be updated.
+                          type: string
+                        ports:
+                          description: List of ports to expose from the container.
+                            Exposing a port here gives the system additional information
+                            about the network connections a container uses, but is
+                            primarily informational. Not specifying a port here DOES
+                            NOT prevent that port from being exposed. Any port which
+                            is listening on the default "0.0.0.0" address inside a
+                            container will be accessible from the network. Cannot
+                            be updated.
+                          items:
+                            description: ContainerPort represents a network port in
+                              a single container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's
+                                  IP address. This must be a valid port number, 0
+                                  < x < 65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port
+                                  to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host.
+                                  If specified, this must be a valid port number,
+                                  0 < x < 65536. If HostNetwork is specified, this
+                                  must match ContainerPort. Most containers do not
+                                  need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a
+                                  pod must have a unique name. Name for the port that
+                                  can be referred to by services.
+                                type: string
+                              protocol:
+                                default: TCP
+                                description: Protocol for port. Must be UDP, TCP,
+                                  or SCTP. Defaults to "TCP".
+                                type: string
+                            required:
+                            - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - containerPort
+                          - protocol
+                          x-kubernetes-list-type: map
+                        readinessProbe:
+                          description: 'Periodic probe of container service readiness.
+                            Container will be removed from service endpoints if the
+                            probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                an alpha field and requires enabling ProbeTerminationGracePeriod
+                                feature gate.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          description: 'Compute Resources required by this container.
+                            Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        securityContext:
+                          description: 'Security options the pod should run with.
+                            More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                            More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                          properties:
+                            allowPrivilegeEscalation:
+                              description: 'AllowPrivilegeEscalation controls whether
+                                a process can gain more privileges than its parent
+                                process. This bool directly controls if the no_new_privs
+                                flag will be set on the container process. AllowPrivilegeEscalation
+                                is true always when the container is: 1) run as Privileged
+                                2) has CAP_SYS_ADMIN'
+                              type: boolean
+                            capabilities:
+                              description: The capabilities to add/drop when running
+                                containers. Defaults to the default set of capabilities
+                                granted by the container runtime.
+                              properties:
+                                add:
+                                  description: Added capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                                drop:
+                                  description: Removed capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            privileged:
+                              description: Run container in privileged mode. Processes
+                                in privileged containers are essentially equivalent
+                                to root on the host. Defaults to false.
+                              type: boolean
+                            procMount:
+                              description: procMount denotes the type of proc mount
+                                to use for the containers. The default is DefaultProcMount
+                                which uses the container runtime defaults for readonly
+                                paths and masked paths. This requires the ProcMountType
+                                feature flag to be enabled.
+                              type: string
+                            readOnlyRootFilesystem:
+                              description: Whether this container has a read-only
+                                root filesystem. Default is false.
+                              type: boolean
+                            runAsGroup:
+                              description: The GID to run the entrypoint of the container
+                                process. Uses runtime default if unset. May also be
+                                set in PodSecurityContext.  If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              description: Indicates that the container must run as
+                                a non-root user. If true, the Kubelet will validate
+                                the image at runtime to ensure that it does not run
+                                as UID 0 (root) and fail to start the container if
+                                it does. If unset or false, no such validation will
+                                be performed. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                              type: boolean
+                            runAsUser:
+                              description: The UID to run the entrypoint of the container
+                                process. Defaults to user specified in image metadata
+                                if unspecified. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              description: The SELinux context to be applied to the
+                                container. If unspecified, the container runtime will
+                                allocate a random SELinux context for each container.  May
+                                also be set in PodSecurityContext.  If set in both
+                                SecurityContext and PodSecurityContext, the value
+                                specified in SecurityContext takes precedence.
+                              properties:
+                                level:
+                                  description: Level is SELinux level label that applies
+                                    to the container.
+                                  type: string
+                                role:
+                                  description: Role is a SELinux role label that applies
+                                    to the container.
+                                  type: string
+                                type:
+                                  description: Type is a SELinux type label that applies
+                                    to the container.
+                                  type: string
+                                user:
+                                  description: User is a SELinux user label that applies
+                                    to the container.
+                                  type: string
+                              type: object
+                            seccompProfile:
+                              description: The seccomp options to use by this container.
+                                If seccomp options are provided at both the pod &
+                                container level, the container options override the
+                                pod options.
+                              properties:
+                                localhostProfile:
+                                  description: localhostProfile indicates a profile
+                                    defined in a file on the node should be used.
+                                    The profile must be preconfigured on the node
+                                    to work. Must be a descending path, relative to
+                                    the kubelet's configured seccomp profile location.
+                                    Must only be set if type is "Localhost".
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                    Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            windowsOptions:
+                              description: The Windows specific settings applied to
+                                all containers. If unspecified, the options from the
+                                PodSecurityContext will be used. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
+                              properties:
+                                gmsaCredentialSpec:
+                                  description: GMSACredentialSpec is where the GMSA
+                                    admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                    inlines the contents of the GMSA credential spec
+                                    named by the GMSACredentialSpecName field.
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  description: GMSACredentialSpecName is the name
+                                    of the GMSA credential spec to use.
+                                  type: string
+                                runAsUserName:
+                                  description: The UserName in Windows to run the
+                                    entrypoint of the container process. Defaults
+                                    to the user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  type: string
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: 'StartupProbe indicates that the Pod has successfully
+                            initialized. If specified, no other probes are executed
+                            until this completes successfully. If this probe fails,
+                            the Pod will be restarted, just as if the livenessProbe
+                            failed. This can be used to provide different probe parameters
+                            at the beginning of a Pod''s lifecycle, when it might
+                            take a long time to load data or warm a cache, than during
+                            steady-state operation. This cannot be updated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                an alpha field and requires enabling ProbeTerminationGracePeriod
+                                feature gate.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        stdin:
+                          description: Whether this container should allocate a buffer
+                            for stdin in the container runtime. If this is not set,
+                            reads from stdin in the container will always result in
+                            EOF. Default is false.
+                          type: boolean
+                        stdinOnce:
+                          description: Whether the container runtime should close
+                            the stdin channel after it has been opened by a single
+                            attach. When stdin is true the stdin stream will remain
+                            open across multiple attach sessions. If stdinOnce is
+                            set to true, stdin is opened on container start, is empty
+                            until the first client attaches to stdin, and then remains
+                            open and accepts data until the client disconnects, at
+                            which time stdin is closed and remains closed until the
+                            container is restarted. If this flag is false, a container
+                            processes that reads from stdin will never receive an
+                            EOF. Default is false
+                          type: boolean
+                        terminationMessagePath:
+                          description: 'Optional: Path at which the file to which
+                            the container''s termination message will be written is
+                            mounted into the container''s filesystem. Message written
+                            is intended to be brief final status, such as an assertion
+                            failure message. Will be truncated by the node if greater
+                            than 4096 bytes. The total message length across all containers
+                            will be limited to 12kb. Defaults to /dev/termination-log.
+                            Cannot be updated.'
+                          type: string
+                        terminationMessagePolicy:
+                          description: Indicate how the termination message should
+                            be populated. File will use the contents of terminationMessagePath
+                            to populate the container status message on both success
+                            and failure. FallbackToLogsOnError will use the last chunk
+                            of container log output if the termination message file
+                            is empty and the container exited with an error. The log
+                            output is limited to 2048 bytes or 80 lines, whichever
+                            is smaller. Defaults to File. Cannot be updated.
+                          type: string
+                        tty:
+                          description: Whether this container should allocate a TTY
+                            for itself, also requires 'stdin' to be true. Default
+                            is false.
+                          type: boolean
+                        volumeDevices:
+                          description: volumeDevices is the list of block devices
+                            to be used by the container.
+                          items:
+                            description: volumeDevice describes a mapping of a raw
+                              block device within a container.
+                            properties:
+                              devicePath:
+                                description: devicePath is the path inside of the
+                                  container that the device will be mapped to.
+                                type: string
+                              name:
+                                description: name must match the name of a persistentVolumeClaim
+                                  in the pod
+                                type: string
+                            required:
+                            - devicePath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - devicePath
+                          x-kubernetes-list-type: map
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                            Cannot be updated.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write
+                                  otherwise (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the
+                                  container's volume should be mounted. Defaults to
+                                  "" (volume's root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from
+                                  which the container's volume should be mounted.
+                                  Behaves similarly to SubPath but environment variable
+                                  references $(VAR_NAME) are expanded using the container's
+                                  environment. Defaults to "" (volume's root). SubPathExpr
+                                  and SubPath are mutually exclusive.
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - mountPath
+                          x-kubernetes-list-type: map
+                        workingDir:
+                          description: Container's working directory. If not specified,
+                            the container runtime's default will be used, which might
+                            be configured in the container image. Cannot be updated.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  dnsConfig:
+                    description: Specifies the DNS parameters of a pod. Parameters
+                      specified here will be merged to the generated DNS configuration
+                      based on DNSPolicy.
+                    properties:
+                      nameservers:
+                        description: A list of DNS name server IP addresses. This
+                          will be appended to the base nameservers generated from
+                          DNSPolicy. Duplicated nameservers will be removed.
+                        items:
+                          type: string
+                        type: array
+                      options:
+                        description: A list of DNS resolver options. This will be
+                          merged with the base options generated from DNSPolicy. Duplicated
+                          entries will be removed. Resolution options given in Options
+                          will override those that appear in the base DNSPolicy.
+                        items:
+                          description: PodDNSConfigOption defines DNS resolver options
+                            of a pod.
+                          properties:
+                            name:
+                              description: Required.
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                      searches:
+                        description: A list of DNS search domains for host-name lookup.
+                          This will be appended to the base search paths generated
+                          from DNSPolicy. Duplicated search paths will be removed.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  dnsPolicy:
+                    description: Set DNS policy for the pod. Defaults to "ClusterFirst".
+                      Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst',
+                      'Default' or 'None'. DNS parameters given in DNSConfig will
+                      be merged with the policy selected with DNSPolicy. To have DNS
+                      options set along with hostNetwork, you have to specify DNS
+                      policy explicitly to 'ClusterFirstWithHostNet'.
+                    type: string
+                  enableServiceLinks:
+                    description: 'EnableServiceLinks indicates whether information
+                      about services should be injected into pod''s environment variables,
+                      matching the syntax of Docker links. Optional: Defaults to true.'
+                    type: boolean
+                  ephemeralContainers:
+                    description: List of ephemeral containers run in this pod. Ephemeral
+                      containers may be run in an existing pod to perform user-initiated
+                      actions such as debugging. This list cannot be specified when
+                      creating a pod, and it cannot be modified by updating the pod
+                      spec. In order to add an ephemeral container to an existing
+                      pod, use the pod's ephemeralcontainers subresource. This field
+                      is alpha-level and is only honored by servers that enable the
+                      EphemeralContainers feature.
+                    items:
+                      description: An EphemeralContainer is a container that may be
+                        added temporarily to an existing pod for user-initiated activities
+                        such as debugging. Ephemeral containers have no resource or
+                        scheduling guarantees, and they will not be restarted when
+                        they exit or when a pod is removed or restarted. If an ephemeral
+                        container causes a pod to exceed its resource allocation,
+                        the pod may be evicted. Ephemeral containers may not be added
+                        by directly updating the pod spec. They must be added via
+                        the pod's ephemeralcontainers subresource, and they will appear
+                        in the pod spec once added. This is an alpha feature enabled
+                        by the EphemeralContainers feature flag.
+                      properties:
+                        args:
+                          description: 'Arguments to the entrypoint. The docker image''s
+                            CMD is used if this is not provided. Variable references
+                            $(VAR_NAME) are expanded using the container''s environment.
+                            If a variable cannot be resolved, the reference in the
+                            input string will be unchanged. The $(VAR_NAME) syntax
+                            can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                            references will never be expanded, regardless of whether
+                            the variable exists or not. Cannot be updated. More info:
+                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: 'Entrypoint array. Not executed within a shell.
+                            The docker image''s ENTRYPOINT is used if this is not
+                            provided. Variable references $(VAR_NAME) are expanded
+                            using the container''s environment. If a variable cannot
+                            be resolved, the reference in the input string will be
+                            unchanged. The $(VAR_NAME) syntax can be escaped with
+                            a double $$, ie: $$(VAR_NAME). Escaped references will
+                            never be expanded, regardless of whether the variable
+                            exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the
+                            container. Cannot be updated.
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previous defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  The $(VAR_NAME) syntax can be escaped with a double
+                                  $$, ie: $$(VAR_NAME). Escaped references will never
+                                  be expanded, regardless of whether the variable
+                                  exists or not. Defaults to "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's
+                                  value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container. The keys defined within a source must
+                            be a C_IDENTIFIER. All invalid keys will be reported as
+                            an event when the container is starting. When a key exists
+                            in multiple sources, the value associated with the last
+                            source will take precedence. Values defined by an Env
+                            with a duplicate key will take precedence. Cannot be updated.
+                          items:
+                            description: EnvFromSource represents the source of a
+                              set of ConfigMaps
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must
+                                      be defined
+                                    type: boolean
+                                type: object
+                              prefix:
+                                description: An optional identifier to prepend to
+                                  each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be
+                                      defined
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                          type: string
+                        imagePullPolicy:
+                          description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                            Defaults to Always if :latest tag is specified, or IfNotPresent
+                            otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                          type: string
+                        lifecycle:
+                          description: Lifecycle is not allowed for ephemeral containers.
+                          properties:
+                            postStart:
+                              description: 'PostStart is called immediately after
+                                a container is created. If the handler fails, the
+                                container is terminated and restarted according to
+                                its restart policy. Other management of the container
+                                blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            preStop:
+                              description: 'PreStop is called immediately before a
+                                container is terminated due to an API request or management
+                                event such as liveness/startup probe failure, preemption,
+                                resource contention, etc. The handler is not called
+                                if the container crashes or exits. The reason for
+                                termination is passed to the handler. The Pod''s termination
+                                grace period countdown begins before the PreStop hooked
+                                is executed. Regardless of the outcome of the handler,
+                                the container will eventually terminate within the
+                                Pod''s termination grace period. Other management
+                                of the container blocks until the hook completes or
+                                until the termination grace period is reached. More
+                                info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                          type: object
+                        livenessProbe:
+                          description: Probes are not allowed for ephemeral containers.
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                an alpha field and requires enabling ProbeTerminationGracePeriod
+                                feature gate.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: Name of the ephemeral container specified as
+                            a DNS_LABEL. This name must be unique among all containers,
+                            init containers and ephemeral containers.
+                          type: string
+                        ports:
+                          description: Ports are not allowed for ephemeral containers.
+                          items:
+                            description: ContainerPort represents a network port in
+                              a single container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's
+                                  IP address. This must be a valid port number, 0
+                                  < x < 65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port
+                                  to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host.
+                                  If specified, this must be a valid port number,
+                                  0 < x < 65536. If HostNetwork is specified, this
+                                  must match ContainerPort. Most containers do not
+                                  need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a
+                                  pod must have a unique name. Name for the port that
+                                  can be referred to by services.
+                                type: string
+                              protocol:
+                                default: TCP
+                                description: Protocol for port. Must be UDP, TCP,
+                                  or SCTP. Defaults to "TCP".
+                                type: string
+                            required:
+                            - containerPort
+                            type: object
+                          type: array
+                        readinessProbe:
+                          description: Probes are not allowed for ephemeral containers.
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                an alpha field and requires enabling ProbeTerminationGracePeriod
+                                feature gate.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          description: Resources are not allowed for ephemeral containers.
+                            Ephemeral containers use spare resources already allocated
+                            to the pod.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        securityContext:
+                          description: SecurityContext is not allowed for ephemeral
+                            containers.
+                          properties:
+                            allowPrivilegeEscalation:
+                              description: 'AllowPrivilegeEscalation controls whether
+                                a process can gain more privileges than its parent
+                                process. This bool directly controls if the no_new_privs
+                                flag will be set on the container process. AllowPrivilegeEscalation
+                                is true always when the container is: 1) run as Privileged
+                                2) has CAP_SYS_ADMIN'
+                              type: boolean
+                            capabilities:
+                              description: The capabilities to add/drop when running
+                                containers. Defaults to the default set of capabilities
+                                granted by the container runtime.
+                              properties:
+                                add:
+                                  description: Added capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                                drop:
+                                  description: Removed capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            privileged:
+                              description: Run container in privileged mode. Processes
+                                in privileged containers are essentially equivalent
+                                to root on the host. Defaults to false.
+                              type: boolean
+                            procMount:
+                              description: procMount denotes the type of proc mount
+                                to use for the containers. The default is DefaultProcMount
+                                which uses the container runtime defaults for readonly
+                                paths and masked paths. This requires the ProcMountType
+                                feature flag to be enabled.
+                              type: string
+                            readOnlyRootFilesystem:
+                              description: Whether this container has a read-only
+                                root filesystem. Default is false.
+                              type: boolean
+                            runAsGroup:
+                              description: The GID to run the entrypoint of the container
+                                process. Uses runtime default if unset. May also be
+                                set in PodSecurityContext.  If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              description: Indicates that the container must run as
+                                a non-root user. If true, the Kubelet will validate
+                                the image at runtime to ensure that it does not run
+                                as UID 0 (root) and fail to start the container if
+                                it does. If unset or false, no such validation will
+                                be performed. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                              type: boolean
+                            runAsUser:
+                              description: The UID to run the entrypoint of the container
+                                process. Defaults to user specified in image metadata
+                                if unspecified. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              description: The SELinux context to be applied to the
+                                container. If unspecified, the container runtime will
+                                allocate a random SELinux context for each container.  May
+                                also be set in PodSecurityContext.  If set in both
+                                SecurityContext and PodSecurityContext, the value
+                                specified in SecurityContext takes precedence.
+                              properties:
+                                level:
+                                  description: Level is SELinux level label that applies
+                                    to the container.
+                                  type: string
+                                role:
+                                  description: Role is a SELinux role label that applies
+                                    to the container.
+                                  type: string
+                                type:
+                                  description: Type is a SELinux type label that applies
+                                    to the container.
+                                  type: string
+                                user:
+                                  description: User is a SELinux user label that applies
+                                    to the container.
+                                  type: string
+                              type: object
+                            seccompProfile:
+                              description: The seccomp options to use by this container.
+                                If seccomp options are provided at both the pod &
+                                container level, the container options override the
+                                pod options.
+                              properties:
+                                localhostProfile:
+                                  description: localhostProfile indicates a profile
+                                    defined in a file on the node should be used.
+                                    The profile must be preconfigured on the node
+                                    to work. Must be a descending path, relative to
+                                    the kubelet's configured seccomp profile location.
+                                    Must only be set if type is "Localhost".
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                    Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            windowsOptions:
+                              description: The Windows specific settings applied to
+                                all containers. If unspecified, the options from the
+                                PodSecurityContext will be used. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
+                              properties:
+                                gmsaCredentialSpec:
+                                  description: GMSACredentialSpec is where the GMSA
+                                    admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                    inlines the contents of the GMSA credential spec
+                                    named by the GMSACredentialSpecName field.
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  description: GMSACredentialSpecName is the name
+                                    of the GMSA credential spec to use.
+                                  type: string
+                                runAsUserName:
+                                  description: The UserName in Windows to run the
+                                    entrypoint of the container process. Defaults
+                                    to the user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  type: string
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: Probes are not allowed for ephemeral containers.
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                an alpha field and requires enabling ProbeTerminationGracePeriod
+                                feature gate.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        stdin:
+                          description: Whether this container should allocate a buffer
+                            for stdin in the container runtime. If this is not set,
+                            reads from stdin in the container will always result in
+                            EOF. Default is false.
+                          type: boolean
+                        stdinOnce:
+                          description: Whether the container runtime should close
+                            the stdin channel after it has been opened by a single
+                            attach. When stdin is true the stdin stream will remain
+                            open across multiple attach sessions. If stdinOnce is
+                            set to true, stdin is opened on container start, is empty
+                            until the first client attaches to stdin, and then remains
+                            open and accepts data until the client disconnects, at
+                            which time stdin is closed and remains closed until the
+                            container is restarted. If this flag is false, a container
+                            processes that reads from stdin will never receive an
+                            EOF. Default is false
+                          type: boolean
+                        targetContainerName:
+                          description: If set, the name of the container from PodSpec
+                            that this ephemeral container targets. The ephemeral container
+                            will be run in the namespaces (IPC, PID, etc) of this
+                            container. If not set then the ephemeral container is
+                            run in whatever namespaces are shared for the pod. Note
+                            that the container runtime must support this feature.
+                          type: string
+                        terminationMessagePath:
+                          description: 'Optional: Path at which the file to which
+                            the container''s termination message will be written is
+                            mounted into the container''s filesystem. Message written
+                            is intended to be brief final status, such as an assertion
+                            failure message. Will be truncated by the node if greater
+                            than 4096 bytes. The total message length across all containers
+                            will be limited to 12kb. Defaults to /dev/termination-log.
+                            Cannot be updated.'
+                          type: string
+                        terminationMessagePolicy:
+                          description: Indicate how the termination message should
+                            be populated. File will use the contents of terminationMessagePath
+                            to populate the container status message on both success
+                            and failure. FallbackToLogsOnError will use the last chunk
+                            of container log output if the termination message file
+                            is empty and the container exited with an error. The log
+                            output is limited to 2048 bytes or 80 lines, whichever
+                            is smaller. Defaults to File. Cannot be updated.
+                          type: string
+                        tty:
+                          description: Whether this container should allocate a TTY
+                            for itself, also requires 'stdin' to be true. Default
+                            is false.
+                          type: boolean
+                        volumeDevices:
+                          description: volumeDevices is the list of block devices
+                            to be used by the container.
+                          items:
+                            description: volumeDevice describes a mapping of a raw
+                              block device within a container.
+                            properties:
+                              devicePath:
+                                description: devicePath is the path inside of the
+                                  container that the device will be mapped to.
+                                type: string
+                              name:
+                                description: name must match the name of a persistentVolumeClaim
+                                  in the pod
+                                type: string
+                            required:
+                            - devicePath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - devicePath
+                          x-kubernetes-list-type: map
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                            Cannot be updated.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write
+                                  otherwise (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the
+                                  container's volume should be mounted. Defaults to
+                                  "" (volume's root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from
+                                  which the container's volume should be mounted.
+                                  Behaves similarly to SubPath but environment variable
+                                  references $(VAR_NAME) are expanded using the container's
+                                  environment. Defaults to "" (volume's root). SubPathExpr
+                                  and SubPath are mutually exclusive.
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - mountPath
+                          x-kubernetes-list-type: map
+                        workingDir:
+                          description: Container's working directory. If not specified,
+                            the container runtime's default will be used, which might
+                            be configured in the container image. Cannot be updated.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  hostAliases:
+                    description: HostAliases is an optional list of hosts and IPs
+                      that will be injected into the pod's hosts file if specified.
+                      This is only valid for non-hostNetwork pods.
+                    items:
+                      description: HostAlias holds the mapping between IP and hostnames
+                        that will be injected as an entry in the pod's hosts file.
+                      properties:
+                        hostnames:
+                          description: Hostnames for the above IP address.
+                          items:
+                            type: string
+                          type: array
+                        ip:
+                          description: IP address of the host file entry.
+                          type: string
+                      required:
+                      - ip
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - ip
+                    x-kubernetes-list-type: map
+                  hostIPC:
+                    description: 'Use the host''s ipc namespace. Optional: Default
+                      to false.'
+                    type: boolean
+                  hostNetwork:
+                    description: Host networking requested for this pod. Use the host's
+                      network namespace. If this option is set, the ports that will
+                      be used must be specified. Default to false.
+                    type: boolean
+                  hostPID:
+                    description: 'Use the host''s pid namespace. Optional: Default
+                      to false.'
+                    type: boolean
+                  hostname:
+                    description: Specifies the hostname of the Pod If not specified,
+                      the pod's hostname will be set to a system-defined value.
+                    type: string
+                  imagePullSecrets:
+                    description: 'ImagePullSecrets is an optional list of references
+                      to secrets in the same namespace to use for pulling any of the
+                      images used by this PodSpec. If specified, these secrets will
+                      be passed to individual puller implementations for them to use.
+                      For example, in the case of docker, only DockerConfig type secrets
+                      are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                    items:
+                      description: LocalObjectReference contains enough information
+                        to let you locate the referenced object inside the same namespace.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  initContainers:
+                    description: 'List of initialization containers belonging to the
+                      pod. Init containers are executed in order prior to containers
+                      being started. If any init container fails, the pod is considered
+                      to have failed and is handled according to its restartPolicy.
+                      The name for an init container or normal container must be unique
+                      among all containers. Init containers may not have Lifecycle
+                      actions, Readiness probes, Liveness probes, or Startup probes.
+                      The resourceRequirements of an init container are taken into
+                      account during scheduling by finding the highest request/limit
+                      for each resource type, and then using the max of of that value
+                      or the sum of the normal containers. Limits are applied to init
+                      containers in a similar fashion. Init containers cannot currently
+                      be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                    items:
+                      description: A single application container that you want to
+                        run within a pod.
+                      properties:
+                        args:
+                          description: 'Arguments to the entrypoint. The docker image''s
+                            CMD is used if this is not provided. Variable references
+                            $(VAR_NAME) are expanded using the container''s environment.
+                            If a variable cannot be resolved, the reference in the
+                            input string will be unchanged. The $(VAR_NAME) syntax
+                            can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                            references will never be expanded, regardless of whether
+                            the variable exists or not. Cannot be updated. More info:
+                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: 'Entrypoint array. Not executed within a shell.
+                            The docker image''s ENTRYPOINT is used if this is not
+                            provided. Variable references $(VAR_NAME) are expanded
+                            using the container''s environment. If a variable cannot
+                            be resolved, the reference in the input string will be
+                            unchanged. The $(VAR_NAME) syntax can be escaped with
+                            a double $$, ie: $$(VAR_NAME). Escaped references will
+                            never be expanded, regardless of whether the variable
+                            exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the
+                            container. Cannot be updated.
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previous defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  The $(VAR_NAME) syntax can be escaped with a double
+                                  $$, ie: $$(VAR_NAME). Escaped references will never
+                                  be expanded, regardless of whether the variable
+                                  exists or not. Defaults to "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's
+                                  value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container. The keys defined within a source must
+                            be a C_IDENTIFIER. All invalid keys will be reported as
+                            an event when the container is starting. When a key exists
+                            in multiple sources, the value associated with the last
+                            source will take precedence. Values defined by an Env
+                            with a duplicate key will take precedence. Cannot be updated.
+                          items:
+                            description: EnvFromSource represents the source of a
+                              set of ConfigMaps
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must
+                                      be defined
+                                    type: boolean
+                                type: object
+                              prefix:
+                                description: An optional identifier to prepend to
+                                  each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be
+                                      defined
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                            This field is optional to allow higher level config management
+                            to default or override container images in workload controllers
+                            like Deployments and StatefulSets.'
+                          type: string
+                        imagePullPolicy:
+                          description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                            Defaults to Always if :latest tag is specified, or IfNotPresent
+                            otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                          type: string
+                        lifecycle:
+                          description: Actions that the management system should take
+                            in response to container lifecycle events. Cannot be updated.
+                          properties:
+                            postStart:
+                              description: 'PostStart is called immediately after
+                                a container is created. If the handler fails, the
+                                container is terminated and restarted according to
+                                its restart policy. Other management of the container
+                                blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            preStop:
+                              description: 'PreStop is called immediately before a
+                                container is terminated due to an API request or management
+                                event such as liveness/startup probe failure, preemption,
+                                resource contention, etc. The handler is not called
+                                if the container crashes or exits. The reason for
+                                termination is passed to the handler. The Pod''s termination
+                                grace period countdown begins before the PreStop hooked
+                                is executed. Regardless of the outcome of the handler,
+                                the container will eventually terminate within the
+                                Pod''s termination grace period. Other management
+                                of the container blocks until the hook completes or
+                                until the termination grace period is reached. More
+                                info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                          type: object
+                        livenessProbe:
+                          description: 'Periodic probe of container liveness. Container
+                            will be restarted if the probe fails. Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                an alpha field and requires enabling ProbeTerminationGracePeriod
+                                feature gate.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: Name of the container specified as a DNS_LABEL.
+                            Each container in a pod must have a unique name (DNS_LABEL).
+                            Cannot be updated.
+                          type: string
+                        ports:
+                          description: List of ports to expose from the container.
+                            Exposing a port here gives the system additional information
+                            about the network connections a container uses, but is
+                            primarily informational. Not specifying a port here DOES
+                            NOT prevent that port from being exposed. Any port which
+                            is listening on the default "0.0.0.0" address inside a
+                            container will be accessible from the network. Cannot
+                            be updated.
+                          items:
+                            description: ContainerPort represents a network port in
+                              a single container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's
+                                  IP address. This must be a valid port number, 0
+                                  < x < 65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port
+                                  to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host.
+                                  If specified, this must be a valid port number,
+                                  0 < x < 65536. If HostNetwork is specified, this
+                                  must match ContainerPort. Most containers do not
+                                  need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a
+                                  pod must have a unique name. Name for the port that
+                                  can be referred to by services.
+                                type: string
+                              protocol:
+                                default: TCP
+                                description: Protocol for port. Must be UDP, TCP,
+                                  or SCTP. Defaults to "TCP".
+                                type: string
+                            required:
+                            - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - containerPort
+                          - protocol
+                          x-kubernetes-list-type: map
+                        readinessProbe:
+                          description: 'Periodic probe of container service readiness.
+                            Container will be removed from service endpoints if the
+                            probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                an alpha field and requires enabling ProbeTerminationGracePeriod
+                                feature gate.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          description: 'Compute Resources required by this container.
+                            Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        securityContext:
+                          description: 'Security options the pod should run with.
+                            More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                            More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                          properties:
+                            allowPrivilegeEscalation:
+                              description: 'AllowPrivilegeEscalation controls whether
+                                a process can gain more privileges than its parent
+                                process. This bool directly controls if the no_new_privs
+                                flag will be set on the container process. AllowPrivilegeEscalation
+                                is true always when the container is: 1) run as Privileged
+                                2) has CAP_SYS_ADMIN'
+                              type: boolean
+                            capabilities:
+                              description: The capabilities to add/drop when running
+                                containers. Defaults to the default set of capabilities
+                                granted by the container runtime.
+                              properties:
+                                add:
+                                  description: Added capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                                drop:
+                                  description: Removed capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            privileged:
+                              description: Run container in privileged mode. Processes
+                                in privileged containers are essentially equivalent
+                                to root on the host. Defaults to false.
+                              type: boolean
+                            procMount:
+                              description: procMount denotes the type of proc mount
+                                to use for the containers. The default is DefaultProcMount
+                                which uses the container runtime defaults for readonly
+                                paths and masked paths. This requires the ProcMountType
+                                feature flag to be enabled.
+                              type: string
+                            readOnlyRootFilesystem:
+                              description: Whether this container has a read-only
+                                root filesystem. Default is false.
+                              type: boolean
+                            runAsGroup:
+                              description: The GID to run the entrypoint of the container
+                                process. Uses runtime default if unset. May also be
+                                set in PodSecurityContext.  If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              description: Indicates that the container must run as
+                                a non-root user. If true, the Kubelet will validate
+                                the image at runtime to ensure that it does not run
+                                as UID 0 (root) and fail to start the container if
+                                it does. If unset or false, no such validation will
+                                be performed. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                              type: boolean
+                            runAsUser:
+                              description: The UID to run the entrypoint of the container
+                                process. Defaults to user specified in image metadata
+                                if unspecified. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              description: The SELinux context to be applied to the
+                                container. If unspecified, the container runtime will
+                                allocate a random SELinux context for each container.  May
+                                also be set in PodSecurityContext.  If set in both
+                                SecurityContext and PodSecurityContext, the value
+                                specified in SecurityContext takes precedence.
+                              properties:
+                                level:
+                                  description: Level is SELinux level label that applies
+                                    to the container.
+                                  type: string
+                                role:
+                                  description: Role is a SELinux role label that applies
+                                    to the container.
+                                  type: string
+                                type:
+                                  description: Type is a SELinux type label that applies
+                                    to the container.
+                                  type: string
+                                user:
+                                  description: User is a SELinux user label that applies
+                                    to the container.
+                                  type: string
+                              type: object
+                            seccompProfile:
+                              description: The seccomp options to use by this container.
+                                If seccomp options are provided at both the pod &
+                                container level, the container options override the
+                                pod options.
+                              properties:
+                                localhostProfile:
+                                  description: localhostProfile indicates a profile
+                                    defined in a file on the node should be used.
+                                    The profile must be preconfigured on the node
+                                    to work. Must be a descending path, relative to
+                                    the kubelet's configured seccomp profile location.
+                                    Must only be set if type is "Localhost".
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                    Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            windowsOptions:
+                              description: The Windows specific settings applied to
+                                all containers. If unspecified, the options from the
+                                PodSecurityContext will be used. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
+                              properties:
+                                gmsaCredentialSpec:
+                                  description: GMSACredentialSpec is where the GMSA
+                                    admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                    inlines the contents of the GMSA credential spec
+                                    named by the GMSACredentialSpecName field.
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  description: GMSACredentialSpecName is the name
+                                    of the GMSA credential spec to use.
+                                  type: string
+                                runAsUserName:
+                                  description: The UserName in Windows to run the
+                                    entrypoint of the container process. Defaults
+                                    to the user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  type: string
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: 'StartupProbe indicates that the Pod has successfully
+                            initialized. If specified, no other probes are executed
+                            until this completes successfully. If this probe fails,
+                            the Pod will be restarted, just as if the livenessProbe
+                            failed. This can be used to provide different probe parameters
+                            at the beginning of a Pod''s lifecycle, when it might
+                            take a long time to load data or warm a cache, than during
+                            steady-state operation. This cannot be updated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                an alpha field and requires enabling ProbeTerminationGracePeriod
+                                feature gate.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        stdin:
+                          description: Whether this container should allocate a buffer
+                            for stdin in the container runtime. If this is not set,
+                            reads from stdin in the container will always result in
+                            EOF. Default is false.
+                          type: boolean
+                        stdinOnce:
+                          description: Whether the container runtime should close
+                            the stdin channel after it has been opened by a single
+                            attach. When stdin is true the stdin stream will remain
+                            open across multiple attach sessions. If stdinOnce is
+                            set to true, stdin is opened on container start, is empty
+                            until the first client attaches to stdin, and then remains
+                            open and accepts data until the client disconnects, at
+                            which time stdin is closed and remains closed until the
+                            container is restarted. If this flag is false, a container
+                            processes that reads from stdin will never receive an
+                            EOF. Default is false
+                          type: boolean
+                        terminationMessagePath:
+                          description: 'Optional: Path at which the file to which
+                            the container''s termination message will be written is
+                            mounted into the container''s filesystem. Message written
+                            is intended to be brief final status, such as an assertion
+                            failure message. Will be truncated by the node if greater
+                            than 4096 bytes. The total message length across all containers
+                            will be limited to 12kb. Defaults to /dev/termination-log.
+                            Cannot be updated.'
+                          type: string
+                        terminationMessagePolicy:
+                          description: Indicate how the termination message should
+                            be populated. File will use the contents of terminationMessagePath
+                            to populate the container status message on both success
+                            and failure. FallbackToLogsOnError will use the last chunk
+                            of container log output if the termination message file
+                            is empty and the container exited with an error. The log
+                            output is limited to 2048 bytes or 80 lines, whichever
+                            is smaller. Defaults to File. Cannot be updated.
+                          type: string
+                        tty:
+                          description: Whether this container should allocate a TTY
+                            for itself, also requires 'stdin' to be true. Default
+                            is false.
+                          type: boolean
+                        volumeDevices:
+                          description: volumeDevices is the list of block devices
+                            to be used by the container.
+                          items:
+                            description: volumeDevice describes a mapping of a raw
+                              block device within a container.
+                            properties:
+                              devicePath:
+                                description: devicePath is the path inside of the
+                                  container that the device will be mapped to.
+                                type: string
+                              name:
+                                description: name must match the name of a persistentVolumeClaim
+                                  in the pod
+                                type: string
+                            required:
+                            - devicePath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - devicePath
+                          x-kubernetes-list-type: map
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                            Cannot be updated.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write
+                                  otherwise (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the
+                                  container's volume should be mounted. Defaults to
+                                  "" (volume's root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from
+                                  which the container's volume should be mounted.
+                                  Behaves similarly to SubPath but environment variable
+                                  references $(VAR_NAME) are expanded using the container's
+                                  environment. Defaults to "" (volume's root). SubPathExpr
+                                  and SubPath are mutually exclusive.
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - mountPath
+                          x-kubernetes-list-type: map
+                        workingDir:
+                          description: Container's working directory. If not specified,
+                            the container runtime's default will be used, which might
+                            be configured in the container image. Cannot be updated.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  nodeName:
+                    description: NodeName is a request to schedule this pod onto a
+                      specific node. If it is non-empty, the scheduler simply schedules
+                      this pod onto that node, assuming that it fits resource requirements.
+                    type: string
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'NodeSelector is a selector which must be true for
+                      the pod to fit on a node. Selector which must match a node''s
+                      labels for the pod to be scheduled on that node. More info:
+                      https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                    type: object
+                  overhead:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Overhead represents the resource overhead associated
+                      with running a pod for a given RuntimeClass. This field will
+                      be autopopulated at admission time by the RuntimeClass admission
+                      controller. If the RuntimeClass admission controller is enabled,
+                      overhead must not be set in Pod create requests. The RuntimeClass
+                      admission controller will reject Pod create requests which have
+                      the overhead already set. If RuntimeClass is configured and
+                      selected in the PodSpec, Overhead will be set to the value defined
+                      in the corresponding RuntimeClass, otherwise it will remain
+                      unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md
+                      This field is alpha-level as of Kubernetes v1.16, and is only
+                      honored by servers that enable the PodOverhead feature.'
+                    type: object
+                  preemptionPolicy:
+                    description: PreemptionPolicy is the Policy for preempting pods
+                      with lower priority. One of Never, PreemptLowerPriority. Defaults
+                      to PreemptLowerPriority if unset. This field is beta-level,
+                      gated by the NonPreemptingPriority feature-gate.
+                    type: string
+                  priority:
+                    description: The priority value. Various system components use
+                      this field to find the priority of the pod. When Priority Admission
+                      Controller is enabled, it prevents users from setting this field.
+                      The admission controller populates this field from PriorityClassName.
+                      The higher the value, the higher the priority.
+                    format: int32
+                    type: integer
+                  priorityClassName:
+                    description: If specified, indicates the pod's priority. "system-node-critical"
+                      and "system-cluster-critical" are two special keywords which
+                      indicate the highest priorities with the former being the highest
+                      priority. Any other name must be defined by creating a PriorityClass
+                      object with that name. If not specified, the pod priority will
+                      be default or zero if there is no default.
+                    type: string
+                  readinessGates:
+                    description: 'If specified, all readiness gates will be evaluated
+                      for pod readiness. A pod is ready when all its containers are
+                      ready AND all conditions specified in the readiness gates have
+                      status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md'
+                    items:
+                      description: PodReadinessGate contains the reference to a pod
+                        condition
+                      properties:
+                        conditionType:
+                          description: ConditionType refers to a condition in the
+                            pod's condition list with matching type.
+                          type: string
+                      required:
+                      - conditionType
+                      type: object
+                    type: array
+                  restartPolicy:
+                    description: 'Restart policy for all containers within the pod.
+                      One of Always, OnFailure, Never. Default to Always. More info:
+                      https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
+                    type: string
+                  runtimeClassName:
+                    description: 'RuntimeClassName refers to a RuntimeClass object
+                      in the node.k8s.io group, which should be used to run this pod.  If
+                      no RuntimeClass resource matches the named class, the pod will
+                      not be run. If unset or empty, the "legacy" RuntimeClass will
+                      be used, which is an implicit class with an empty definition
+                      that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
+                      This is a beta feature as of Kubernetes v1.14.'
+                    type: string
+                  schedulerName:
+                    description: If specified, the pod will be dispatched by specified
+                      scheduler. If not specified, the pod will be dispatched by default
+                      scheduler.
+                    type: string
+                  securityContext:
+                    description: 'SecurityContext holds pod-level security attributes
+                      and common container settings. Optional: Defaults to empty.  See
+                      type description for default values of each field.'
+                    properties:
+                      fsGroup:
+                        description: |-
+                          A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
+                          1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
+                          If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                        format: int64
+                        type: integer
+                      fsGroupChangePolicy:
+                        description: 'fsGroupChangePolicy defines behavior of changing
+                          ownership and permission of the volume before being exposed
+                          inside Pod. This field will only apply to volume types which
+                          support fsGroup based ownership(and permissions). It will
+                          have no effect on ephemeral volume types such as: secret,
+                          configmaps and emptydir. Valid values are "OnRootMismatch"
+                          and "Always". If not specified, "Always" is used.'
+                        type: string
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence for that container.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in SecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in SecurityContext.  If set
+                          in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence for that container.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to all containers.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          SecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence
+                          for that container.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: The seccomp options to use by the containers
+                          in this pod.
+                        properties:
+                          localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used. The profile must
+                              be preconfigured on the node to work. Must be a descending
+                              path, relative to the kubelet's configured seccomp profile
+                              location. Must only be set if type is "Localhost".
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                              Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      supplementalGroups:
+                        description: A list of groups applied to the first process
+                          run in each container, in addition to the container's primary
+                          GID.  If unspecified, no groups will be added to any container.
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      sysctls:
+                        description: Sysctls hold a list of namespaced sysctls used
+                          for the pod. Pods with unsupported sysctls (by the container
+                          runtime) might fail to launch.
+                        items:
+                          description: Sysctl defines a kernel parameter to be set
+                          properties:
+                            name:
+                              description: Name of a property to set
+                              type: string
+                            value:
+                              description: Value of a property to set
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options within a container's
+                          SecurityContext will be used. If set in both SecurityContext
+                          and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  serviceAccount:
+                    description: 'DeprecatedServiceAccount is a depreciated alias
+                      for ServiceAccountName. Deprecated: Use serviceAccountName instead.'
+                    type: string
+                  serviceAccountName:
+                    description: 'ServiceAccountName is the name of the ServiceAccount
+                      to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                    type: string
+                  setHostnameAsFQDN:
+                    description: If true the pod's hostname will be configured as
+                      the pod's FQDN, rather than the leaf name (the default). In
+                      Linux containers, this means setting the FQDN in the hostname
+                      field of the kernel (the nodename field of struct utsname).
+                      In Windows containers, this means setting the registry value
+                      of hostname for the registry key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters
+                      to FQDN. If a pod does not have FQDN, this has no effect. Default
+                      to false.
+                    type: boolean
+                  shareProcessNamespace:
+                    description: 'Share a single process namespace between all of
+                      the containers in a pod. When this is set containers will be
+                      able to view and signal processes from other containers in the
+                      same pod, and the first process in each container will not be
+                      assigned PID 1. HostPID and ShareProcessNamespace cannot both
+                      be set. Optional: Default to false.'
+                    type: boolean
+                  subdomain:
+                    description: If specified, the fully qualified Pod hostname will
+                      be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+                      If not specified, the pod will not have a domainname at all.
+                    type: string
+                  terminationGracePeriodSeconds:
+                    description: Optional duration in seconds the pod needs to terminate
+                      gracefully. May be decreased in delete request. Value must be
+                      non-negative integer. The value zero indicates stop immediately
+                      via the kill signal (no opportunity to shut down). If this value
+                      is nil, the default grace period will be used instead. The grace
+                      period is the duration in seconds after the processes running
+                      in the pod are sent a termination signal and the time when the
+                      processes are forcibly halted with a kill signal. Set this value
+                      longer than the expected cleanup time for your process. Defaults
+                      to 30 seconds.
+                    format: int64
+                    type: integer
+                  tolerations:
+                    description: If specified, the pod's tolerations.
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using
+                        the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match.
+                            Empty means match all taint effects. When specified, allowed
+                            values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to
+                            the value. Valid operators are Exists and Equal. Defaults
+                            to Equal. Exists is equivalent to wildcard for value,
+                            so that a pod can tolerate all taints of a particular
+                            category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of
+                            time the toleration (which must be of effect NoExecute,
+                            otherwise this field is ignored) tolerates the taint.
+                            By default, it is not set, which means tolerate the taint
+                            forever (do not evict). Zero and negative values will
+                            be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  topologySpreadConstraints:
+                    description: TopologySpreadConstraints describes how a group of
+                      pods ought to spread across topology domains. Scheduler will
+                      schedule pods in a way which abides by the constraints. All
+                      topologySpreadConstraints are ANDed.
+                    items:
+                      description: TopologySpreadConstraint specifies how to spread
+                        matching pods among the given topology.
+                      properties:
+                        labelSelector:
+                          description: LabelSelector is used to find matching pods.
+                            Pods that match this label selector are counted to determine
+                            the number of pods in their corresponding topology domain.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        maxSkew:
+                          description: 'MaxSkew describes the degree to which pods
+                            may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                            it is the maximum permitted difference between the number
+                            of matching pods in the target topology and the global
+                            minimum. For example, in a 3-zone cluster, MaxSkew is
+                            set to 1, and pods with the same labelSelector spread
+                            as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
+                            - if MaxSkew is 1, incoming pod can only be scheduled
+                            to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(2-0) on zone1(zone2) violate
+                            MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
+                            onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                            it is used to give higher precedence to topologies that
+                            satisfy it. It''s a required field. Default value is 1
+                            and 0 is not allowed.'
+                          format: int32
+                          type: integer
+                        topologyKey:
+                          description: TopologyKey is the key of node labels. Nodes
+                            that have a label with this key and identical values are
+                            considered to be in the same topology. We consider each
+                            <key, value> as a "bucket", and try to put balanced number
+                            of pods into each bucket. It's a required field.
+                          type: string
+                        whenUnsatisfiable:
+                          description: |-
+                            WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                              but giving higher precedence to topologies that would help reduce the
+                              skew.
+                            A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assigment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
+                          type: string
+                      required:
+                      - maxSkew
+                      - topologyKey
+                      - whenUnsatisfiable
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - topologyKey
+                    - whenUnsatisfiable
+                    x-kubernetes-list-type: map
+                  volumes:
+                    description: 'List of volumes that can be mounted by containers
+                      belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                    items:
+                      description: Volume represents a named volume in a pod that
+                        may be accessed by any container in the pod.
+                      properties:
+                        awsElasticBlockStore:
+                          description: 'AWSElasticBlockStore represents an AWS Disk
+                            resource that is attached to a kubelet''s host machine
+                            and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                          properties:
+                            fsType:
+                              description: 'Filesystem type of the volume that you
+                                want to mount. Tip: Ensure that the filesystem type
+                                is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              type: string
+                            partition:
+                              description: 'The partition in the volume that you want
+                                to mount. If omitted, the default is to mount by volume
+                                name. Examples: For volume /dev/sda1, you specify
+                                the partition as "1". Similarly, the volume partition
+                                for /dev/sda is "0" (or you can leave the property
+                                empty).'
+                              format: int32
+                              type: integer
+                            readOnly:
+                              description: 'Specify "true" to force and set the ReadOnly
+                                property in VolumeMounts to "true". If omitted, the
+                                default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              type: boolean
+                            volumeID:
+                              description: 'Unique ID of the persistent disk resource
+                                in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        azureDisk:
+                          description: AzureDisk represents an Azure Data Disk mount
+                            on the host and bind mount to the pod.
+                          properties:
+                            cachingMode:
+                              description: 'Host Caching mode: None, Read Only, Read
+                                Write.'
+                              type: string
+                            diskName:
+                              description: The Name of the data disk in the blob storage
+                              type: string
+                            diskURI:
+                              description: The URI the data disk in the blob storage
+                              type: string
+                            fsType:
+                              description: Filesystem type to mount. Must be a filesystem
+                                type supported by the host operating system. Ex. "ext4",
+                                "xfs", "ntfs". Implicitly inferred to be "ext4" if
+                                unspecified.
+                              type: string
+                            kind:
+                              description: 'Expected values Shared: multiple blob
+                                disks per storage account  Dedicated: single blob
+                                disk per storage account  Managed: azure managed data
+                                disk (only in managed availability set). defaults
+                                to shared'
+                              type: string
+                            readOnly:
+                              description: Defaults to false (read/write). ReadOnly
+                                here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                          required:
+                          - diskName
+                          - diskURI
+                          type: object
+                        azureFile:
+                          description: AzureFile represents an Azure File Service
+                            mount on the host and bind mount to the pod.
+                          properties:
+                            readOnly:
+                              description: Defaults to false (read/write). ReadOnly
+                                here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretName:
+                              description: the name of secret that contains Azure
+                                Storage Account Name and Key
+                              type: string
+                            shareName:
+                              description: Share Name
+                              type: string
+                          required:
+                          - secretName
+                          - shareName
+                          type: object
+                        cephfs:
+                          description: CephFS represents a Ceph FS mount on the host
+                            that shares a pod's lifetime
+                          properties:
+                            monitors:
+                              description: 'Required: Monitors is a collection of
+                                Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              items:
+                                type: string
+                              type: array
+                            path:
+                              description: 'Optional: Used as the mounted root, rather
+                                than the full Ceph tree, default is /'
+                              type: string
+                            readOnly:
+                              description: 'Optional: Defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              type: boolean
+                            secretFile:
+                              description: 'Optional: SecretFile is the path to key
+                                ring for User, default is /etc/ceph/user.secret More
+                                info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              type: string
+                            secretRef:
+                              description: 'Optional: SecretRef is reference to the
+                                authentication secret for User, default is empty.
+                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            user:
+                              description: 'Optional: User is the rados user name,
+                                default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              type: string
+                          required:
+                          - monitors
+                          type: object
+                        cinder:
+                          description: 'Cinder represents a cinder volume attached
+                            and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                          properties:
+                            fsType:
+                              description: 'Filesystem type to mount. Must be a filesystem
+                                type supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              type: string
+                            readOnly:
+                              description: 'Optional: Defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              type: boolean
+                            secretRef:
+                              description: 'Optional: points to a secret object containing
+                                parameters used to connect to OpenStack.'
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            volumeID:
+                              description: 'volume id used to identify the volume
+                                in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        configMap:
+                          description: ConfigMap represents a configMap that should
+                            populate this volume
+                          properties:
+                            defaultMode:
+                              description: 'Optional: mode bits used to set permissions
+                                on created files by default. Must be an octal value
+                                between 0000 and 0777 or a decimal value between 0
+                                and 511. YAML accepts both octal and decimal values,
+                                JSON requires decimal values for mode bits. Defaults
+                                to 0644. Directories within the path are not affected
+                                by this setting. This might be in conflict with other
+                                options that affect the file mode, like fsGroup, and
+                                the result can be other mode bits set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: If unspecified, each key-value pair in
+                                the Data field of the referenced ConfigMap will be
+                                projected into the volume as a file whose name is
+                                the key and content is the value. If specified, the
+                                listed keys will be projected into the specified paths,
+                                and unlisted keys will not be present. If a key is
+                                specified which is not present in the ConfigMap, the
+                                volume setup will error unless it is marked optional.
+                                Paths must be relative and may not contain the '..'
+                                path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a
+                                  volume.
+                                properties:
+                                  key:
+                                    description: The key to project.
+                                    type: string
+                                  mode:
+                                    description: 'Optional: mode bits used to set
+                                      permissions on this file. Must be an octal value
+                                      between 0000 and 0777 or a decimal value between
+                                      0 and 511. YAML accepts both octal and decimal
+                                      values, JSON requires decimal values for mode
+                                      bits. If not specified, the volume defaultMode
+                                      will be used. This might be in conflict with
+                                      other options that affect the file mode, like
+                                      fsGroup, and the result can be other mode bits
+                                      set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: The relative path of the file to
+                                      map the key to. May not be an absolute path.
+                                      May not contain the path element '..'. May not
+                                      start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its keys
+                                must be defined
+                              type: boolean
+                          type: object
+                        csi:
+                          description: CSI (Container Storage Interface) represents
+                            ephemeral storage that is handled by certain external
+                            CSI drivers (Beta feature).
+                          properties:
+                            driver:
+                              description: Driver is the name of the CSI driver that
+                                handles this volume. Consult with your admin for the
+                                correct name as registered in the cluster.
+                              type: string
+                            fsType:
+                              description: Filesystem type to mount. Ex. "ext4", "xfs",
+                                "ntfs". If not provided, the empty value is passed
+                                to the associated CSI driver which will determine
+                                the default filesystem to apply.
+                              type: string
+                            nodePublishSecretRef:
+                              description: NodePublishSecretRef is a reference to
+                                the secret object containing sensitive information
+                                to pass to the CSI driver to complete the CSI NodePublishVolume
+                                and NodeUnpublishVolume calls. This field is optional,
+                                and  may be empty if no secret is required. If the
+                                secret object contains more than one secret, all secret
+                                references are passed.
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            readOnly:
+                              description: Specifies a read-only configuration for
+                                the volume. Defaults to false (read/write).
+                              type: boolean
+                            volumeAttributes:
+                              additionalProperties:
+                                type: string
+                              description: VolumeAttributes stores driver-specific
+                                properties that are passed to the CSI driver. Consult
+                                your driver's documentation for supported values.
+                              type: object
+                          required:
+                          - driver
+                          type: object
+                        downwardAPI:
+                          description: DownwardAPI represents downward API about the
+                            pod that should populate this volume
+                          properties:
+                            defaultMode:
+                              description: 'Optional: mode bits to use on created
+                                files by default. Must be a Optional: mode bits used
+                                to set permissions on created files by default. Must
+                                be an octal value between 0000 and 0777 or a decimal
+                                value between 0 and 511. YAML accepts both octal and
+                                decimal values, JSON requires decimal values for mode
+                                bits. Defaults to 0644. Directories within the path
+                                are not affected by this setting. This might be in
+                                conflict with other options that affect the file mode,
+                                like fsGroup, and the result can be other mode bits
+                                set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: Items is a list of downward API volume
+                                file
+                              items:
+                                description: DownwardAPIVolumeFile represents information
+                                  to create the file containing the pod field
+                                properties:
+                                  fieldRef:
+                                    description: 'Required: Selects a field of the
+                                      pod: only annotations, labels, name and namespace
+                                      are supported.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  mode:
+                                    description: 'Optional: mode bits used to set
+                                      permissions on this file, must be an octal value
+                                      between 0000 and 0777 or a decimal value between
+                                      0 and 511. YAML accepts both octal and decimal
+                                      values, JSON requires decimal values for mode
+                                      bits. If not specified, the volume defaultMode
+                                      will be used. This might be in conflict with
+                                      other options that affect the file mode, like
+                                      fsGroup, and the result can be other mode bits
+                                      set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: 'Required: Path is  the relative
+                                      path name of the file to be created. Must not
+                                      be absolute or contain the ''..'' path. Must
+                                      be utf-8 encoded. The first item of the relative
+                                      path must not start with ''..'''
+                                    type: string
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, requests.cpu and requests.memory)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                required:
+                                - path
+                                type: object
+                              type: array
+                          type: object
+                        emptyDir:
+                          description: 'EmptyDir represents a temporary directory
+                            that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                          properties:
+                            medium:
+                              description: 'What type of storage medium should back
+                                this directory. The default is "" which means to use
+                                the node''s default medium. Must be an empty string
+                                (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              type: string
+                            sizeLimit:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: 'Total amount of local storage required
+                                for this EmptyDir volume. The size limit is also applicable
+                                for memory medium. The maximum usage on memory medium
+                                EmptyDir would be the minimum value between the SizeLimit
+                                specified here and the sum of memory limits of all
+                                containers in a pod. The default is nil which means
+                                that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          type: object
+                        ephemeral:
+                          description: |-
+                            Ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+
+                            Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+                               tracking are needed,
+                            c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+                               a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                               information on the connection between this volume type
+                               and PersistentVolumeClaim).
+
+                            Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+
+                            Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+
+                            A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+
+                            This is a beta feature and only available when the GenericEphemeralVolume feature gate is enabled.
+                          properties:
+                            volumeClaimTemplate:
+                              description: |-
+                                Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+
+                                An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+
+                                This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+
+                                Required, must not be nil.
+                              properties:
+                                metadata:
+                                  description: May contain labels and annotations
+                                    that will be copied into the PVC when creating
+                                    it. No other fields are allowed and will be rejected
+                                    during validation.
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                spec:
+                                  description: The specification for the PersistentVolumeClaim.
+                                    The entire content is copied unchanged into the
+                                    PVC that gets created from this template. The
+                                    same fields as in a PersistentVolumeClaim are
+                                    also valid here.
+                                  properties:
+                                    accessModes:
+                                      description: 'AccessModes contains the desired
+                                        access modes the volume should have. More
+                                        info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                      items:
+                                        type: string
+                                      type: array
+                                    dataSource:
+                                      description: 'This field can be used to specify
+                                        either: * An existing VolumeSnapshot object
+                                        (snapshot.storage.k8s.io/VolumeSnapshot) *
+                                        An existing PVC (PersistentVolumeClaim) *
+                                        An existing custom resource that implements
+                                        data population (Alpha) In order to use custom
+                                        resource types that implement data population,
+                                        the AnyVolumeDataSource feature gate must
+                                        be enabled. If the provisioner or an external
+                                        controller can support the specified data
+                                        source, it will create a new volume based
+                                        on the contents of the specified data source.'
+                                      properties:
+                                        apiGroup:
+                                          description: APIGroup is the group for the
+                                            resource being referenced. If APIGroup
+                                            is not specified, the specified Kind must
+                                            be in the core API group. For any other
+                                            third-party types, APIGroup is required.
+                                          type: string
+                                        kind:
+                                          description: Kind is the type of resource
+                                            being referenced
+                                          type: string
+                                        name:
+                                          description: Name is the name of resource
+                                            being referenced
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                    resources:
+                                      description: 'Resources represents the minimum
+                                        resources the volume should have. More info:
+                                        https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Limits describes the maximum
+                                            amount of compute resources allowed. More
+                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Requests describes the minimum
+                                            amount of compute resources required.
+                                            If Requests is omitted for a container,
+                                            it defaults to Limits if that is explicitly
+                                            specified, otherwise to an implementation-defined
+                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                      type: object
+                                    selector:
+                                      description: A label query over volumes to consider
+                                        for binding.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    storageClassName:
+                                      description: 'Name of the StorageClass required
+                                        by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                      type: string
+                                    volumeMode:
+                                      description: volumeMode defines what type of
+                                        volume is required by the claim. Value of
+                                        Filesystem is implied when not included in
+                                        claim spec.
+                                      type: string
+                                    volumeName:
+                                      description: VolumeName is the binding reference
+                                        to the PersistentVolume backing this claim.
+                                      type: string
+                                  type: object
+                              required:
+                              - spec
+                              type: object
+                          type: object
+                        fc:
+                          description: FC represents a Fibre Channel resource that
+                            is attached to a kubelet's host machine and then exposed
+                            to the pod.
+                          properties:
+                            fsType:
+                              description: Filesystem type to mount. Must be a filesystem
+                                type supported by the host operating system. Ex. "ext4",
+                                "xfs", "ntfs". Implicitly inferred to be "ext4" if
+                                unspecified.
+                              type: string
+                            lun:
+                              description: 'Optional: FC target lun number'
+                              format: int32
+                              type: integer
+                            readOnly:
+                              description: 'Optional: Defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                              type: boolean
+                            targetWWNs:
+                              description: 'Optional: FC target worldwide names (WWNs)'
+                              items:
+                                type: string
+                              type: array
+                            wwids:
+                              description: 'Optional: FC volume world wide identifiers
+                                (wwids) Either wwids or combination of targetWWNs
+                                and lun must be set, but not both simultaneously.'
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        flexVolume:
+                          description: FlexVolume represents a generic volume resource
+                            that is provisioned/attached using an exec based plugin.
+                          properties:
+                            driver:
+                              description: Driver is the name of the driver to use
+                                for this volume.
+                              type: string
+                            fsType:
+                              description: Filesystem type to mount. Must be a filesystem
+                                type supported by the host operating system. Ex. "ext4",
+                                "xfs", "ntfs". The default filesystem depends on FlexVolume
+                                script.
+                              type: string
+                            options:
+                              additionalProperties:
+                                type: string
+                              description: 'Optional: Extra command options if any.'
+                              type: object
+                            readOnly:
+                              description: 'Optional: Defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                              type: boolean
+                            secretRef:
+                              description: 'Optional: SecretRef is reference to the
+                                secret object containing sensitive information to
+                                pass to the plugin scripts. This may be empty if no
+                                secret object is specified. If the secret object contains
+                                more than one secret, all secrets are passed to the
+                                plugin scripts.'
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                          required:
+                          - driver
+                          type: object
+                        flocker:
+                          description: Flocker represents a Flocker volume attached
+                            to a kubelet's host machine. This depends on the Flocker
+                            control service being running
+                          properties:
+                            datasetName:
+                              description: Name of the dataset stored as metadata
+                                -> name on the dataset for Flocker should be considered
+                                as deprecated
+                              type: string
+                            datasetUUID:
+                              description: UUID of the dataset. This is unique identifier
+                                of a Flocker dataset
+                              type: string
+                          type: object
+                        gcePersistentDisk:
+                          description: 'GCEPersistentDisk represents a GCE Disk resource
+                            that is attached to a kubelet''s host machine and then
+                            exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                          properties:
+                            fsType:
+                              description: 'Filesystem type of the volume that you
+                                want to mount. Tip: Ensure that the filesystem type
+                                is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              type: string
+                            partition:
+                              description: 'The partition in the volume that you want
+                                to mount. If omitted, the default is to mount by volume
+                                name. Examples: For volume /dev/sda1, you specify
+                                the partition as "1". Similarly, the volume partition
+                                for /dev/sda is "0" (or you can leave the property
+                                empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              format: int32
+                              type: integer
+                            pdName:
+                              description: 'Unique name of the PD resource in GCE.
+                                Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              type: string
+                            readOnly:
+                              description: 'ReadOnly here will force the ReadOnly
+                                setting in VolumeMounts. Defaults to false. More info:
+                                https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              type: boolean
+                          required:
+                          - pdName
+                          type: object
+                        gitRepo:
+                          description: 'GitRepo represents a git repository at a particular
+                            revision. DEPRECATED: GitRepo is deprecated. To provision
+                            a container with a git repo, mount an EmptyDir into an
+                            InitContainer that clones the repo using git, then mount
+                            the EmptyDir into the Pod''s container.'
+                          properties:
+                            directory:
+                              description: Target directory name. Must not contain
+                                or start with '..'.  If '.' is supplied, the volume
+                                directory will be the git repository.  Otherwise,
+                                if specified, the volume will contain the git repository
+                                in the subdirectory with the given name.
+                              type: string
+                            repository:
+                              description: Repository URL
+                              type: string
+                            revision:
+                              description: Commit hash for the specified revision.
+                              type: string
+                          required:
+                          - repository
+                          type: object
+                        glusterfs:
+                          description: 'Glusterfs represents a Glusterfs mount on
+                            the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                          properties:
+                            endpoints:
+                              description: 'EndpointsName is the endpoint name that
+                                details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                              type: string
+                            path:
+                              description: 'Path is the Glusterfs volume path. More
+                                info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                              type: string
+                            readOnly:
+                              description: 'ReadOnly here will force the Glusterfs
+                                volume to be mounted with read-only permissions. Defaults
+                                to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                              type: boolean
+                          required:
+                          - endpoints
+                          - path
+                          type: object
+                        hostPath:
+                          description: 'HostPath represents a pre-existing file or
+                            directory on the host machine that is directly exposed
+                            to the container. This is generally used for system agents
+                            or other privileged things that are allowed to see the
+                            host machine. Most containers will NOT need this. More
+                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                          properties:
+                            path:
+                              description: 'Path of the directory on the host. If
+                                the path is a symlink, it will follow the link to
+                                the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                              type: string
+                            type:
+                              description: 'Type for HostPath Volume Defaults to ""
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        iscsi:
+                          description: 'ISCSI represents an ISCSI Disk resource that
+                            is attached to a kubelet''s host machine and then exposed
+                            to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                          properties:
+                            chapAuthDiscovery:
+                              description: whether support iSCSI Discovery CHAP authentication
+                              type: boolean
+                            chapAuthSession:
+                              description: whether support iSCSI Session CHAP authentication
+                              type: boolean
+                            fsType:
+                              description: 'Filesystem type of the volume that you
+                                want to mount. Tip: Ensure that the filesystem type
+                                is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                              type: string
+                            initiatorName:
+                              description: Custom iSCSI Initiator Name. If initiatorName
+                                is specified with iscsiInterface simultaneously, new
+                                iSCSI interface <target portal>:<volume name> will
+                                be created for the connection.
+                              type: string
+                            iqn:
+                              description: Target iSCSI Qualified Name.
+                              type: string
+                            iscsiInterface:
+                              description: iSCSI Interface Name that uses an iSCSI
+                                transport. Defaults to 'default' (tcp).
+                              type: string
+                            lun:
+                              description: iSCSI Target Lun number.
+                              format: int32
+                              type: integer
+                            portals:
+                              description: iSCSI Target Portal List. The portal is
+                                either an IP or ip_addr:port if the port is other
+                                than default (typically TCP ports 860 and 3260).
+                              items:
+                                type: string
+                              type: array
+                            readOnly:
+                              description: ReadOnly here will force the ReadOnly setting
+                                in VolumeMounts. Defaults to false.
+                              type: boolean
+                            secretRef:
+                              description: CHAP Secret for iSCSI target and initiator
+                                authentication
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            targetPortal:
+                              description: iSCSI Target Portal. The Portal is either
+                                an IP or ip_addr:port if the port is other than default
+                                (typically TCP ports 860 and 3260).
+                              type: string
+                          required:
+                          - targetPortal
+                          - iqn
+                          - lun
+                          type: object
+                        name:
+                          description: 'Volume''s name. Must be a DNS_LABEL and unique
+                            within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        nfs:
+                          description: 'NFS represents an NFS mount on the host that
+                            shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                          properties:
+                            path:
+                              description: 'Path that is exported by the NFS server.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              type: string
+                            readOnly:
+                              description: 'ReadOnly here will force the NFS export
+                                to be mounted with read-only permissions. Defaults
+                                to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              type: boolean
+                            server:
+                              description: 'Server is the hostname or IP address of
+                                the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              type: string
+                          required:
+                          - server
+                          - path
+                          type: object
+                        persistentVolumeClaim:
+                          description: 'PersistentVolumeClaimVolumeSource represents
+                            a reference to a PersistentVolumeClaim in the same namespace.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          properties:
+                            claimName:
+                              description: 'ClaimName is the name of a PersistentVolumeClaim
+                                in the same namespace as the pod using this volume.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              type: string
+                            readOnly:
+                              description: Will force the ReadOnly setting in VolumeMounts.
+                                Default false.
+                              type: boolean
+                          required:
+                          - claimName
+                          type: object
+                        photonPersistentDisk:
+                          description: PhotonPersistentDisk represents a PhotonController
+                            persistent disk attached and mounted on kubelets host
+                            machine
+                          properties:
+                            fsType:
+                              description: Filesystem type to mount. Must be a filesystem
+                                type supported by the host operating system. Ex. "ext4",
+                                "xfs", "ntfs". Implicitly inferred to be "ext4" if
+                                unspecified.
+                              type: string
+                            pdID:
+                              description: ID that identifies Photon Controller persistent
+                                disk
+                              type: string
+                          required:
+                          - pdID
+                          type: object
+                        portworxVolume:
+                          description: PortworxVolume represents a portworx volume
+                            attached and mounted on kubelets host machine
+                          properties:
+                            fsType:
+                              description: FSType represents the filesystem type to
+                                mount Must be a filesystem type supported by the host
+                                operating system. Ex. "ext4", "xfs". Implicitly inferred
+                                to be "ext4" if unspecified.
+                              type: string
+                            readOnly:
+                              description: Defaults to false (read/write). ReadOnly
+                                here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            volumeID:
+                              description: VolumeID uniquely identifies a Portworx
+                                volume
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        projected:
+                          description: Items for all in one resources secrets, configmaps,
+                            and downward API
+                          properties:
+                            defaultMode:
+                              description: Mode bits used to set permissions on created
+                                files by default. Must be an octal value between 0000
+                                and 0777 or a decimal value between 0 and 511. YAML
+                                accepts both octal and decimal values, JSON requires
+                                decimal values for mode bits. Directories within the
+                                path are not affected by this setting. This might
+                                be in conflict with other options that affect the
+                                file mode, like fsGroup, and the result can be other
+                                mode bits set.
+                              format: int32
+                              type: integer
+                            sources:
+                              description: list of volume projections
+                              items:
+                                description: Projection that may be projected along
+                                  with other supported volume types
+                                properties:
+                                  configMap:
+                                    description: information about the configMap data
+                                      to project
+                                    properties:
+                                      items:
+                                        description: If unspecified, each key-value
+                                          pair in the Data field of the referenced
+                                          ConfigMap will be projected into the volume
+                                          as a file whose name is the key and content
+                                          is the value. If specified, the listed keys
+                                          will be projected into the specified paths,
+                                          and unlisted keys will not be present. If
+                                          a key is specified which is not present
+                                          in the ConfigMap, the volume setup will
+                                          error unless it is marked optional. Paths
+                                          must be relative and may not contain the
+                                          '..' path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: The key to project.
+                                              type: string
+                                            mode:
+                                              description: 'Optional: mode bits used
+                                                to set permissions on this file. Must
+                                                be an octal value between 0000 and
+                                                0777 or a decimal value between 0
+                                                and 511. YAML accepts both octal and
+                                                decimal values, JSON requires decimal
+                                                values for mode bits. If not specified,
+                                                the volume defaultMode will be used.
+                                                This might be in conflict with other
+                                                options that affect the file mode,
+                                                like fsGroup, and the result can be
+                                                other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: The relative path of the
+                                                file to map the key to. May not be
+                                                an absolute path. May not contain
+                                                the path element '..'. May not start
+                                                with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its keys must be defined
+                                        type: boolean
+                                    type: object
+                                  downwardAPI:
+                                    description: information about the downwardAPI
+                                      data to project
+                                    properties:
+                                      items:
+                                        description: Items is a list of DownwardAPIVolume
+                                          file
+                                        items:
+                                          description: DownwardAPIVolumeFile represents
+                                            information to create the file containing
+                                            the pod field
+                                          properties:
+                                            fieldRef:
+                                              description: 'Required: Selects a field
+                                                of the pod: only annotations, labels,
+                                                name and namespace are supported.'
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                            mode:
+                                              description: 'Optional: mode bits used
+                                                to set permissions on this file, must
+                                                be an octal value between 0000 and
+                                                0777 or a decimal value between 0
+                                                and 511. YAML accepts both octal and
+                                                decimal values, JSON requires decimal
+                                                values for mode bits. If not specified,
+                                                the volume defaultMode will be used.
+                                                This might be in conflict with other
+                                                options that affect the file mode,
+                                                like fsGroup, and the result can be
+                                                other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: 'Required: Path is  the
+                                                relative path name of the file to
+                                                be created. Must not be absolute or
+                                                contain the ''..'' path. Must be utf-8
+                                                encoded. The first item of the relative
+                                                path must not start with ''..'''
+                                              type: string
+                                            resourceFieldRef:
+                                              description: 'Selects a resource of
+                                                the container: only resources limits
+                                                and requests (limits.cpu, limits.memory,
+                                                requests.cpu and requests.memory)
+                                                are currently supported.'
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                          required:
+                                          - path
+                                          type: object
+                                        type: array
+                                    type: object
+                                  secret:
+                                    description: information about the secret data
+                                      to project
+                                    properties:
+                                      items:
+                                        description: If unspecified, each key-value
+                                          pair in the Data field of the referenced
+                                          Secret will be projected into the volume
+                                          as a file whose name is the key and content
+                                          is the value. If specified, the listed keys
+                                          will be projected into the specified paths,
+                                          and unlisted keys will not be present. If
+                                          a key is specified which is not present
+                                          in the Secret, the volume setup will error
+                                          unless it is marked optional. Paths must
+                                          be relative and may not contain the '..'
+                                          path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: The key to project.
+                                              type: string
+                                            mode:
+                                              description: 'Optional: mode bits used
+                                                to set permissions on this file. Must
+                                                be an octal value between 0000 and
+                                                0777 or a decimal value between 0
+                                                and 511. YAML accepts both octal and
+                                                decimal values, JSON requires decimal
+                                                values for mode bits. If not specified,
+                                                the volume defaultMode will be used.
+                                                This might be in conflict with other
+                                                options that affect the file mode,
+                                                like fsGroup, and the result can be
+                                                other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: The relative path of the
+                                                file to map the key to. May not be
+                                                an absolute path. May not contain
+                                                the path element '..'. May not start
+                                                with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    type: object
+                                  serviceAccountToken:
+                                    description: information about the serviceAccountToken
+                                      data to project
+                                    properties:
+                                      audience:
+                                        description: Audience is the intended audience
+                                          of the token. A recipient of a token must
+                                          identify itself with an identifier specified
+                                          in the audience of the token, and otherwise
+                                          should reject the token. The audience defaults
+                                          to the identifier of the apiserver.
+                                        type: string
+                                      expirationSeconds:
+                                        description: ExpirationSeconds is the requested
+                                          duration of validity of the service account
+                                          token. As the token approaches expiration,
+                                          the kubelet volume plugin will proactively
+                                          rotate the service account token. The kubelet
+                                          will start trying to rotate the token if
+                                          the token is older than 80 percent of its
+                                          time to live or if the token is older than
+                                          24 hours.Defaults to 1 hour and must be
+                                          at least 10 minutes.
+                                        format: int64
+                                        type: integer
+                                      path:
+                                        description: Path is the path relative to
+                                          the mount point of the file to project the
+                                          token into.
+                                        type: string
+                                    required:
+                                    - path
+                                    type: object
+                                type: object
+                              type: array
+                          type: object
+                        quobyte:
+                          description: Quobyte represents a Quobyte mount on the host
+                            that shares a pod's lifetime
+                          properties:
+                            group:
+                              description: Group to map volume access to Default is
+                                no group
+                              type: string
+                            readOnly:
+                              description: ReadOnly here will force the Quobyte volume
+                                to be mounted with read-only permissions. Defaults
+                                to false.
+                              type: boolean
+                            registry:
+                              description: Registry represents a single or multiple
+                                Quobyte Registry services specified as a string as
+                                host:port pair (multiple entries are separated with
+                                commas) which acts as the central registry for volumes
+                              type: string
+                            tenant:
+                              description: Tenant owning the given Quobyte volume
+                                in the Backend Used with dynamically provisioned Quobyte
+                                volumes, value is set by the plugin
+                              type: string
+                            user:
+                              description: User to map volume access to Defaults to
+                                serivceaccount user
+                              type: string
+                            volume:
+                              description: Volume is a string that references an already
+                                created Quobyte volume by name.
+                              type: string
+                          required:
+                          - registry
+                          - volume
+                          type: object
+                        rbd:
+                          description: 'RBD represents a Rados Block Device mount
+                            on the host that shares a pod''s lifetime. More info:
+                            https://examples.k8s.io/volumes/rbd/README.md'
+                          properties:
+                            fsType:
+                              description: 'Filesystem type of the volume that you
+                                want to mount. Tip: Ensure that the filesystem type
+                                is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                              type: string
+                            image:
+                              description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: string
+                            keyring:
+                              description: 'Keyring is the path to key ring for RBDUser.
+                                Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: string
+                            monitors:
+                              description: 'A collection of Ceph monitors. More info:
+                                https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              items:
+                                type: string
+                              type: array
+                            pool:
+                              description: 'The rados pool name. Default is rbd. More
+                                info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: string
+                            readOnly:
+                              description: 'ReadOnly here will force the ReadOnly
+                                setting in VolumeMounts. Defaults to false. More info:
+                                https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: boolean
+                            secretRef:
+                              description: 'SecretRef is name of the authentication
+                                secret for RBDUser. If provided overrides keyring.
+                                Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            user:
+                              description: 'The rados user name. Default is admin.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: string
+                          required:
+                          - monitors
+                          - image
+                          type: object
+                        scaleIO:
+                          description: ScaleIO represents a ScaleIO persistent volume
+                            attached and mounted on Kubernetes nodes.
+                          properties:
+                            fsType:
+                              description: Filesystem type to mount. Must be a filesystem
+                                type supported by the host operating system. Ex. "ext4",
+                                "xfs", "ntfs". Default is "xfs".
+                              type: string
+                            gateway:
+                              description: The host address of the ScaleIO API Gateway.
+                              type: string
+                            protectionDomain:
+                              description: The name of the ScaleIO Protection Domain
+                                for the configured storage.
+                              type: string
+                            readOnly:
+                              description: Defaults to false (read/write). ReadOnly
+                                here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretRef:
+                              description: SecretRef references to the secret for
+                                ScaleIO user and other sensitive information. If this
+                                is not provided, Login operation will fail.
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            sslEnabled:
+                              description: Flag to enable/disable SSL communication
+                                with Gateway, default false
+                              type: boolean
+                            storageMode:
+                              description: Indicates whether the storage for a volume
+                                should be ThickProvisioned or ThinProvisioned. Default
+                                is ThinProvisioned.
+                              type: string
+                            storagePool:
+                              description: The ScaleIO Storage Pool associated with
+                                the protection domain.
+                              type: string
+                            system:
+                              description: The name of the storage system as configured
+                                in ScaleIO.
+                              type: string
+                            volumeName:
+                              description: The name of a volume already created in
+                                the ScaleIO system that is associated with this volume
+                                source.
+                              type: string
+                          required:
+                          - gateway
+                          - system
+                          - secretRef
+                          type: object
+                        secret:
+                          description: 'Secret represents a secret that should populate
+                            this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                          properties:
+                            defaultMode:
+                              description: 'Optional: mode bits used to set permissions
+                                on created files by default. Must be an octal value
+                                between 0000 and 0777 or a decimal value between 0
+                                and 511. YAML accepts both octal and decimal values,
+                                JSON requires decimal values for mode bits. Defaults
+                                to 0644. Directories within the path are not affected
+                                by this setting. This might be in conflict with other
+                                options that affect the file mode, like fsGroup, and
+                                the result can be other mode bits set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: If unspecified, each key-value pair in
+                                the Data field of the referenced Secret will be projected
+                                into the volume as a file whose name is the key and
+                                content is the value. If specified, the listed keys
+                                will be projected into the specified paths, and unlisted
+                                keys will not be present. If a key is specified which
+                                is not present in the Secret, the volume setup will
+                                error unless it is marked optional. Paths must be
+                                relative and may not contain the '..' path or start
+                                with '..'.
+                              items:
+                                description: Maps a string key to a path within a
+                                  volume.
+                                properties:
+                                  key:
+                                    description: The key to project.
+                                    type: string
+                                  mode:
+                                    description: 'Optional: mode bits used to set
+                                      permissions on this file. Must be an octal value
+                                      between 0000 and 0777 or a decimal value between
+                                      0 and 511. YAML accepts both octal and decimal
+                                      values, JSON requires decimal values for mode
+                                      bits. If not specified, the volume defaultMode
+                                      will be used. This might be in conflict with
+                                      other options that affect the file mode, like
+                                      fsGroup, and the result can be other mode bits
+                                      set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: The relative path of the file to
+                                      map the key to. May not be an absolute path.
+                                      May not contain the path element '..'. May not
+                                      start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                            optional:
+                              description: Specify whether the Secret or its keys
+                                must be defined
+                              type: boolean
+                            secretName:
+                              description: 'Name of the secret in the pod''s namespace
+                                to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              type: string
+                          type: object
+                        storageos:
+                          description: StorageOS represents a StorageOS volume attached
+                            and mounted on Kubernetes nodes.
+                          properties:
+                            fsType:
+                              description: Filesystem type to mount. Must be a filesystem
+                                type supported by the host operating system. Ex. "ext4",
+                                "xfs", "ntfs". Implicitly inferred to be "ext4" if
+                                unspecified.
+                              type: string
+                            readOnly:
+                              description: Defaults to false (read/write). ReadOnly
+                                here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretRef:
+                              description: SecretRef specifies the secret to use for
+                                obtaining the StorageOS API credentials.  If not specified,
+                                default values will be attempted.
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            volumeName:
+                              description: VolumeName is the human-readable name of
+                                the StorageOS volume.  Volume names are only unique
+                                within a namespace.
+                              type: string
+                            volumeNamespace:
+                              description: VolumeNamespace specifies the scope of
+                                the volume within StorageOS.  If no namespace is specified
+                                then the Pod's namespace will be used.  This allows
+                                the Kubernetes name scoping to be mirrored within
+                                StorageOS for tighter integration. Set VolumeName
+                                to any name to override the default behaviour. Set
+                                to "default" if you are not using namespaces within
+                                StorageOS. Namespaces that do not pre-exist within
+                                StorageOS will be created.
+                              type: string
+                          type: object
+                        vsphereVolume:
+                          description: VsphereVolume represents a vSphere volume attached
+                            and mounted on kubelets host machine
+                          properties:
+                            fsType:
+                              description: Filesystem type to mount. Must be a filesystem
+                                type supported by the host operating system. Ex. "ext4",
+                                "xfs", "ntfs". Implicitly inferred to be "ext4" if
+                                unspecified.
+                              type: string
+                            storagePolicyID:
+                              description: Storage Policy Based Management (SPBM)
+                                profile ID associated with the StoragePolicyName.
+                              type: string
+                            storagePolicyName:
+                              description: Storage Policy Based Management (SPBM)
+                                profile name.
+                              type: string
+                            volumePath:
+                              description: Path that identifies vSphere volume vmdk
+                              type: string
+                          required:
+                          - volumePath
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                required:
+                - containers
+                type: object
+            type: object
+        required:
+        - selector
+        - template
+        type: object
+      status:
+        description: Most recently observed status of the Deployment.
+        properties:
+          availableReplicas:
+            description: Total number of available pods (ready for at least minReadySeconds)
+              targeted by this deployment.
+            format: int32
+            type: integer
+          collisionCount:
+            description: Count of hash collisions for the Deployment. The Deployment
+              controller uses this field as a collision avoidance mechanism when it
+              needs to create the name for the newest ReplicaSet.
+            format: int32
+            type: integer
+          conditions:
+            description: Represents the latest available observations of a deployment's
+              current state.
+            items:
+              description: DeploymentCondition describes the state of a deployment
+                at a certain point.
+              properties:
+                lastTransitionTime:
+                  description: Last time the condition transitioned from one status
+                    to another.
+                  format: date-time
+                  type: string
+                lastUpdateTime:
+                  description: The last time this condition was updated.
+                  format: date-time
+                  type: string
+                message:
+                  description: A human readable message indicating details about the
+                    transition.
+                  type: string
+                reason:
+                  description: The reason for the condition's last transition.
+                  type: string
+                status:
+                  description: Status of the condition, one of True, False, Unknown.
+                  type: string
+                type:
+                  description: Type of deployment condition.
+                  type: string
+              required:
+              - status
+              - type
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - type
+            x-kubernetes-list-type: map
+          observedGeneration:
+            description: The generation observed by the deployment controller.
+            format: int64
+            type: integer
+          readyReplicas:
+            description: Total number of ready pods targeted by this deployment.
+            format: int32
+            type: integer
+          replicas:
+            description: Total number of non-terminated pods targeted by this deployment
+              (their labels match the selector).
+            format: int32
+            type: integer
+          unavailableReplicas:
+            description: Total number of unavailable pods targeted by this deployment.
+              This is the total number of pods that are still required for the deployment
+              to have 100% available capacity. They may either be pods that are running
+              but not yet available or pods that still have not been created.
+            format: int32
+            type: integer
+          updatedReplicas:
+            description: Total number of non-terminated pods targeted by this deployment
+              that have the desired template spec.
+            format: int32
+            type: integer
+        type: object
+    type: object
+  plural: deployments
+  scope: Namespaced
+  shortNames:
+  - deploy
+  singular: deployment
+  subResources:
+  - name: scale
+  - name: status

--- a/docs/content/concepts/scenarios/jn-scenario/yamls/4-NegotiatedAPIResource-ingresses.v1.networking.k8s.io.yaml
+++ b/docs/content/concepts/scenarios/jn-scenario/yamls/4-NegotiatedAPIResource-ingresses.v1.networking.k8s.io.yaml
@@ -1,0 +1,338 @@
+apiVersion: apiresource.kcp.io/v1alpha1
+kind: NegotiatedAPIResource
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kcp-dev/kubernetes/pull/4
+    apiresource.kcp.io/apiVersion: networking.k8s.io/v1
+    kcp.io/cluster: 49adf4fn8ks8x43u
+  creationTimestamp: "2023-03-20T19:08:21Z"
+  generation: 1
+  name: ingresses.v1.networking.k8s.io
+  resourceVersion: "789"
+  uid: ec957146-0918-49c3-9869-8134517471b9
+spec:
+  groupVersion:
+    group: networking.k8s.io
+    version: v1
+  kind: Ingress
+  listKind: IngressList
+  openAPIV3Schema:
+    description: Ingress is a collection of rules that allow inbound connections to
+      reach the endpoints defined by a backend. An Ingress can be configured to give
+      services externally-reachable urls, load balance traffic, terminate SSL, offer
+      name based virtual hosting etc.
+    properties:
+      apiVersion:
+        description: 'APIVersion defines the versioned schema of this representation
+          of an object. Servers should convert recognized schemas to the latest internal
+          value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+        type: string
+      kind:
+        description: 'Kind is a string value representing the REST resource this object
+          represents. Servers may infer this from the endpoint the client submits
+          requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+        type: string
+      metadata:
+        type: object
+      spec:
+        description: 'Spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+        properties:
+          defaultBackend:
+            description: DefaultBackend is the backend that should handle requests
+              that don't match any rule. If Rules are not specified, DefaultBackend
+              must be specified. If DefaultBackend is not set, the handling of requests
+              that do not match any of the rules will be up to the Ingress controller.
+            properties:
+              resource:
+                description: Resource is an ObjectRef to another Kubernetes resource
+                  in the namespace of the Ingress object. If resource is specified,
+                  a service.Name and service.Port must not be specified. This is a
+                  mutually exclusive setting with "Service".
+                properties:
+                  apiGroup:
+                    description: APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in
+                      the core API group. For any other third-party types, APIGroup
+                      is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              service:
+                description: Service references a Service as a Backend. This is a
+                  mutually exclusive setting with "Resource".
+                properties:
+                  name:
+                    description: Name is the referenced service. The service must
+                      exist in the same namespace as the Ingress object.
+                    type: string
+                  port:
+                    description: Port of the referenced service. A port name or port
+                      number is required for a IngressServiceBackend.
+                    properties:
+                      name:
+                        description: Name is the name of the port on the Service.
+                          This is a mutually exclusive setting with "Number".
+                        type: string
+                      number:
+                        description: Number is the numerical port number (e.g. 80)
+                          on the Service. This is a mutually exclusive setting with
+                          "Name".
+                        format: int32
+                        type: integer
+                    type: object
+                required:
+                - name
+                type: object
+            type: object
+          ingressClassName:
+            description: IngressClassName is the name of the IngressClass cluster
+              resource. The associated IngressClass defines which controller will
+              implement the resource. This replaces the deprecated `kubernetes.io/ingress.class`
+              annotation. For backwards compatibility, when that annotation is set,
+              it must be given precedence over this field. The controller may emit
+              a warning if the field and annotation have different values. Implementations
+              of this API should ignore Ingresses without a class specified. An IngressClass
+              resource may be marked as default, which can be used to set a default
+              value for this field. For more information, refer to the IngressClass
+              documentation.
+            type: string
+          rules:
+            description: A list of host rules used to configure the Ingress. If unspecified,
+              or no rule matches, all traffic is sent to the default backend.
+            items:
+              description: IngressRule represents the rules mapping the paths under
+                a specified host to the related backend services. Incoming requests
+                are first evaluated for a host match, then routed to the backend associated
+                with the matching IngressRuleValue.
+              properties:
+                host:
+                  description: "Host is the fully qualified domain name of a network
+                    host, as defined by RFC 3986. Note the following deviations from
+                    the \"host\" part of the URI as defined in RFC 3986: 1. IPs are
+                    not allowed. Currently an IngressRuleValue can only apply to\n
+                    \  the IP in the Spec of the parent Ingress.\n2. The `:` delimiter
+                    is not respected because ports are not allowed.\n\t  Currently
+                    the port of an Ingress is implicitly :80 for http and\n\t  :443
+                    for https.\nBoth these may change in the future. Incoming requests
+                    are matched against the host before the IngressRuleValue. If the
+                    host is unspecified, the Ingress routes all traffic based on the
+                    specified IngressRuleValue.\n\nHost can be \"precise\" which is
+                    a domain name without the terminating dot of a network host (e.g.
+                    \"foo.bar.com\") or \"wildcard\", which is a domain name prefixed
+                    with a single wildcard label (e.g. \"*.foo.com\"). The wildcard
+                    character '*' must appear by itself as the first DNS label and
+                    matches only a single label. You cannot have a wildcard label
+                    by itself (e.g. Host == \"*\"). Requests will be matched against
+                    the Host field in the following way: 1. If Host is precise, the
+                    request matches this rule if the http host header is equal to
+                    Host. 2. If Host is a wildcard, then the request matches this
+                    rule if the http host header is to equal to the suffix (removing
+                    the first label) of the wildcard rule."
+                  type: string
+                http:
+                  description: 'HTTPIngressRuleValue is a list of http selectors pointing
+                    to backends. In the example: http://<host>/<path>?<searchpart>
+                    -> backend where where parts of the url correspond to RFC 3986,
+                    this resource will be used to match against everything after the
+                    last ''/'' and before the first ''?'' or ''#''.'
+                  properties:
+                    paths:
+                      description: A collection of paths that map requests to backends.
+                      items:
+                        description: HTTPIngressPath associates a path with a backend.
+                          Incoming urls matching the path are forwarded to the backend.
+                        properties:
+                          backend:
+                            description: Backend defines the referenced service endpoint
+                              to which the traffic will be forwarded to.
+                            properties:
+                              resource:
+                                description: Resource is an ObjectRef to another Kubernetes
+                                  resource in the namespace of the Ingress object.
+                                  If resource is specified, a service.Name and service.Port
+                                  must not be specified. This is a mutually exclusive
+                                  setting with "Service".
+                                properties:
+                                  apiGroup:
+                                    description: APIGroup is the group for the resource
+                                      being referenced. If APIGroup is not specified,
+                                      the specified Kind must be in the core API group.
+                                      For any other third-party types, APIGroup is
+                                      required.
+                                    type: string
+                                  kind:
+                                    description: Kind is the type of resource being
+                                      referenced
+                                    type: string
+                                  name:
+                                    description: Name is the name of resource being
+                                      referenced
+                                    type: string
+                                required:
+                                - kind
+                                - name
+                                type: object
+                              service:
+                                description: Service references a Service as a Backend.
+                                  This is a mutually exclusive setting with "Resource".
+                                properties:
+                                  name:
+                                    description: Name is the referenced service. The
+                                      service must exist in the same namespace as
+                                      the Ingress object.
+                                    type: string
+                                  port:
+                                    description: Port of the referenced service. A
+                                      port name or port number is required for a IngressServiceBackend.
+                                    properties:
+                                      name:
+                                        description: Name is the name of the port
+                                          on the Service. This is a mutually exclusive
+                                          setting with "Number".
+                                        type: string
+                                      number:
+                                        description: Number is the numerical port
+                                          number (e.g. 80) on the Service. This is
+                                          a mutually exclusive setting with "Name".
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                            type: object
+                          path:
+                            description: Path is matched against the path of an incoming
+                              request. Currently it can contain characters disallowed
+                              from the conventional "path" part of a URL as defined
+                              by RFC 3986. Paths must begin with a '/'. When unspecified,
+                              all paths from incoming requests are matched.
+                            type: string
+                          pathType:
+                            description: |-
+                              PathType determines the interpretation of the Path matching. PathType can be one of the following values: * Exact: Matches the URL path exactly. * Prefix: Matches based on a URL path prefix split by '/'. Matching is
+                                done on a path element by element basis. A path element refers is the
+                                list of labels in the path split by the '/' separator. A request is a
+                                match for path p if every p is an element-wise prefix of p of the
+                                request path. Note that if the last element of the path is a substring
+                                of the last element in request path, it is not a match (e.g. /foo/bar
+                                matches /foo/bar/baz, but does not match /foo/barbaz).
+                              * ImplementationSpecific: Interpretation of the Path matching is up to
+                                the IngressClass. Implementations can treat this as a separate PathType
+                                or treat it identically to Prefix or Exact path types.
+                              Implementations are required to support all path types.
+                            type: string
+                        required:
+                        - backend
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  required:
+                  - paths
+                  type: object
+              type: object
+            type: array
+            x-kubernetes-list-type: atomic
+          tls:
+            description: TLS configuration. Currently the Ingress only supports a
+              single TLS port, 443. If multiple members of this list specify different
+              hosts, they will be multiplexed on the same port according to the hostname
+              specified through the SNI TLS extension, if the ingress controller fulfilling
+              the ingress supports SNI.
+            items:
+              description: IngressTLS describes the transport layer security associated
+                with an Ingress.
+              properties:
+                hosts:
+                  description: Hosts are a list of hosts included in the TLS certificate.
+                    The values in this list must match the name/s used in the tlsSecret.
+                    Defaults to the wildcard host setting for the loadbalancer controller
+                    fulfilling this Ingress, if left unspecified.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: atomic
+                secretName:
+                  description: SecretName is the name of the secret used to terminate
+                    TLS traffic on port 443. Field is left optional to allow TLS routing
+                    based on SNI hostname alone. If the SNI host in a listener conflicts
+                    with the "Host" header field used by an IngressRule, the SNI host
+                    is used for termination and value of the Host header is used for
+                    routing.
+                  type: string
+              type: object
+            type: array
+            x-kubernetes-list-type: atomic
+        type: object
+      status:
+        description: 'Status is the current state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+        properties:
+          loadBalancer:
+            description: LoadBalancer contains the current status of the load-balancer.
+            properties:
+              ingress:
+                description: Ingress is a list containing ingress points for the load-balancer.
+                  Traffic intended for the service should be sent to these ingress
+                  points.
+                items:
+                  description: 'LoadBalancerIngress represents the status of a load-balancer
+                    ingress point: traffic intended for the service should be sent
+                    to an ingress point.'
+                  properties:
+                    hostname:
+                      description: Hostname is set for load-balancer ingress points
+                        that are DNS based (typically AWS load-balancers)
+                      type: string
+                    ip:
+                      description: IP is set for load-balancer ingress points that
+                        are IP based (typically GCE or OpenStack load-balancers)
+                      type: string
+                    ports:
+                      description: Ports is a list of records of service ports If
+                        used, every port defined in the service should have an entry
+                        in it
+                      items:
+                        properties:
+                          error:
+                            description: |-
+                              Error is to record the problem with the service port The format of the error shall comply with the following rules: - built-in error values shall be specified in this file and those shall use
+                                CamelCase names
+                              - cloud provider specific error values must have names that comply with the
+                                format foo.example.com/CamelCase.
+                            type: string
+                          port:
+                            description: Port is the port number of the service port
+                              of which status is recorded here
+                            format: int32
+                            type: integer
+                          protocol:
+                            description: 'Protocol is the protocol of the service
+                              port of which status is recorded here The supported
+                              values are: "TCP", "UDP", "SCTP"'
+                            type: string
+                        required:
+                        - port
+                        - protocol
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  type: object
+                type: array
+            type: object
+        type: object
+    type: object
+  plural: ingresses
+  scope: Namespaced
+  shortNames:
+  - ing
+  singular: ingress
+  subResources:
+  - name: status

--- a/docs/content/concepts/scenarios/jn-scenario/yamls/4-NegotiatedAPIResource-pods.v1.core.yaml
+++ b/docs/content/concepts/scenarios/jn-scenario/yamls/4-NegotiatedAPIResource-pods.v1.core.yaml
@@ -1,0 +1,6580 @@
+apiVersion: apiresource.kcp.io/v1alpha1
+kind: NegotiatedAPIResource
+metadata:
+  annotations:
+    apiresource.kcp.io/apiVersion: v1
+    kcp.io/cluster: 49adf4fn8ks8x43u
+  creationTimestamp: "2023-03-20T19:08:21Z"
+  generation: 1
+  name: pods.v1.core
+  resourceVersion: "774"
+  uid: 69637ba5-054c-43c5-8ed1-0528d12523dc
+spec:
+  categories:
+  - all
+  groupVersion:
+    version: v1
+  kind: Pod
+  listKind: PodList
+  openAPIV3Schema:
+    description: Pod is a collection of containers that can run on a host. This resource
+      is created by clients and scheduled onto hosts.
+    properties:
+      apiVersion:
+        description: 'APIVersion defines the versioned schema of this representation
+          of an object. Servers should convert recognized schemas to the latest internal
+          value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+        type: string
+      kind:
+        description: 'Kind is a string value representing the REST resource this object
+          represents. Servers may infer this from the endpoint the client submits
+          requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+        type: string
+      metadata:
+        type: object
+      spec:
+        description: 'Specification of the desired behavior of the pod. More info:
+          https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+        properties:
+          activeDeadlineSeconds:
+            description: Optional duration in seconds the pod may be active on the
+              node relative to StartTime before the system will actively try to mark
+              it failed and kill associated containers. Value must be a positive integer.
+            format: int64
+            type: integer
+          affinity:
+            description: If specified, the pod's scheduling constraints
+            properties:
+              nodeAffinity:
+                description: Describes node affinity scheduling rules for the pod.
+                properties:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    description: The scheduler will prefer to schedule pods to nodes
+                      that satisfy the affinity expressions specified by this field,
+                      but it may choose a node that violates one or more of the expressions.
+                      The node that is most preferred is the one with the greatest
+                      sum of weights, i.e. for each node that meets all of the scheduling
+                      requirements (resource request, requiredDuringScheduling affinity
+                      expressions, etc.), compute a sum by iterating through the elements
+                      of this field and adding "weight" to the sum if the node matches
+                      the corresponding matchExpressions; the node(s) with the highest
+                      sum are the most preferred.
+                    items:
+                      description: An empty preferred scheduling term matches all
+                        objects with implicit weight 0 (i.e. it's a no-op). A null
+                        preferred scheduling term matches no objects (i.e. is also
+                        a no-op).
+                      properties:
+                        preference:
+                          description: A node selector term, associated with the corresponding
+                            weight.
+                          properties:
+                            matchExpressions:
+                              description: A list of node selector requirements by
+                                node's labels.
+                              items:
+                                description: A node selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: The label key that the selector applies
+                                      to.
+                                    type: string
+                                  operator:
+                                    description: Represents a key's relationship to
+                                      a set of values. Valid operators are In, NotIn,
+                                      Exists, DoesNotExist. Gt, and Lt.
+                                    type: string
+                                  values:
+                                    description: An array of string values. If the
+                                      operator is In or NotIn, the values array must
+                                      be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator
+                                      is Gt or Lt, the values array must have a single
+                                      element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchFields:
+                              description: A list of node selector requirements by
+                                node's fields.
+                              items:
+                                description: A node selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: The label key that the selector applies
+                                      to.
+                                    type: string
+                                  operator:
+                                    description: Represents a key's relationship to
+                                      a set of values. Valid operators are In, NotIn,
+                                      Exists, DoesNotExist. Gt, and Lt.
+                                    type: string
+                                  values:
+                                    description: An array of string values. If the
+                                      operator is In or NotIn, the values array must
+                                      be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator
+                                      is Gt or Lt, the values array must have a single
+                                      element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                          type: object
+                        weight:
+                          description: Weight associated with matching the corresponding
+                            nodeSelectorTerm, in the range 1-100.
+                          format: int32
+                          type: integer
+                      required:
+                      - weight
+                      - preference
+                      type: object
+                    type: array
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    description: If the affinity requirements specified by this field
+                      are not met at scheduling time, the pod will not be scheduled
+                      onto the node. If the affinity requirements specified by this
+                      field cease to be met at some point during pod execution (e.g.
+                      due to an update), the system may or may not try to eventually
+                      evict the pod from its node.
+                    properties:
+                      nodeSelectorTerms:
+                        description: Required. A list of node selector terms. The
+                          terms are ORed.
+                        items:
+                          description: A null or empty node selector term matches
+                            no objects. The requirements of them are ANDed. The TopologySelectorTerm
+                            type implements a subset of the NodeSelectorTerm.
+                          properties:
+                            matchExpressions:
+                              description: A list of node selector requirements by
+                                node's labels.
+                              items:
+                                description: A node selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: The label key that the selector applies
+                                      to.
+                                    type: string
+                                  operator:
+                                    description: Represents a key's relationship to
+                                      a set of values. Valid operators are In, NotIn,
+                                      Exists, DoesNotExist. Gt, and Lt.
+                                    type: string
+                                  values:
+                                    description: An array of string values. If the
+                                      operator is In or NotIn, the values array must
+                                      be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator
+                                      is Gt or Lt, the values array must have a single
+                                      element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchFields:
+                              description: A list of node selector requirements by
+                                node's fields.
+                              items:
+                                description: A node selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: The label key that the selector applies
+                                      to.
+                                    type: string
+                                  operator:
+                                    description: Represents a key's relationship to
+                                      a set of values. Valid operators are In, NotIn,
+                                      Exists, DoesNotExist. Gt, and Lt.
+                                    type: string
+                                  values:
+                                    description: An array of string values. If the
+                                      operator is In or NotIn, the values array must
+                                      be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator
+                                      is Gt or Lt, the values array must have a single
+                                      element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                          type: object
+                        type: array
+                    required:
+                    - nodeSelectorTerms
+                    type: object
+                type: object
+              podAffinity:
+                description: Describes pod affinity scheduling rules (e.g. co-locate
+                  this pod in the same node, zone, etc. as some other pod(s)).
+                properties:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    description: The scheduler will prefer to schedule pods to nodes
+                      that satisfy the affinity expressions specified by this field,
+                      but it may choose a node that violates one or more of the expressions.
+                      The node that is most preferred is the one with the greatest
+                      sum of weights, i.e. for each node that meets all of the scheduling
+                      requirements (resource request, requiredDuringScheduling affinity
+                      expressions, etc.), compute a sum by iterating through the elements
+                      of this field and adding "weight" to the sum if the node has
+                      pods which matches the corresponding podAffinityTerm; the node(s)
+                      with the highest sum are the most preferred.
+                    items:
+                      description: The weights of all of the matched WeightedPodAffinityTerm
+                        fields are added per-node to find the most preferred node(s)
+                      properties:
+                        podAffinityTerm:
+                          description: Required. A pod affinity term, associated with
+                            the corresponding weight.
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field. null selector
+                                and null or empty namespaces list means "this pod's
+                                namespace". An empty selector ({}) matches all namespaces.
+                                This field is alpha-level and is only honored when
+                                PodAffinityNamespaceSelector feature is enabled.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector. null or
+                                empty namespaces list and null namespaceSelector means
+                                "this pod's namespace"
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        weight:
+                          description: weight associated with matching the corresponding
+                            podAffinityTerm, in the range 1-100.
+                          format: int32
+                          type: integer
+                      required:
+                      - weight
+                      - podAffinityTerm
+                      type: object
+                    type: array
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    description: If the affinity requirements specified by this field
+                      are not met at scheduling time, the pod will not be scheduled
+                      onto the node. If the affinity requirements specified by this
+                      field cease to be met at some point during pod execution (e.g.
+                      due to a pod label update), the system may or may not try to
+                      eventually evict the pod from its node. When there are multiple
+                      elements, the lists of nodes corresponding to each podAffinityTerm
+                      are intersected, i.e. all terms must be satisfied.
+                    items:
+                      description: Defines a set of pods (namely those matching the
+                        labelSelector relative to the given namespace(s)) that this
+                        pod should be co-located (affinity) or not co-located (anti-affinity)
+                        with, where co-located is defined as running on a node whose
+                        value of the label with key <topologyKey> matches that of
+                        any node on which a pod of the set of pods is running
+                      properties:
+                        labelSelector:
+                          description: A label query over a set of resources, in this
+                            case pods.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        namespaceSelector:
+                          description: A label query over the set of namespaces that
+                            the term applies to. The term is applied to the union
+                            of the namespaces selected by this field and the ones
+                            listed in the namespaces field. null selector and null
+                            or empty namespaces list means "this pod's namespace".
+                            An empty selector ({}) matches all namespaces. This field
+                            is alpha-level and is only honored when PodAffinityNamespaceSelector
+                            feature is enabled.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        namespaces:
+                          description: namespaces specifies a static list of namespace
+                            names that the term applies to. The term is applied to
+                            the union of the namespaces listed in this field and the
+                            ones selected by namespaceSelector. null or empty namespaces
+                            list and null namespaceSelector means "this pod's namespace"
+                          items:
+                            type: string
+                          type: array
+                        topologyKey:
+                          description: This pod should be co-located (affinity) or
+                            not co-located (anti-affinity) with the pods matching
+                            the labelSelector in the specified namespaces, where co-located
+                            is defined as running on a node whose value of the label
+                            with key topologyKey matches that of any node on which
+                            any of the selected pods is running. Empty topologyKey
+                            is not allowed.
+                          type: string
+                      required:
+                      - topologyKey
+                      type: object
+                    type: array
+                type: object
+              podAntiAffinity:
+                description: Describes pod anti-affinity scheduling rules (e.g. avoid
+                  putting this pod in the same node, zone, etc. as some other pod(s)).
+                properties:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    description: The scheduler will prefer to schedule pods to nodes
+                      that satisfy the anti-affinity expressions specified by this
+                      field, but it may choose a node that violates one or more of
+                      the expressions. The node that is most preferred is the one
+                      with the greatest sum of weights, i.e. for each node that meets
+                      all of the scheduling requirements (resource request, requiredDuringScheduling
+                      anti-affinity expressions, etc.), compute a sum by iterating
+                      through the elements of this field and adding "weight" to the
+                      sum if the node has pods which matches the corresponding podAffinityTerm;
+                      the node(s) with the highest sum are the most preferred.
+                    items:
+                      description: The weights of all of the matched WeightedPodAffinityTerm
+                        fields are added per-node to find the most preferred node(s)
+                      properties:
+                        podAffinityTerm:
+                          description: Required. A pod affinity term, associated with
+                            the corresponding weight.
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field. null selector
+                                and null or empty namespaces list means "this pod's
+                                namespace". An empty selector ({}) matches all namespaces.
+                                This field is alpha-level and is only honored when
+                                PodAffinityNamespaceSelector feature is enabled.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector. null or
+                                empty namespaces list and null namespaceSelector means
+                                "this pod's namespace"
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        weight:
+                          description: weight associated with matching the corresponding
+                            podAffinityTerm, in the range 1-100.
+                          format: int32
+                          type: integer
+                      required:
+                      - weight
+                      - podAffinityTerm
+                      type: object
+                    type: array
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    description: If the anti-affinity requirements specified by this
+                      field are not met at scheduling time, the pod will not be scheduled
+                      onto the node. If the anti-affinity requirements specified by
+                      this field cease to be met at some point during pod execution
+                      (e.g. due to a pod label update), the system may or may not
+                      try to eventually evict the pod from its node. When there are
+                      multiple elements, the lists of nodes corresponding to each
+                      podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                    items:
+                      description: Defines a set of pods (namely those matching the
+                        labelSelector relative to the given namespace(s)) that this
+                        pod should be co-located (affinity) or not co-located (anti-affinity)
+                        with, where co-located is defined as running on a node whose
+                        value of the label with key <topologyKey> matches that of
+                        any node on which a pod of the set of pods is running
+                      properties:
+                        labelSelector:
+                          description: A label query over a set of resources, in this
+                            case pods.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        namespaceSelector:
+                          description: A label query over the set of namespaces that
+                            the term applies to. The term is applied to the union
+                            of the namespaces selected by this field and the ones
+                            listed in the namespaces field. null selector and null
+                            or empty namespaces list means "this pod's namespace".
+                            An empty selector ({}) matches all namespaces. This field
+                            is alpha-level and is only honored when PodAffinityNamespaceSelector
+                            feature is enabled.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        namespaces:
+                          description: namespaces specifies a static list of namespace
+                            names that the term applies to. The term is applied to
+                            the union of the namespaces listed in this field and the
+                            ones selected by namespaceSelector. null or empty namespaces
+                            list and null namespaceSelector means "this pod's namespace"
+                          items:
+                            type: string
+                          type: array
+                        topologyKey:
+                          description: This pod should be co-located (affinity) or
+                            not co-located (anti-affinity) with the pods matching
+                            the labelSelector in the specified namespaces, where co-located
+                            is defined as running on a node whose value of the label
+                            with key topologyKey matches that of any node on which
+                            any of the selected pods is running. Empty topologyKey
+                            is not allowed.
+                          type: string
+                      required:
+                      - topologyKey
+                      type: object
+                    type: array
+                type: object
+            type: object
+          automountServiceAccountToken:
+            description: AutomountServiceAccountToken indicates whether a service
+              account token should be automatically mounted.
+            type: boolean
+          containers:
+            description: List of containers belonging to the pod. Containers cannot
+              currently be added or removed. There must be at least one container
+              in a Pod. Cannot be updated.
+            items:
+              description: A single application container that you want to run within
+                a pod.
+              properties:
+                args:
+                  description: 'Arguments to the entrypoint. The docker image''s CMD
+                    is used if this is not provided. Variable references $(VAR_NAME)
+                    are expanded using the container''s environment. If a variable
+                    cannot be resolved, the reference in the input string will be
+                    unchanged. The $(VAR_NAME) syntax can be escaped with a double
+                    $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                    regardless of whether the variable exists or not. Cannot be updated.
+                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                command:
+                  description: 'Entrypoint array. Not executed within a shell. The
+                    docker image''s ENTRYPOINT is used if this is not provided. Variable
+                    references $(VAR_NAME) are expanded using the container''s environment.
+                    If a variable cannot be resolved, the reference in the input string
+                    will be unchanged. The $(VAR_NAME) syntax can be escaped with
+                    a double $$, ie: $$(VAR_NAME). Escaped references will never be
+                    expanded, regardless of whether the variable exists or not. Cannot
+                    be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                env:
+                  description: List of environment variables to set in the container.
+                    Cannot be updated.
+                  items:
+                    description: EnvVar represents an environment variable present
+                      in a Container.
+                    properties:
+                      name:
+                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        type: string
+                      value:
+                        description: 'Variable references $(VAR_NAME) are expanded
+                          using the previous defined environment variables in the
+                          container and any service environment variables. If a variable
+                          cannot be resolved, the reference in the input string will
+                          be unchanged. The $(VAR_NAME) syntax can be escaped with
+                          a double $$, ie: $$(VAR_NAME). Escaped references will never
+                          be expanded, regardless of whether the variable exists or
+                          not. Defaults to "".'
+                        type: string
+                      valueFrom:
+                        description: Source for the environment variable's value.
+                          Cannot be used if value is not empty.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          fieldRef:
+                            description: 'Selects a field of the pod: supports metadata.name,
+                              metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                              spec.nodeName, spec.serviceAccountName, status.hostIP,
+                              status.podIP, status.podIPs.'
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                            - fieldPath
+                            type: object
+                          resourceFieldRef:
+                            description: 'Selects a resource of the container: only
+                              resources limits and requests (limits.cpu, limits.memory,
+                              limits.ephemeral-storage, requests.cpu, requests.memory
+                              and requests.ephemeral-storage) are currently supported.'
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Specifies the output format of the exposed
+                                  resources, defaults to "1"
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                            - resource
+                            type: object
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - name
+                  x-kubernetes-list-type: map
+                envFrom:
+                  description: List of sources to populate environment variables in
+                    the container. The keys defined within a source must be a C_IDENTIFIER.
+                    All invalid keys will be reported as an event when the container
+                    is starting. When a key exists in multiple sources, the value
+                    associated with the last source will take precedence. Values defined
+                    by an Env with a duplicate key will take precedence. Cannot be
+                    updated.
+                  items:
+                    description: EnvFromSource represents the source of a set of ConfigMaps
+                    properties:
+                      configMapRef:
+                        description: The ConfigMap to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the ConfigMap must be defined
+                            type: boolean
+                        type: object
+                      prefix:
+                        description: An optional identifier to prepend to each key
+                          in the ConfigMap. Must be a C_IDENTIFIER.
+                        type: string
+                      secretRef:
+                        description: The Secret to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret must be defined
+                            type: boolean
+                        type: object
+                    type: object
+                  type: array
+                image:
+                  description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                    This field is optional to allow higher level config management
+                    to default or override container images in workload controllers
+                    like Deployments and StatefulSets.'
+                  type: string
+                imagePullPolicy:
+                  description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                    Defaults to Always if :latest tag is specified, or IfNotPresent
+                    otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                  type: string
+                lifecycle:
+                  description: Actions that the management system should take in response
+                    to container lifecycle events. Cannot be updated.
+                  properties:
+                    postStart:
+                      description: 'PostStart is called immediately after a container
+                        is created. If the handler fails, the container is terminated
+                        and restarted according to its restart policy. Other management
+                        of the container blocks until the hook completes. More info:
+                        https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: TCPSocket specifies an action involving a TCP
+                            port. TCP hooks not yet supported
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                    preStop:
+                      description: 'PreStop is called immediately before a container
+                        is terminated due to an API request or management event such
+                        as liveness/startup probe failure, preemption, resource contention,
+                        etc. The handler is not called if the container crashes or
+                        exits. The reason for termination is passed to the handler.
+                        The Pod''s termination grace period countdown begins before
+                        the PreStop hooked is executed. Regardless of the outcome
+                        of the handler, the container will eventually terminate within
+                        the Pod''s termination grace period. Other management of the
+                        container blocks until the hook completes or until the termination
+                        grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: TCPSocket specifies an action involving a TCP
+                            port. TCP hooks not yet supported
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                  type: object
+                livenessProbe:
+                  description: 'Periodic probe of container liveness. Container will
+                    be restarted if the probe fails. Cannot be updated. More info:
+                    https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: One and only one of the following should be specified.
+                        Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: Scheme to use for connecting to the host. Defaults
+                            to HTTP.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                        TCP hooks not yet supported
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is an alpha field and requires enabling ProbeTerminationGracePeriod
+                        feature gate.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                name:
+                  description: Name of the container specified as a DNS_LABEL. Each
+                    container in a pod must have a unique name (DNS_LABEL). Cannot
+                    be updated.
+                  type: string
+                ports:
+                  description: List of ports to expose from the container. Exposing
+                    a port here gives the system additional information about the
+                    network connections a container uses, but is primarily informational.
+                    Not specifying a port here DOES NOT prevent that port from being
+                    exposed. Any port which is listening on the default "0.0.0.0"
+                    address inside a container will be accessible from the network.
+                    Cannot be updated.
+                  items:
+                    description: ContainerPort represents a network port in a single
+                      container.
+                    properties:
+                      containerPort:
+                        description: Number of port to expose on the pod's IP address.
+                          This must be a valid port number, 0 < x < 65536.
+                        format: int32
+                        type: integer
+                      hostIP:
+                        description: What host IP to bind the external port to.
+                        type: string
+                      hostPort:
+                        description: Number of port to expose on the host. If specified,
+                          this must be a valid port number, 0 < x < 65536. If HostNetwork
+                          is specified, this must match ContainerPort. Most containers
+                          do not need this.
+                        format: int32
+                        type: integer
+                      name:
+                        description: If specified, this must be an IANA_SVC_NAME and
+                          unique within the pod. Each named port in a pod must have
+                          a unique name. Name for the port that can be referred to
+                          by services.
+                        type: string
+                      protocol:
+                        default: TCP
+                        description: Protocol for port. Must be UDP, TCP, or SCTP.
+                          Defaults to "TCP".
+                        type: string
+                    required:
+                    - containerPort
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - containerPort
+                  - protocol
+                  x-kubernetes-list-type: map
+                readinessProbe:
+                  description: 'Periodic probe of container service readiness. Container
+                    will be removed from service endpoints if the probe fails. Cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: One and only one of the following should be specified.
+                        Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: Scheme to use for connecting to the host. Defaults
+                            to HTTP.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                        TCP hooks not yet supported
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is an alpha field and requires enabling ProbeTerminationGracePeriod
+                        feature gate.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                resources:
+                  description: 'Compute Resources required by this container. Cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                  type: object
+                securityContext:
+                  description: 'Security options the pod should run with. More info:
+                    https://kubernetes.io/docs/concepts/policy/security-context/ More
+                    info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                  properties:
+                    allowPrivilegeEscalation:
+                      description: 'AllowPrivilegeEscalation controls whether a process
+                        can gain more privileges than its parent process. This bool
+                        directly controls if the no_new_privs flag will be set on
+                        the container process. AllowPrivilegeEscalation is true always
+                        when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                      type: boolean
+                    capabilities:
+                      description: The capabilities to add/drop when running containers.
+                        Defaults to the default set of capabilities granted by the
+                        container runtime.
+                      properties:
+                        add:
+                          description: Added capabilities
+                          items:
+                            type: string
+                          type: array
+                        drop:
+                          description: Removed capabilities
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    privileged:
+                      description: Run container in privileged mode. Processes in
+                        privileged containers are essentially equivalent to root on
+                        the host. Defaults to false.
+                      type: boolean
+                    procMount:
+                      description: procMount denotes the type of proc mount to use
+                        for the containers. The default is DefaultProcMount which
+                        uses the container runtime defaults for readonly paths and
+                        masked paths. This requires the ProcMountType feature flag
+                        to be enabled.
+                      type: string
+                    readOnlyRootFilesystem:
+                      description: Whether this container has a read-only root filesystem.
+                        Default is false.
+                      type: boolean
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container
+                        process. Uses runtime default if unset. May also be set in
+                        PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to
+                        start the container if it does. If unset or false, no such
+                        validation will be performed. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container
+                        process. Defaults to user specified in image metadata if unspecified.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: The SELinux context to be applied to the container.
+                        If unspecified, the container runtime will allocate a random
+                        SELinux context for each container.  May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
+                      type: object
+                    seccompProfile:
+                      description: The seccomp options to use by this container. If
+                        seccomp options are provided at both the pod & container level,
+                        the container options override the pod options.
+                      properties:
+                        localhostProfile:
+                          description: localhostProfile indicates a profile defined
+                            in a file on the node should be used. The profile must
+                            be preconfigured on the node to work. Must be a descending
+                            path, relative to the kubelet's configured seccomp profile
+                            location. Must only be set if type is "Localhost".
+                          type: string
+                        type:
+                          description: |-
+                            type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                            Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    windowsOptions:
+                      description: The Windows specific settings applied to all containers.
+                        If unspecified, the options from the PodSecurityContext will
+                        be used. If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence.
+                      properties:
+                        gmsaCredentialSpec:
+                          description: GMSACredentialSpec is where the GMSA admission
+                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                            inlines the contents of the GMSA credential spec named
+                            by the GMSACredentialSpecName field.
+                          type: string
+                        gmsaCredentialSpecName:
+                          description: GMSACredentialSpecName is the name of the GMSA
+                            credential spec to use.
+                          type: string
+                        runAsUserName:
+                          description: The UserName in Windows to run the entrypoint
+                            of the container process. Defaults to the user specified
+                            in image metadata if unspecified. May also be set in PodSecurityContext.
+                            If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence.
+                          type: string
+                      type: object
+                  type: object
+                startupProbe:
+                  description: 'StartupProbe indicates that the Pod has successfully
+                    initialized. If specified, no other probes are executed until
+                    this completes successfully. If this probe fails, the Pod will
+                    be restarted, just as if the livenessProbe failed. This can be
+                    used to provide different probe parameters at the beginning of
+                    a Pod''s lifecycle, when it might take a long time to load data
+                    or warm a cache, than during steady-state operation. This cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: One and only one of the following should be specified.
+                        Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: Scheme to use for connecting to the host. Defaults
+                            to HTTP.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                        TCP hooks not yet supported
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is an alpha field and requires enabling ProbeTerminationGracePeriod
+                        feature gate.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                stdin:
+                  description: Whether this container should allocate a buffer for
+                    stdin in the container runtime. If this is not set, reads from
+                    stdin in the container will always result in EOF. Default is false.
+                  type: boolean
+                stdinOnce:
+                  description: Whether the container runtime should close the stdin
+                    channel after it has been opened by a single attach. When stdin
+                    is true the stdin stream will remain open across multiple attach
+                    sessions. If stdinOnce is set to true, stdin is opened on container
+                    start, is empty until the first client attaches to stdin, and
+                    then remains open and accepts data until the client disconnects,
+                    at which time stdin is closed and remains closed until the container
+                    is restarted. If this flag is false, a container processes that
+                    reads from stdin will never receive an EOF. Default is false
+                  type: boolean
+                terminationMessagePath:
+                  description: 'Optional: Path at which the file to which the container''s
+                    termination message will be written is mounted into the container''s
+                    filesystem. Message written is intended to be brief final status,
+                    such as an assertion failure message. Will be truncated by the
+                    node if greater than 4096 bytes. The total message length across
+                    all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                    Cannot be updated.'
+                  type: string
+                terminationMessagePolicy:
+                  description: Indicate how the termination message should be populated.
+                    File will use the contents of terminationMessagePath to populate
+                    the container status message on both success and failure. FallbackToLogsOnError
+                    will use the last chunk of container log output if the termination
+                    message file is empty and the container exited with an error.
+                    The log output is limited to 2048 bytes or 80 lines, whichever
+                    is smaller. Defaults to File. Cannot be updated.
+                  type: string
+                tty:
+                  description: Whether this container should allocate a TTY for itself,
+                    also requires 'stdin' to be true. Default is false.
+                  type: boolean
+                volumeDevices:
+                  description: volumeDevices is the list of block devices to be used
+                    by the container.
+                  items:
+                    description: volumeDevice describes a mapping of a raw block device
+                      within a container.
+                    properties:
+                      devicePath:
+                        description: devicePath is the path inside of the container
+                          that the device will be mapped to.
+                        type: string
+                      name:
+                        description: name must match the name of a persistentVolumeClaim
+                          in the pod
+                        type: string
+                    required:
+                    - devicePath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - devicePath
+                  x-kubernetes-list-type: map
+                volumeMounts:
+                  description: Pod volumes to mount into the container's filesystem.
+                    Cannot be updated.
+                  items:
+                    description: VolumeMount describes a mounting of a Volume within
+                      a container.
+                    properties:
+                      mountPath:
+                        description: Path within the container at which the volume
+                          should be mounted.  Must not contain ':'.
+                        type: string
+                      mountPropagation:
+                        description: mountPropagation determines how mounts are propagated
+                          from the host to container and the other way around. When
+                          not set, MountPropagationNone is used. This field is beta
+                          in 1.10.
+                        type: string
+                      name:
+                        description: This must match the Name of a Volume.
+                        type: string
+                      readOnly:
+                        description: Mounted read-only if true, read-write otherwise
+                          (false or unspecified). Defaults to false.
+                        type: boolean
+                      subPath:
+                        description: Path within the volume from which the container's
+                          volume should be mounted. Defaults to "" (volume's root).
+                        type: string
+                      subPathExpr:
+                        description: Expanded path within the volume from which the
+                          container's volume should be mounted. Behaves similarly
+                          to SubPath but environment variable references $(VAR_NAME)
+                          are expanded using the container's environment. Defaults
+                          to "" (volume's root). SubPathExpr and SubPath are mutually
+                          exclusive.
+                        type: string
+                    required:
+                    - mountPath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - mountPath
+                  x-kubernetes-list-type: map
+                workingDir:
+                  description: Container's working directory. If not specified, the
+                    container runtime's default will be used, which might be configured
+                    in the container image. Cannot be updated.
+                  type: string
+              required:
+              - name
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - name
+            x-kubernetes-list-type: map
+          dnsConfig:
+            description: Specifies the DNS parameters of a pod. Parameters specified
+              here will be merged to the generated DNS configuration based on DNSPolicy.
+            properties:
+              nameservers:
+                description: A list of DNS name server IP addresses. This will be
+                  appended to the base nameservers generated from DNSPolicy. Duplicated
+                  nameservers will be removed.
+                items:
+                  type: string
+                type: array
+              options:
+                description: A list of DNS resolver options. This will be merged with
+                  the base options generated from DNSPolicy. Duplicated entries will
+                  be removed. Resolution options given in Options will override those
+                  that appear in the base DNSPolicy.
+                items:
+                  description: PodDNSConfigOption defines DNS resolver options of
+                    a pod.
+                  properties:
+                    name:
+                      description: Required.
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
+              searches:
+                description: A list of DNS search domains for host-name lookup. This
+                  will be appended to the base search paths generated from DNSPolicy.
+                  Duplicated search paths will be removed.
+                items:
+                  type: string
+                type: array
+            type: object
+          dnsPolicy:
+            description: Set DNS policy for the pod. Defaults to "ClusterFirst". Valid
+              values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
+              DNS parameters given in DNSConfig will be merged with the policy selected
+              with DNSPolicy. To have DNS options set along with hostNetwork, you
+              have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+            type: string
+          enableServiceLinks:
+            description: 'EnableServiceLinks indicates whether information about services
+              should be injected into pod''s environment variables, matching the syntax
+              of Docker links. Optional: Defaults to true.'
+            type: boolean
+          ephemeralContainers:
+            description: List of ephemeral containers run in this pod. Ephemeral containers
+              may be run in an existing pod to perform user-initiated actions such
+              as debugging. This list cannot be specified when creating a pod, and
+              it cannot be modified by updating the pod spec. In order to add an ephemeral
+              container to an existing pod, use the pod's ephemeralcontainers subresource.
+              This field is alpha-level and is only honored by servers that enable
+              the EphemeralContainers feature.
+            items:
+              description: An EphemeralContainer is a container that may be added
+                temporarily to an existing pod for user-initiated activities such
+                as debugging. Ephemeral containers have no resource or scheduling
+                guarantees, and they will not be restarted when they exit or when
+                a pod is removed or restarted. If an ephemeral container causes a
+                pod to exceed its resource allocation, the pod may be evicted. Ephemeral
+                containers may not be added by directly updating the pod spec. They
+                must be added via the pod's ephemeralcontainers subresource, and they
+                will appear in the pod spec once added. This is an alpha feature enabled
+                by the EphemeralContainers feature flag.
+              properties:
+                args:
+                  description: 'Arguments to the entrypoint. The docker image''s CMD
+                    is used if this is not provided. Variable references $(VAR_NAME)
+                    are expanded using the container''s environment. If a variable
+                    cannot be resolved, the reference in the input string will be
+                    unchanged. The $(VAR_NAME) syntax can be escaped with a double
+                    $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                    regardless of whether the variable exists or not. Cannot be updated.
+                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                command:
+                  description: 'Entrypoint array. Not executed within a shell. The
+                    docker image''s ENTRYPOINT is used if this is not provided. Variable
+                    references $(VAR_NAME) are expanded using the container''s environment.
+                    If a variable cannot be resolved, the reference in the input string
+                    will be unchanged. The $(VAR_NAME) syntax can be escaped with
+                    a double $$, ie: $$(VAR_NAME). Escaped references will never be
+                    expanded, regardless of whether the variable exists or not. Cannot
+                    be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                env:
+                  description: List of environment variables to set in the container.
+                    Cannot be updated.
+                  items:
+                    description: EnvVar represents an environment variable present
+                      in a Container.
+                    properties:
+                      name:
+                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        type: string
+                      value:
+                        description: 'Variable references $(VAR_NAME) are expanded
+                          using the previous defined environment variables in the
+                          container and any service environment variables. If a variable
+                          cannot be resolved, the reference in the input string will
+                          be unchanged. The $(VAR_NAME) syntax can be escaped with
+                          a double $$, ie: $$(VAR_NAME). Escaped references will never
+                          be expanded, regardless of whether the variable exists or
+                          not. Defaults to "".'
+                        type: string
+                      valueFrom:
+                        description: Source for the environment variable's value.
+                          Cannot be used if value is not empty.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          fieldRef:
+                            description: 'Selects a field of the pod: supports metadata.name,
+                              metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                              spec.nodeName, spec.serviceAccountName, status.hostIP,
+                              status.podIP, status.podIPs.'
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                            - fieldPath
+                            type: object
+                          resourceFieldRef:
+                            description: 'Selects a resource of the container: only
+                              resources limits and requests (limits.cpu, limits.memory,
+                              limits.ephemeral-storage, requests.cpu, requests.memory
+                              and requests.ephemeral-storage) are currently supported.'
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Specifies the output format of the exposed
+                                  resources, defaults to "1"
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                            - resource
+                            type: object
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - name
+                  x-kubernetes-list-type: map
+                envFrom:
+                  description: List of sources to populate environment variables in
+                    the container. The keys defined within a source must be a C_IDENTIFIER.
+                    All invalid keys will be reported as an event when the container
+                    is starting. When a key exists in multiple sources, the value
+                    associated with the last source will take precedence. Values defined
+                    by an Env with a duplicate key will take precedence. Cannot be
+                    updated.
+                  items:
+                    description: EnvFromSource represents the source of a set of ConfigMaps
+                    properties:
+                      configMapRef:
+                        description: The ConfigMap to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the ConfigMap must be defined
+                            type: boolean
+                        type: object
+                      prefix:
+                        description: An optional identifier to prepend to each key
+                          in the ConfigMap. Must be a C_IDENTIFIER.
+                        type: string
+                      secretRef:
+                        description: The Secret to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret must be defined
+                            type: boolean
+                        type: object
+                    type: object
+                  type: array
+                image:
+                  description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                  type: string
+                imagePullPolicy:
+                  description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                    Defaults to Always if :latest tag is specified, or IfNotPresent
+                    otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                  type: string
+                lifecycle:
+                  description: Lifecycle is not allowed for ephemeral containers.
+                  properties:
+                    postStart:
+                      description: 'PostStart is called immediately after a container
+                        is created. If the handler fails, the container is terminated
+                        and restarted according to its restart policy. Other management
+                        of the container blocks until the hook completes. More info:
+                        https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: TCPSocket specifies an action involving a TCP
+                            port. TCP hooks not yet supported
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                    preStop:
+                      description: 'PreStop is called immediately before a container
+                        is terminated due to an API request or management event such
+                        as liveness/startup probe failure, preemption, resource contention,
+                        etc. The handler is not called if the container crashes or
+                        exits. The reason for termination is passed to the handler.
+                        The Pod''s termination grace period countdown begins before
+                        the PreStop hooked is executed. Regardless of the outcome
+                        of the handler, the container will eventually terminate within
+                        the Pod''s termination grace period. Other management of the
+                        container blocks until the hook completes or until the termination
+                        grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: TCPSocket specifies an action involving a TCP
+                            port. TCP hooks not yet supported
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                  type: object
+                livenessProbe:
+                  description: Probes are not allowed for ephemeral containers.
+                  properties:
+                    exec:
+                      description: One and only one of the following should be specified.
+                        Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: Scheme to use for connecting to the host. Defaults
+                            to HTTP.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                        TCP hooks not yet supported
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is an alpha field and requires enabling ProbeTerminationGracePeriod
+                        feature gate.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                name:
+                  description: Name of the ephemeral container specified as a DNS_LABEL.
+                    This name must be unique among all containers, init containers
+                    and ephemeral containers.
+                  type: string
+                ports:
+                  description: Ports are not allowed for ephemeral containers.
+                  items:
+                    description: ContainerPort represents a network port in a single
+                      container.
+                    properties:
+                      containerPort:
+                        description: Number of port to expose on the pod's IP address.
+                          This must be a valid port number, 0 < x < 65536.
+                        format: int32
+                        type: integer
+                      hostIP:
+                        description: What host IP to bind the external port to.
+                        type: string
+                      hostPort:
+                        description: Number of port to expose on the host. If specified,
+                          this must be a valid port number, 0 < x < 65536. If HostNetwork
+                          is specified, this must match ContainerPort. Most containers
+                          do not need this.
+                        format: int32
+                        type: integer
+                      name:
+                        description: If specified, this must be an IANA_SVC_NAME and
+                          unique within the pod. Each named port in a pod must have
+                          a unique name. Name for the port that can be referred to
+                          by services.
+                        type: string
+                      protocol:
+                        default: TCP
+                        description: Protocol for port. Must be UDP, TCP, or SCTP.
+                          Defaults to "TCP".
+                        type: string
+                    required:
+                    - containerPort
+                    type: object
+                  type: array
+                readinessProbe:
+                  description: Probes are not allowed for ephemeral containers.
+                  properties:
+                    exec:
+                      description: One and only one of the following should be specified.
+                        Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: Scheme to use for connecting to the host. Defaults
+                            to HTTP.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                        TCP hooks not yet supported
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is an alpha field and requires enabling ProbeTerminationGracePeriod
+                        feature gate.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                resources:
+                  description: Resources are not allowed for ephemeral containers.
+                    Ephemeral containers use spare resources already allocated to
+                    the pod.
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                  type: object
+                securityContext:
+                  description: SecurityContext is not allowed for ephemeral containers.
+                  properties:
+                    allowPrivilegeEscalation:
+                      description: 'AllowPrivilegeEscalation controls whether a process
+                        can gain more privileges than its parent process. This bool
+                        directly controls if the no_new_privs flag will be set on
+                        the container process. AllowPrivilegeEscalation is true always
+                        when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                      type: boolean
+                    capabilities:
+                      description: The capabilities to add/drop when running containers.
+                        Defaults to the default set of capabilities granted by the
+                        container runtime.
+                      properties:
+                        add:
+                          description: Added capabilities
+                          items:
+                            type: string
+                          type: array
+                        drop:
+                          description: Removed capabilities
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    privileged:
+                      description: Run container in privileged mode. Processes in
+                        privileged containers are essentially equivalent to root on
+                        the host. Defaults to false.
+                      type: boolean
+                    procMount:
+                      description: procMount denotes the type of proc mount to use
+                        for the containers. The default is DefaultProcMount which
+                        uses the container runtime defaults for readonly paths and
+                        masked paths. This requires the ProcMountType feature flag
+                        to be enabled.
+                      type: string
+                    readOnlyRootFilesystem:
+                      description: Whether this container has a read-only root filesystem.
+                        Default is false.
+                      type: boolean
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container
+                        process. Uses runtime default if unset. May also be set in
+                        PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to
+                        start the container if it does. If unset or false, no such
+                        validation will be performed. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container
+                        process. Defaults to user specified in image metadata if unspecified.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: The SELinux context to be applied to the container.
+                        If unspecified, the container runtime will allocate a random
+                        SELinux context for each container.  May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
+                      type: object
+                    seccompProfile:
+                      description: The seccomp options to use by this container. If
+                        seccomp options are provided at both the pod & container level,
+                        the container options override the pod options.
+                      properties:
+                        localhostProfile:
+                          description: localhostProfile indicates a profile defined
+                            in a file on the node should be used. The profile must
+                            be preconfigured on the node to work. Must be a descending
+                            path, relative to the kubelet's configured seccomp profile
+                            location. Must only be set if type is "Localhost".
+                          type: string
+                        type:
+                          description: |-
+                            type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                            Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    windowsOptions:
+                      description: The Windows specific settings applied to all containers.
+                        If unspecified, the options from the PodSecurityContext will
+                        be used. If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence.
+                      properties:
+                        gmsaCredentialSpec:
+                          description: GMSACredentialSpec is where the GMSA admission
+                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                            inlines the contents of the GMSA credential spec named
+                            by the GMSACredentialSpecName field.
+                          type: string
+                        gmsaCredentialSpecName:
+                          description: GMSACredentialSpecName is the name of the GMSA
+                            credential spec to use.
+                          type: string
+                        runAsUserName:
+                          description: The UserName in Windows to run the entrypoint
+                            of the container process. Defaults to the user specified
+                            in image metadata if unspecified. May also be set in PodSecurityContext.
+                            If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence.
+                          type: string
+                      type: object
+                  type: object
+                startupProbe:
+                  description: Probes are not allowed for ephemeral containers.
+                  properties:
+                    exec:
+                      description: One and only one of the following should be specified.
+                        Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: Scheme to use for connecting to the host. Defaults
+                            to HTTP.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                        TCP hooks not yet supported
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is an alpha field and requires enabling ProbeTerminationGracePeriod
+                        feature gate.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                stdin:
+                  description: Whether this container should allocate a buffer for
+                    stdin in the container runtime. If this is not set, reads from
+                    stdin in the container will always result in EOF. Default is false.
+                  type: boolean
+                stdinOnce:
+                  description: Whether the container runtime should close the stdin
+                    channel after it has been opened by a single attach. When stdin
+                    is true the stdin stream will remain open across multiple attach
+                    sessions. If stdinOnce is set to true, stdin is opened on container
+                    start, is empty until the first client attaches to stdin, and
+                    then remains open and accepts data until the client disconnects,
+                    at which time stdin is closed and remains closed until the container
+                    is restarted. If this flag is false, a container processes that
+                    reads from stdin will never receive an EOF. Default is false
+                  type: boolean
+                targetContainerName:
+                  description: If set, the name of the container from PodSpec that
+                    this ephemeral container targets. The ephemeral container will
+                    be run in the namespaces (IPC, PID, etc) of this container. If
+                    not set then the ephemeral container is run in whatever namespaces
+                    are shared for the pod. Note that the container runtime must support
+                    this feature.
+                  type: string
+                terminationMessagePath:
+                  description: 'Optional: Path at which the file to which the container''s
+                    termination message will be written is mounted into the container''s
+                    filesystem. Message written is intended to be brief final status,
+                    such as an assertion failure message. Will be truncated by the
+                    node if greater than 4096 bytes. The total message length across
+                    all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                    Cannot be updated.'
+                  type: string
+                terminationMessagePolicy:
+                  description: Indicate how the termination message should be populated.
+                    File will use the contents of terminationMessagePath to populate
+                    the container status message on both success and failure. FallbackToLogsOnError
+                    will use the last chunk of container log output if the termination
+                    message file is empty and the container exited with an error.
+                    The log output is limited to 2048 bytes or 80 lines, whichever
+                    is smaller. Defaults to File. Cannot be updated.
+                  type: string
+                tty:
+                  description: Whether this container should allocate a TTY for itself,
+                    also requires 'stdin' to be true. Default is false.
+                  type: boolean
+                volumeDevices:
+                  description: volumeDevices is the list of block devices to be used
+                    by the container.
+                  items:
+                    description: volumeDevice describes a mapping of a raw block device
+                      within a container.
+                    properties:
+                      devicePath:
+                        description: devicePath is the path inside of the container
+                          that the device will be mapped to.
+                        type: string
+                      name:
+                        description: name must match the name of a persistentVolumeClaim
+                          in the pod
+                        type: string
+                    required:
+                    - devicePath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - devicePath
+                  x-kubernetes-list-type: map
+                volumeMounts:
+                  description: Pod volumes to mount into the container's filesystem.
+                    Cannot be updated.
+                  items:
+                    description: VolumeMount describes a mounting of a Volume within
+                      a container.
+                    properties:
+                      mountPath:
+                        description: Path within the container at which the volume
+                          should be mounted.  Must not contain ':'.
+                        type: string
+                      mountPropagation:
+                        description: mountPropagation determines how mounts are propagated
+                          from the host to container and the other way around. When
+                          not set, MountPropagationNone is used. This field is beta
+                          in 1.10.
+                        type: string
+                      name:
+                        description: This must match the Name of a Volume.
+                        type: string
+                      readOnly:
+                        description: Mounted read-only if true, read-write otherwise
+                          (false or unspecified). Defaults to false.
+                        type: boolean
+                      subPath:
+                        description: Path within the volume from which the container's
+                          volume should be mounted. Defaults to "" (volume's root).
+                        type: string
+                      subPathExpr:
+                        description: Expanded path within the volume from which the
+                          container's volume should be mounted. Behaves similarly
+                          to SubPath but environment variable references $(VAR_NAME)
+                          are expanded using the container's environment. Defaults
+                          to "" (volume's root). SubPathExpr and SubPath are mutually
+                          exclusive.
+                        type: string
+                    required:
+                    - mountPath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - mountPath
+                  x-kubernetes-list-type: map
+                workingDir:
+                  description: Container's working directory. If not specified, the
+                    container runtime's default will be used, which might be configured
+                    in the container image. Cannot be updated.
+                  type: string
+              required:
+              - name
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - name
+            x-kubernetes-list-type: map
+          hostAliases:
+            description: HostAliases is an optional list of hosts and IPs that will
+              be injected into the pod's hosts file if specified. This is only valid
+              for non-hostNetwork pods.
+            items:
+              description: HostAlias holds the mapping between IP and hostnames that
+                will be injected as an entry in the pod's hosts file.
+              properties:
+                hostnames:
+                  description: Hostnames for the above IP address.
+                  items:
+                    type: string
+                  type: array
+                ip:
+                  description: IP address of the host file entry.
+                  type: string
+              required:
+              - ip
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - ip
+            x-kubernetes-list-type: map
+          hostIPC:
+            description: 'Use the host''s ipc namespace. Optional: Default to false.'
+            type: boolean
+          hostNetwork:
+            description: Host networking requested for this pod. Use the host's network
+              namespace. If this option is set, the ports that will be used must be
+              specified. Default to false.
+            type: boolean
+          hostPID:
+            description: 'Use the host''s pid namespace. Optional: Default to false.'
+            type: boolean
+          hostname:
+            description: Specifies the hostname of the Pod If not specified, the pod's
+              hostname will be set to a system-defined value.
+            type: string
+          imagePullSecrets:
+            description: 'ImagePullSecrets is an optional list of references to secrets
+              in the same namespace to use for pulling any of the images used by this
+              PodSpec. If specified, these secrets will be passed to individual puller
+              implementations for them to use. For example, in the case of docker,
+              only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+            items:
+              description: LocalObjectReference contains enough information to let
+                you locate the referenced object inside the same namespace.
+              properties:
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+              required:
+              - name
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - name
+            x-kubernetes-list-type: map
+          initContainers:
+            description: 'List of initialization containers belonging to the pod.
+              Init containers are executed in order prior to containers being started.
+              If any init container fails, the pod is considered to have failed and
+              is handled according to its restartPolicy. The name for an init container
+              or normal container must be unique among all containers. Init containers
+              may not have Lifecycle actions, Readiness probes, Liveness probes, or
+              Startup probes. The resourceRequirements of an init container are taken
+              into account during scheduling by finding the highest request/limit
+              for each resource type, and then using the max of of that value or the
+              sum of the normal containers. Limits are applied to init containers
+              in a similar fashion. Init containers cannot currently be added or removed.
+              Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+            items:
+              description: A single application container that you want to run within
+                a pod.
+              properties:
+                args:
+                  description: 'Arguments to the entrypoint. The docker image''s CMD
+                    is used if this is not provided. Variable references $(VAR_NAME)
+                    are expanded using the container''s environment. If a variable
+                    cannot be resolved, the reference in the input string will be
+                    unchanged. The $(VAR_NAME) syntax can be escaped with a double
+                    $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                    regardless of whether the variable exists or not. Cannot be updated.
+                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                command:
+                  description: 'Entrypoint array. Not executed within a shell. The
+                    docker image''s ENTRYPOINT is used if this is not provided. Variable
+                    references $(VAR_NAME) are expanded using the container''s environment.
+                    If a variable cannot be resolved, the reference in the input string
+                    will be unchanged. The $(VAR_NAME) syntax can be escaped with
+                    a double $$, ie: $$(VAR_NAME). Escaped references will never be
+                    expanded, regardless of whether the variable exists or not. Cannot
+                    be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                env:
+                  description: List of environment variables to set in the container.
+                    Cannot be updated.
+                  items:
+                    description: EnvVar represents an environment variable present
+                      in a Container.
+                    properties:
+                      name:
+                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        type: string
+                      value:
+                        description: 'Variable references $(VAR_NAME) are expanded
+                          using the previous defined environment variables in the
+                          container and any service environment variables. If a variable
+                          cannot be resolved, the reference in the input string will
+                          be unchanged. The $(VAR_NAME) syntax can be escaped with
+                          a double $$, ie: $$(VAR_NAME). Escaped references will never
+                          be expanded, regardless of whether the variable exists or
+                          not. Defaults to "".'
+                        type: string
+                      valueFrom:
+                        description: Source for the environment variable's value.
+                          Cannot be used if value is not empty.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          fieldRef:
+                            description: 'Selects a field of the pod: supports metadata.name,
+                              metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                              spec.nodeName, spec.serviceAccountName, status.hostIP,
+                              status.podIP, status.podIPs.'
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                            - fieldPath
+                            type: object
+                          resourceFieldRef:
+                            description: 'Selects a resource of the container: only
+                              resources limits and requests (limits.cpu, limits.memory,
+                              limits.ephemeral-storage, requests.cpu, requests.memory
+                              and requests.ephemeral-storage) are currently supported.'
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Specifies the output format of the exposed
+                                  resources, defaults to "1"
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                            - resource
+                            type: object
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - name
+                  x-kubernetes-list-type: map
+                envFrom:
+                  description: List of sources to populate environment variables in
+                    the container. The keys defined within a source must be a C_IDENTIFIER.
+                    All invalid keys will be reported as an event when the container
+                    is starting. When a key exists in multiple sources, the value
+                    associated with the last source will take precedence. Values defined
+                    by an Env with a duplicate key will take precedence. Cannot be
+                    updated.
+                  items:
+                    description: EnvFromSource represents the source of a set of ConfigMaps
+                    properties:
+                      configMapRef:
+                        description: The ConfigMap to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the ConfigMap must be defined
+                            type: boolean
+                        type: object
+                      prefix:
+                        description: An optional identifier to prepend to each key
+                          in the ConfigMap. Must be a C_IDENTIFIER.
+                        type: string
+                      secretRef:
+                        description: The Secret to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret must be defined
+                            type: boolean
+                        type: object
+                    type: object
+                  type: array
+                image:
+                  description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                    This field is optional to allow higher level config management
+                    to default or override container images in workload controllers
+                    like Deployments and StatefulSets.'
+                  type: string
+                imagePullPolicy:
+                  description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                    Defaults to Always if :latest tag is specified, or IfNotPresent
+                    otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                  type: string
+                lifecycle:
+                  description: Actions that the management system should take in response
+                    to container lifecycle events. Cannot be updated.
+                  properties:
+                    postStart:
+                      description: 'PostStart is called immediately after a container
+                        is created. If the handler fails, the container is terminated
+                        and restarted according to its restart policy. Other management
+                        of the container blocks until the hook completes. More info:
+                        https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: TCPSocket specifies an action involving a TCP
+                            port. TCP hooks not yet supported
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                    preStop:
+                      description: 'PreStop is called immediately before a container
+                        is terminated due to an API request or management event such
+                        as liveness/startup probe failure, preemption, resource contention,
+                        etc. The handler is not called if the container crashes or
+                        exits. The reason for termination is passed to the handler.
+                        The Pod''s termination grace period countdown begins before
+                        the PreStop hooked is executed. Regardless of the outcome
+                        of the handler, the container will eventually terminate within
+                        the Pod''s termination grace period. Other management of the
+                        container blocks until the hook completes or until the termination
+                        grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: TCPSocket specifies an action involving a TCP
+                            port. TCP hooks not yet supported
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                  type: object
+                livenessProbe:
+                  description: 'Periodic probe of container liveness. Container will
+                    be restarted if the probe fails. Cannot be updated. More info:
+                    https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: One and only one of the following should be specified.
+                        Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: Scheme to use for connecting to the host. Defaults
+                            to HTTP.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                        TCP hooks not yet supported
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is an alpha field and requires enabling ProbeTerminationGracePeriod
+                        feature gate.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                name:
+                  description: Name of the container specified as a DNS_LABEL. Each
+                    container in a pod must have a unique name (DNS_LABEL). Cannot
+                    be updated.
+                  type: string
+                ports:
+                  description: List of ports to expose from the container. Exposing
+                    a port here gives the system additional information about the
+                    network connections a container uses, but is primarily informational.
+                    Not specifying a port here DOES NOT prevent that port from being
+                    exposed. Any port which is listening on the default "0.0.0.0"
+                    address inside a container will be accessible from the network.
+                    Cannot be updated.
+                  items:
+                    description: ContainerPort represents a network port in a single
+                      container.
+                    properties:
+                      containerPort:
+                        description: Number of port to expose on the pod's IP address.
+                          This must be a valid port number, 0 < x < 65536.
+                        format: int32
+                        type: integer
+                      hostIP:
+                        description: What host IP to bind the external port to.
+                        type: string
+                      hostPort:
+                        description: Number of port to expose on the host. If specified,
+                          this must be a valid port number, 0 < x < 65536. If HostNetwork
+                          is specified, this must match ContainerPort. Most containers
+                          do not need this.
+                        format: int32
+                        type: integer
+                      name:
+                        description: If specified, this must be an IANA_SVC_NAME and
+                          unique within the pod. Each named port in a pod must have
+                          a unique name. Name for the port that can be referred to
+                          by services.
+                        type: string
+                      protocol:
+                        default: TCP
+                        description: Protocol for port. Must be UDP, TCP, or SCTP.
+                          Defaults to "TCP".
+                        type: string
+                    required:
+                    - containerPort
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - containerPort
+                  - protocol
+                  x-kubernetes-list-type: map
+                readinessProbe:
+                  description: 'Periodic probe of container service readiness. Container
+                    will be removed from service endpoints if the probe fails. Cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: One and only one of the following should be specified.
+                        Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: Scheme to use for connecting to the host. Defaults
+                            to HTTP.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                        TCP hooks not yet supported
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is an alpha field and requires enabling ProbeTerminationGracePeriod
+                        feature gate.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                resources:
+                  description: 'Compute Resources required by this container. Cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                  type: object
+                securityContext:
+                  description: 'Security options the pod should run with. More info:
+                    https://kubernetes.io/docs/concepts/policy/security-context/ More
+                    info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                  properties:
+                    allowPrivilegeEscalation:
+                      description: 'AllowPrivilegeEscalation controls whether a process
+                        can gain more privileges than its parent process. This bool
+                        directly controls if the no_new_privs flag will be set on
+                        the container process. AllowPrivilegeEscalation is true always
+                        when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                      type: boolean
+                    capabilities:
+                      description: The capabilities to add/drop when running containers.
+                        Defaults to the default set of capabilities granted by the
+                        container runtime.
+                      properties:
+                        add:
+                          description: Added capabilities
+                          items:
+                            type: string
+                          type: array
+                        drop:
+                          description: Removed capabilities
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    privileged:
+                      description: Run container in privileged mode. Processes in
+                        privileged containers are essentially equivalent to root on
+                        the host. Defaults to false.
+                      type: boolean
+                    procMount:
+                      description: procMount denotes the type of proc mount to use
+                        for the containers. The default is DefaultProcMount which
+                        uses the container runtime defaults for readonly paths and
+                        masked paths. This requires the ProcMountType feature flag
+                        to be enabled.
+                      type: string
+                    readOnlyRootFilesystem:
+                      description: Whether this container has a read-only root filesystem.
+                        Default is false.
+                      type: boolean
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container
+                        process. Uses runtime default if unset. May also be set in
+                        PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to
+                        start the container if it does. If unset or false, no such
+                        validation will be performed. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container
+                        process. Defaults to user specified in image metadata if unspecified.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: The SELinux context to be applied to the container.
+                        If unspecified, the container runtime will allocate a random
+                        SELinux context for each container.  May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
+                      type: object
+                    seccompProfile:
+                      description: The seccomp options to use by this container. If
+                        seccomp options are provided at both the pod & container level,
+                        the container options override the pod options.
+                      properties:
+                        localhostProfile:
+                          description: localhostProfile indicates a profile defined
+                            in a file on the node should be used. The profile must
+                            be preconfigured on the node to work. Must be a descending
+                            path, relative to the kubelet's configured seccomp profile
+                            location. Must only be set if type is "Localhost".
+                          type: string
+                        type:
+                          description: |-
+                            type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                            Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    windowsOptions:
+                      description: The Windows specific settings applied to all containers.
+                        If unspecified, the options from the PodSecurityContext will
+                        be used. If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence.
+                      properties:
+                        gmsaCredentialSpec:
+                          description: GMSACredentialSpec is where the GMSA admission
+                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                            inlines the contents of the GMSA credential spec named
+                            by the GMSACredentialSpecName field.
+                          type: string
+                        gmsaCredentialSpecName:
+                          description: GMSACredentialSpecName is the name of the GMSA
+                            credential spec to use.
+                          type: string
+                        runAsUserName:
+                          description: The UserName in Windows to run the entrypoint
+                            of the container process. Defaults to the user specified
+                            in image metadata if unspecified. May also be set in PodSecurityContext.
+                            If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence.
+                          type: string
+                      type: object
+                  type: object
+                startupProbe:
+                  description: 'StartupProbe indicates that the Pod has successfully
+                    initialized. If specified, no other probes are executed until
+                    this completes successfully. If this probe fails, the Pod will
+                    be restarted, just as if the livenessProbe failed. This can be
+                    used to provide different probe parameters at the beginning of
+                    a Pod''s lifecycle, when it might take a long time to load data
+                    or warm a cache, than during steady-state operation. This cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: One and only one of the following should be specified.
+                        Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: Scheme to use for connecting to the host. Defaults
+                            to HTTP.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                        TCP hooks not yet supported
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is an alpha field and requires enabling ProbeTerminationGracePeriod
+                        feature gate.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                stdin:
+                  description: Whether this container should allocate a buffer for
+                    stdin in the container runtime. If this is not set, reads from
+                    stdin in the container will always result in EOF. Default is false.
+                  type: boolean
+                stdinOnce:
+                  description: Whether the container runtime should close the stdin
+                    channel after it has been opened by a single attach. When stdin
+                    is true the stdin stream will remain open across multiple attach
+                    sessions. If stdinOnce is set to true, stdin is opened on container
+                    start, is empty until the first client attaches to stdin, and
+                    then remains open and accepts data until the client disconnects,
+                    at which time stdin is closed and remains closed until the container
+                    is restarted. If this flag is false, a container processes that
+                    reads from stdin will never receive an EOF. Default is false
+                  type: boolean
+                terminationMessagePath:
+                  description: 'Optional: Path at which the file to which the container''s
+                    termination message will be written is mounted into the container''s
+                    filesystem. Message written is intended to be brief final status,
+                    such as an assertion failure message. Will be truncated by the
+                    node if greater than 4096 bytes. The total message length across
+                    all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                    Cannot be updated.'
+                  type: string
+                terminationMessagePolicy:
+                  description: Indicate how the termination message should be populated.
+                    File will use the contents of terminationMessagePath to populate
+                    the container status message on both success and failure. FallbackToLogsOnError
+                    will use the last chunk of container log output if the termination
+                    message file is empty and the container exited with an error.
+                    The log output is limited to 2048 bytes or 80 lines, whichever
+                    is smaller. Defaults to File. Cannot be updated.
+                  type: string
+                tty:
+                  description: Whether this container should allocate a TTY for itself,
+                    also requires 'stdin' to be true. Default is false.
+                  type: boolean
+                volumeDevices:
+                  description: volumeDevices is the list of block devices to be used
+                    by the container.
+                  items:
+                    description: volumeDevice describes a mapping of a raw block device
+                      within a container.
+                    properties:
+                      devicePath:
+                        description: devicePath is the path inside of the container
+                          that the device will be mapped to.
+                        type: string
+                      name:
+                        description: name must match the name of a persistentVolumeClaim
+                          in the pod
+                        type: string
+                    required:
+                    - devicePath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - devicePath
+                  x-kubernetes-list-type: map
+                volumeMounts:
+                  description: Pod volumes to mount into the container's filesystem.
+                    Cannot be updated.
+                  items:
+                    description: VolumeMount describes a mounting of a Volume within
+                      a container.
+                    properties:
+                      mountPath:
+                        description: Path within the container at which the volume
+                          should be mounted.  Must not contain ':'.
+                        type: string
+                      mountPropagation:
+                        description: mountPropagation determines how mounts are propagated
+                          from the host to container and the other way around. When
+                          not set, MountPropagationNone is used. This field is beta
+                          in 1.10.
+                        type: string
+                      name:
+                        description: This must match the Name of a Volume.
+                        type: string
+                      readOnly:
+                        description: Mounted read-only if true, read-write otherwise
+                          (false or unspecified). Defaults to false.
+                        type: boolean
+                      subPath:
+                        description: Path within the volume from which the container's
+                          volume should be mounted. Defaults to "" (volume's root).
+                        type: string
+                      subPathExpr:
+                        description: Expanded path within the volume from which the
+                          container's volume should be mounted. Behaves similarly
+                          to SubPath but environment variable references $(VAR_NAME)
+                          are expanded using the container's environment. Defaults
+                          to "" (volume's root). SubPathExpr and SubPath are mutually
+                          exclusive.
+                        type: string
+                    required:
+                    - mountPath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - mountPath
+                  x-kubernetes-list-type: map
+                workingDir:
+                  description: Container's working directory. If not specified, the
+                    container runtime's default will be used, which might be configured
+                    in the container image. Cannot be updated.
+                  type: string
+              required:
+              - name
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - name
+            x-kubernetes-list-type: map
+          nodeName:
+            description: NodeName is a request to schedule this pod onto a specific
+              node. If it is non-empty, the scheduler simply schedules this pod onto
+              that node, assuming that it fits resource requirements.
+            type: string
+          nodeSelector:
+            additionalProperties:
+              type: string
+            description: 'NodeSelector is a selector which must be true for the pod
+              to fit on a node. Selector which must match a node''s labels for the
+              pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+            type: object
+          overhead:
+            additionalProperties:
+              anyOf:
+              - type: integer
+              - type: string
+              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+              x-kubernetes-int-or-string: true
+            description: 'Overhead represents the resource overhead associated with
+              running a pod for a given RuntimeClass. This field will be autopopulated
+              at admission time by the RuntimeClass admission controller. If the RuntimeClass
+              admission controller is enabled, overhead must not be set in Pod create
+              requests. The RuntimeClass admission controller will reject Pod create
+              requests which have the overhead already set. If RuntimeClass is configured
+              and selected in the PodSpec, Overhead will be set to the value defined
+              in the corresponding RuntimeClass, otherwise it will remain unset and
+              treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md
+              This field is alpha-level as of Kubernetes v1.16, and is only honored
+              by servers that enable the PodOverhead feature.'
+            type: object
+          preemptionPolicy:
+            description: PreemptionPolicy is the Policy for preempting pods with lower
+              priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority
+              if unset. This field is beta-level, gated by the NonPreemptingPriority
+              feature-gate.
+            type: string
+          priority:
+            description: The priority value. Various system components use this field
+              to find the priority of the pod. When Priority Admission Controller
+              is enabled, it prevents users from setting this field. The admission
+              controller populates this field from PriorityClassName. The higher the
+              value, the higher the priority.
+            format: int32
+            type: integer
+          priorityClassName:
+            description: If specified, indicates the pod's priority. "system-node-critical"
+              and "system-cluster-critical" are two special keywords which indicate
+              the highest priorities with the former being the highest priority. Any
+              other name must be defined by creating a PriorityClass object with that
+              name. If not specified, the pod priority will be default or zero if
+              there is no default.
+            type: string
+          readinessGates:
+            description: 'If specified, all readiness gates will be evaluated for
+              pod readiness. A pod is ready when all its containers are ready AND
+              all conditions specified in the readiness gates have status equal to
+              "True" More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md'
+            items:
+              description: PodReadinessGate contains the reference to a pod condition
+              properties:
+                conditionType:
+                  description: ConditionType refers to a condition in the pod's condition
+                    list with matching type.
+                  type: string
+              required:
+              - conditionType
+              type: object
+            type: array
+          restartPolicy:
+            description: 'Restart policy for all containers within the pod. One of
+              Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
+            type: string
+          runtimeClassName:
+            description: 'RuntimeClassName refers to a RuntimeClass object in the
+              node.k8s.io group, which should be used to run this pod.  If no RuntimeClass
+              resource matches the named class, the pod will not be run. If unset
+              or empty, the "legacy" RuntimeClass will be used, which is an implicit
+              class with an empty definition that uses the default runtime handler.
+              More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
+              This is a beta feature as of Kubernetes v1.14.'
+            type: string
+          schedulerName:
+            description: If specified, the pod will be dispatched by specified scheduler.
+              If not specified, the pod will be dispatched by default scheduler.
+            type: string
+          securityContext:
+            description: 'SecurityContext holds pod-level security attributes and
+              common container settings. Optional: Defaults to empty.  See type description
+              for default values of each field.'
+            properties:
+              fsGroup:
+                description: |-
+                  A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
+                  1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
+                  If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                format: int64
+                type: integer
+              fsGroupChangePolicy:
+                description: 'fsGroupChangePolicy defines behavior of changing ownership
+                  and permission of the volume before being exposed inside Pod. This
+                  field will only apply to volume types which support fsGroup based
+                  ownership(and permissions). It will have no effect on ephemeral
+                  volume types such as: secret, configmaps and emptydir. Valid values
+                  are "OnRootMismatch" and "Always". If not specified, "Always" is
+                  used.'
+                type: string
+              runAsGroup:
+                description: The GID to run the entrypoint of the container process.
+                  Uses runtime default if unset. May also be set in SecurityContext.  If
+                  set in both SecurityContext and PodSecurityContext, the value specified
+                  in SecurityContext takes precedence for that container.
+                format: int64
+                type: integer
+              runAsNonRoot:
+                description: Indicates that the container must run as a non-root user.
+                  If true, the Kubelet will validate the image at runtime to ensure
+                  that it does not run as UID 0 (root) and fail to start the container
+                  if it does. If unset or false, no such validation will be performed.
+                  May also be set in SecurityContext.  If set in both SecurityContext
+                  and PodSecurityContext, the value specified in SecurityContext takes
+                  precedence.
+                type: boolean
+              runAsUser:
+                description: The UID to run the entrypoint of the container process.
+                  Defaults to user specified in image metadata if unspecified. May
+                  also be set in SecurityContext.  If set in both SecurityContext
+                  and PodSecurityContext, the value specified in SecurityContext takes
+                  precedence for that container.
+                format: int64
+                type: integer
+              seLinuxOptions:
+                description: The SELinux context to be applied to all containers.
+                  If unspecified, the container runtime will allocate a random SELinux
+                  context for each container.  May also be set in SecurityContext.  If
+                  set in both SecurityContext and PodSecurityContext, the value specified
+                  in SecurityContext takes precedence for that container.
+                properties:
+                  level:
+                    description: Level is SELinux level label that applies to the
+                      container.
+                    type: string
+                  role:
+                    description: Role is a SELinux role label that applies to the
+                      container.
+                    type: string
+                  type:
+                    description: Type is a SELinux type label that applies to the
+                      container.
+                    type: string
+                  user:
+                    description: User is a SELinux user label that applies to the
+                      container.
+                    type: string
+                type: object
+              seccompProfile:
+                description: The seccomp options to use by the containers in this
+                  pod.
+                properties:
+                  localhostProfile:
+                    description: localhostProfile indicates a profile defined in a
+                      file on the node should be used. The profile must be preconfigured
+                      on the node to work. Must be a descending path, relative to
+                      the kubelet's configured seccomp profile location. Must only
+                      be set if type is "Localhost".
+                    type: string
+                  type:
+                    description: |-
+                      type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                      Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                    type: string
+                required:
+                - type
+                type: object
+              supplementalGroups:
+                description: A list of groups applied to the first process run in
+                  each container, in addition to the container's primary GID.  If
+                  unspecified, no groups will be added to any container.
+                items:
+                  format: int64
+                  type: integer
+                type: array
+              sysctls:
+                description: Sysctls hold a list of namespaced sysctls used for the
+                  pod. Pods with unsupported sysctls (by the container runtime) might
+                  fail to launch.
+                items:
+                  description: Sysctl defines a kernel parameter to be set
+                  properties:
+                    name:
+                      description: Name of a property to set
+                      type: string
+                    value:
+                      description: Value of a property to set
+                      type: string
+                  required:
+                  - name
+                  - value
+                  type: object
+                type: array
+              windowsOptions:
+                description: The Windows specific settings applied to all containers.
+                  If unspecified, the options within a container's SecurityContext
+                  will be used. If set in both SecurityContext and PodSecurityContext,
+                  the value specified in SecurityContext takes precedence.
+                properties:
+                  gmsaCredentialSpec:
+                    description: GMSACredentialSpec is where the GMSA admission webhook
+                      (https://github.com/kubernetes-sigs/windows-gmsa) inlines the
+                      contents of the GMSA credential spec named by the GMSACredentialSpecName
+                      field.
+                    type: string
+                  gmsaCredentialSpecName:
+                    description: GMSACredentialSpecName is the name of the GMSA credential
+                      spec to use.
+                    type: string
+                  runAsUserName:
+                    description: The UserName in Windows to run the entrypoint of
+                      the container process. Defaults to the user specified in image
+                      metadata if unspecified. May also be set in PodSecurityContext.
+                      If set in both SecurityContext and PodSecurityContext, the value
+                      specified in SecurityContext takes precedence.
+                    type: string
+                type: object
+            type: object
+          serviceAccount:
+            description: 'DeprecatedServiceAccount is a depreciated alias for ServiceAccountName.
+              Deprecated: Use serviceAccountName instead.'
+            type: string
+          serviceAccountName:
+            description: 'ServiceAccountName is the name of the ServiceAccount to
+              use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+            type: string
+          setHostnameAsFQDN:
+            description: If true the pod's hostname will be configured as the pod's
+              FQDN, rather than the leaf name (the default). In Linux containers,
+              this means setting the FQDN in the hostname field of the kernel (the
+              nodename field of struct utsname). In Windows containers, this means
+              setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters
+              to FQDN. If a pod does not have FQDN, this has no effect. Default to
+              false.
+            type: boolean
+          shareProcessNamespace:
+            description: 'Share a single process namespace between all of the containers
+              in a pod. When this is set containers will be able to view and signal
+              processes from other containers in the same pod, and the first process
+              in each container will not be assigned PID 1. HostPID and ShareProcessNamespace
+              cannot both be set. Optional: Default to false.'
+            type: boolean
+          subdomain:
+            description: If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod
+              namespace>.svc.<cluster domain>". If not specified, the pod will not
+              have a domainname at all.
+            type: string
+          terminationGracePeriodSeconds:
+            description: Optional duration in seconds the pod needs to terminate gracefully.
+              May be decreased in delete request. Value must be non-negative integer.
+              The value zero indicates stop immediately via the kill signal (no opportunity
+              to shut down). If this value is nil, the default grace period will be
+              used instead. The grace period is the duration in seconds after the
+              processes running in the pod are sent a termination signal and the time
+              when the processes are forcibly halted with a kill signal. Set this
+              value longer than the expected cleanup time for your process. Defaults
+              to 30 seconds.
+            format: int64
+            type: integer
+          tolerations:
+            description: If specified, the pod's tolerations.
+            items:
+              description: The pod this Toleration is attached to tolerates any taint
+                that matches the triple <key,value,effect> using the matching operator
+                <operator>.
+              properties:
+                effect:
+                  description: Effect indicates the taint effect to match. Empty means
+                    match all taint effects. When specified, allowed values are NoSchedule,
+                    PreferNoSchedule and NoExecute.
+                  type: string
+                key:
+                  description: Key is the taint key that the toleration applies to.
+                    Empty means match all taint keys. If the key is empty, operator
+                    must be Exists; this combination means to match all values and
+                    all keys.
+                  type: string
+                operator:
+                  description: Operator represents a key's relationship to the value.
+                    Valid operators are Exists and Equal. Defaults to Equal. Exists
+                    is equivalent to wildcard for value, so that a pod can tolerate
+                    all taints of a particular category.
+                  type: string
+                tolerationSeconds:
+                  description: TolerationSeconds represents the period of time the
+                    toleration (which must be of effect NoExecute, otherwise this
+                    field is ignored) tolerates the taint. By default, it is not set,
+                    which means tolerate the taint forever (do not evict). Zero and
+                    negative values will be treated as 0 (evict immediately) by the
+                    system.
+                  format: int64
+                  type: integer
+                value:
+                  description: Value is the taint value the toleration matches to.
+                    If the operator is Exists, the value should be empty, otherwise
+                    just a regular string.
+                  type: string
+              type: object
+            type: array
+          topologySpreadConstraints:
+            description: TopologySpreadConstraints describes how a group of pods ought
+              to spread across topology domains. Scheduler will schedule pods in a
+              way which abides by the constraints. All topologySpreadConstraints are
+              ANDed.
+            items:
+              description: TopologySpreadConstraint specifies how to spread matching
+                pods among the given topology.
+              properties:
+                labelSelector:
+                  description: LabelSelector is used to find matching pods. Pods that
+                    match this label selector are counted to determine the number
+                    of pods in their corresponding topology domain.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                maxSkew:
+                  description: 'MaxSkew describes the degree to which pods may be
+                    unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                    it is the maximum permitted difference between the number of matching
+                    pods in the target topology and the global minimum. For example,
+                    in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                    labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
+                    - if MaxSkew is 1, incoming pod can only be scheduled to zone3
+                    to become 1/1/1; scheduling it onto zone1(zone2) would make the
+                    ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew
+                    is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                    it is used to give higher precedence to topologies that satisfy
+                    it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                  format: int32
+                  type: integer
+                topologyKey:
+                  description: TopologyKey is the key of node labels. Nodes that have
+                    a label with this key and identical values are considered to be
+                    in the same topology. We consider each <key, value> as a "bucket",
+                    and try to put balanced number of pods into each bucket. It's
+                    a required field.
+                  type: string
+                whenUnsatisfiable:
+                  description: |-
+                    WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                      but giving higher precedence to topologies that would help reduce the
+                      skew.
+                    A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assigment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
+                  type: string
+              required:
+              - maxSkew
+              - topologyKey
+              - whenUnsatisfiable
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - topologyKey
+            - whenUnsatisfiable
+            x-kubernetes-list-type: map
+          volumes:
+            description: 'List of volumes that can be mounted by containers belonging
+              to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+            items:
+              description: Volume represents a named volume in a pod that may be accessed
+                by any container in the pod.
+              properties:
+                awsElasticBlockStore:
+                  description: 'AWSElasticBlockStore represents an AWS Disk resource
+                    that is attached to a kubelet''s host machine and then exposed
+                    to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                  properties:
+                    fsType:
+                      description: 'Filesystem type of the volume that you want to
+                        mount. Tip: Ensure that the filesystem type is supported by
+                        the host operating system. Examples: "ext4", "xfs", "ntfs".
+                        Implicitly inferred to be "ext4" if unspecified. More info:
+                        https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                      type: string
+                    partition:
+                      description: 'The partition in the volume that you want to mount.
+                        If omitted, the default is to mount by volume name. Examples:
+                        For volume /dev/sda1, you specify the partition as "1". Similarly,
+                        the volume partition for /dev/sda is "0" (or you can leave
+                        the property empty).'
+                      format: int32
+                      type: integer
+                    readOnly:
+                      description: 'Specify "true" to force and set the ReadOnly property
+                        in VolumeMounts to "true". If omitted, the default is "false".
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                      type: boolean
+                    volumeID:
+                      description: 'Unique ID of the persistent disk resource in AWS
+                        (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                      type: string
+                  required:
+                  - volumeID
+                  type: object
+                azureDisk:
+                  description: AzureDisk represents an Azure Data Disk mount on the
+                    host and bind mount to the pod.
+                  properties:
+                    cachingMode:
+                      description: 'Host Caching mode: None, Read Only, Read Write.'
+                      type: string
+                    diskName:
+                      description: The Name of the data disk in the blob storage
+                      type: string
+                    diskURI:
+                      description: The URI the data disk in the blob storage
+                      type: string
+                    fsType:
+                      description: Filesystem type to mount. Must be a filesystem
+                        type supported by the host operating system. Ex. "ext4", "xfs",
+                        "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                      type: string
+                    kind:
+                      description: 'Expected values Shared: multiple blob disks per
+                        storage account  Dedicated: single blob disk per storage account  Managed:
+                        azure managed data disk (only in managed availability set).
+                        defaults to shared'
+                      type: string
+                    readOnly:
+                      description: Defaults to false (read/write). ReadOnly here will
+                        force the ReadOnly setting in VolumeMounts.
+                      type: boolean
+                  required:
+                  - diskName
+                  - diskURI
+                  type: object
+                azureFile:
+                  description: AzureFile represents an Azure File Service mount on
+                    the host and bind mount to the pod.
+                  properties:
+                    readOnly:
+                      description: Defaults to false (read/write). ReadOnly here will
+                        force the ReadOnly setting in VolumeMounts.
+                      type: boolean
+                    secretName:
+                      description: the name of secret that contains Azure Storage
+                        Account Name and Key
+                      type: string
+                    shareName:
+                      description: Share Name
+                      type: string
+                  required:
+                  - secretName
+                  - shareName
+                  type: object
+                cephfs:
+                  description: CephFS represents a Ceph FS mount on the host that
+                    shares a pod's lifetime
+                  properties:
+                    monitors:
+                      description: 'Required: Monitors is a collection of Ceph monitors
+                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                      items:
+                        type: string
+                      type: array
+                    path:
+                      description: 'Optional: Used as the mounted root, rather than
+                        the full Ceph tree, default is /'
+                      type: string
+                    readOnly:
+                      description: 'Optional: Defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts. More
+                        info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                      type: boolean
+                    secretFile:
+                      description: 'Optional: SecretFile is the path to key ring for
+                        User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                      type: string
+                    secretRef:
+                      description: 'Optional: SecretRef is reference to the authentication
+                        secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    user:
+                      description: 'Optional: User is the rados user name, default
+                        is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                      type: string
+                  required:
+                  - monitors
+                  type: object
+                cinder:
+                  description: 'Cinder represents a cinder volume attached and mounted
+                    on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                  properties:
+                    fsType:
+                      description: 'Filesystem type to mount. Must be a filesystem
+                        type supported by the host operating system. Examples: "ext4",
+                        "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                      type: string
+                    readOnly:
+                      description: 'Optional: Defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts. More
+                        info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                      type: boolean
+                    secretRef:
+                      description: 'Optional: points to a secret object containing
+                        parameters used to connect to OpenStack.'
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    volumeID:
+                      description: 'volume id used to identify the volume in cinder.
+                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                      type: string
+                  required:
+                  - volumeID
+                  type: object
+                configMap:
+                  description: ConfigMap represents a configMap that should populate
+                    this volume
+                  properties:
+                    defaultMode:
+                      description: 'Optional: mode bits used to set permissions on
+                        created files by default. Must be an octal value between 0000
+                        and 0777 or a decimal value between 0 and 511. YAML accepts
+                        both octal and decimal values, JSON requires decimal values
+                        for mode bits. Defaults to 0644. Directories within the path
+                        are not affected by this setting. This might be in conflict
+                        with other options that affect the file mode, like fsGroup,
+                        and the result can be other mode bits set.'
+                      format: int32
+                      type: integer
+                    items:
+                      description: If unspecified, each key-value pair in the Data
+                        field of the referenced ConfigMap will be projected into the
+                        volume as a file whose name is the key and content is the
+                        value. If specified, the listed keys will be projected into
+                        the specified paths, and unlisted keys will not be present.
+                        If a key is specified which is not present in the ConfigMap,
+                        the volume setup will error unless it is marked optional.
+                        Paths must be relative and may not contain the '..' path or
+                        start with '..'.
+                      items:
+                        description: Maps a string key to a path within a volume.
+                        properties:
+                          key:
+                            description: The key to project.
+                            type: string
+                          mode:
+                            description: 'Optional: mode bits used to set permissions
+                              on this file. Must be an octal value between 0000 and
+                              0777 or a decimal value between 0 and 511. YAML accepts
+                              both octal and decimal values, JSON requires decimal
+                              values for mode bits. If not specified, the volume defaultMode
+                              will be used. This might be in conflict with other options
+                              that affect the file mode, like fsGroup, and the result
+                              can be other mode bits set.'
+                            format: int32
+                            type: integer
+                          path:
+                            description: The relative path of the file to map the
+                              key to. May not be an absolute path. May not contain
+                              the path element '..'. May not start with the string
+                              '..'.
+                            type: string
+                        required:
+                        - key
+                        - path
+                        type: object
+                      type: array
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    optional:
+                      description: Specify whether the ConfigMap or its keys must
+                        be defined
+                      type: boolean
+                  type: object
+                csi:
+                  description: CSI (Container Storage Interface) represents ephemeral
+                    storage that is handled by certain external CSI drivers (Beta
+                    feature).
+                  properties:
+                    driver:
+                      description: Driver is the name of the CSI driver that handles
+                        this volume. Consult with your admin for the correct name
+                        as registered in the cluster.
+                      type: string
+                    fsType:
+                      description: Filesystem type to mount. Ex. "ext4", "xfs", "ntfs".
+                        If not provided, the empty value is passed to the associated
+                        CSI driver which will determine the default filesystem to
+                        apply.
+                      type: string
+                    nodePublishSecretRef:
+                      description: NodePublishSecretRef is a reference to the secret
+                        object containing sensitive information to pass to the CSI
+                        driver to complete the CSI NodePublishVolume and NodeUnpublishVolume
+                        calls. This field is optional, and  may be empty if no secret
+                        is required. If the secret object contains more than one secret,
+                        all secret references are passed.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    readOnly:
+                      description: Specifies a read-only configuration for the volume.
+                        Defaults to false (read/write).
+                      type: boolean
+                    volumeAttributes:
+                      additionalProperties:
+                        type: string
+                      description: VolumeAttributes stores driver-specific properties
+                        that are passed to the CSI driver. Consult your driver's documentation
+                        for supported values.
+                      type: object
+                  required:
+                  - driver
+                  type: object
+                downwardAPI:
+                  description: DownwardAPI represents downward API about the pod that
+                    should populate this volume
+                  properties:
+                    defaultMode:
+                      description: 'Optional: mode bits to use on created files by
+                        default. Must be a Optional: mode bits used to set permissions
+                        on created files by default. Must be an octal value between
+                        0000 and 0777 or a decimal value between 0 and 511. YAML accepts
+                        both octal and decimal values, JSON requires decimal values
+                        for mode bits. Defaults to 0644. Directories within the path
+                        are not affected by this setting. This might be in conflict
+                        with other options that affect the file mode, like fsGroup,
+                        and the result can be other mode bits set.'
+                      format: int32
+                      type: integer
+                    items:
+                      description: Items is a list of downward API volume file
+                      items:
+                        description: DownwardAPIVolumeFile represents information
+                          to create the file containing the pod field
+                        properties:
+                          fieldRef:
+                            description: 'Required: Selects a field of the pod: only
+                              annotations, labels, name and namespace are supported.'
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                            - fieldPath
+                            type: object
+                          mode:
+                            description: 'Optional: mode bits used to set permissions
+                              on this file, must be an octal value between 0000 and
+                              0777 or a decimal value between 0 and 511. YAML accepts
+                              both octal and decimal values, JSON requires decimal
+                              values for mode bits. If not specified, the volume defaultMode
+                              will be used. This might be in conflict with other options
+                              that affect the file mode, like fsGroup, and the result
+                              can be other mode bits set.'
+                            format: int32
+                            type: integer
+                          path:
+                            description: 'Required: Path is  the relative path name
+                              of the file to be created. Must not be absolute or contain
+                              the ''..'' path. Must be utf-8 encoded. The first item
+                              of the relative path must not start with ''..'''
+                            type: string
+                          resourceFieldRef:
+                            description: 'Selects a resource of the container: only
+                              resources limits and requests (limits.cpu, limits.memory,
+                              requests.cpu and requests.memory) are currently supported.'
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Specifies the output format of the exposed
+                                  resources, defaults to "1"
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                            - resource
+                            type: object
+                        required:
+                        - path
+                        type: object
+                      type: array
+                  type: object
+                emptyDir:
+                  description: 'EmptyDir represents a temporary directory that shares
+                    a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                  properties:
+                    medium:
+                      description: 'What type of storage medium should back this directory.
+                        The default is "" which means to use the node''s default medium.
+                        Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                      type: string
+                    sizeLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: 'Total amount of local storage required for this
+                        EmptyDir volume. The size limit is also applicable for memory
+                        medium. The maximum usage on memory medium EmptyDir would
+                        be the minimum value between the SizeLimit specified here
+                        and the sum of memory limits of all containers in a pod. The
+                        default is nil which means that the limit is undefined. More
+                        info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  type: object
+                ephemeral:
+                  description: |-
+                    Ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+
+                    Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+                       tracking are needed,
+                    c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+                       a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                       information on the connection between this volume type
+                       and PersistentVolumeClaim).
+
+                    Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+
+                    Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+
+                    A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+
+                    This is a beta feature and only available when the GenericEphemeralVolume feature gate is enabled.
+                  properties:
+                    volumeClaimTemplate:
+                      description: |-
+                        Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+
+                        An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+
+                        This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+
+                        Required, must not be nil.
+                      properties:
+                        metadata:
+                          description: May contain labels and annotations that will
+                            be copied into the PVC when creating it. No other fields
+                            are allowed and will be rejected during validation.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        spec:
+                          description: The specification for the PersistentVolumeClaim.
+                            The entire content is copied unchanged into the PVC that
+                            gets created from this template. The same fields as in
+                            a PersistentVolumeClaim are also valid here.
+                          properties:
+                            accessModes:
+                              description: 'AccessModes contains the desired access
+                                modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                              items:
+                                type: string
+                              type: array
+                            dataSource:
+                              description: 'This field can be used to specify either:
+                                * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                * An existing PVC (PersistentVolumeClaim) * An existing
+                                custom resource that implements data population (Alpha)
+                                In order to use custom resource types that implement
+                                data population, the AnyVolumeDataSource feature gate
+                                must be enabled. If the provisioner or an external
+                                controller can support the specified data source,
+                                it will create a new volume based on the contents
+                                of the specified data source.'
+                              properties:
+                                apiGroup:
+                                  description: APIGroup is the group for the resource
+                                    being referenced. If APIGroup is not specified,
+                                    the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being
+                                    referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being
+                                    referenced
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            resources:
+                              description: 'Resources represents the minimum resources
+                                the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                              type: object
+                            selector:
+                              description: A label query over volumes to consider
+                                for binding.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            storageClassName:
+                              description: 'Name of the StorageClass required by the
+                                claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                              type: string
+                            volumeMode:
+                              description: volumeMode defines what type of volume
+                                is required by the claim. Value of Filesystem is implied
+                                when not included in claim spec.
+                              type: string
+                            volumeName:
+                              description: VolumeName is the binding reference to
+                                the PersistentVolume backing this claim.
+                              type: string
+                          type: object
+                      required:
+                      - spec
+                      type: object
+                  type: object
+                fc:
+                  description: FC represents a Fibre Channel resource that is attached
+                    to a kubelet's host machine and then exposed to the pod.
+                  properties:
+                    fsType:
+                      description: Filesystem type to mount. Must be a filesystem
+                        type supported by the host operating system. Ex. "ext4", "xfs",
+                        "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                      type: string
+                    lun:
+                      description: 'Optional: FC target lun number'
+                      format: int32
+                      type: integer
+                    readOnly:
+                      description: 'Optional: Defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts.'
+                      type: boolean
+                    targetWWNs:
+                      description: 'Optional: FC target worldwide names (WWNs)'
+                      items:
+                        type: string
+                      type: array
+                    wwids:
+                      description: 'Optional: FC volume world wide identifiers (wwids)
+                        Either wwids or combination of targetWWNs and lun must be
+                        set, but not both simultaneously.'
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                flexVolume:
+                  description: FlexVolume represents a generic volume resource that
+                    is provisioned/attached using an exec based plugin.
+                  properties:
+                    driver:
+                      description: Driver is the name of the driver to use for this
+                        volume.
+                      type: string
+                    fsType:
+                      description: Filesystem type to mount. Must be a filesystem
+                        type supported by the host operating system. Ex. "ext4", "xfs",
+                        "ntfs". The default filesystem depends on FlexVolume script.
+                      type: string
+                    options:
+                      additionalProperties:
+                        type: string
+                      description: 'Optional: Extra command options if any.'
+                      type: object
+                    readOnly:
+                      description: 'Optional: Defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts.'
+                      type: boolean
+                    secretRef:
+                      description: 'Optional: SecretRef is reference to the secret
+                        object containing sensitive information to pass to the plugin
+                        scripts. This may be empty if no secret object is specified.
+                        If the secret object contains more than one secret, all secrets
+                        are passed to the plugin scripts.'
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                  required:
+                  - driver
+                  type: object
+                flocker:
+                  description: Flocker represents a Flocker volume attached to a kubelet's
+                    host machine. This depends on the Flocker control service being
+                    running
+                  properties:
+                    datasetName:
+                      description: Name of the dataset stored as metadata -> name
+                        on the dataset for Flocker should be considered as deprecated
+                      type: string
+                    datasetUUID:
+                      description: UUID of the dataset. This is unique identifier
+                        of a Flocker dataset
+                      type: string
+                  type: object
+                gcePersistentDisk:
+                  description: 'GCEPersistentDisk represents a GCE Disk resource that
+                    is attached to a kubelet''s host machine and then exposed to the
+                    pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                  properties:
+                    fsType:
+                      description: 'Filesystem type of the volume that you want to
+                        mount. Tip: Ensure that the filesystem type is supported by
+                        the host operating system. Examples: "ext4", "xfs", "ntfs".
+                        Implicitly inferred to be "ext4" if unspecified. More info:
+                        https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                      type: string
+                    partition:
+                      description: 'The partition in the volume that you want to mount.
+                        If omitted, the default is to mount by volume name. Examples:
+                        For volume /dev/sda1, you specify the partition as "1". Similarly,
+                        the volume partition for /dev/sda is "0" (or you can leave
+                        the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                      format: int32
+                      type: integer
+                    pdName:
+                      description: 'Unique name of the PD resource in GCE. Used to
+                        identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                      type: string
+                    readOnly:
+                      description: 'ReadOnly here will force the ReadOnly setting
+                        in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                      type: boolean
+                  required:
+                  - pdName
+                  type: object
+                gitRepo:
+                  description: 'GitRepo represents a git repository at a particular
+                    revision. DEPRECATED: GitRepo is deprecated. To provision a container
+                    with a git repo, mount an EmptyDir into an InitContainer that
+                    clones the repo using git, then mount the EmptyDir into the Pod''s
+                    container.'
+                  properties:
+                    directory:
+                      description: Target directory name. Must not contain or start
+                        with '..'.  If '.' is supplied, the volume directory will
+                        be the git repository.  Otherwise, if specified, the volume
+                        will contain the git repository in the subdirectory with the
+                        given name.
+                      type: string
+                    repository:
+                      description: Repository URL
+                      type: string
+                    revision:
+                      description: Commit hash for the specified revision.
+                      type: string
+                  required:
+                  - repository
+                  type: object
+                glusterfs:
+                  description: 'Glusterfs represents a Glusterfs mount on the host
+                    that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                  properties:
+                    endpoints:
+                      description: 'EndpointsName is the endpoint name that details
+                        Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                      type: string
+                    path:
+                      description: 'Path is the Glusterfs volume path. More info:
+                        https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                      type: string
+                    readOnly:
+                      description: 'ReadOnly here will force the Glusterfs volume
+                        to be mounted with read-only permissions. Defaults to false.
+                        More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                      type: boolean
+                  required:
+                  - endpoints
+                  - path
+                  type: object
+                hostPath:
+                  description: 'HostPath represents a pre-existing file or directory
+                    on the host machine that is directly exposed to the container.
+                    This is generally used for system agents or other privileged things
+                    that are allowed to see the host machine. Most containers will
+                    NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                  properties:
+                    path:
+                      description: 'Path of the directory on the host. If the path
+                        is a symlink, it will follow the link to the real path. More
+                        info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                      type: string
+                    type:
+                      description: 'Type for HostPath Volume Defaults to "" More info:
+                        https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                      type: string
+                  required:
+                  - path
+                  type: object
+                iscsi:
+                  description: 'ISCSI represents an ISCSI Disk resource that is attached
+                    to a kubelet''s host machine and then exposed to the pod. More
+                    info: https://examples.k8s.io/volumes/iscsi/README.md'
+                  properties:
+                    chapAuthDiscovery:
+                      description: whether support iSCSI Discovery CHAP authentication
+                      type: boolean
+                    chapAuthSession:
+                      description: whether support iSCSI Session CHAP authentication
+                      type: boolean
+                    fsType:
+                      description: 'Filesystem type of the volume that you want to
+                        mount. Tip: Ensure that the filesystem type is supported by
+                        the host operating system. Examples: "ext4", "xfs", "ntfs".
+                        Implicitly inferred to be "ext4" if unspecified. More info:
+                        https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                      type: string
+                    initiatorName:
+                      description: Custom iSCSI Initiator Name. If initiatorName is
+                        specified with iscsiInterface simultaneously, new iSCSI interface
+                        <target portal>:<volume name> will be created for the connection.
+                      type: string
+                    iqn:
+                      description: Target iSCSI Qualified Name.
+                      type: string
+                    iscsiInterface:
+                      description: iSCSI Interface Name that uses an iSCSI transport.
+                        Defaults to 'default' (tcp).
+                      type: string
+                    lun:
+                      description: iSCSI Target Lun number.
+                      format: int32
+                      type: integer
+                    portals:
+                      description: iSCSI Target Portal List. The portal is either
+                        an IP or ip_addr:port if the port is other than default (typically
+                        TCP ports 860 and 3260).
+                      items:
+                        type: string
+                      type: array
+                    readOnly:
+                      description: ReadOnly here will force the ReadOnly setting in
+                        VolumeMounts. Defaults to false.
+                      type: boolean
+                    secretRef:
+                      description: CHAP Secret for iSCSI target and initiator authentication
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    targetPortal:
+                      description: iSCSI Target Portal. The Portal is either an IP
+                        or ip_addr:port if the port is other than default (typically
+                        TCP ports 860 and 3260).
+                      type: string
+                  required:
+                  - targetPortal
+                  - iqn
+                  - lun
+                  type: object
+                name:
+                  description: 'Volume''s name. Must be a DNS_LABEL and unique within
+                    the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                nfs:
+                  description: 'NFS represents an NFS mount on the host that shares
+                    a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                  properties:
+                    path:
+                      description: 'Path that is exported by the NFS server. More
+                        info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                      type: string
+                    readOnly:
+                      description: 'ReadOnly here will force the NFS export to be
+                        mounted with read-only permissions. Defaults to false. More
+                        info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                      type: boolean
+                    server:
+                      description: 'Server is the hostname or IP address of the NFS
+                        server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                      type: string
+                  required:
+                  - server
+                  - path
+                  type: object
+                persistentVolumeClaim:
+                  description: 'PersistentVolumeClaimVolumeSource represents a reference
+                    to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                  properties:
+                    claimName:
+                      description: 'ClaimName is the name of a PersistentVolumeClaim
+                        in the same namespace as the pod using this volume. More info:
+                        https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                      type: string
+                    readOnly:
+                      description: Will force the ReadOnly setting in VolumeMounts.
+                        Default false.
+                      type: boolean
+                  required:
+                  - claimName
+                  type: object
+                photonPersistentDisk:
+                  description: PhotonPersistentDisk represents a PhotonController
+                    persistent disk attached and mounted on kubelets host machine
+                  properties:
+                    fsType:
+                      description: Filesystem type to mount. Must be a filesystem
+                        type supported by the host operating system. Ex. "ext4", "xfs",
+                        "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                      type: string
+                    pdID:
+                      description: ID that identifies Photon Controller persistent
+                        disk
+                      type: string
+                  required:
+                  - pdID
+                  type: object
+                portworxVolume:
+                  description: PortworxVolume represents a portworx volume attached
+                    and mounted on kubelets host machine
+                  properties:
+                    fsType:
+                      description: FSType represents the filesystem type to mount
+                        Must be a filesystem type supported by the host operating
+                        system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
+                        if unspecified.
+                      type: string
+                    readOnly:
+                      description: Defaults to false (read/write). ReadOnly here will
+                        force the ReadOnly setting in VolumeMounts.
+                      type: boolean
+                    volumeID:
+                      description: VolumeID uniquely identifies a Portworx volume
+                      type: string
+                  required:
+                  - volumeID
+                  type: object
+                projected:
+                  description: Items for all in one resources secrets, configmaps,
+                    and downward API
+                  properties:
+                    defaultMode:
+                      description: Mode bits used to set permissions on created files
+                        by default. Must be an octal value between 0000 and 0777 or
+                        a decimal value between 0 and 511. YAML accepts both octal
+                        and decimal values, JSON requires decimal values for mode
+                        bits. Directories within the path are not affected by this
+                        setting. This might be in conflict with other options that
+                        affect the file mode, like fsGroup, and the result can be
+                        other mode bits set.
+                      format: int32
+                      type: integer
+                    sources:
+                      description: list of volume projections
+                      items:
+                        description: Projection that may be projected along with other
+                          supported volume types
+                        properties:
+                          configMap:
+                            description: information about the configMap data to project
+                            properties:
+                              items:
+                                description: If unspecified, each key-value pair in
+                                  the Data field of the referenced ConfigMap will
+                                  be projected into the volume as a file whose name
+                                  is the key and content is the value. If specified,
+                                  the listed keys will be projected into the specified
+                                  paths, and unlisted keys will not be present. If
+                                  a key is specified which is not present in the ConfigMap,
+                                  the volume setup will error unless it is marked
+                                  optional. Paths must be relative and may not contain
+                                  the '..' path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: The key to project.
+                                      type: string
+                                    mode:
+                                      description: 'Optional: mode bits used to set
+                                        permissions on this file. Must be an octal
+                                        value between 0000 and 0777 or a decimal value
+                                        between 0 and 511. YAML accepts both octal
+                                        and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: The relative path of the file to
+                                        map the key to. May not be an absolute path.
+                                        May not contain the path element '..'. May
+                                        not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its
+                                  keys must be defined
+                                type: boolean
+                            type: object
+                          downwardAPI:
+                            description: information about the downwardAPI data to
+                              project
+                            properties:
+                              items:
+                                description: Items is a list of DownwardAPIVolume
+                                  file
+                                items:
+                                  description: DownwardAPIVolumeFile represents information
+                                    to create the file containing the pod field
+                                  properties:
+                                    fieldRef:
+                                      description: 'Required: Selects a field of the
+                                        pod: only annotations, labels, name and namespace
+                                        are supported.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    mode:
+                                      description: 'Optional: mode bits used to set
+                                        permissions on this file, must be an octal
+                                        value between 0000 and 0777 or a decimal value
+                                        between 0 and 511. YAML accepts both octal
+                                        and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: 'Required: Path is  the relative
+                                        path name of the file to be created. Must
+                                        not be absolute or contain the ''..'' path.
+                                        Must be utf-8 encoded. The first item of the
+                                        relative path must not start with ''..'''
+                                      type: string
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, requests.cpu and requests.memory)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                  required:
+                                  - path
+                                  type: object
+                                type: array
+                            type: object
+                          secret:
+                            description: information about the secret data to project
+                            properties:
+                              items:
+                                description: If unspecified, each key-value pair in
+                                  the Data field of the referenced Secret will be
+                                  projected into the volume as a file whose name is
+                                  the key and content is the value. If specified,
+                                  the listed keys will be projected into the specified
+                                  paths, and unlisted keys will not be present. If
+                                  a key is specified which is not present in the Secret,
+                                  the volume setup will error unless it is marked
+                                  optional. Paths must be relative and may not contain
+                                  the '..' path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: The key to project.
+                                      type: string
+                                    mode:
+                                      description: 'Optional: mode bits used to set
+                                        permissions on this file. Must be an octal
+                                        value between 0000 and 0777 or a decimal value
+                                        between 0 and 511. YAML accepts both octal
+                                        and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: The relative path of the file to
+                                        map the key to. May not be an absolute path.
+                                        May not contain the path element '..'. May
+                                        not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            type: object
+                          serviceAccountToken:
+                            description: information about the serviceAccountToken
+                              data to project
+                            properties:
+                              audience:
+                                description: Audience is the intended audience of
+                                  the token. A recipient of a token must identify
+                                  itself with an identifier specified in the audience
+                                  of the token, and otherwise should reject the token.
+                                  The audience defaults to the identifier of the apiserver.
+                                type: string
+                              expirationSeconds:
+                                description: ExpirationSeconds is the requested duration
+                                  of validity of the service account token. As the
+                                  token approaches expiration, the kubelet volume
+                                  plugin will proactively rotate the service account
+                                  token. The kubelet will start trying to rotate the
+                                  token if the token is older than 80 percent of its
+                                  time to live or if the token is older than 24 hours.Defaults
+                                  to 1 hour and must be at least 10 minutes.
+                                format: int64
+                                type: integer
+                              path:
+                                description: Path is the path relative to the mount
+                                  point of the file to project the token into.
+                                type: string
+                            required:
+                            - path
+                            type: object
+                        type: object
+                      type: array
+                  type: object
+                quobyte:
+                  description: Quobyte represents a Quobyte mount on the host that
+                    shares a pod's lifetime
+                  properties:
+                    group:
+                      description: Group to map volume access to Default is no group
+                      type: string
+                    readOnly:
+                      description: ReadOnly here will force the Quobyte volume to
+                        be mounted with read-only permissions. Defaults to false.
+                      type: boolean
+                    registry:
+                      description: Registry represents a single or multiple Quobyte
+                        Registry services specified as a string as host:port pair
+                        (multiple entries are separated with commas) which acts as
+                        the central registry for volumes
+                      type: string
+                    tenant:
+                      description: Tenant owning the given Quobyte volume in the Backend
+                        Used with dynamically provisioned Quobyte volumes, value is
+                        set by the plugin
+                      type: string
+                    user:
+                      description: User to map volume access to Defaults to serivceaccount
+                        user
+                      type: string
+                    volume:
+                      description: Volume is a string that references an already created
+                        Quobyte volume by name.
+                      type: string
+                  required:
+                  - registry
+                  - volume
+                  type: object
+                rbd:
+                  description: 'RBD represents a Rados Block Device mount on the host
+                    that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                  properties:
+                    fsType:
+                      description: 'Filesystem type of the volume that you want to
+                        mount. Tip: Ensure that the filesystem type is supported by
+                        the host operating system. Examples: "ext4", "xfs", "ntfs".
+                        Implicitly inferred to be "ext4" if unspecified. More info:
+                        https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                      type: string
+                    image:
+                      description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      type: string
+                    keyring:
+                      description: 'Keyring is the path to key ring for RBDUser. Default
+                        is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      type: string
+                    monitors:
+                      description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      items:
+                        type: string
+                      type: array
+                    pool:
+                      description: 'The rados pool name. Default is rbd. More info:
+                        https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      type: string
+                    readOnly:
+                      description: 'ReadOnly here will force the ReadOnly setting
+                        in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      type: boolean
+                    secretRef:
+                      description: 'SecretRef is name of the authentication secret
+                        for RBDUser. If provided overrides keyring. Default is nil.
+                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    user:
+                      description: 'The rados user name. Default is admin. More info:
+                        https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      type: string
+                  required:
+                  - monitors
+                  - image
+                  type: object
+                scaleIO:
+                  description: ScaleIO represents a ScaleIO persistent volume attached
+                    and mounted on Kubernetes nodes.
+                  properties:
+                    fsType:
+                      description: Filesystem type to mount. Must be a filesystem
+                        type supported by the host operating system. Ex. "ext4", "xfs",
+                        "ntfs". Default is "xfs".
+                      type: string
+                    gateway:
+                      description: The host address of the ScaleIO API Gateway.
+                      type: string
+                    protectionDomain:
+                      description: The name of the ScaleIO Protection Domain for the
+                        configured storage.
+                      type: string
+                    readOnly:
+                      description: Defaults to false (read/write). ReadOnly here will
+                        force the ReadOnly setting in VolumeMounts.
+                      type: boolean
+                    secretRef:
+                      description: SecretRef references to the secret for ScaleIO
+                        user and other sensitive information. If this is not provided,
+                        Login operation will fail.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    sslEnabled:
+                      description: Flag to enable/disable SSL communication with Gateway,
+                        default false
+                      type: boolean
+                    storageMode:
+                      description: Indicates whether the storage for a volume should
+                        be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                      type: string
+                    storagePool:
+                      description: The ScaleIO Storage Pool associated with the protection
+                        domain.
+                      type: string
+                    system:
+                      description: The name of the storage system as configured in
+                        ScaleIO.
+                      type: string
+                    volumeName:
+                      description: The name of a volume already created in the ScaleIO
+                        system that is associated with this volume source.
+                      type: string
+                  required:
+                  - gateway
+                  - system
+                  - secretRef
+                  type: object
+                secret:
+                  description: 'Secret represents a secret that should populate this
+                    volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                  properties:
+                    defaultMode:
+                      description: 'Optional: mode bits used to set permissions on
+                        created files by default. Must be an octal value between 0000
+                        and 0777 or a decimal value between 0 and 511. YAML accepts
+                        both octal and decimal values, JSON requires decimal values
+                        for mode bits. Defaults to 0644. Directories within the path
+                        are not affected by this setting. This might be in conflict
+                        with other options that affect the file mode, like fsGroup,
+                        and the result can be other mode bits set.'
+                      format: int32
+                      type: integer
+                    items:
+                      description: If unspecified, each key-value pair in the Data
+                        field of the referenced Secret will be projected into the
+                        volume as a file whose name is the key and content is the
+                        value. If specified, the listed keys will be projected into
+                        the specified paths, and unlisted keys will not be present.
+                        If a key is specified which is not present in the Secret,
+                        the volume setup will error unless it is marked optional.
+                        Paths must be relative and may not contain the '..' path or
+                        start with '..'.
+                      items:
+                        description: Maps a string key to a path within a volume.
+                        properties:
+                          key:
+                            description: The key to project.
+                            type: string
+                          mode:
+                            description: 'Optional: mode bits used to set permissions
+                              on this file. Must be an octal value between 0000 and
+                              0777 or a decimal value between 0 and 511. YAML accepts
+                              both octal and decimal values, JSON requires decimal
+                              values for mode bits. If not specified, the volume defaultMode
+                              will be used. This might be in conflict with other options
+                              that affect the file mode, like fsGroup, and the result
+                              can be other mode bits set.'
+                            format: int32
+                            type: integer
+                          path:
+                            description: The relative path of the file to map the
+                              key to. May not be an absolute path. May not contain
+                              the path element '..'. May not start with the string
+                              '..'.
+                            type: string
+                        required:
+                        - key
+                        - path
+                        type: object
+                      type: array
+                    optional:
+                      description: Specify whether the Secret or its keys must be
+                        defined
+                      type: boolean
+                    secretName:
+                      description: 'Name of the secret in the pod''s namespace to
+                        use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                      type: string
+                  type: object
+                storageos:
+                  description: StorageOS represents a StorageOS volume attached and
+                    mounted on Kubernetes nodes.
+                  properties:
+                    fsType:
+                      description: Filesystem type to mount. Must be a filesystem
+                        type supported by the host operating system. Ex. "ext4", "xfs",
+                        "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                      type: string
+                    readOnly:
+                      description: Defaults to false (read/write). ReadOnly here will
+                        force the ReadOnly setting in VolumeMounts.
+                      type: boolean
+                    secretRef:
+                      description: SecretRef specifies the secret to use for obtaining
+                        the StorageOS API credentials.  If not specified, default
+                        values will be attempted.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    volumeName:
+                      description: VolumeName is the human-readable name of the StorageOS
+                        volume.  Volume names are only unique within a namespace.
+                      type: string
+                    volumeNamespace:
+                      description: VolumeNamespace specifies the scope of the volume
+                        within StorageOS.  If no namespace is specified then the Pod's
+                        namespace will be used.  This allows the Kubernetes name scoping
+                        to be mirrored within StorageOS for tighter integration. Set
+                        VolumeName to any name to override the default behaviour.
+                        Set to "default" if you are not using namespaces within StorageOS.
+                        Namespaces that do not pre-exist within StorageOS will be
+                        created.
+                      type: string
+                  type: object
+                vsphereVolume:
+                  description: VsphereVolume represents a vSphere volume attached
+                    and mounted on kubelets host machine
+                  properties:
+                    fsType:
+                      description: Filesystem type to mount. Must be a filesystem
+                        type supported by the host operating system. Ex. "ext4", "xfs",
+                        "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                      type: string
+                    storagePolicyID:
+                      description: Storage Policy Based Management (SPBM) profile
+                        ID associated with the StoragePolicyName.
+                      type: string
+                    storagePolicyName:
+                      description: Storage Policy Based Management (SPBM) profile
+                        name.
+                      type: string
+                    volumePath:
+                      description: Path that identifies vSphere volume vmdk
+                      type: string
+                  required:
+                  - volumePath
+                  type: object
+              required:
+              - name
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - name
+            x-kubernetes-list-type: map
+        required:
+        - containers
+        type: object
+      status:
+        description: 'Most recently observed status of the pod. This data may not
+          be up to date. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+        properties:
+          conditions:
+            description: 'Current service state of pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions'
+            items:
+              description: PodCondition contains details for the current condition
+                of this pod.
+              properties:
+                lastProbeTime:
+                  description: Last time we probed the condition.
+                  format: date-time
+                  type: string
+                lastTransitionTime:
+                  description: Last time the condition transitioned from one status
+                    to another.
+                  format: date-time
+                  type: string
+                message:
+                  description: Human-readable message indicating details about last
+                    transition.
+                  type: string
+                reason:
+                  description: Unique, one-word, CamelCase reason for the condition's
+                    last transition.
+                  type: string
+                status:
+                  description: 'Status is the status of the condition. Can be True,
+                    False, Unknown. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions'
+                  type: string
+                type:
+                  description: 'Type is the type of the condition. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions'
+                  type: string
+              required:
+              - status
+              - type
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - type
+            x-kubernetes-list-type: map
+          containerStatuses:
+            description: 'The list has one entry per container in the manifest. Each
+              entry is currently the output of `docker inspect`. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status'
+            items:
+              description: ContainerStatus contains details for the current status
+                of this container.
+              properties:
+                containerID:
+                  description: Container's ID in the format 'docker://<container_id>'.
+                  type: string
+                image:
+                  description: 'The image the container is running. More info: https://kubernetes.io/docs/concepts/containers/images'
+                  type: string
+                imageID:
+                  description: ImageID of the container's image.
+                  type: string
+                lastState:
+                  description: Details about the container's last termination condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format 'docker://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+                name:
+                  description: This must be a DNS_LABEL. Each container in a pod must
+                    have a unique name. Cannot be updated.
+                  type: string
+                ready:
+                  description: Specifies whether the container has passed its readiness
+                    probe.
+                  type: boolean
+                restartCount:
+                  description: The number of times the container has been restarted,
+                    currently based on the number of dead containers that have not
+                    yet been removed. Note that this is calculated from dead containers.
+                    But those containers are subject to garbage collection. This value
+                    will get capped at 5 by GC.
+                  format: int32
+                  type: integer
+                started:
+                  description: Specifies whether the container has passed its startup
+                    probe. Initialized as false, becomes true after startupProbe is
+                    considered successful. Resets to false when the container is restarted,
+                    or if kubelet loses state temporarily. Is always true when no
+                    startupProbe is defined.
+                  type: boolean
+                state:
+                  description: Details about the container's current condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format 'docker://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+              required:
+              - name
+              - ready
+              - restartCount
+              - image
+              - imageID
+              type: object
+            type: array
+          ephemeralContainerStatuses:
+            description: Status for any ephemeral containers that have run in this
+              pod. This field is alpha-level and is only populated by servers that
+              enable the EphemeralContainers feature.
+            items:
+              description: ContainerStatus contains details for the current status
+                of this container.
+              properties:
+                containerID:
+                  description: Container's ID in the format 'docker://<container_id>'.
+                  type: string
+                image:
+                  description: 'The image the container is running. More info: https://kubernetes.io/docs/concepts/containers/images'
+                  type: string
+                imageID:
+                  description: ImageID of the container's image.
+                  type: string
+                lastState:
+                  description: Details about the container's last termination condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format 'docker://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+                name:
+                  description: This must be a DNS_LABEL. Each container in a pod must
+                    have a unique name. Cannot be updated.
+                  type: string
+                ready:
+                  description: Specifies whether the container has passed its readiness
+                    probe.
+                  type: boolean
+                restartCount:
+                  description: The number of times the container has been restarted,
+                    currently based on the number of dead containers that have not
+                    yet been removed. Note that this is calculated from dead containers.
+                    But those containers are subject to garbage collection. This value
+                    will get capped at 5 by GC.
+                  format: int32
+                  type: integer
+                started:
+                  description: Specifies whether the container has passed its startup
+                    probe. Initialized as false, becomes true after startupProbe is
+                    considered successful. Resets to false when the container is restarted,
+                    or if kubelet loses state temporarily. Is always true when no
+                    startupProbe is defined.
+                  type: boolean
+                state:
+                  description: Details about the container's current condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format 'docker://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+              required:
+              - name
+              - ready
+              - restartCount
+              - image
+              - imageID
+              type: object
+            type: array
+          hostIP:
+            description: IP address of the host to which the pod is assigned. Empty
+              if not yet scheduled.
+            type: string
+          initContainerStatuses:
+            description: 'The list has one entry per init container in the manifest.
+              The most recent successful init container will have ready = true, the
+              most recently started container will have startTime set. More info:
+              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status'
+            items:
+              description: ContainerStatus contains details for the current status
+                of this container.
+              properties:
+                containerID:
+                  description: Container's ID in the format 'docker://<container_id>'.
+                  type: string
+                image:
+                  description: 'The image the container is running. More info: https://kubernetes.io/docs/concepts/containers/images'
+                  type: string
+                imageID:
+                  description: ImageID of the container's image.
+                  type: string
+                lastState:
+                  description: Details about the container's last termination condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format 'docker://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+                name:
+                  description: This must be a DNS_LABEL. Each container in a pod must
+                    have a unique name. Cannot be updated.
+                  type: string
+                ready:
+                  description: Specifies whether the container has passed its readiness
+                    probe.
+                  type: boolean
+                restartCount:
+                  description: The number of times the container has been restarted,
+                    currently based on the number of dead containers that have not
+                    yet been removed. Note that this is calculated from dead containers.
+                    But those containers are subject to garbage collection. This value
+                    will get capped at 5 by GC.
+                  format: int32
+                  type: integer
+                started:
+                  description: Specifies whether the container has passed its startup
+                    probe. Initialized as false, becomes true after startupProbe is
+                    considered successful. Resets to false when the container is restarted,
+                    or if kubelet loses state temporarily. Is always true when no
+                    startupProbe is defined.
+                  type: boolean
+                state:
+                  description: Details about the container's current condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format 'docker://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+              required:
+              - name
+              - ready
+              - restartCount
+              - image
+              - imageID
+              type: object
+            type: array
+          message:
+            description: A human readable message indicating details about why the
+              pod is in this condition.
+            type: string
+          nominatedNodeName:
+            description: nominatedNodeName is set only when this pod preempts other
+              pods on the node, but it cannot be scheduled right away as preemption
+              victims receive their graceful termination periods. This field does
+              not guarantee that the pod will be scheduled on this node. Scheduler
+              may decide to place the pod elsewhere if other nodes become available
+              sooner. Scheduler may also decide to give the resources on this node
+              to a higher priority pod that is created after preemption. As a result,
+              this field may be different than PodSpec.nodeName when the pod is scheduled.
+            type: string
+          phase:
+            description: |-
+              The phase of a Pod is a simple, high-level summary of where the Pod is in its lifecycle. The conditions array, the reason and message fields, and the individual container status arrays contain more detail about the pod's status. There are five possible phase values:
+
+              Pending: The pod has been accepted by the Kubernetes system, but one or more of the container images has not been created. This includes time before being scheduled as well as time spent downloading images over the network, which could take a while. Running: The pod has been bound to a node, and all of the containers have been created. At least one container is still running, or is in the process of starting or restarting. Succeeded: All containers in the pod have terminated in success, and will not be restarted. Failed: All containers in the pod have terminated, and at least one container has terminated in failure. The container either exited with non-zero status or was terminated by the system. Unknown: For some reason the state of the pod could not be obtained, typically due to an error in communicating with the host of the pod.
+
+              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-phase
+            type: string
+          podIP:
+            description: IP address allocated to the pod. Routable at least within
+              the cluster. Empty if not yet allocated.
+            type: string
+          podIPs:
+            description: podIPs holds the IP addresses allocated to the pod. If this
+              field is specified, the 0th entry must match the podIP field. Pods may
+              be allocated at most 1 value for each of IPv4 and IPv6. This list is
+              empty if no IPs have been allocated yet.
+            items:
+              description: |-
+                IP address information for entries in the (plural) PodIPs field. Each entry includes:
+                   IP: An IP address allocated to the pod. Routable at least within the cluster.
+              properties:
+                ip:
+                  description: ip is an IP address (IPv4 or IPv6) assigned to the
+                    pod
+                  type: string
+              required:
+              - ip
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - ip
+            x-kubernetes-list-type: map
+          qosClass:
+            description: 'The Quality of Service (QOS) classification assigned to
+              the pod based on resource requirements See PodQOSClass type for available
+              QOS classes More info: https://git.k8s.io/community/contributors/design-proposals/node/resource-qos.md'
+            type: string
+          reason:
+            description: A brief CamelCase message indicating details about why the
+              pod is in this state. e.g. 'Evicted'
+            type: string
+          startTime:
+            description: RFC 3339 date and time at which the object was acknowledged
+              by the Kubelet. This is before the Kubelet pulled the container image(s)
+              for the pod.
+            format: date-time
+            type: string
+        type: object
+    type: object
+  plural: pods
+  scope: Namespaced
+  shortNames:
+  - po
+  singular: pod
+  subResources:
+  - name: status

--- a/docs/content/concepts/scenarios/jn-scenario/yamls/4-NegotiatedAPIResource-services.v1.core.yaml
+++ b/docs/content/concepts/scenarios/jn-scenario/yamls/4-NegotiatedAPIResource-services.v1.core.yaml
@@ -1,0 +1,425 @@
+apiVersion: apiresource.kcp.io/v1alpha1
+kind: NegotiatedAPIResource
+metadata:
+  annotations:
+    apiresource.kcp.io/apiVersion: v1
+    kcp.io/cluster: 49adf4fn8ks8x43u
+  creationTimestamp: "2023-03-20T19:08:21Z"
+  generation: 1
+  name: services.v1.core
+  resourceVersion: "770"
+  uid: bd58f380-6532-4cc0-b469-d1e005fd46c1
+spec:
+  categories:
+  - all
+  groupVersion:
+    version: v1
+  kind: Service
+  listKind: ServiceList
+  openAPIV3Schema:
+    description: Service is a named abstraction of software service (for example,
+      mysql) consisting of local port (for example 3306) that the proxy listens on,
+      and the selector that determines which pods will answer requests sent through
+      the proxy.
+    properties:
+      apiVersion:
+        description: 'APIVersion defines the versioned schema of this representation
+          of an object. Servers should convert recognized schemas to the latest internal
+          value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+        type: string
+      kind:
+        description: 'Kind is a string value representing the REST resource this object
+          represents. Servers may infer this from the endpoint the client submits
+          requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+        type: string
+      metadata:
+        type: object
+      spec:
+        description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        properties:
+          allocateLoadBalancerNodePorts:
+            description: allocateLoadBalancerNodePorts defines if NodePorts will be
+              automatically allocated for services with type LoadBalancer.  Default
+              is "true". It may be set to "false" if the cluster load-balancer does
+              not rely on NodePorts. allocateLoadBalancerNodePorts may only be set
+              for services with type LoadBalancer and will be cleared if the type
+              is changed to any other type. This field is alpha-level and is only
+              honored by servers that enable the ServiceLBNodePortControl feature.
+            type: boolean
+          clusterIP:
+            description: 'clusterIP is the IP address of the service and is usually
+              assigned randomly. If an address is specified manually, is in-range
+              (as per system configuration), and is not in use, it will be allocated
+              to the service; otherwise creation of the service will fail. This field
+              may not be changed through updates unless the type field is also being
+              changed to ExternalName (which requires this field to be blank) or the
+              type field is being changed from ExternalName (in which case this field
+              may optionally be specified, as describe above).  Valid values are "None",
+              empty string (""), or a valid IP address. Setting this to "None" makes
+              a "headless service" (no virtual IP), which is useful when direct endpoint
+              connections are preferred and proxying is not required.  Only applies
+              to types ClusterIP, NodePort, and LoadBalancer. If this field is specified
+              when creating a Service of type ExternalName, creation will fail. This
+              field will be wiped when updating a Service to type ExternalName. More
+              info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+            type: string
+          clusterIPs:
+            description: |-
+              ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address.  Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value.
+
+              Unless the "IPv6DualStack" feature gate is enabled, this field is limited to one value, which must be the same as the clusterIP field.  If the feature gate is enabled, this field may hold a maximum of two entries (dual-stack IPs, in either order).  These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+            items:
+              type: string
+            type: array
+            x-kubernetes-list-type: atomic
+          externalIPs:
+            description: externalIPs is a list of IP addresses for which nodes in
+              the cluster will also accept traffic for this service.  These IPs are
+              not managed by Kubernetes.  The user is responsible for ensuring that
+              traffic arrives at a node with this IP.  A common example is external
+              load-balancers that are not part of the Kubernetes system.
+            items:
+              type: string
+            type: array
+          externalName:
+            description: externalName is the external reference that discovery mechanisms
+              will return as an alias for this service (e.g. a DNS CNAME record).
+              No proxying will be involved.  Must be a lowercase RFC-1123 hostname
+              (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
+            type: string
+          externalTrafficPolicy:
+            description: externalTrafficPolicy denotes if this Service desires to
+              route external traffic to node-local or cluster-wide endpoints. "Local"
+              preserves the client source IP and avoids a second hop for LoadBalancer
+              and Nodeport type services, but risks potentially imbalanced traffic
+              spreading. "Cluster" obscures the client source IP and may cause a second
+              hop to another node, but should have good overall load-spreading.
+            type: string
+          healthCheckNodePort:
+            description: healthCheckNodePort specifies the healthcheck nodePort for
+              the service. This only applies when type is set to LoadBalancer and
+              externalTrafficPolicy is set to Local. If a value is specified, is in-range,
+              and is not in use, it will be used.  If not specified, a value will
+              be automatically allocated.  External systems (e.g. load-balancers)
+              can use this port to determine if a given node holds endpoints for this
+              service or not.  If this field is specified when creating a Service
+              which does not need it, creation will fail. This field will be wiped
+              when updating a Service to no longer need it (e.g. changing type).
+            format: int32
+            type: integer
+          internalTrafficPolicy:
+            description: InternalTrafficPolicy specifies if the cluster internal traffic
+              should be routed to all endpoints or node-local endpoints only. "Cluster"
+              routes internal traffic to a Service to all endpoints. "Local" routes
+              traffic to node-local endpoints only, traffic is dropped if no node-local
+              endpoints are ready. The default value is "Cluster".
+            type: string
+          ipFamilies:
+            description: |-
+              IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service, and is gated by the "IPv6DualStack" feature gate.  This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail.  This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service.  Valid values are "IPv4" and "IPv6".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to "headless" services.  This field will be wiped when updating a Service to type ExternalName.
+
+              This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field.
+            items:
+              type: string
+            type: array
+            x-kubernetes-list-type: atomic
+          ipFamilyPolicy:
+            description: IPFamilyPolicy represents the dual-stack-ness requested or
+              required by this Service, and is gated by the "IPv6DualStack" feature
+              gate.  If there is no value provided, then this field will be set to
+              SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack"
+              (two IP families on dual-stack configured clusters or a single IP family
+              on single-stack clusters), or "RequireDualStack" (two IP families on
+              dual-stack configured clusters, otherwise fail). The ipFamilies and
+              clusterIPs fields depend on the value of this field.  This field will
+              be wiped when updating a service to type ExternalName.
+            type: string
+          loadBalancerClass:
+            description: loadBalancerClass is the class of the load balancer implementation
+              this Service belongs to. If specified, the value of this field must
+              be a label-style identifier, with an optional prefix, e.g. "internal-vip"
+              or "example.com/internal-vip". Unprefixed names are reserved for end-users.
+              This field can only be set when the Service type is 'LoadBalancer'.
+              If not set, the default load balancer implementation is used, today
+              this is typically done through the cloud provider integration, but should
+              apply for any default implementation. If set, it is assumed that a load
+              balancer implementation is watching for Services with a matching class.
+              Any default load balancer implementation (e.g. cloud providers) should
+              ignore Services that set this field. This field can only be set when
+              creating or updating a Service to type 'LoadBalancer'. Once set, it
+              can not be changed. This field will be wiped when a service is updated
+              to a non 'LoadBalancer' type.
+            type: string
+          loadBalancerIP:
+            description: 'Only applies to Service Type: LoadBalancer LoadBalancer
+              will get created with the IP specified in this field. This feature depends
+              on whether the underlying cloud-provider supports specifying the loadBalancerIP
+              when a load balancer is created. This field will be ignored if the cloud-provider
+              does not support the feature.'
+            type: string
+          loadBalancerSourceRanges:
+            description: 'If specified and supported by the platform, this will restrict
+              traffic through the cloud-provider load-balancer will be restricted
+              to the specified client IPs. This field will be ignored if the cloud-provider
+              does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+            items:
+              type: string
+            type: array
+          ports:
+            description: 'The list of ports that are exposed by this service. More
+              info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+            items:
+              description: ServicePort contains information on service's port.
+              properties:
+                appProtocol:
+                  description: The application protocol for this port. This field
+                    follows standard Kubernetes label syntax. Un-prefixed names are
+                    reserved for IANA standard service names (as per RFC-6335 and
+                    http://www.iana.org/assignments/service-names). Non-standard protocols
+                    should use prefixed names such as mycompany.com/my-custom-protocol.
+                    This is a beta field that is guarded by the ServiceAppProtocol
+                    feature gate and enabled by default.
+                  type: string
+                name:
+                  description: The name of this port within the service. This must
+                    be a DNS_LABEL. All ports within a ServiceSpec must have unique
+                    names. When considering the endpoints for a Service, this must
+                    match the 'name' field in the EndpointPort. Optional if only one
+                    ServicePort is defined on this service.
+                  type: string
+                nodePort:
+                  description: 'The port on each node on which this service is exposed
+                    when type is NodePort or LoadBalancer.  Usually assigned by the
+                    system. If a value is specified, in-range, and not in use it will
+                    be used, otherwise the operation will fail.  If not specified,
+                    a port will be allocated if this Service requires one.  If this
+                    field is specified when creating a Service which does not need
+                    it, creation will fail. This field will be wiped when updating
+                    a Service to no longer need it (e.g. changing type from NodePort
+                    to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                  format: int32
+                  type: integer
+                port:
+                  description: The port that will be exposed by this service.
+                  format: int32
+                  type: integer
+                protocol:
+                  default: TCP
+                  description: The IP protocol for this port. Supports "TCP", "UDP",
+                    and "SCTP". Default is TCP.
+                  type: string
+                targetPort:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: 'Number or name of the port to access on the pods targeted
+                    by the service. Number must be in the range 1 to 65535. Name must
+                    be an IANA_SVC_NAME. If this is a string, it will be looked up
+                    as a named port in the target Pod''s container ports. If this
+                    is not specified, the value of the ''port'' field is used (an
+                    identity map). This field is ignored for services with clusterIP=None,
+                    and should be omitted or set equal to the ''port'' field. More
+                    info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                  x-kubernetes-int-or-string: true
+              required:
+              - port
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - port
+            - protocol
+            x-kubernetes-list-type: map
+          publishNotReadyAddresses:
+            description: publishNotReadyAddresses indicates that any agent which deals
+              with endpoints for this Service should disregard any indications of
+              ready/not-ready. The primary use case for setting this field is for
+              a StatefulSet's Headless Service to propagate SRV DNS records for its
+              Pods for the purpose of peer discovery. The Kubernetes controllers that
+              generate Endpoints and EndpointSlice resources for Services interpret
+              this to mean that all endpoints are considered "ready" even if the Pods
+              themselves are not. Agents which consume only Kubernetes generated endpoints
+              through the Endpoints or EndpointSlice resources can safely assume this
+              behavior.
+            type: boolean
+          selector:
+            additionalProperties:
+              type: string
+            description: 'Route service traffic to pods with label keys and values
+              matching this selector. If empty or not present, the service is assumed
+              to have an external process managing its endpoints, which Kubernetes
+              will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer.
+              Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+            type: object
+          sessionAffinity:
+            description: 'Supports "ClientIP" and "None". Used to maintain session
+              affinity. Enable client IP based session affinity. Must be ClientIP
+              or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+            type: string
+          sessionAffinityConfig:
+            description: sessionAffinityConfig contains the configurations of session
+              affinity.
+            properties:
+              clientIP:
+                description: clientIP contains the configurations of Client IP based
+                  session affinity.
+                properties:
+                  timeoutSeconds:
+                    description: timeoutSeconds specifies the seconds of ClientIP
+                      type session sticky time. The value must be >0 && <=86400(for
+                      1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for
+                      3 hours).
+                    format: int32
+                    type: integer
+                type: object
+            type: object
+          topologyKeys:
+            description: topologyKeys is a preference-order list of topology keys
+              which implementations of services should use to preferentially sort
+              endpoints when accessing this Service, it can not be used at the same
+              time as externalTrafficPolicy=Local. Topology keys must be valid label
+              keys and at most 16 keys may be specified. Endpoints are chosen based
+              on the first topology key with available backends. If this field is
+              specified and all entries have no backends that match the topology of
+              the client, the service has no backends for that client and connections
+              should fail. The special value "*" may be used to mean "any topology".
+              This catch-all value, if used, only makes sense as the last value in
+              the list. If this is not specified or empty, no topology constraints
+              will be applied. This field is alpha-level and is only honored by servers
+              that enable the ServiceTopology feature. This field is deprecated and
+              will be removed in a future version.
+            items:
+              type: string
+            type: array
+          type:
+            description: 'type determines how the Service is exposed. Defaults to
+              ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and
+              LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for
+              load-balancing to endpoints. Endpoints are determined by the selector
+              or if that is not specified, by manual construction of an Endpoints
+              object or EndpointSlice objects. If clusterIP is "None", no virtual
+              IP is allocated and the endpoints are published as a set of endpoints
+              rather than a virtual IP. "NodePort" builds on ClusterIP and allocates
+              a port on every node which routes to the same endpoints as the clusterIP.
+              "LoadBalancer" builds on NodePort and creates an external load-balancer
+              (if supported in the current cloud) which routes to the same endpoints
+              as the clusterIP. "ExternalName" aliases this service to the specified
+              externalName. Several other fields do not apply to ExternalName services.
+              More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+            type: string
+        type: object
+      status:
+        description: 'Most recently observed status of the service. Populated by the
+          system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+        properties:
+          conditions:
+            description: Current service state
+            items:
+              description: Condition contains details for one aspect of the current
+                state of this API Resource.
+              properties:
+                lastTransitionTime:
+                  description: lastTransitionTime is the last time the condition transitioned
+                    from one status to another. This should be when the underlying
+                    condition changed.  If that is not known, then using the time
+                    when the API field changed is acceptable.
+                  format: date-time
+                  type: string
+                message:
+                  description: message is a human readable message indicating details
+                    about the transition. This may be an empty string.
+                  type: string
+                observedGeneration:
+                  description: observedGeneration represents the .metadata.generation
+                    that the condition was set based upon. For instance, if .metadata.generation
+                    is currently 12, but the .status.conditions[x].observedGeneration
+                    is 9, the condition is out of date with respect to the current
+                    state of the instance.
+                  format: int64
+                  type: integer
+                reason:
+                  description: reason contains a programmatic identifier indicating
+                    the reason for the condition's last transition. Producers of specific
+                    condition types may define expected values and meanings for this
+                    field, and whether the values are considered a guaranteed API.
+                    The value should be a CamelCase string. This field may not be
+                    empty.
+                  type: string
+                status:
+                  description: status of the condition, one of True, False, Unknown.
+                  type: string
+                type:
+                  description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                  type: string
+              required:
+              - lastTransitionTime
+              - message
+              - reason
+              - status
+              - type
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - type
+            x-kubernetes-list-type: map
+          loadBalancer:
+            description: LoadBalancer contains the current status of the load-balancer,
+              if one is present.
+            properties:
+              ingress:
+                description: Ingress is a list containing ingress points for the load-balancer.
+                  Traffic intended for the service should be sent to these ingress
+                  points.
+                items:
+                  description: 'LoadBalancerIngress represents the status of a load-balancer
+                    ingress point: traffic intended for the service should be sent
+                    to an ingress point.'
+                  properties:
+                    hostname:
+                      description: Hostname is set for load-balancer ingress points
+                        that are DNS based (typically AWS load-balancers)
+                      type: string
+                    ip:
+                      description: IP is set for load-balancer ingress points that
+                        are IP based (typically GCE or OpenStack load-balancers)
+                      type: string
+                    ports:
+                      description: Ports is a list of records of service ports If
+                        used, every port defined in the service should have an entry
+                        in it
+                      items:
+                        properties:
+                          error:
+                            description: |-
+                              Error is to record the problem with the service port The format of the error shall comply with the following rules: - built-in error values shall be specified in this file and those shall use
+                                CamelCase names
+                              - cloud provider specific error values must have names that comply with the
+                                format foo.example.com/CamelCase.
+                            type: string
+                          port:
+                            description: Port is the port number of the service port
+                              of which status is recorded here
+                            format: int32
+                            type: integer
+                          protocol:
+                            description: 'Protocol is the protocol of the service
+                              port of which status is recorded here The supported
+                              values are: "TCP", "UDP", "SCTP"'
+                            type: string
+                        required:
+                        - port
+                        - protocol
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  type: object
+                type: array
+            type: object
+        type: object
+    type: object
+  plural: services
+  scope: Namespaced
+  shortNames:
+  - svc
+  singular: service
+  subResources:
+  - name: status

--- a/docs/content/concepts/scenarios/jn-scenario/yamls/4-apibinding-kubernetes.yaml
+++ b/docs/content/concepts/scenarios/jn-scenario/yamls/4-apibinding-kubernetes.yaml
@@ -1,0 +1,75 @@
+  apiVersion: apis.kcp.io/v1alpha1
+kind: APIBinding
+metadata:
+  annotations:
+    extra.apis.kcp.io/compute.workload.kcp.io: "true"
+    kcp.io/cluster: 49adf4fn8ks8x43u
+  creationTimestamp: "2023-03-20T18:37:20Z"
+  finalizers:
+  - apis.kcp.io/apibinding-finalizer
+  generation: 1
+  labels:
+    claimed.internal.apis.kcp.io/40Zi0j9PsQDYRFZUfMx8bfzH69sqffiovtyuvN: LstvmbbzVDDOn90ZbhzSQO5U3DMCf88h1pZ
+    internal.apis.kcp.io/export: 40Zi0j9PsQDYRFZUfMx8bfzH69sqffiovtyuvN
+  name: kubernetes
+  resourceVersion: "819"
+  uid: bf4cb1a5-c734-4a88-a1a4-b1d630289b9d
+spec:
+  reference:
+    export:
+      name: kubernetes
+status:
+  apiExportClusterName: 49adf4fn8ks8x43u
+  boundResources:
+  - group: ""
+    resource: services
+    schema:
+      UID: ddee1955-e64e-478b-9310-f934fac54910
+      identityHash: <id-hash>
+      name: rev-770.services.core
+    storageVersions:
+    - v1
+  - group: ""
+    resource: pods
+    schema:
+      UID: a5fe7c2d-adb9-4109-a4ee-8d703b27f2a9
+      identityHash: <id-hash>
+      name: rev-774.pods.core
+    storageVersions:
+    - v1
+  - group: apps
+    resource: deployments
+    schema:
+      UID: 309b6c26-5aa4-41d5-8afa-ce718ac1ea67
+      identityHash: <id-hash>
+      name: rev-788.deployments.apps
+    storageVersions:
+    - v1
+  - group: networking.k8s.io
+    resource: ingresses
+    schema:
+      UID: 6ab13f61-194b-4e0d-9816-b574cae3f875
+      identityHash: <id-hash>
+      name: rev-789.ingresses.networking.k8s.io
+    storageVersions:
+    - v1
+  conditions:
+  - lastTransitionTime: "2023-03-20T18:37:20Z"
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2023-03-20T18:37:20Z"
+    status: "True"
+    type: APIExportValid
+  - lastTransitionTime: "2023-03-20T19:08:23Z"
+    status: "True"
+    type: BindingUpToDate
+  - lastTransitionTime: "2023-03-20T18:37:20Z"
+    status: "True"
+    type: InitialBindingCompleted
+  - lastTransitionTime: "2023-03-20T18:37:20Z"
+    status: "True"
+    type: PermissionClaimsApplied
+  - lastTransitionTime: "2023-03-20T18:37:20Z"
+    status: "True"
+    type: PermissionClaimsValid
+  phase: Bound

--- a/docs/content/concepts/scenarios/jn-scenario/yamls/4-apibinding-kubernetes.yaml
+++ b/docs/content/concepts/scenarios/jn-scenario/yamls/4-apibinding-kubernetes.yaml
@@ -25,7 +25,7 @@ status:
     resource: services
     schema:
       UID: ddee1955-e64e-478b-9310-f934fac54910
-      identityHash: <id-hash>
+      identityHash: b20e9ad1d17024e51df7cd1af743cf403e385c3e890c9e1b16034ee604de7b0e
       name: rev-770.services.core
     storageVersions:
     - v1
@@ -33,7 +33,7 @@ status:
     resource: pods
     schema:
       UID: a5fe7c2d-adb9-4109-a4ee-8d703b27f2a9
-      identityHash: <id-hash>
+      identityHash: b20e9ad1d17024e51df7cd1af743cf403e385c3e890c9e1b16034ee604de7b0e
       name: rev-774.pods.core
     storageVersions:
     - v1
@@ -41,7 +41,7 @@ status:
     resource: deployments
     schema:
       UID: 309b6c26-5aa4-41d5-8afa-ce718ac1ea67
-      identityHash: <id-hash>
+      identityHash: b20e9ad1d17024e51df7cd1af743cf403e385c3e890c9e1b16034ee604de7b0e
       name: rev-788.deployments.apps
     storageVersions:
     - v1
@@ -49,7 +49,7 @@ status:
     resource: ingresses
     schema:
       UID: 6ab13f61-194b-4e0d-9816-b574cae3f875
-      identityHash: <id-hash>
+      identityHash: b20e9ad1d17024e51df7cd1af743cf403e385c3e890c9e1b16034ee604de7b0e
       name: rev-789.ingresses.networking.k8s.io
     storageVersions:
     - v1

--- a/docs/content/concepts/scenarios/jn-scenario/yamls/4-apiexport-kubernetes.yaml
+++ b/docs/content/concepts/scenarios/jn-scenario/yamls/4-apiexport-kubernetes.yaml
@@ -1,0 +1,34 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIExport
+metadata:
+  annotations:
+    extra.apis.kcp.io/compute.workload.kcp.io: "true"
+    kcp.io/cluster: 49adf4fn8ks8x43u
+    kcp.io/path: root:jn
+    workload.kcp.io/skip-default-object-creation: "true"
+  creationTimestamp: "2023-03-20T18:37:20Z"
+  generation: 5
+  name: kubernetes
+  resourceVersion: "801"
+  uid: 9af84401-21f1-400e-b570-6cd38fb8713b
+spec:
+  identity:
+    secretRef:
+      name: kubernetes
+      namespace: kcp-system
+  latestResourceSchemas:
+  - rev-788.deployments.apps
+  - rev-789.ingresses.networking.k8s.io
+  - rev-774.pods.core
+  - rev-770.services.core
+status:
+  conditions:
+  - lastTransitionTime: "2023-03-20T18:37:20Z"
+    status: "True"
+    type: IdentityValid
+  - lastTransitionTime: "2023-03-20T18:37:20Z"
+    status: "True"
+    type: VirtualWorkspaceURLsReady
+  identityHash: <id-hash>
+  virtualWorkspaces:
+  - url: https://<kcp-url>:6443/services/apiexport/49adf4fn8ks8x43u/kubernetes

--- a/docs/content/concepts/scenarios/jn-scenario/yamls/4-apiexport-kubernetes.yaml
+++ b/docs/content/concepts/scenarios/jn-scenario/yamls/4-apiexport-kubernetes.yaml
@@ -29,6 +29,6 @@ status:
   - lastTransitionTime: "2023-03-20T18:37:20Z"
     status: "True"
     type: VirtualWorkspaceURLsReady
-  identityHash: <id-hash>
+  identityHash: b20e9ad1d17024e51df7cd1af743cf403e385c3e890c9e1b16034ee604de7b0e
   virtualWorkspaces:
   - url: https://<kcp-url>:6443/services/apiexport/49adf4fn8ks8x43u/kubernetes

--- a/docs/content/concepts/scenarios/jn-scenario/yamls/4-location-default.yaml
+++ b/docs/content/concepts/scenarios/jn-scenario/yamls/4-location-default.yaml
@@ -1,0 +1,20 @@
+apiVersion: scheduling.kcp.io/v1alpha1
+kind: Location
+metadata:
+  annotations:
+    kcp.io/cluster: 49adf4fn8ks8x43u
+    kcp.io/path: root:jn
+  creationTimestamp: "2023-03-20T18:37:20Z"
+  generation: 1
+  name: default
+  resourceVersion: "763"
+  uid: 39d5688a-704e-436d-8300-24fd851d00dd
+spec:
+  instanceSelector: {}
+  resource:
+    group: workload.kcp.io
+    resource: synctargets
+    version: v1alpha1
+status:
+  availableInstances: 1
+  instances: 1

--- a/docs/content/concepts/scenarios/jn-scenario/yamls/4-placement.yaml
+++ b/docs/content/concepts/scenarios/jn-scenario/yamls/4-placement.yaml
@@ -1,0 +1,32 @@
+apiVersion: scheduling.kcp.io/v1alpha1
+kind: Placement
+metadata:
+  annotations:
+    internal.workload.kcp.io/synctarget: 8GswqbXhDhJDayJn7uG56ILV6BjJYgcKLWUGSH
+    kcp.io/cluster: 49adf4fn8ks8x43u
+  creationTimestamp: "2023-03-20T19:43:41Z"
+  generation: 1
+  name: placement-268us406
+  resourceVersion: "1054"
+  uid: 805afa25-9100-4a4c-be55-b92f34c40c2f
+spec:
+  locationResource:
+    group: workload.kcp.io
+    resource: synctargets
+    version: v1alpha1
+  locationSelectors:
+  - {}
+  locationWorkspace: root:jn
+  namespaceSelector: {}
+status:
+  conditions:
+  - lastTransitionTime: "2023-03-20T19:43:41Z"
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2023-03-20T19:43:41Z"
+    status: "True"
+    type: Scheduled
+  phase: Bound
+  selectedLocation:
+    locationName: default
+    path: 49adf4fn8ks8x43u

--- a/docs/content/concepts/scenarios/jn-scenario/yamls/4-synctarget-jn.yaml
+++ b/docs/content/concepts/scenarios/jn-scenario/yamls/4-synctarget-jn.yaml
@@ -27,24 +27,24 @@ status:
     type: SyncerAuthorized
   lastSyncerHeartbeatTime: "2023-03-20T19:48:57Z"
   syncedResources:
-  - identityHash: <id-hash>
+  - identityHash: b20e9ad1d17024e51df7cd1af743cf403e385c3e890c9e1b16034ee604de7b0e
     resource: services
     state: Accepted
     versions:
     - v1
-  - identityHash: <id-hash>
+  - identityHash: b20e9ad1d17024e51df7cd1af743cf403e385c3e890c9e1b16034ee604de7b0e
     resource: pods
     state: Accepted
     versions:
     - v1
   - group: networking.k8s.io
-    identityHash: <id-hash>
+    identityHash: b20e9ad1d17024e51df7cd1af743cf403e385c3e890c9e1b16034ee604de7b0e
     resource: ingresses
     state: Accepted
     versions:
     - v1
   - group: apps
-    identityHash: <id-hash>
+    identityHash: b20e9ad1d17024e51df7cd1af743cf403e385c3e890c9e1b16034ee604de7b0e
     resource: deployments
     state: Accepted
     versions:

--- a/docs/content/concepts/scenarios/jn-scenario/yamls/4-synctarget-jn.yaml
+++ b/docs/content/concepts/scenarios/jn-scenario/yamls/4-synctarget-jn.yaml
@@ -1,0 +1,54 @@
+apiVersion: workload.kcp.io/v1alpha1
+kind: SyncTarget
+metadata:
+  annotations:
+    kcp.io/cluster: 49adf4fn8ks8x43u
+  creationTimestamp: "2023-03-20T18:37:20Z"
+  generation: 1
+  labels:
+    internal.workload.kcp.io/key: 8GswqbXhDhJDayJn7uG56ILV6BjJYgcKLWUGSH
+  name: jn
+  resourceVersion: "1097"
+  uid: 72de24eb-7d49-4aca-be22-63f95548a816
+spec:
+  supportedAPIExports:
+  - export: kubernetes
+  unschedulable: false
+status:
+  conditions:
+  - lastTransitionTime: "2023-03-20T19:08:14Z"
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2023-03-20T19:08:14Z"
+    status: "True"
+    type: HeartbeatHealthy
+  - lastTransitionTime: "2023-03-20T19:08:16Z"
+    status: "True"
+    type: SyncerAuthorized
+  lastSyncerHeartbeatTime: "2023-03-20T19:48:57Z"
+  syncedResources:
+  - identityHash: <id-hash>
+    resource: services
+    state: Accepted
+    versions:
+    - v1
+  - identityHash: <id-hash>
+    resource: pods
+    state: Accepted
+    versions:
+    - v1
+  - group: networking.k8s.io
+    identityHash: <id-hash>
+    resource: ingresses
+    state: Accepted
+    versions:
+    - v1
+  - group: apps
+    identityHash: <id-hash>
+    resource: deployments
+    state: Accepted
+    versions:
+    - v1
+  virtualWorkspaces:
+  - syncerURL: https://<kcp-url>:6443/services/syncer/49adf4fn8ks8x43u/jn/72de24eb-7d49-4aca-be22-63f95548a816
+    upsyncerURL: https://<kcp-url>:6443/services/upsyncer/49adf4fn8ks8x43u/jn/72de24eb-7d49-4aca-be22-63f95548a816

--- a/docs/content/concepts/scenarios/jn-scenario/yamls/syncer-jn.yaml
+++ b/docs/content/concepts/scenarios/jn-scenario/yamls/syncer-jn.yaml
@@ -1,0 +1,243 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kcp-syncer-jn-11hmg5wf
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kcp-syncer-jn-11hmg5wf
+  namespace: kcp-syncer-jn-11hmg5wf
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kcp-syncer-jn-11hmg5wf-token
+  namespace: kcp-syncer-jn-11hmg5wf
+  annotations:
+    kubernetes.io/service-account.name: kcp-syncer-jn-11hmg5wf
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kcp-syncer-jn-11hmg5wf
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - "create"
+  - "get"
+  - "list"
+  - "watch"
+  - "delete"
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - "get"
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - "get"
+  - "watch"
+  - "list"
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - "create"
+  - "list"
+  - "watch"
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - pods/log
+  - pods/exec
+  - pods/attach
+  - pods/binding
+  - pods/portforward
+  - pods/proxy
+  - pods/ephemeralcontainers
+  - secrets
+  - services
+  verbs:
+  - "*"
+- apiGroups:
+  - "apps"
+  resources:
+  - deployments
+  verbs:
+  - "*"
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - ingresses
+  verbs:
+  - "*"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kcp-syncer-jn-11hmg5wf
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kcp-syncer-jn-11hmg5wf
+subjects:
+- kind: ServiceAccount
+  name: kcp-syncer-jn-11hmg5wf
+  namespace: kcp-syncer-jn-11hmg5wf
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kcp-dns-jn-11hmg5wf
+  namespace: kcp-syncer-jn-11hmg5wf
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  - services
+  verbs:
+  - "create"
+  - "get"
+  - "list"
+  - "update"
+  - "delete"
+  - "watch"
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+- apiGroups:
+  - "apps"
+  resources:
+  - deployments
+  verbs:
+  - "create"
+  - "get"
+  - "list"
+  - "update"
+  - "delete"
+  - "watch"
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - "create"
+  - "get"
+  - "list"
+  - "update"
+  - "delete"
+  - "watch"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kcp-dns-jn-11hmg5wf
+  namespace: kcp-syncer-jn-11hmg5wf
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kcp-dns-jn-11hmg5wf
+subjects:
+  - kind: ServiceAccount
+    name: kcp-syncer-jn-11hmg5wf
+    namespace: kcp-syncer-jn-11hmg5wf
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kcp-syncer-jn-11hmg5wf
+  namespace: kcp-syncer-jn-11hmg5wf
+stringData:
+  kubeconfig: |
+    apiVersion: v1
+    kind: Config
+    clusters:
+    - name: default-cluster
+      cluster:
+        certificate-authority-data: <certificate>
+        server: https://<kcp-url>:6443
+    contexts:
+    - name: default-context
+      context:
+        cluster: default-cluster
+        namespace: default
+        user: default-user
+    current-context: default-context
+    users:
+    - name: default-user
+      user:
+        token: <token>
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kcp-syncer-jn-11hmg5wf
+  namespace: kcp-syncer-jn-11hmg5wf
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: kcp-syncer-jn-11hmg5wf
+  template:
+    metadata:
+      labels:
+        app: kcp-syncer-jn-11hmg5wf
+    spec:
+      containers:
+      - name: kcp-syncer
+        command:
+        - /ko-app/syncer
+        args:
+        - --from-kubeconfig=/kcp/kubeconfig
+        - --sync-target-name=jn
+        - --sync-target-uid=72de24eb-7d49-4aca-be22-63f95548a816
+        - --from-cluster=49adf4fn8ks8x43u
+        - --api-import-poll-interval=1m0s
+        - --downstream-namespace-clean-delay=30s
+        - --resources=pods
+        - --resources=deployments.apps
+        - --resources=services
+        - --resources=ingresses.networking.k8s.io
+        - --qps=20
+        - --burst=30
+        - --dns-image=ghcr.io/kcp-dev/kcp/syncer:v0.11.0
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: ghcr.io/kcp-dev/kcp/syncer:v0.11.0
+        imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - name: kcp-config
+          mountPath: /kcp/
+          readOnly: true
+      serviceAccountName: kcp-syncer-jn-11hmg5wf
+      volumes:
+        - name: kcp-config
+          secret:
+            secretName: kcp-syncer-jn-11hmg5wf
+            optional: false

--- a/docs/content/concepts/scenarios/kind-scenario/README.md
+++ b/docs/content/concepts/scenarios/kind-scenario/README.md
@@ -90,6 +90,18 @@ $ k get APIConversions
 No resources found
 ```
 
+Objects yamls:
+
+- [APIBinding `apiresource.kcp.io-c8wp6`](yamls/1-apibinding-apiresource.kcp.io-c8wp6.yaml) from `k get APIBinding apiresource.kcp.io-c8wp6 -o yaml > 1-apibinding-apiresource.kcp.io-c8wp6.yaml`
+
+- [APIBinding `scheduling.kcp.io-7rr1j`](yamls/1-apibinding-scheduling.kcp.io-7rr1j.yaml) from `k get APIBinding scheduling.kcp.io-7rr1j -o yaml > 1-apibinding-scheduling.kcp.io-7rr1j.yaml`
+
+- [APIBinding `tenancy.kcp.io-5qqol`](yamls/1-apibinding-tenancy.kcp.io-5qqol.yaml) from `k get APIBinding tenancy.kcp.io-5qqol -o yaml > 1-apibinding-tenancy.kcp.io-5qqol.yaml`
+
+- [APIBinding `topology.kcp.io-2eqkm`](yamls/1-apibinding-topology.kcp.io-2eqkm.yaml) from `k get APIBinding topology.kcp.io-2eqkm -o yaml > 1-apibinding-topology.kcp.io-2eqkm.yaml`
+
+- [APIBinding `workload.kcp.io-dil2i`](yamls/1-apibinding-workload.kcp.io-dil2i.yaml) from `k get APIBinding workload.kcp.io-dil2i -o yaml > 1-apibinding-workload.kcp.io-dil2i.yaml`
+
 ## 3. Create a syncer at the center
 
 Given:
@@ -179,6 +191,7 @@ No resources found
 ```
 
 Objects yamls:
+
 - [APIExport `kubernetes`](yamls/2-apiexport-kubernetes.yaml) from `k get apiexport kubernetes -o yaml > 2-apiexport-kubernetes.yaml`
 - [APIBinding `kubernetes`](yamls/2-apibinding-kubernetes.yaml) from `k get apibinding kubernetes -o yaml > 2-apibinding-kubernetes.yaml`
 - [SyncTarget `kind`](yamls/2-synctarget-kind.yaml) from `k get synctarget kind -o yaml > 2-synctarget-kind.yaml`
@@ -309,6 +322,7 @@ No resources found
 ```
 
 Objects yamls:
+
 - [APIExport `kubernetes`](yamls/3-apiexport-kubernetes.yaml) from `k get apiexport kubernetes -o yaml > 3-apiexport-kubernetes.yaml`
 
     No difference. Compared to the MicroShift case (NVIDIA Jetson Nano) there is no `latestResourceSchemas` in the `spec`.
@@ -489,6 +503,7 @@ No resources found
 ```
 
 Objects yamls:
+
 - [APIExport `kubernetes`](yamls/4-apiexport-kubernetes.yaml) from `k get apiexport kubernetes -o yaml > 4-apiexport-kubernetes.yaml`
 
     No difference.

--- a/docs/content/concepts/scenarios/kind-scenario/README.md
+++ b/docs/content/concepts/scenarios/kind-scenario/README.md
@@ -1,0 +1,613 @@
+# List KCP Workspace objects (Kind cluster scenario)
+
+Table of content:
+
+- [List KCP Workspace objects (Kind cluster scenario)](#list-kcp-workspace-objects-kind-cluster-scenario)
+  - [1. Start KCP](#1-start-kcp)
+  - [2. Check objects in the new `kind` KCP Workspace at the center (#1)](#2-check-objects-in-the-new-kind-kcp-workspace-at-the-center-1)
+  - [3. Create a syncer at the center](#3-create-a-syncer-at-the-center)
+  - [4. Check objects that were created in the `kind` KCP Workspace after running `kcp workload sync` at the center (#2)](#4-check-objects-that-were-created-in-the-kind-kcp-workspace-after-running-kcp-workload-sync-at-the-center-2)
+  - [5. Apply the syncer on the pcluster at the edge (Kind cluster)](#5-apply-the-syncer-on-the-pcluster-at-the-edge-kind-cluster)
+  - [6. Check objects that were created in the `kind` KCP Workspace at the center after running the syncer in the pcluster at the edge (#3)](#6-check-objects-that-were-created-in-the-kind-kcp-workspace-at-the-center-after-running-the-syncer-in-the-pcluster-at-the-edge-3)
+  - [7. Bind to `compute` at the center](#7-bind-to-compute-at-the-center)
+  - [8. Check objects that were created in the `kind` KCP Workspace after binding to `compute` at the center (#4)](#8-check-objects-that-were-created-in-the-kind-kcp-workspace-after-binding-to-compute-at-the-center-4)
+
+## 1. Start KCP
+
+Given KCP 0.11:
+
+```bash
+$ k version --short
+Client Version: v1.25.3
+Kustomize Version: v4.5.7
+Server Version: v1.24.3+kcp-v0.11.0
+```
+
+Start KCP with an external IP address binding:
+
+```bash
+$ kcp start --bind-address $(ifconfig | grep -A 1 'enp0s8' | tail -1 | awk '{print $2}')
+```
+
+Create a new KCP Workspace called `kind`:
+
+```bash
+$ k ws create kind --enter
+Workspace "kind" (type root:organization) created. Waiting for it to be ready...
+Workspace "kind" (type root:organization) is ready to use.
+Current workspace is "root:kind" (type root:organization).
+
+$ k ws tree
+.
+└── root
+    ├── compute
+    ├── jn
+    └── kind
+```
+
+## 2. Check objects in the new `kind` KCP Workspace at the center (#1)
+
+Given:
+
+```bash
+$ echo $KUBECONFIG
+~/.kcp/admin.kubeconfig
+
+$ k ws .
+Current workspace is "root:kind".
+```
+
+List key objects:
+
+```bash
+$ k get apiexports
+No resources found
+
+$ k get apibindings
+NAME                       AGE
+apiresource.kcp.io-c8wp6   49m
+scheduling.kcp.io-7rr1j    49m
+tenancy.kcp.io-5qqol       49m
+topology.kcp.io-2eqkm      49m
+workload.kcp.io-dil2i      49m
+
+$ k get synctargets
+No resources found
+
+$ k get locations
+No resources found
+
+$ k get placements
+No resources found
+
+$ k get APIResourceImports
+No resources found
+
+$ k get NegotiatedAPIResources
+No resources found
+
+$ k get APIConversions
+No resources found
+```
+
+## 3. Create a syncer at the center
+
+Given:
+
+```bash
+$ echo $KUBECONFIG
+~/.kcp/admin.kubeconfig
+
+$ k ws .
+Current workspace is "root:kind".
+```
+
+Create the [syncer YAML](yamls/syncer-kind.yaml):
+
+```bash
+$ k kcp workload sync kind --syncer-image ghcr.io/kcp-dev/kcp/syncer:v0.11.0 -o syncer-kind.yaml
+Creating synctarget "kind"
+Creating service account "kcp-syncer-kind-37zv5s0u"
+Creating cluster role "kcp-syncer-kind-37zv5s0u" to give service account "kcp-syncer-kind-37zv5s0u"
+```
+
+Note that in this scenario, the `kind` `SyncTarget` contains a `supportedAPIExports` with `path` pointing to the [`kuberntes` `APIExport` object in the `root:compute` Workspace](yamls/root-compute-apiexport-kubernetes.yaml).
+
+```yaml
+supportedAPIExports:
+  - export: kubernetes
+    path: root:compute
+```
+
+ So in this case KCP will be using the schema specified by the [`kuberntes` `APIExport` object in the `root:compute` Workspace](yamls/root-compute-apiexport-kubernetes.yaml):
+
+ ```yaml
+ latestResourceSchemas:
+  - v124.ingresses.networking.k8s.io
+  - v124.services.core
+  - v124.deployments.apps
+  - v124.pods.core
+  ```
+
+## 4. Check objects that were created in the `kind` KCP Workspace after running `kcp workload sync` at the center (#2)
+
+Given:
+
+```bash
+$ echo $KUBECONFIG
+~/.kcp/admin.kubeconfig
+
+$ k ws .
+Current workspace is "root:kind".
+```
+
+List key objects:
+
+```bash
+$ k get apiexports
+NAME         AGE
+kubernetes   35s
+
+$ k get apibindings
+NAME                       AGE
+apiresource.kcp.io-c8wp6   53m
+kubernetes                 42s
+scheduling.kcp.io-7rr1j    53m
+tenancy.kcp.io-5qqol       53m
+topology.kcp.io-2eqkm      53m
+workload.kcp.io-dil2i      53m
+
+$ k get synctargets
+NAME   AGE
+kind   47s
+
+$ k get locations
+NAME      RESOURCE      AVAILABLE   INSTANCES   LABELS   AGE
+default   synctargets   0           1                    54s
+
+$ k get placements
+No resources found
+
+$ k get APIResourceImports
+No resources found
+
+$ k get NegotiatedAPIResources
+No resources found
+
+$ k get APIConversions
+No resources found
+```
+
+Objects yamls:
+- [APIExport `kubernetes`](yamls/2-apiexport-kubernetes.yaml) from `k get apiexport kubernetes -o yaml > 2-apiexport-kubernetes.yaml`
+- [APIBinding `kubernetes`](yamls/2-apibinding-kubernetes.yaml) from `k get apibinding kubernetes -o yaml > 2-apibinding-kubernetes.yaml`
+- [SyncTarget `kind`](yamls/2-synctarget-kind.yaml) from `k get synctarget kind -o yaml > 2-synctarget-kind.yaml`
+- [Location `default`](yamls/2-location-default.yaml) from `k get location default -o yaml > 2-location-default.yaml`
+
+## 5. Apply the syncer on the pcluster at the edge (Kind cluster)
+
+Create a kind cluster:
+
+```bash
+$ kind create cluster
+Creating cluster "kind" ...
+ ✓ Ensuring node image (kindest/node:v1.25.3) 🖼
+ ✓ Preparing nodes 📦
+ ✓ Writing configuration 📜
+ ✓ Starting control-plane 🕹️
+ ✓ Installing CNI 🔌
+ ✓ Installing StorageClass 💾
+Set kubectl context to "kind-kind"
+
+$ echo $KUBECONFIG
+~/.kube/config
+
+$ k get pods -A
+NAMESPACE            NAME                                         READY   STATUS    RESTARTS   AGE
+kube-system          coredns-565d847f94-9nhw2                     1/1     Running   0          6m37s
+kube-system          coredns-565d847f94-pvfc7                     1/1     Running   0          6m37s
+kube-system          etcd-kind-control-plane                      1/1     Running   0          6m53s
+kube-system          kindnet-8b7sd                                1/1     Running   0          6m37s
+kube-system          kube-apiserver-kind-control-plane            1/1     Running   0          6m49s
+kube-system          kube-controller-manager-kind-control-plane   1/1     Running   0          6m59s
+kube-system          kube-proxy-c9nzm                             1/1     Running   0          6m37s
+kube-system          kube-scheduler-kind-control-plane            1/1     Running   0          6m55s
+local-path-storage   local-path-provisioner-684f458cdd-ctpsx      1/1     Running   0          6m37s
+```
+
+Apply the syncer:
+
+```bash
+$ k apply -f syncer-kind.yaml
+namespace/kcp-syncer-kind-37zv5s0u created
+serviceaccount/kcp-syncer-kind-37zv5s0u created
+secret/kcp-syncer-kind-37zv5s0u-token created
+clusterrole.rbac.authorization.k8s.io/kcp-syncer-kind-37zv5s0u created
+clusterrolebinding.rbac.authorization.k8s.io/kcp-syncer-kind-37zv5s0u created
+role.rbac.authorization.k8s.io/kcp-dns-kind-37zv5s0u created
+rolebinding.rbac.authorization.k8s.io/kcp-dns-kind-37zv5s0u created
+secret/kcp-syncer-kind-37zv5s0u created
+deployment.apps/kcp-syncer-kind-37zv5s0u created
+
+$ $ k get pods -A
+NAMESPACE                  NAME                                         READY   STATUS    RESTARTS   AGE
+kcp-syncer-kind-37zv5s0u   kcp-syncer-kind-37zv5s0u-6949dd87f8-zdsxm    1/1     Running   0          17s
+```
+
+## 6. Check objects that were created in the `kind` KCP Workspace at the center after running the syncer in the pcluster at the edge (#3)
+
+Given:
+
+```bash
+$ echo $KUBECONFIG
+~/.kcp/admin.kubeconfig
+
+$ k ws .
+Current workspace is "root:kind".
+```
+
+The `synctarget default` is not `available`:
+
+```bash
+$ k get apiexports
+NAME         AGE
+kubernetes   5m21s
+
+$ k get apibindings
+NAME                       AGE
+apiresource.kcp.io-c8wp6   58m
+kubernetes                 5m26s
+scheduling.kcp.io-7rr1j    58m
+tenancy.kcp.io-5qqol       58m
+topology.kcp.io-2eqkm      58m
+workload.kcp.io-dil2i      58m
+
+$ k get synctargets
+NAME   AGE
+kind   5m35s
+
+$ k get locations
+NAME      RESOURCE      AVAILABLE   INSTANCES   LABELS   AGE
+default   synctargets   1           1                    5m40s
+
+$ k get placements
+No resources found
+
+$ k get APIResourceImports
+NAME
+deployments.kind2.v1.apps
+ingresses.kind2.v1.networking.k8s.io
+pods.kind2.v1.core
+services.kind2.v1.core
+
+$ k get NegotiatedAPIResources
+NAME
+deployments.v1.apps
+ingresses.v1.networking.k8s.io
+pods.v1.core
+services.v1.core
+
+$ k get APIConversions
+No resources found
+
+$ k get APIResourceImports
+NAME
+deployments.kind.v1.apps
+ingresses.kind.v1.networking.k8s.io
+pods.kind.v1.core
+services.kind.v1.core
+
+$ k get NegotiatedAPIResources
+NAME
+deployments.v1.apps
+ingresses.v1.networking.k8s.io
+pods.v1.core
+services.v1.core
+
+$ k get APIConversions
+No resources found
+```
+
+Objects yamls:
+- [APIExport `kubernetes`](yamls/3-apiexport-kubernetes.yaml) from `k get apiexport kubernetes -o yaml > 3-apiexport-kubernetes.yaml`
+
+    No difference. Compared to the MicroShift case (NVIDIA Jetson Nano) there is no `latestResourceSchemas` in the `spec`.
+
+- [APIBinding `kubernetes`](yamls/3-apibinding-kubernetes.yaml) from `k get apibinding kubernetes -o yaml > 3-apibinding-kubernetes.yaml`
+
+    No difference.
+
+- [SyncTarget `kind`](yamls/3-synctarget-kind.yaml) from `k get synctarget kind -o yaml > 3-synctarget-kind.yaml`
+
+    State changes:
+
+    ```bash
+    $ diff 2-synctarget-kind.yaml 3-synctarget-kind.yaml
+    11c11
+    <   resourceVersion: "9104"
+    ---
+    >   resourceVersion: "9266"
+    20,24c20,21
+    <   - lastTransitionTime: "2023-03-21T17:05:37Z"
+    <     message: No heartbeat yet seen
+    <     reason: ErrorHeartbeat
+    <     severity: Warning
+    <     status: "False"
+    ---
+    >   - lastTransitionTime: "2023-03-21T17:10:07Z"
+    >     status: "True"
+    26,30c23,24
+    <   - lastTransitionTime: "2023-03-21T17:05:37Z"
+    <     message: No heartbeat yet seen
+    <     reason: ErrorHeartbeat
+    <     severity: Warning
+    <     status: "False"
+    ---
+    >   - lastTransitionTime: "2023-03-21T17:10:07Z"
+    >     status: "True"
+    31a26,29
+    >   - lastTransitionTime: "2023-03-21T17:10:07Z"
+    >     status: "True"
+    >     type: SyncerAuthorized
+    >   lastSyncerHeartbeatTime: "2023-03-21T17:19:07Z"
+    35c33
+    <     state: Incompatible
+    ---
+    >     state: Accepted
+    40c38
+    <     state: Incompatible
+    ---
+    >     state: Accepted
+    46c44
+    <     state: Incompatible
+    ---
+    >     state: Accepted
+    52c50
+    <     state: Incompatible
+    ---
+    >     state: Accepted
+    ```
+
+- [Location `default`](yamls/3-location-default.yaml) from `k get location default -o yaml > 3-location-default.yaml`
+
+    Syncer instance is now available:
+
+    ```bash
+    $ diff 2-location-default.yaml 3-location-default.yaml
+    10c10
+    <   resourceVersion: "9078"
+    ---
+    >   resourceVersion: "9136"
+    19c19
+    <   availableInstances: 0
+    ---
+    >   availableInstances: 1
+    ```
+
+- [APIResourceImport deployments.kind.v1.apps`](yamls/3-APIResourceImport-deployments.kind.v1.apps.yaml) from `k get APIResourceImport deployments.kind.v1.apps -o yaml > 3-APIResourceImport-deployments.kind.v1.apps.yaml`
+
+- [APIResourceImport ingresses.kind.v1.networking.k8s.io`](yamls/3-APIResourceImport-ingresses.kind.v1.networking.k8s.io.yaml) from `k get APIResourceImport ingresses.kind.v1.networking.k8s.io -o yaml > 3-APIResourceImport-ingresses.kind.v1.networking.k8s.io.yaml`
+
+- [APIResourceImport pods.kind.v1.core`](yamls/3-APIResourceImport-pods.kind.v1.core.yaml) from `k get APIResourceImport pods.kind.v1.core -o yaml > 3-APIResourceImport-pods.kind.v1.core.yaml`
+
+- [APIResourceImport services.kind.v1.core`](yamls/3-APIResourceImport-services.kind.v1.core.yaml) from `k get APIResourceImport services.kind.v1.core -o yaml > 3-APIResourceImport-services.kind.v1.core.yaml`
+
+- [NegotiatedAPIResource deployments.v1.apps`](yamls/3-NegotiatedAPIResource-deployments.v1.apps.yaml) from `k get NegotiatedAPIResource deployments.v1.apps -o yaml > 3-NegotiatedAPIResource-deployments.v1.apps.yaml`
+
+- [NegotiatedAPIResource ingresses.v1.networking.k8s.io`](yamls/3-NegotiatedAPIResource-ingresses.v1.networking.k8s.io.yaml) from `k get NegotiatedAPIResource ingresses.v1.networking.k8s.io -o yaml > 3-NegotiatedAPIResource-ingresses.v1.networking.k8s.io.yaml`
+
+- [NegotiatedAPIResource pods.v1.core`](yamls/3-NegotiatedAPIResource-pods.v1.core.yaml) from `k get NegotiatedAPIResource pods.v1.core -o yaml > 3-NegotiatedAPIResource-pods.v1.core.yaml`
+
+- [NegotiatedAPIResource services.v1.core`](yamls/3-NegotiatedAPIResource-services.v1.core.yaml) from `k get NegotiatedAPIResource services.v1.core -o yaml > 3-NegotiatedAPIResource-services.v1.core.yaml`
+
+## 7. Bind to `compute` at the center
+
+Given:
+
+```bash
+$ echo $KUBECONFIG
+~/.kcp/admin.kubeconfig
+
+$ k ws .
+Current workspace is "root:kind".
+```
+
+Run the bind command at the center:
+
+```bash
+$ k kcp bind compute root:kind
+placement placement-2iddvmcj created.
+Placement "placement-2iddvmcj" is ready.
+```
+
+Note that kcp DNS pod is also started at the edge:
+
+```bash
+$ echo $KUBECONFIG
+~/.kube/config
+
+$ k get pods -A
+NAMESPACE                  NAME                                              READY   STATUS    RESTARTS   AGE
+kcp-syncer-kind-37zv5s0u   kcp-dns-kind-37zv5s0u-2ruw4p1u-6f476948b4-nsqlh   1/1     Running   0          53s
+kcp-syncer-kind-37zv5s0u   kcp-syncer-kind-37zv5s0u-6949dd87f8-zdsxm         1/1     Running   0          14m
+```
+
+## 8. Check objects that were created in the `kind` KCP Workspace after binding to `compute` at the center (#4)
+
+A `placement` object is created.
+Also, differently from the MicroShift case, a new `APIBinding` is also created.
+
+```bash
+$ echo $KUBECONFIG
+~/.kube/config
+
+$ k ws .
+Current workspace is "root:kind".
+
+$ k get apiexports
+NAME         AGE
+kubernetes   19m
+
+$ k get apibindings
+NAME                       AGE
+apiresource.kcp.io-c8wp6   72m
+kubernetes                 19m
+kubernetes-1pre20xf        3m36s
+scheduling.kcp.io-7rr1j    72m
+tenancy.kcp.io-5qqol       72m
+topology.kcp.io-2eqkm      72m
+workload.kcp.io-dil2i      72m
+
+$ k get synctargets
+NAME   AGE
+kind   20m
+
+$ k get locations
+NAME      RESOURCE      AVAILABLE   INSTANCES   LABELS   AGE
+default   synctargets   1           1                    20m
+
+$ k get placements
+NAME                 AGE
+placement-2iddvmcj   2m7s
+
+$ k get APIResourceImports
+NAME
+deployments.kind.v1.apps
+ingresses.kind.v1.networking.k8s.io
+pods.kind.v1.core
+services.kind.v1.core
+
+$ k get NegotiatedAPIResources
+NAME
+deployments.v1.apps
+ingresses.v1.networking.k8s.io
+pods.v1.core
+services.v1.core
+
+$ k get APIConversions
+No resources found
+```
+
+Objects yamls:
+- [APIExport `kubernetes`](yamls/4-apiexport-kubernetes.yaml) from `k get apiexport kubernetes -o yaml > 4-apiexport-kubernetes.yaml`
+
+    No difference.
+
+- [APIBinding `kubernetes`](yamls/4-apibinding-kubernetes.yaml) from `k get apibinding kubernetes -o yaml > 4-apibinding-kubernetes.yaml`
+
+    No difference.
+
+- [APIBinding `kubernetes-1pre20xf`](yamls/4-apibinding-kubernetes-1pre20xf.yaml) from `k get apibinding kubernetes-1pre20xf -o yaml > 4-apibinding-kubernetes-1pre20xf.yaml`
+
+    Compared to the plainly named `kubernetes` `APIBinding`, this file contains the schemas of the exported resources:
+
+    ```bash
+    $ diff 4-apibinding-kubernetes-1pre20xf.yaml 4-apibinding-kubernetes.yaml
+    7c7
+    <   creationTimestamp: "2023-03-21T17:21:48Z"
+    ---
+    >   creationTimestamp: "2023-03-21T17:05:37Z"
+    12,16c12,16
+    <     claimed.internal.apis.kcp.io/77zi8i256rosNE0ykJyOOB4OwxAMrho27rckj3: LstvmbbzVDDOn90ZbhzSQO5U3DMCf88h1pZ
+    <     internal.apis.kcp.io/export: 77zi8i256rosNE0ykJyOOB4OwxAMrho27rckj3
+    <   name: kubernetes-1pre20xf
+    <   resourceVersion: "9320"
+    <   uid: 35bd2e6c-ebc4-411b-ab95-f706841c9441
+    ---
+    >     claimed.internal.apis.kcp.io/2rwzR3UC0Z0lSFUGD5EuXbE1OSTXPKljY8O67v: LstvmbbzVDDOn90ZbhzSQO5U3DMCf88h1pZ
+    >     internal.apis.kcp.io/export: 2rwzR3UC0Z0lSFUGD5EuXbE1OSTXPKljY8O67v
+    >   name: kubernetes
+    >   resourceVersion: "9101"
+    >   uid: ba26edd8-fb9c-4b85-a5e1-e662e882a8ca
+    21d20
+    <       path: root:compute
+    23,56c22
+    <   apiExportClusterName: 2ei017lw8ljpxp5x
+    <   boundResources:
+    <   - group: networking.k8s.io
+    <     resource: ingresses
+    <     schema:
+    <       UID: ac065681-9ce8-4798-956b-347dfe2610f2
+    <       identityHash: <id-hash>
+    <       name: v124.ingresses.networking.k8s.io
+    <     storageVersions:
+    <     - v1
+    <   - group: ""
+    <     resource: services
+    <     schema:
+    <       UID: 06b1ff23-56af-42bd-b3f9-d016dbbf6000
+    <       identityHash: <id-hash>
+    <       name: v124.services.core
+    <     storageVersions:
+    <     - v1
+    <   - group: apps
+    <     resource: deployments
+    <     schema:
+    <       UID: 8eb70a7d-6856-4b52-8a88-7adcf40b6c49
+    <       identityHash: <id-hash>
+    <       name: v124.deployments.apps
+    <     storageVersions:
+    <     - v1
+    <   - group: ""
+    <     resource: pods
+    <     schema:
+    <       UID: ad4c06b1-3d92-46d4-8ca7-78ee41548b40
+    <       identityHash: <id-hash>
+    <       name: v124.pods.core
+    <     storageVersions:
+    <     - v1
+    ---
+    >   apiExportClusterName: br3qimk2t1o3jb70
+    58c24
+    <   - lastTransitionTime: "2023-03-21T17:21:48Z"
+    ---
+    >   - lastTransitionTime: "2023-03-21T17:05:37Z"
+    61c27
+    <   - lastTransitionTime: "2023-03-21T17:21:48Z"
+    ---
+    >   - lastTransitionTime: "2023-03-21T17:05:37Z"
+    64c30
+    <   - lastTransitionTime: "2023-03-21T17:21:48Z"
+    ---
+    >   - lastTransitionTime: "2023-03-21T17:05:37Z"
+    67c33
+    <   - lastTransitionTime: "2023-03-21T17:21:48Z"
+    ---
+    >   - lastTransitionTime: "2023-03-21T17:05:37Z"
+    70c36
+    <   - lastTransitionTime: "2023-03-21T17:21:48Z"
+    ---
+    >   - lastTransitionTime: "2023-03-21T17:05:37Z"
+    73c39
+    <   - lastTransitionTime: "2023-03-21T17:21:48Z"
+    ---
+    >   - lastTransitionTime: "2023-03-21T17:05:37Z"
+    ```
+
+- [SyncTarget `kind`](yamls/4-synctarget-kind.yaml) from `k get synctarget kind -o yaml > 4-synctarget-kind.yaml`
+
+    Resource version change.
+
+- [Location `default`](yamls/4-location-default.yaml) from `k get location default -o yaml > 4-location-default.yaml`
+
+    No difference.
+
+- [Placement `placement-2iddvmcj`](yamls/4-placement.yaml) from `k get placement placement-2iddvmcj -o yaml > 4-placement.yaml`
+
+    New object.
+
+- [APIResourceImport deployments.kind.v1.apps`](yamls/4-APIResourceImport-deployments.kind.v1.apps.yaml) from `k get APIResourceImport deployments.kind.v1.apps -o yaml > 4-APIResourceImport-deployments.kind.v1.apps.yaml`
+
+- [APIResourceImport ingresses.kind.v1.networking.k8s.io`](yamls/4-APIResourceImport-ingresses.kind.v1.networking.k8s.io.yaml) from `k get APIResourceImport ingresses.kind.v1.networking.k8s.io -o yaml > 4-APIResourceImport-ingresses.kind.v1.networking.k8s.io.yaml`
+
+- [APIResourceImport pods.kind.v1.core`](yamls/4-APIResourceImport-pods.kind.v1.core.yaml) from `k get APIResourceImport pods.kind.v1.core -o yaml > 4-APIResourceImport-pods.kind.v1.core.yaml`
+
+- [APIResourceImport services.kind.v1.core`](yamls/4-APIResourceImport-services.kind.v1.core.yaml) from `k get APIResourceImport services.kind.v1.core -o yaml > 4-APIResourceImport-services.kind.v1.core.yaml`
+
+- [NegotiatedAPIResource deployments.v1.apps`](yamls/4-NegotiatedAPIResource-deployments.v1.apps.yaml) from `k get NegotiatedAPIResource deployments.v1.apps -o yaml > 4-NegotiatedAPIResource-deployments.v1.apps.yaml`
+
+- [NegotiatedAPIResource ingresses.v1.networking.k8s.io`](yamls/4-NegotiatedAPIResource-ingresses.v1.networking.k8s.io.yaml) from `k get NegotiatedAPIResource ingresses.v1.networking.k8s.io -o yaml > 4-NegotiatedAPIResource-ingresses.v1.networking.k8s.io.yaml`
+
+- [NegotiatedAPIResource pods.v1.core`](yamls/4-NegotiatedAPIResource-pods.v1.core.yaml) from `k get NegotiatedAPIResource pods.v1.core -o yaml > 4-NegotiatedAPIResource-pods.v1.core.yaml`
+
+- [NegotiatedAPIResource services.v1.core`](yamls/4-NegotiatedAPIResource-services.v1.core.yaml) from `k get NegotiatedAPIResource services.v1.core -o yaml > 4-NegotiatedAPIResource-services.v1.core.yaml`

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/1-apibinding-apiresource.kcp.io-c8wp6.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/1-apibinding-apiresource.kcp.io-c8wp6.yaml
@@ -1,0 +1,59 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIBinding
+metadata:
+  annotations:
+    kcp.io/cluster: br3qimk2t1o3jb70
+  creationTimestamp: "2023-03-21T16:12:44Z"
+  finalizers:
+  - apis.kcp.io/apibinding-finalizer
+  generation: 1
+  labels:
+    claimed.internal.apis.kcp.io/ahnWRDJw63QggF1foil1RXbW9P9PfRFOltnChg: LstvmbbzVDDOn90ZbhzSQO5U3DMCf88h1pZ
+    internal.apis.kcp.io/export: ahnWRDJw63QggF1foil1RXbW9P9PfRFOltnChg
+  name: apiresource.kcp.io-c8wp6
+  resourceVersion: "8727"
+  uid: e380654a-4a55-44be-a97c-44bc7c49e0e8
+spec:
+  reference:
+    export:
+      name: apiresource.kcp.io
+      path: root
+status:
+  apiExportClusterName: root
+  boundResources:
+  - group: apiresource.kcp.io
+    resource: apiresourceimports
+    schema:
+      UID: 29ee7819-e850-4c79-9fc9-fcd3df50ec6c
+      identityHash: 5bfce2f1622b9059caac79b2629edc40815aaa5786dc2d3507206f709b3435c9
+      name: v220628-546034da.apiresourceimports.apiresource.kcp.io
+    storageVersions:
+    - v1alpha1
+  - group: apiresource.kcp.io
+    resource: negotiatedapiresources
+    schema:
+      UID: 7145a586-4e5d-4a79-9ec2-b4c1ea7fb4a8
+      identityHash: 5bfce2f1622b9059caac79b2629edc40815aaa5786dc2d3507206f709b3435c9
+      name: v220628-546034da.negotiatedapiresources.apiresource.kcp.io
+    storageVersions:
+    - v1alpha1
+  conditions:
+  - lastTransitionTime: "2023-03-21T16:12:44Z"
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2023-03-21T16:12:44Z"
+    status: "True"
+    type: APIExportValid
+  - lastTransitionTime: "2023-03-21T16:12:44Z"
+    status: "True"
+    type: BindingUpToDate
+  - lastTransitionTime: "2023-03-21T16:12:44Z"
+    status: "True"
+    type: InitialBindingCompleted
+  - lastTransitionTime: "2023-03-21T16:12:44Z"
+    status: "True"
+    type: PermissionClaimsApplied
+  - lastTransitionTime: "2023-03-21T16:12:44Z"
+    status: "True"
+    type: PermissionClaimsValid
+  phase: Bound

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/1-apibinding-scheduling.kcp.io-7rr1j.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/1-apibinding-scheduling.kcp.io-7rr1j.yaml
@@ -1,0 +1,59 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIBinding
+metadata:
+  annotations:
+    kcp.io/cluster: br3qimk2t1o3jb70
+  creationTimestamp: "2023-03-21T16:12:44Z"
+  finalizers:
+  - apis.kcp.io/apibinding-finalizer
+  generation: 1
+  labels:
+    claimed.internal.apis.kcp.io/8aZfSHUSG9wQttJSddiQz0e6FYRaCeqmEvcA3j: LstvmbbzVDDOn90ZbhzSQO5U3DMCf88h1pZ
+    internal.apis.kcp.io/export: 8aZfSHUSG9wQttJSddiQz0e6FYRaCeqmEvcA3j
+  name: scheduling.kcp.io-7rr1j
+  resourceVersion: "8722"
+  uid: 54495690-35e2-41f4-bff3-fceff0f235c7
+spec:
+  reference:
+    export:
+      name: scheduling.kcp.io
+      path: root
+status:
+  apiExportClusterName: root
+  boundResources:
+  - group: scheduling.kcp.io
+    resource: locations
+    schema:
+      UID: 2061e191-c4c5-4c0b-8ee4-6fad5527f5e3
+      identityHash: 1e770024e464271c0907a46fa6154a498417a05ea50e67d5d492c6b07786c81d
+      name: v221006-eaaf199d.locations.scheduling.kcp.io
+    storageVersions:
+    - v1alpha1
+  - group: scheduling.kcp.io
+    resource: placements
+    schema:
+      UID: e41dc47d-b12f-42eb-9fd8-0cbf88389dea
+      identityHash: 1e770024e464271c0907a46fa6154a498417a05ea50e67d5d492c6b07786c81d
+      name: v221212-cf67ac73a.placements.scheduling.kcp.io
+    storageVersions:
+    - v1alpha1
+  conditions:
+  - lastTransitionTime: "2023-03-21T16:12:44Z"
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2023-03-21T16:12:44Z"
+    status: "True"
+    type: APIExportValid
+  - lastTransitionTime: "2023-03-21T16:12:44Z"
+    status: "True"
+    type: BindingUpToDate
+  - lastTransitionTime: "2023-03-21T16:12:44Z"
+    status: "True"
+    type: InitialBindingCompleted
+  - lastTransitionTime: "2023-03-21T16:12:44Z"
+    status: "True"
+    type: PermissionClaimsApplied
+  - lastTransitionTime: "2023-03-21T16:12:44Z"
+    status: "True"
+    type: PermissionClaimsValid
+  phase: Bound

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/1-apibinding-tenancy.kcp.io-5qqol.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/1-apibinding-tenancy.kcp.io-5qqol.yaml
@@ -1,0 +1,67 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIBinding
+metadata:
+  annotations:
+    kcp.io/cluster: br3qimk2t1o3jb70
+  creationTimestamp: "2023-03-21T16:12:44Z"
+  finalizers:
+  - apis.kcp.io/apibinding-finalizer
+  generation: 1
+  labels:
+    claimed.internal.apis.kcp.io/bmCdly9xXiUpEHe3ypvDwvXMTfoVZUE92mqAQf: LstvmbbzVDDOn90ZbhzSQO5U3DMCf88h1pZ
+    internal.apis.kcp.io/export: bmCdly9xXiUpEHe3ypvDwvXMTfoVZUE92mqAQf
+  name: tenancy.kcp.io-5qqol
+  resourceVersion: "8715"
+  uid: 3df82e63-04f5-4eb4-996e-b31107ec6639
+spec:
+  reference:
+    export:
+      name: tenancy.kcp.io
+      path: root
+status:
+  apiExportClusterName: root
+  boundResources:
+  - group: tenancy.kcp.io
+    resource: clusterworkspaces
+    schema:
+      UID: 4c8fb1a4-16c9-40f5-9f99-832fd4209c49
+      identityHash: 58e0c91beecd0df4a83ba96f7b39bab6f2fbae9423198c00aa1b14fa611d5625
+      name: v221219-c92ed8152.clusterworkspaces.tenancy.kcp.io
+    storageVersions:
+    - v1alpha1
+  - group: tenancy.kcp.io
+    resource: workspacetypes
+    schema:
+      UID: 5a005041-76b7-45f0-a9d7-d22902f3d1b3
+      identityHash: 58e0c91beecd0df4a83ba96f7b39bab6f2fbae9423198c00aa1b14fa611d5625
+      name: v230110-89146c99.workspacetypes.tenancy.kcp.io
+    storageVersions:
+    - v1alpha1
+  - group: tenancy.kcp.io
+    resource: workspaces
+    schema:
+      UID: f695f3ec-6f4a-45c5-a765-045294138189
+      identityHash: 58e0c91beecd0df4a83ba96f7b39bab6f2fbae9423198c00aa1b14fa611d5625
+      name: v230116-832a4a55d.workspaces.tenancy.kcp.io
+    storageVersions:
+    - v1alpha1
+  conditions:
+  - lastTransitionTime: "2023-03-21T16:12:44Z"
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2023-03-21T16:12:44Z"
+    status: "True"
+    type: APIExportValid
+  - lastTransitionTime: "2023-03-21T16:12:44Z"
+    status: "True"
+    type: BindingUpToDate
+  - lastTransitionTime: "2023-03-21T16:12:44Z"
+    status: "True"
+    type: InitialBindingCompleted
+  - lastTransitionTime: "2023-03-21T16:12:44Z"
+    status: "True"
+    type: PermissionClaimsApplied
+  - lastTransitionTime: "2023-03-21T16:12:44Z"
+    status: "True"
+    type: PermissionClaimsValid
+  phase: Bound

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/1-apibinding-topology.kcp.io-2eqkm.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/1-apibinding-topology.kcp.io-2eqkm.yaml
@@ -1,0 +1,59 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIBinding
+metadata:
+  annotations:
+    kcp.io/cluster: br3qimk2t1o3jb70
+  creationTimestamp: "2023-03-21T16:12:44Z"
+  finalizers:
+  - apis.kcp.io/apibinding-finalizer
+  generation: 1
+  labels:
+    claimed.internal.apis.kcp.io/7QHLqjz8KlhjPddt8MECYq0OLDUNvLAO5v9x4x: LstvmbbzVDDOn90ZbhzSQO5U3DMCf88h1pZ
+    internal.apis.kcp.io/export: 7QHLqjz8KlhjPddt8MECYq0OLDUNvLAO5v9x4x
+  name: topology.kcp.io-2eqkm
+  resourceVersion: "8728"
+  uid: b79c8c18-7698-45ca-8bc6-85daf3f10c34
+spec:
+  reference:
+    export:
+      name: topology.kcp.io
+      path: root
+status:
+  apiExportClusterName: root
+  boundResources:
+  - group: topology.kcp.io
+    resource: partitions
+    schema:
+      UID: 7e71bb77-e28f-4153-912d-dcf31a29ea2b
+      identityHash: 55303337649adc08e12ed03c2fb1c99f0102abe45b066471ed68f772818506c9
+      name: v221115-9b370eb8.partitions.topology.kcp.io
+    storageVersions:
+    - v1alpha1
+  - group: topology.kcp.io
+    resource: partitionsets
+    schema:
+      UID: 29e32771-d550-4000-9e1c-245a9e2a78d3
+      identityHash: 55303337649adc08e12ed03c2fb1c99f0102abe45b066471ed68f772818506c9
+      name: v230202-eee1a845.partitionsets.topology.kcp.io
+    storageVersions:
+    - v1alpha1
+  conditions:
+  - lastTransitionTime: "2023-03-21T16:12:44Z"
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2023-03-21T16:12:44Z"
+    status: "True"
+    type: APIExportValid
+  - lastTransitionTime: "2023-03-21T16:12:44Z"
+    status: "True"
+    type: BindingUpToDate
+  - lastTransitionTime: "2023-03-21T16:12:44Z"
+    status: "True"
+    type: InitialBindingCompleted
+  - lastTransitionTime: "2023-03-21T16:12:44Z"
+    status: "True"
+    type: PermissionClaimsApplied
+  - lastTransitionTime: "2023-03-21T16:12:44Z"
+    status: "True"
+    type: PermissionClaimsValid
+  phase: Bound

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/1-apibinding-workload.kcp.io-dil2i.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/1-apibinding-workload.kcp.io-dil2i.yaml
@@ -1,0 +1,51 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIBinding
+metadata:
+  annotations:
+    kcp.io/cluster: br3qimk2t1o3jb70
+  creationTimestamp: "2023-03-21T16:12:44Z"
+  finalizers:
+  - apis.kcp.io/apibinding-finalizer
+  generation: 1
+  labels:
+    claimed.internal.apis.kcp.io/dVu53medKhDTkZGOwOJZA2llRa3TUeGHwzWm9: LstvmbbzVDDOn90ZbhzSQO5U3DMCf88h1pZ
+    internal.apis.kcp.io/export: dVu53medKhDTkZGOwOJZA2llRa3TUeGHwzWm9
+  name: workload.kcp.io-dil2i
+  resourceVersion: "8724"
+  uid: a8df7a0f-4237-4f27-a750-3f90478bf16b
+spec:
+  reference:
+    export:
+      name: workload.kcp.io
+      path: root
+status:
+  apiExportClusterName: root
+  boundResources:
+  - group: workload.kcp.io
+    resource: synctargets
+    schema:
+      UID: b04de63e-a290-4d17-8fc4-ec8f59b2f1af
+      identityHash: d8b380917662ba269c5428943831c7e5c4677254efe87b9456933eb71fafe1cb
+      name: v230109-773b219c.synctargets.workload.kcp.io
+    storageVersions:
+    - v1alpha1
+  conditions:
+  - lastTransitionTime: "2023-03-21T16:12:44Z"
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2023-03-21T16:12:44Z"
+    status: "True"
+    type: APIExportValid
+  - lastTransitionTime: "2023-03-21T16:12:44Z"
+    status: "True"
+    type: BindingUpToDate
+  - lastTransitionTime: "2023-03-21T16:12:44Z"
+    status: "True"
+    type: InitialBindingCompleted
+  - lastTransitionTime: "2023-03-21T16:12:44Z"
+    status: "True"
+    type: PermissionClaimsApplied
+  - lastTransitionTime: "2023-03-21T16:12:44Z"
+    status: "True"
+    type: PermissionClaimsValid
+  phase: Bound

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/2-apibinding-kubernetes.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/2-apibinding-kubernetes.yaml
@@ -1,0 +1,42 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIBinding
+metadata:
+  annotations:
+    extra.apis.kcp.io/compute.workload.kcp.io: "true"
+    kcp.io/cluster: br3qimk2t1o3jb70
+  creationTimestamp: "2023-03-21T17:05:37Z"
+  finalizers:
+  - apis.kcp.io/apibinding-finalizer
+  generation: 1
+  labels:
+    claimed.internal.apis.kcp.io/2rwzR3UC0Z0lSFUGD5EuXbE1OSTXPKljY8O67v: LstvmbbzVDDOn90ZbhzSQO5U3DMCf88h1pZ
+    internal.apis.kcp.io/export: 2rwzR3UC0Z0lSFUGD5EuXbE1OSTXPKljY8O67v
+  name: kubernetes
+  resourceVersion: "9101"
+  uid: ba26edd8-fb9c-4b85-a5e1-e662e882a8ca
+spec:
+  reference:
+    export:
+      name: kubernetes
+status:
+  apiExportClusterName: br3qimk2t1o3jb70
+  conditions:
+  - lastTransitionTime: "2023-03-21T17:05:37Z"
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2023-03-21T17:05:37Z"
+    status: "True"
+    type: APIExportValid
+  - lastTransitionTime: "2023-03-21T17:05:37Z"
+    status: "True"
+    type: BindingUpToDate
+  - lastTransitionTime: "2023-03-21T17:05:37Z"
+    status: "True"
+    type: InitialBindingCompleted
+  - lastTransitionTime: "2023-03-21T17:05:37Z"
+    status: "True"
+    type: PermissionClaimsApplied
+  - lastTransitionTime: "2023-03-21T17:05:37Z"
+    status: "True"
+    type: PermissionClaimsValid
+  phase: Bound

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/2-apiexport-kubernetes.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/2-apiexport-kubernetes.yaml
@@ -1,0 +1,29 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIExport
+metadata:
+  annotations:
+    extra.apis.kcp.io/compute.workload.kcp.io: "true"
+    kcp.io/cluster: br3qimk2t1o3jb70
+    kcp.io/path: root:kind
+    workload.kcp.io/skip-default-object-creation: "true"
+  creationTimestamp: "2023-03-21T17:05:37Z"
+  generation: 2
+  name: kubernetes
+  resourceVersion: "9098"
+  uid: 92c4a3e0-c366-466b-8474-b905d81f8fc2
+spec:
+  identity:
+    secretRef:
+      name: kubernetes
+      namespace: kcp-system
+status:
+  conditions:
+  - lastTransitionTime: "2023-03-21T17:05:37Z"
+    status: "True"
+    type: IdentityValid
+  - lastTransitionTime: "2023-03-21T17:05:37Z"
+    status: "True"
+    type: VirtualWorkspaceURLsReady
+  identityHash: 2650446b7496d5eb53a84d078251342a607b3e638c0e1477b3999b02b8fe307d
+  virtualWorkspaces:
+  - url: https://<kcp-url>:6443/services/apiexport/br3qimk2t1o3jb70/kubernetes

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/2-location-default.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/2-location-default.yaml
@@ -1,0 +1,20 @@
+apiVersion: scheduling.kcp.io/v1alpha1
+kind: Location
+metadata:
+  annotations:
+    kcp.io/cluster: br3qimk2t1o3jb70
+    kcp.io/path: root:kind
+  creationTimestamp: "2023-03-21T17:05:37Z"
+  generation: 1
+  name: default
+  resourceVersion: "9078"
+  uid: d5ecd13e-d413-4d87-a62b-c154f9156e73
+spec:
+  instanceSelector: {}
+  resource:
+    group: workload.kcp.io
+    resource: synctargets
+    version: v1alpha1
+status:
+  availableInstances: 0
+  instances: 1

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/2-synctarget-kind.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/2-synctarget-kind.yaml
@@ -30,24 +30,24 @@ status:
     status: "False"
     type: HeartbeatHealthy
   syncedResources:
-  - identityHash: <id-hash>
+  - identityHash: 1215a6f9c5bad3a00c7af77b1bd715f81357d9238b1f4d2968b0a23cb3412217
     resource: services
     state: Incompatible
     versions:
     - v1
-  - identityHash: <id-hash>
+  - identityHash: 1215a6f9c5bad3a00c7af77b1bd715f81357d9238b1f4d2968b0a23cb3412217
     resource: pods
     state: Incompatible
     versions:
     - v1
   - group: networking.k8s.io
-    identityHash: <id-hash>
+    identityHash: 1215a6f9c5bad3a00c7af77b1bd715f81357d9238b1f4d2968b0a23cb3412217
     resource: ingresses
     state: Incompatible
     versions:
     - v1
   - group: apps
-    identityHash: <id-hash>
+    identityHash: 1215a6f9c5bad3a00c7af77b1bd715f81357d9238b1f4d2968b0a23cb3412217
     resource: deployments
     state: Incompatible
     versions:

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/2-synctarget-kind.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/2-synctarget-kind.yaml
@@ -1,0 +1,57 @@
+apiVersion: workload.kcp.io/v1alpha1
+kind: SyncTarget
+metadata:
+  annotations:
+    kcp.io/cluster: br3qimk2t1o3jb70
+  creationTimestamp: "2023-03-21T17:05:37Z"
+  generation: 1
+  labels:
+    internal.workload.kcp.io/key: alIviEyJiysDMorx9fWmI2ygTHSTrvxXGyVwSJ
+  name: kind
+  resourceVersion: "9104"
+  uid: 8df305e7-f4f8-439f-9115-51054d519361
+spec:
+  supportedAPIExports:
+  - export: kubernetes
+    path: root:compute
+  unschedulable: false
+status:
+  conditions:
+  - lastTransitionTime: "2023-03-21T17:05:37Z"
+    message: No heartbeat yet seen
+    reason: ErrorHeartbeat
+    severity: Warning
+    status: "False"
+    type: Ready
+  - lastTransitionTime: "2023-03-21T17:05:37Z"
+    message: No heartbeat yet seen
+    reason: ErrorHeartbeat
+    severity: Warning
+    status: "False"
+    type: HeartbeatHealthy
+  syncedResources:
+  - identityHash: <id-hash>
+    resource: services
+    state: Incompatible
+    versions:
+    - v1
+  - identityHash: <id-hash>
+    resource: pods
+    state: Incompatible
+    versions:
+    - v1
+  - group: networking.k8s.io
+    identityHash: <id-hash>
+    resource: ingresses
+    state: Incompatible
+    versions:
+    - v1
+  - group: apps
+    identityHash: <id-hash>
+    resource: deployments
+    state: Incompatible
+    versions:
+    - v1
+  virtualWorkspaces:
+  - syncerURL: https://<kcp-url>:6443/services/syncer/br3qimk2t1o3jb70/kind/8df305e7-f4f8-439f-9115-51054d519361
+    upsyncerURL: https://<kcp-url>:6443/services/upsyncer/br3qimk2t1o3jb70/kind/8df305e7-f4f8-439f-9115-51054d519361

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/3-APIResourceImport-deployments.kind.v1.apps.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/3-APIResourceImport-deployments.kind.v1.apps.yaml
@@ -1,0 +1,7132 @@
+apiVersion: apiresource.kcp.io/v1alpha1
+kind: APIResourceImport
+metadata:
+  annotations:
+    apiresource.kcp.io/apiVersion: apps/v1
+    kcp.io/cluster: br3qimk2t1o3jb70
+  creationTimestamp: "2023-03-21T17:10:10Z"
+  generation: 1
+  name: deployments.kind.v1.apps
+  ownerReferences:
+  - apiVersion: workload.kcp.io/v1alpha1
+    controller: true
+    kind: SyncTarget
+    name: kind
+    uid: 8df305e7-f4f8-439f-9115-51054d519361
+  resourceVersion: "9155"
+  uid: 7ccaf56d-a031-477a-92f3-1ab9c5c8acfb
+spec:
+  categories:
+  - all
+  groupVersion:
+    group: apps
+    version: v1
+  kind: Deployment
+  listKind: DeploymentList
+  location: kind
+  openAPIV3Schema:
+    description: Deployment enables declarative updates for Pods and ReplicaSets.
+    properties:
+      apiVersion:
+        description: 'APIVersion defines the versioned schema of this representation
+          of an object. Servers should convert recognized schemas to the latest internal
+          value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+        type: string
+      kind:
+        description: 'Kind is a string value representing the REST resource this object
+          represents. Servers may infer this from the endpoint the client submits
+          requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+        type: string
+      metadata:
+        type: object
+      spec:
+        description: Specification of the desired behavior of the Deployment.
+        properties:
+          minReadySeconds:
+            description: Minimum number of seconds for which a newly created pod should
+              be ready without any of its container crashing, for it to be considered
+              available. Defaults to 0 (pod will be considered available as soon as
+              it is ready)
+            format: int32
+            type: integer
+          paused:
+            description: Indicates that the deployment is paused.
+            type: boolean
+          progressDeadlineSeconds:
+            description: The maximum time in seconds for a deployment to make progress
+              before it is considered to be failed. The deployment controller will
+              continue to process failed deployments and a condition with a ProgressDeadlineExceeded
+              reason will be surfaced in the deployment status. Note that progress
+              will not be estimated during the time a deployment is paused. Defaults
+              to 600s.
+            format: int32
+            type: integer
+          replicas:
+            description: Number of desired pods. This is a pointer to distinguish
+              between explicit zero and not specified. Defaults to 1.
+            format: int32
+            type: integer
+          revisionHistoryLimit:
+            description: The number of old ReplicaSets to retain to allow rollback.
+              This is a pointer to distinguish between explicit zero and not specified.
+              Defaults to 10.
+            format: int32
+            type: integer
+          selector:
+            description: Label selector for pods. Existing ReplicaSets whose pods
+              are selected by this will be the ones affected by this deployment. It
+              must match the pod template's labels.
+            properties:
+              matchExpressions:
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
+                items:
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
+                  properties:
+                    key:
+                      description: key is the label key that the selector applies
+                        to.
+                      type: string
+                    operator:
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      type: string
+                    values:
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - key
+                  - operator
+                  type: object
+                type: array
+              matchLabels:
+                additionalProperties:
+                  type: string
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
+                type: object
+            type: object
+          strategy:
+            description: The deployment strategy to use to replace existing pods with
+              new ones.
+            properties:
+              rollingUpdate:
+                description: Rolling update config params. Present only if DeploymentStrategyType
+                  = RollingUpdate.
+                properties:
+                  maxSurge:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'The maximum number of pods that can be scheduled
+                      above the desired number of pods. Value can be an absolute number
+                      (ex: 5) or a percentage of desired pods (ex: 10%). This can
+                      not be 0 if MaxUnavailable is 0. Absolute number is calculated
+                      from percentage by rounding up. Defaults to 25%. Example: when
+                      this is set to 30%, the new ReplicaSet can be scaled up immediately
+                      when the rolling update starts, such that the total number of
+                      old and new pods do not exceed 130% of desired pods. Once old
+                      pods have been killed, new ReplicaSet can be scaled up further,
+                      ensuring that total number of pods running at any time during
+                      the update is at most 130% of desired pods.'
+                    x-kubernetes-int-or-string: true
+                  maxUnavailable:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'The maximum number of pods that can be unavailable
+                      during the update. Value can be an absolute number (ex: 5) or
+                      a percentage of desired pods (ex: 10%). Absolute number is calculated
+                      from percentage by rounding down. This can not be 0 if MaxSurge
+                      is 0. Defaults to 25%. Example: when this is set to 30%, the
+                      old ReplicaSet can be scaled down to 70% of desired pods immediately
+                      when the rolling update starts. Once new pods are ready, old
+                      ReplicaSet can be scaled down further, followed by scaling up
+                      the new ReplicaSet, ensuring that the total number of pods available
+                      at all times during the update is at least 70% of desired pods.'
+                    x-kubernetes-int-or-string: true
+                type: object
+              type:
+                description: |-
+                  Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+
+                  Possible enum values:
+                   - `"Recreate"` Kill all existing pods before creating new ones.
+                   - `"RollingUpdate"` Replace the old ReplicaSets by new one using rolling update i.e gradually scale down the old ReplicaSets and scale up the new one.
+                type: string
+            type: object
+          template:
+            description: Template describes the pods that will be created.
+            properties:
+              metadata:
+                description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              spec:
+                description: 'Specification of the desired behavior of the pod. More
+                  info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                properties:
+                  activeDeadlineSeconds:
+                    description: Optional duration in seconds the pod may be active
+                      on the node relative to StartTime before the system will actively
+                      try to mark it failed and kill associated containers. Value
+                      must be a positive integer.
+                    format: int64
+                    type: integer
+                  affinity:
+                    description: If specified, the pod's scheduling constraints
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for
+                          the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node matches the corresponding matchExpressions;
+                              the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches
+                                all objects with implicit weight 0 (i.e. it's a no-op).
+                                A null preferred scheduling term matches no objects
+                                (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                              Possible enum values:
+                                               - `"DoesNotExist"`
+                                               - `"Exists"`
+                                               - `"Gt"`
+                                               - `"In"`
+                                               - `"Lt"`
+                                               - `"NotIn"`
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                              Possible enum values:
+                                               - `"DoesNotExist"`
+                                               - `"Exists"`
+                                               - `"Gt"`
+                                               - `"In"`
+                                               - `"Lt"`
+                                               - `"NotIn"`
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the
+                                    corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - weight
+                              - preference
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by
+                              this field are not met at scheduling time, the pod will
+                              not be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from
+                              its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term
+                                    matches no objects. The requirements of them are
+                                    ANDed. The TopologySelectorTerm type implements
+                                    a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                              Possible enum values:
+                                               - `"DoesNotExist"`
+                                               - `"Exists"`
+                                               - `"Gt"`
+                                               - `"In"`
+                                               - `"Lt"`
+                                               - `"NotIn"`
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                              Possible enum values:
+                                               - `"DoesNotExist"`
+                                               - `"Exists"`
+                                               - `"Gt"`
+                                               - `"In"`
+                                               - `"Lt"`
+                                               - `"NotIn"`
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g.
+                          co-locate this pod in the same node, zone, etc. as some
+                          other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node has pods which matches the corresponding
+                              podAffinityTerm; the node(s) with the highest sum are
+                              the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the
+                                    corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - weight
+                              - podAffinityTerm
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by
+                              this field are not met at scheduling time, the pod will
+                              not be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to a pod label update),
+                              the system may or may not try to eventually evict the
+                              pod from its node. When there are multiple elements,
+                              the lists of nodes corresponding to each podAffinityTerm
+                              are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located
+                                is defined as running on a node whose value of the
+                                label with key <topologyKey> matches that of any node
+                                on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules
+                          (e.g. avoid putting this pod in the same node, zone, etc.
+                          as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the anti-affinity expressions
+                              specified by this field, but it may choose a node that
+                              violates one or more of the expressions. The node that
+                              is most preferred is the one with the greatest sum of
+                              weights, i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              anti-affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node has pods which matches the corresponding
+                              podAffinityTerm; the node(s) with the highest sum are
+                              the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the
+                                    corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - weight
+                              - podAffinityTerm
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified
+                              by this field are not met at scheduling time, the pod
+                              will not be scheduled onto the node. If the anti-affinity
+                              requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod
+                              label update), the system may or may not try to eventually
+                              evict the pod from its node. When there are multiple
+                              elements, the lists of nodes corresponding to each podAffinityTerm
+                              are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located
+                                is defined as running on a node whose value of the
+                                label with key <topologyKey> matches that of any node
+                                on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  automountServiceAccountToken:
+                    description: AutomountServiceAccountToken indicates whether a
+                      service account token should be automatically mounted.
+                    type: boolean
+                  containers:
+                    description: List of containers belonging to the pod. Containers
+                      cannot currently be added or removed. There must be at least
+                      one container in a Pod. Cannot be updated.
+                    items:
+                      description: A single application container that you want to
+                        run within a pod.
+                      properties:
+                        args:
+                          description: 'Arguments to the entrypoint. The container
+                            image''s CMD is used if this is not provided. Variable
+                            references $(VAR_NAME) are expanded using the container''s
+                            environment. If a variable cannot be resolved, the reference
+                            in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME)
+                            syntax: i.e. "$$(VAR_NAME)" will produce the string literal
+                            "$(VAR_NAME)". Escaped references will never be expanded,
+                            regardless of whether the variable exists or not. Cannot
+                            be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: 'Entrypoint array. Not executed within a shell.
+                            The container image''s ENTRYPOINT is used if this is not
+                            provided. Variable references $(VAR_NAME) are expanded
+                            using the container''s environment. If a variable cannot
+                            be resolved, the reference in the input string will be
+                            unchanged. Double $$ are reduced to a single $, which
+                            allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                            will produce the string literal "$(VAR_NAME)". Escaped
+                            references will never be expanded, regardless of whether
+                            the variable exists or not. Cannot be updated. More info:
+                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the
+                            container. Cannot be updated.
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previously defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  Double $$ are reduced to a single $, which allows
+                                  for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                  will produce the string literal "$(VAR_NAME)". Escaped
+                                  references will never be expanded, regardless of
+                                  whether the variable exists or not. Defaults to
+                                  "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's
+                                  value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container. The keys defined within a source must
+                            be a C_IDENTIFIER. All invalid keys will be reported as
+                            an event when the container is starting. When a key exists
+                            in multiple sources, the value associated with the last
+                            source will take precedence. Values defined by an Env
+                            with a duplicate key will take precedence. Cannot be updated.
+                          items:
+                            description: EnvFromSource represents the source of a
+                              set of ConfigMaps
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must
+                                      be defined
+                                    type: boolean
+                                type: object
+                              prefix:
+                                description: An optional identifier to prepend to
+                                  each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be
+                                      defined
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                            This field is optional to allow higher level config management
+                            to default or override container images in workload controllers
+                            like Deployments and StatefulSets.'
+                          type: string
+                        imagePullPolicy:
+                          description: |-
+                            Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                            Possible enum values:
+                             - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                             - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                             - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                          type: string
+                        lifecycle:
+                          description: Actions that the management system should take
+                            in response to container lifecycle events. Cannot be updated.
+                          properties:
+                            postStart:
+                              description: 'PostStart is called immediately after
+                                a container is created. If the handler fails, the
+                                container is terminated and restarted according to
+                                its restart policy. Other management of the container
+                                blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            preStop:
+                              description: 'PreStop is called immediately before a
+                                container is terminated due to an API request or management
+                                event such as liveness/startup probe failure, preemption,
+                                resource contention, etc. The handler is not called
+                                if the container crashes or exits. The Pod''s termination
+                                grace period countdown begins before the PreStop hook
+                                is executed. Regardless of the outcome of the handler,
+                                the container will eventually terminate within the
+                                Pod''s termination grace period (unless delayed by
+                                finalizers). Other management of the container blocks
+                                until the hook completes or until the termination
+                                grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                          type: object
+                        livenessProbe:
+                          description: 'Periodic probe of container liveness. Container
+                            will be restarted if the probe fails. Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: Name of the container specified as a DNS_LABEL.
+                            Each container in a pod must have a unique name (DNS_LABEL).
+                            Cannot be updated.
+                          type: string
+                        ports:
+                          description: List of ports to expose from the container.
+                            Not specifying a port here DOES NOT prevent that port
+                            from being exposed. Any port which is listening on the
+                            default "0.0.0.0" address inside a container will be accessible
+                            from the network. Modifying this array with strategic
+                            merge patch may corrupt the data. For more information
+                            See https://github.com/kubernetes/kubernetes/issues/108255.
+                            Cannot be updated.
+                          items:
+                            description: ContainerPort represents a network port in
+                              a single container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's
+                                  IP address. This must be a valid port number, 0
+                                  < x < 65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port
+                                  to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host.
+                                  If specified, this must be a valid port number,
+                                  0 < x < 65536. If HostNetwork is specified, this
+                                  must match ContainerPort. Most containers do not
+                                  need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a
+                                  pod must have a unique name. Name for the port that
+                                  can be referred to by services.
+                                type: string
+                              protocol:
+                                default: TCP
+                                description: |-
+                                  Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                  Possible enum values:
+                                   - `"SCTP"` is the SCTP protocol.
+                                   - `"TCP"` is the TCP protocol.
+                                   - `"UDP"` is the UDP protocol.
+                                type: string
+                            required:
+                            - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - containerPort
+                          - protocol
+                          x-kubernetes-list-type: map
+                        readinessProbe:
+                          description: 'Periodic probe of container service readiness.
+                            Container will be removed from service endpoints if the
+                            probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          description: 'Compute Resources required by this container.
+                            Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        securityContext:
+                          description: 'SecurityContext defines the security options
+                            the container should be run with. If set, the fields of
+                            SecurityContext override the equivalent fields of PodSecurityContext.
+                            More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                          properties:
+                            allowPrivilegeEscalation:
+                              description: 'AllowPrivilegeEscalation controls whether
+                                a process can gain more privileges than its parent
+                                process. This bool directly controls if the no_new_privs
+                                flag will be set on the container process. AllowPrivilegeEscalation
+                                is true always when the container is: 1) run as Privileged
+                                2) has CAP_SYS_ADMIN Note that this field cannot be
+                                set when spec.os.name is windows.'
+                              type: boolean
+                            capabilities:
+                              description: The capabilities to add/drop when running
+                                containers. Defaults to the default set of capabilities
+                                granted by the container runtime. Note that this field
+                                cannot be set when spec.os.name is windows.
+                              properties:
+                                add:
+                                  description: Added capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                                drop:
+                                  description: Removed capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            privileged:
+                              description: Run container in privileged mode. Processes
+                                in privileged containers are essentially equivalent
+                                to root on the host. Defaults to false. Note that
+                                this field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            procMount:
+                              description: procMount denotes the type of proc mount
+                                to use for the containers. The default is DefaultProcMount
+                                which uses the container runtime defaults for readonly
+                                paths and masked paths. This requires the ProcMountType
+                                feature flag to be enabled. Note that this field cannot
+                                be set when spec.os.name is windows.
+                              type: string
+                            readOnlyRootFilesystem:
+                              description: Whether this container has a read-only
+                                root filesystem. Default is false. Note that this
+                                field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            runAsGroup:
+                              description: The GID to run the entrypoint of the container
+                                process. Uses runtime default if unset. May also be
+                                set in PodSecurityContext.  If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is windows.
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              description: Indicates that the container must run as
+                                a non-root user. If true, the Kubelet will validate
+                                the image at runtime to ensure that it does not run
+                                as UID 0 (root) and fail to start the container if
+                                it does. If unset or false, no such validation will
+                                be performed. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                              type: boolean
+                            runAsUser:
+                              description: The UID to run the entrypoint of the container
+                                process. Defaults to user specified in image metadata
+                                if unspecified. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name
+                                is windows.
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              description: The SELinux context to be applied to the
+                                container. If unspecified, the container runtime will
+                                allocate a random SELinux context for each container.  May
+                                also be set in PodSecurityContext.  If set in both
+                                SecurityContext and PodSecurityContext, the value
+                                specified in SecurityContext takes precedence. Note
+                                that this field cannot be set when spec.os.name is
+                                windows.
+                              properties:
+                                level:
+                                  description: Level is SELinux level label that applies
+                                    to the container.
+                                  type: string
+                                role:
+                                  description: Role is a SELinux role label that applies
+                                    to the container.
+                                  type: string
+                                type:
+                                  description: Type is a SELinux type label that applies
+                                    to the container.
+                                  type: string
+                                user:
+                                  description: User is a SELinux user label that applies
+                                    to the container.
+                                  type: string
+                              type: object
+                            seccompProfile:
+                              description: The seccomp options to use by this container.
+                                If seccomp options are provided at both the pod &
+                                container level, the container options override the
+                                pod options. Note that this field cannot be set when
+                                spec.os.name is windows.
+                              properties:
+                                localhostProfile:
+                                  description: localhostProfile indicates a profile
+                                    defined in a file on the node should be used.
+                                    The profile must be preconfigured on the node
+                                    to work. Must be a descending path, relative to
+                                    the kubelet's configured seccomp profile location.
+                                    Must only be set if type is "Localhost".
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                    Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                    Possible enum values:
+                                     - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                     - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                     - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            windowsOptions:
+                              description: The Windows specific settings applied to
+                                all containers. If unspecified, the options from the
+                                PodSecurityContext will be used. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is linux.
+                              properties:
+                                gmsaCredentialSpec:
+                                  description: GMSACredentialSpec is where the GMSA
+                                    admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                    inlines the contents of the GMSA credential spec
+                                    named by the GMSACredentialSpecName field.
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  description: GMSACredentialSpecName is the name
+                                    of the GMSA credential spec to use.
+                                  type: string
+                                hostProcess:
+                                  description: HostProcess determines if a container
+                                    should be run as a 'Host Process' container. This
+                                    field is alpha-level and will only be honored
+                                    by components that enable the WindowsHostProcessContainers
+                                    feature flag. Setting this field without the feature
+                                    flag will result in errors when validating the
+                                    Pod. All of a Pod's containers must have the same
+                                    effective HostProcess value (it is not allowed
+                                    to have a mix of HostProcess containers and non-HostProcess
+                                    containers).  In addition, if HostProcess is true
+                                    then HostNetwork must also be set to true.
+                                  type: boolean
+                                runAsUserName:
+                                  description: The UserName in Windows to run the
+                                    entrypoint of the container process. Defaults
+                                    to the user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  type: string
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: 'StartupProbe indicates that the Pod has successfully
+                            initialized. If specified, no other probes are executed
+                            until this completes successfully. If this probe fails,
+                            the Pod will be restarted, just as if the livenessProbe
+                            failed. This can be used to provide different probe parameters
+                            at the beginning of a Pod''s lifecycle, when it might
+                            take a long time to load data or warm a cache, than during
+                            steady-state operation. This cannot be updated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        stdin:
+                          description: Whether this container should allocate a buffer
+                            for stdin in the container runtime. If this is not set,
+                            reads from stdin in the container will always result in
+                            EOF. Default is false.
+                          type: boolean
+                        stdinOnce:
+                          description: Whether the container runtime should close
+                            the stdin channel after it has been opened by a single
+                            attach. When stdin is true the stdin stream will remain
+                            open across multiple attach sessions. If stdinOnce is
+                            set to true, stdin is opened on container start, is empty
+                            until the first client attaches to stdin, and then remains
+                            open and accepts data until the client disconnects, at
+                            which time stdin is closed and remains closed until the
+                            container is restarted. If this flag is false, a container
+                            processes that reads from stdin will never receive an
+                            EOF. Default is false
+                          type: boolean
+                        terminationMessagePath:
+                          description: 'Optional: Path at which the file to which
+                            the container''s termination message will be written is
+                            mounted into the container''s filesystem. Message written
+                            is intended to be brief final status, such as an assertion
+                            failure message. Will be truncated by the node if greater
+                            than 4096 bytes. The total message length across all containers
+                            will be limited to 12kb. Defaults to /dev/termination-log.
+                            Cannot be updated.'
+                          type: string
+                        terminationMessagePolicy:
+                          description: |-
+                            Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                            Possible enum values:
+                             - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                             - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                          type: string
+                        tty:
+                          description: Whether this container should allocate a TTY
+                            for itself, also requires 'stdin' to be true. Default
+                            is false.
+                          type: boolean
+                        volumeDevices:
+                          description: volumeDevices is the list of block devices
+                            to be used by the container.
+                          items:
+                            description: volumeDevice describes a mapping of a raw
+                              block device within a container.
+                            properties:
+                              devicePath:
+                                description: devicePath is the path inside of the
+                                  container that the device will be mapped to.
+                                type: string
+                              name:
+                                description: name must match the name of a persistentVolumeClaim
+                                  in the pod
+                                type: string
+                            required:
+                            - devicePath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - devicePath
+                          x-kubernetes-list-type: map
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                            Cannot be updated.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write
+                                  otherwise (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the
+                                  container's volume should be mounted. Defaults to
+                                  "" (volume's root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from
+                                  which the container's volume should be mounted.
+                                  Behaves similarly to SubPath but environment variable
+                                  references $(VAR_NAME) are expanded using the container's
+                                  environment. Defaults to "" (volume's root). SubPathExpr
+                                  and SubPath are mutually exclusive.
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - mountPath
+                          x-kubernetes-list-type: map
+                        workingDir:
+                          description: Container's working directory. If not specified,
+                            the container runtime's default will be used, which might
+                            be configured in the container image. Cannot be updated.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  dnsConfig:
+                    description: Specifies the DNS parameters of a pod. Parameters
+                      specified here will be merged to the generated DNS configuration
+                      based on DNSPolicy.
+                    properties:
+                      nameservers:
+                        description: A list of DNS name server IP addresses. This
+                          will be appended to the base nameservers generated from
+                          DNSPolicy. Duplicated nameservers will be removed.
+                        items:
+                          type: string
+                        type: array
+                      options:
+                        description: A list of DNS resolver options. This will be
+                          merged with the base options generated from DNSPolicy. Duplicated
+                          entries will be removed. Resolution options given in Options
+                          will override those that appear in the base DNSPolicy.
+                        items:
+                          description: PodDNSConfigOption defines DNS resolver options
+                            of a pod.
+                          properties:
+                            name:
+                              description: Required.
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                      searches:
+                        description: A list of DNS search domains for host-name lookup.
+                          This will be appended to the base search paths generated
+                          from DNSPolicy. Duplicated search paths will be removed.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  dnsPolicy:
+                    description: |-
+                      Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+
+                      Possible enum values:
+                       - `"ClusterFirst"` indicates that the pod should use cluster DNS first unless hostNetwork is true, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                       - `"ClusterFirstWithHostNet"` indicates that the pod should use cluster DNS first, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                       - `"Default"` indicates that the pod should use the default (as determined by kubelet) DNS settings.
+                       - `"None"` indicates that the pod should use empty DNS settings. DNS parameters such as nameservers and search paths should be defined via DNSConfig.
+                    type: string
+                  enableServiceLinks:
+                    description: 'EnableServiceLinks indicates whether information
+                      about services should be injected into pod''s environment variables,
+                      matching the syntax of Docker links. Optional: Defaults to true.'
+                    type: boolean
+                  ephemeralContainers:
+                    description: List of ephemeral containers run in this pod. Ephemeral
+                      containers may be run in an existing pod to perform user-initiated
+                      actions such as debugging. This list cannot be specified when
+                      creating a pod, and it cannot be modified by updating the pod
+                      spec. In order to add an ephemeral container to an existing
+                      pod, use the pod's ephemeralcontainers subresource.
+                    items:
+                      description: |-
+                        An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation.
+
+                        To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.
+                      properties:
+                        args:
+                          description: 'Arguments to the entrypoint. The image''s
+                            CMD is used if this is not provided. Variable references
+                            $(VAR_NAME) are expanded using the container''s environment.
+                            If a variable cannot be resolved, the reference in the
+                            input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME)
+                            syntax: i.e. "$$(VAR_NAME)" will produce the string literal
+                            "$(VAR_NAME)". Escaped references will never be expanded,
+                            regardless of whether the variable exists or not. Cannot
+                            be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: 'Entrypoint array. Not executed within a shell.
+                            The image''s ENTRYPOINT is used if this is not provided.
+                            Variable references $(VAR_NAME) are expanded using the
+                            container''s environment. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double
+                            $$ are reduced to a single $, which allows for escaping
+                            the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                            the string literal "$(VAR_NAME)". Escaped references will
+                            never be expanded, regardless of whether the variable
+                            exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the
+                            container. Cannot be updated.
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previously defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  Double $$ are reduced to a single $, which allows
+                                  for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                  will produce the string literal "$(VAR_NAME)". Escaped
+                                  references will never be expanded, regardless of
+                                  whether the variable exists or not. Defaults to
+                                  "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's
+                                  value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container. The keys defined within a source must
+                            be a C_IDENTIFIER. All invalid keys will be reported as
+                            an event when the container is starting. When a key exists
+                            in multiple sources, the value associated with the last
+                            source will take precedence. Values defined by an Env
+                            with a duplicate key will take precedence. Cannot be updated.
+                          items:
+                            description: EnvFromSource represents the source of a
+                              set of ConfigMaps
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must
+                                      be defined
+                                    type: boolean
+                                type: object
+                              prefix:
+                                description: An optional identifier to prepend to
+                                  each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be
+                                      defined
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                          type: string
+                        imagePullPolicy:
+                          description: |-
+                            Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                            Possible enum values:
+                             - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                             - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                             - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                          type: string
+                        lifecycle:
+                          description: Lifecycle is not allowed for ephemeral containers.
+                          properties:
+                            postStart:
+                              description: 'PostStart is called immediately after
+                                a container is created. If the handler fails, the
+                                container is terminated and restarted according to
+                                its restart policy. Other management of the container
+                                blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            preStop:
+                              description: 'PreStop is called immediately before a
+                                container is terminated due to an API request or management
+                                event such as liveness/startup probe failure, preemption,
+                                resource contention, etc. The handler is not called
+                                if the container crashes or exits. The Pod''s termination
+                                grace period countdown begins before the PreStop hook
+                                is executed. Regardless of the outcome of the handler,
+                                the container will eventually terminate within the
+                                Pod''s termination grace period (unless delayed by
+                                finalizers). Other management of the container blocks
+                                until the hook completes or until the termination
+                                grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                          type: object
+                        livenessProbe:
+                          description: Probes are not allowed for ephemeral containers.
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: Name of the ephemeral container specified as
+                            a DNS_LABEL. This name must be unique among all containers,
+                            init containers and ephemeral containers.
+                          type: string
+                        ports:
+                          description: Ports are not allowed for ephemeral containers.
+                          items:
+                            description: ContainerPort represents a network port in
+                              a single container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's
+                                  IP address. This must be a valid port number, 0
+                                  < x < 65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port
+                                  to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host.
+                                  If specified, this must be a valid port number,
+                                  0 < x < 65536. If HostNetwork is specified, this
+                                  must match ContainerPort. Most containers do not
+                                  need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a
+                                  pod must have a unique name. Name for the port that
+                                  can be referred to by services.
+                                type: string
+                              protocol:
+                                default: TCP
+                                description: |-
+                                  Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                  Possible enum values:
+                                   - `"SCTP"` is the SCTP protocol.
+                                   - `"TCP"` is the TCP protocol.
+                                   - `"UDP"` is the UDP protocol.
+                                type: string
+                            required:
+                            - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - containerPort
+                          - protocol
+                          x-kubernetes-list-type: map
+                        readinessProbe:
+                          description: Probes are not allowed for ephemeral containers.
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          description: Resources are not allowed for ephemeral containers.
+                            Ephemeral containers use spare resources already allocated
+                            to the pod.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        securityContext:
+                          description: 'Optional: SecurityContext defines the security
+                            options the ephemeral container should be run with. If
+                            set, the fields of SecurityContext override the equivalent
+                            fields of PodSecurityContext.'
+                          properties:
+                            allowPrivilegeEscalation:
+                              description: 'AllowPrivilegeEscalation controls whether
+                                a process can gain more privileges than its parent
+                                process. This bool directly controls if the no_new_privs
+                                flag will be set on the container process. AllowPrivilegeEscalation
+                                is true always when the container is: 1) run as Privileged
+                                2) has CAP_SYS_ADMIN Note that this field cannot be
+                                set when spec.os.name is windows.'
+                              type: boolean
+                            capabilities:
+                              description: The capabilities to add/drop when running
+                                containers. Defaults to the default set of capabilities
+                                granted by the container runtime. Note that this field
+                                cannot be set when spec.os.name is windows.
+                              properties:
+                                add:
+                                  description: Added capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                                drop:
+                                  description: Removed capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            privileged:
+                              description: Run container in privileged mode. Processes
+                                in privileged containers are essentially equivalent
+                                to root on the host. Defaults to false. Note that
+                                this field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            procMount:
+                              description: procMount denotes the type of proc mount
+                                to use for the containers. The default is DefaultProcMount
+                                which uses the container runtime defaults for readonly
+                                paths and masked paths. This requires the ProcMountType
+                                feature flag to be enabled. Note that this field cannot
+                                be set when spec.os.name is windows.
+                              type: string
+                            readOnlyRootFilesystem:
+                              description: Whether this container has a read-only
+                                root filesystem. Default is false. Note that this
+                                field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            runAsGroup:
+                              description: The GID to run the entrypoint of the container
+                                process. Uses runtime default if unset. May also be
+                                set in PodSecurityContext.  If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is windows.
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              description: Indicates that the container must run as
+                                a non-root user. If true, the Kubelet will validate
+                                the image at runtime to ensure that it does not run
+                                as UID 0 (root) and fail to start the container if
+                                it does. If unset or false, no such validation will
+                                be performed. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                              type: boolean
+                            runAsUser:
+                              description: The UID to run the entrypoint of the container
+                                process. Defaults to user specified in image metadata
+                                if unspecified. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name
+                                is windows.
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              description: The SELinux context to be applied to the
+                                container. If unspecified, the container runtime will
+                                allocate a random SELinux context for each container.  May
+                                also be set in PodSecurityContext.  If set in both
+                                SecurityContext and PodSecurityContext, the value
+                                specified in SecurityContext takes precedence. Note
+                                that this field cannot be set when spec.os.name is
+                                windows.
+                              properties:
+                                level:
+                                  description: Level is SELinux level label that applies
+                                    to the container.
+                                  type: string
+                                role:
+                                  description: Role is a SELinux role label that applies
+                                    to the container.
+                                  type: string
+                                type:
+                                  description: Type is a SELinux type label that applies
+                                    to the container.
+                                  type: string
+                                user:
+                                  description: User is a SELinux user label that applies
+                                    to the container.
+                                  type: string
+                              type: object
+                            seccompProfile:
+                              description: The seccomp options to use by this container.
+                                If seccomp options are provided at both the pod &
+                                container level, the container options override the
+                                pod options. Note that this field cannot be set when
+                                spec.os.name is windows.
+                              properties:
+                                localhostProfile:
+                                  description: localhostProfile indicates a profile
+                                    defined in a file on the node should be used.
+                                    The profile must be preconfigured on the node
+                                    to work. Must be a descending path, relative to
+                                    the kubelet's configured seccomp profile location.
+                                    Must only be set if type is "Localhost".
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                    Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                    Possible enum values:
+                                     - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                     - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                     - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            windowsOptions:
+                              description: The Windows specific settings applied to
+                                all containers. If unspecified, the options from the
+                                PodSecurityContext will be used. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is linux.
+                              properties:
+                                gmsaCredentialSpec:
+                                  description: GMSACredentialSpec is where the GMSA
+                                    admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                    inlines the contents of the GMSA credential spec
+                                    named by the GMSACredentialSpecName field.
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  description: GMSACredentialSpecName is the name
+                                    of the GMSA credential spec to use.
+                                  type: string
+                                hostProcess:
+                                  description: HostProcess determines if a container
+                                    should be run as a 'Host Process' container. This
+                                    field is alpha-level and will only be honored
+                                    by components that enable the WindowsHostProcessContainers
+                                    feature flag. Setting this field without the feature
+                                    flag will result in errors when validating the
+                                    Pod. All of a Pod's containers must have the same
+                                    effective HostProcess value (it is not allowed
+                                    to have a mix of HostProcess containers and non-HostProcess
+                                    containers).  In addition, if HostProcess is true
+                                    then HostNetwork must also be set to true.
+                                  type: boolean
+                                runAsUserName:
+                                  description: The UserName in Windows to run the
+                                    entrypoint of the container process. Defaults
+                                    to the user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  type: string
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: Probes are not allowed for ephemeral containers.
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        stdin:
+                          description: Whether this container should allocate a buffer
+                            for stdin in the container runtime. If this is not set,
+                            reads from stdin in the container will always result in
+                            EOF. Default is false.
+                          type: boolean
+                        stdinOnce:
+                          description: Whether the container runtime should close
+                            the stdin channel after it has been opened by a single
+                            attach. When stdin is true the stdin stream will remain
+                            open across multiple attach sessions. If stdinOnce is
+                            set to true, stdin is opened on container start, is empty
+                            until the first client attaches to stdin, and then remains
+                            open and accepts data until the client disconnects, at
+                            which time stdin is closed and remains closed until the
+                            container is restarted. If this flag is false, a container
+                            processes that reads from stdin will never receive an
+                            EOF. Default is false
+                          type: boolean
+                        targetContainerName:
+                          description: |-
+                            If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+                            The container runtime must implement support for this feature. If the runtime does not support namespace targeting then the result of setting this field is undefined.
+                          type: string
+                        terminationMessagePath:
+                          description: 'Optional: Path at which the file to which
+                            the container''s termination message will be written is
+                            mounted into the container''s filesystem. Message written
+                            is intended to be brief final status, such as an assertion
+                            failure message. Will be truncated by the node if greater
+                            than 4096 bytes. The total message length across all containers
+                            will be limited to 12kb. Defaults to /dev/termination-log.
+                            Cannot be updated.'
+                          type: string
+                        terminationMessagePolicy:
+                          description: |-
+                            Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                            Possible enum values:
+                             - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                             - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                          type: string
+                        tty:
+                          description: Whether this container should allocate a TTY
+                            for itself, also requires 'stdin' to be true. Default
+                            is false.
+                          type: boolean
+                        volumeDevices:
+                          description: volumeDevices is the list of block devices
+                            to be used by the container.
+                          items:
+                            description: volumeDevice describes a mapping of a raw
+                              block device within a container.
+                            properties:
+                              devicePath:
+                                description: devicePath is the path inside of the
+                                  container that the device will be mapped to.
+                                type: string
+                              name:
+                                description: name must match the name of a persistentVolumeClaim
+                                  in the pod
+                                type: string
+                            required:
+                            - devicePath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - devicePath
+                          x-kubernetes-list-type: map
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                            Subpath mounts are not allowed for ephemeral containers.
+                            Cannot be updated.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write
+                                  otherwise (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the
+                                  container's volume should be mounted. Defaults to
+                                  "" (volume's root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from
+                                  which the container's volume should be mounted.
+                                  Behaves similarly to SubPath but environment variable
+                                  references $(VAR_NAME) are expanded using the container's
+                                  environment. Defaults to "" (volume's root). SubPathExpr
+                                  and SubPath are mutually exclusive.
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - mountPath
+                          x-kubernetes-list-type: map
+                        workingDir:
+                          description: Container's working directory. If not specified,
+                            the container runtime's default will be used, which might
+                            be configured in the container image. Cannot be updated.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  hostAliases:
+                    description: HostAliases is an optional list of hosts and IPs
+                      that will be injected into the pod's hosts file if specified.
+                      This is only valid for non-hostNetwork pods.
+                    items:
+                      description: HostAlias holds the mapping between IP and hostnames
+                        that will be injected as an entry in the pod's hosts file.
+                      properties:
+                        hostnames:
+                          description: Hostnames for the above IP address.
+                          items:
+                            type: string
+                          type: array
+                        ip:
+                          description: IP address of the host file entry.
+                          type: string
+                      required:
+                      - ip
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - ip
+                    x-kubernetes-list-type: map
+                  hostIPC:
+                    description: 'Use the host''s ipc namespace. Optional: Default
+                      to false.'
+                    type: boolean
+                  hostNetwork:
+                    description: Host networking requested for this pod. Use the host's
+                      network namespace. If this option is set, the ports that will
+                      be used must be specified. Default to false.
+                    type: boolean
+                  hostPID:
+                    description: 'Use the host''s pid namespace. Optional: Default
+                      to false.'
+                    type: boolean
+                  hostUsers:
+                    description: 'Use the host''s user namespace. Optional: Default
+                      to true. If set to true or not present, the pod will be run
+                      in the host user namespace, useful for when the pod needs a
+                      feature only available to the host user namespace, such as loading
+                      a kernel module with CAP_SYS_MODULE. When set to false, a new
+                      userns is created for the pod. Setting false is useful for mitigating
+                      container breakout vulnerabilities even allowing users to run
+                      their containers as root without actually having root privileges
+                      on the host. This field is alpha-level and is only honored by
+                      servers that enable the UserNamespacesSupport feature.'
+                    type: boolean
+                  hostname:
+                    description: Specifies the hostname of the Pod If not specified,
+                      the pod's hostname will be set to a system-defined value.
+                    type: string
+                  imagePullSecrets:
+                    description: 'ImagePullSecrets is an optional list of references
+                      to secrets in the same namespace to use for pulling any of the
+                      images used by this PodSpec. If specified, these secrets will
+                      be passed to individual puller implementations for them to use.
+                      More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                    items:
+                      description: LocalObjectReference contains enough information
+                        to let you locate the referenced object inside the same namespace.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  initContainers:
+                    description: 'List of initialization containers belonging to the
+                      pod. Init containers are executed in order prior to containers
+                      being started. If any init container fails, the pod is considered
+                      to have failed and is handled according to its restartPolicy.
+                      The name for an init container or normal container must be unique
+                      among all containers. Init containers may not have Lifecycle
+                      actions, Readiness probes, Liveness probes, or Startup probes.
+                      The resourceRequirements of an init container are taken into
+                      account during scheduling by finding the highest request/limit
+                      for each resource type, and then using the max of of that value
+                      or the sum of the normal containers. Limits are applied to init
+                      containers in a similar fashion. Init containers cannot currently
+                      be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                    items:
+                      description: A single application container that you want to
+                        run within a pod.
+                      properties:
+                        args:
+                          description: 'Arguments to the entrypoint. The container
+                            image''s CMD is used if this is not provided. Variable
+                            references $(VAR_NAME) are expanded using the container''s
+                            environment. If a variable cannot be resolved, the reference
+                            in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME)
+                            syntax: i.e. "$$(VAR_NAME)" will produce the string literal
+                            "$(VAR_NAME)". Escaped references will never be expanded,
+                            regardless of whether the variable exists or not. Cannot
+                            be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: 'Entrypoint array. Not executed within a shell.
+                            The container image''s ENTRYPOINT is used if this is not
+                            provided. Variable references $(VAR_NAME) are expanded
+                            using the container''s environment. If a variable cannot
+                            be resolved, the reference in the input string will be
+                            unchanged. Double $$ are reduced to a single $, which
+                            allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                            will produce the string literal "$(VAR_NAME)". Escaped
+                            references will never be expanded, regardless of whether
+                            the variable exists or not. Cannot be updated. More info:
+                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the
+                            container. Cannot be updated.
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previously defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  Double $$ are reduced to a single $, which allows
+                                  for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                  will produce the string literal "$(VAR_NAME)". Escaped
+                                  references will never be expanded, regardless of
+                                  whether the variable exists or not. Defaults to
+                                  "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's
+                                  value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container. The keys defined within a source must
+                            be a C_IDENTIFIER. All invalid keys will be reported as
+                            an event when the container is starting. When a key exists
+                            in multiple sources, the value associated with the last
+                            source will take precedence. Values defined by an Env
+                            with a duplicate key will take precedence. Cannot be updated.
+                          items:
+                            description: EnvFromSource represents the source of a
+                              set of ConfigMaps
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must
+                                      be defined
+                                    type: boolean
+                                type: object
+                              prefix:
+                                description: An optional identifier to prepend to
+                                  each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be
+                                      defined
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                            This field is optional to allow higher level config management
+                            to default or override container images in workload controllers
+                            like Deployments and StatefulSets.'
+                          type: string
+                        imagePullPolicy:
+                          description: |-
+                            Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                            Possible enum values:
+                             - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                             - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                             - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                          type: string
+                        lifecycle:
+                          description: Actions that the management system should take
+                            in response to container lifecycle events. Cannot be updated.
+                          properties:
+                            postStart:
+                              description: 'PostStart is called immediately after
+                                a container is created. If the handler fails, the
+                                container is terminated and restarted according to
+                                its restart policy. Other management of the container
+                                blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            preStop:
+                              description: 'PreStop is called immediately before a
+                                container is terminated due to an API request or management
+                                event such as liveness/startup probe failure, preemption,
+                                resource contention, etc. The handler is not called
+                                if the container crashes or exits. The Pod''s termination
+                                grace period countdown begins before the PreStop hook
+                                is executed. Regardless of the outcome of the handler,
+                                the container will eventually terminate within the
+                                Pod''s termination grace period (unless delayed by
+                                finalizers). Other management of the container blocks
+                                until the hook completes or until the termination
+                                grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                          type: object
+                        livenessProbe:
+                          description: 'Periodic probe of container liveness. Container
+                            will be restarted if the probe fails. Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: Name of the container specified as a DNS_LABEL.
+                            Each container in a pod must have a unique name (DNS_LABEL).
+                            Cannot be updated.
+                          type: string
+                        ports:
+                          description: List of ports to expose from the container.
+                            Not specifying a port here DOES NOT prevent that port
+                            from being exposed. Any port which is listening on the
+                            default "0.0.0.0" address inside a container will be accessible
+                            from the network. Modifying this array with strategic
+                            merge patch may corrupt the data. For more information
+                            See https://github.com/kubernetes/kubernetes/issues/108255.
+                            Cannot be updated.
+                          items:
+                            description: ContainerPort represents a network port in
+                              a single container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's
+                                  IP address. This must be a valid port number, 0
+                                  < x < 65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port
+                                  to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host.
+                                  If specified, this must be a valid port number,
+                                  0 < x < 65536. If HostNetwork is specified, this
+                                  must match ContainerPort. Most containers do not
+                                  need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a
+                                  pod must have a unique name. Name for the port that
+                                  can be referred to by services.
+                                type: string
+                              protocol:
+                                default: TCP
+                                description: |-
+                                  Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                  Possible enum values:
+                                   - `"SCTP"` is the SCTP protocol.
+                                   - `"TCP"` is the TCP protocol.
+                                   - `"UDP"` is the UDP protocol.
+                                type: string
+                            required:
+                            - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - containerPort
+                          - protocol
+                          x-kubernetes-list-type: map
+                        readinessProbe:
+                          description: 'Periodic probe of container service readiness.
+                            Container will be removed from service endpoints if the
+                            probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          description: 'Compute Resources required by this container.
+                            Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        securityContext:
+                          description: 'SecurityContext defines the security options
+                            the container should be run with. If set, the fields of
+                            SecurityContext override the equivalent fields of PodSecurityContext.
+                            More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                          properties:
+                            allowPrivilegeEscalation:
+                              description: 'AllowPrivilegeEscalation controls whether
+                                a process can gain more privileges than its parent
+                                process. This bool directly controls if the no_new_privs
+                                flag will be set on the container process. AllowPrivilegeEscalation
+                                is true always when the container is: 1) run as Privileged
+                                2) has CAP_SYS_ADMIN Note that this field cannot be
+                                set when spec.os.name is windows.'
+                              type: boolean
+                            capabilities:
+                              description: The capabilities to add/drop when running
+                                containers. Defaults to the default set of capabilities
+                                granted by the container runtime. Note that this field
+                                cannot be set when spec.os.name is windows.
+                              properties:
+                                add:
+                                  description: Added capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                                drop:
+                                  description: Removed capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            privileged:
+                              description: Run container in privileged mode. Processes
+                                in privileged containers are essentially equivalent
+                                to root on the host. Defaults to false. Note that
+                                this field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            procMount:
+                              description: procMount denotes the type of proc mount
+                                to use for the containers. The default is DefaultProcMount
+                                which uses the container runtime defaults for readonly
+                                paths and masked paths. This requires the ProcMountType
+                                feature flag to be enabled. Note that this field cannot
+                                be set when spec.os.name is windows.
+                              type: string
+                            readOnlyRootFilesystem:
+                              description: Whether this container has a read-only
+                                root filesystem. Default is false. Note that this
+                                field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            runAsGroup:
+                              description: The GID to run the entrypoint of the container
+                                process. Uses runtime default if unset. May also be
+                                set in PodSecurityContext.  If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is windows.
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              description: Indicates that the container must run as
+                                a non-root user. If true, the Kubelet will validate
+                                the image at runtime to ensure that it does not run
+                                as UID 0 (root) and fail to start the container if
+                                it does. If unset or false, no such validation will
+                                be performed. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                              type: boolean
+                            runAsUser:
+                              description: The UID to run the entrypoint of the container
+                                process. Defaults to user specified in image metadata
+                                if unspecified. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name
+                                is windows.
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              description: The SELinux context to be applied to the
+                                container. If unspecified, the container runtime will
+                                allocate a random SELinux context for each container.  May
+                                also be set in PodSecurityContext.  If set in both
+                                SecurityContext and PodSecurityContext, the value
+                                specified in SecurityContext takes precedence. Note
+                                that this field cannot be set when spec.os.name is
+                                windows.
+                              properties:
+                                level:
+                                  description: Level is SELinux level label that applies
+                                    to the container.
+                                  type: string
+                                role:
+                                  description: Role is a SELinux role label that applies
+                                    to the container.
+                                  type: string
+                                type:
+                                  description: Type is a SELinux type label that applies
+                                    to the container.
+                                  type: string
+                                user:
+                                  description: User is a SELinux user label that applies
+                                    to the container.
+                                  type: string
+                              type: object
+                            seccompProfile:
+                              description: The seccomp options to use by this container.
+                                If seccomp options are provided at both the pod &
+                                container level, the container options override the
+                                pod options. Note that this field cannot be set when
+                                spec.os.name is windows.
+                              properties:
+                                localhostProfile:
+                                  description: localhostProfile indicates a profile
+                                    defined in a file on the node should be used.
+                                    The profile must be preconfigured on the node
+                                    to work. Must be a descending path, relative to
+                                    the kubelet's configured seccomp profile location.
+                                    Must only be set if type is "Localhost".
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                    Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                    Possible enum values:
+                                     - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                     - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                     - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            windowsOptions:
+                              description: The Windows specific settings applied to
+                                all containers. If unspecified, the options from the
+                                PodSecurityContext will be used. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is linux.
+                              properties:
+                                gmsaCredentialSpec:
+                                  description: GMSACredentialSpec is where the GMSA
+                                    admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                    inlines the contents of the GMSA credential spec
+                                    named by the GMSACredentialSpecName field.
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  description: GMSACredentialSpecName is the name
+                                    of the GMSA credential spec to use.
+                                  type: string
+                                hostProcess:
+                                  description: HostProcess determines if a container
+                                    should be run as a 'Host Process' container. This
+                                    field is alpha-level and will only be honored
+                                    by components that enable the WindowsHostProcessContainers
+                                    feature flag. Setting this field without the feature
+                                    flag will result in errors when validating the
+                                    Pod. All of a Pod's containers must have the same
+                                    effective HostProcess value (it is not allowed
+                                    to have a mix of HostProcess containers and non-HostProcess
+                                    containers).  In addition, if HostProcess is true
+                                    then HostNetwork must also be set to true.
+                                  type: boolean
+                                runAsUserName:
+                                  description: The UserName in Windows to run the
+                                    entrypoint of the container process. Defaults
+                                    to the user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  type: string
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: 'StartupProbe indicates that the Pod has successfully
+                            initialized. If specified, no other probes are executed
+                            until this completes successfully. If this probe fails,
+                            the Pod will be restarted, just as if the livenessProbe
+                            failed. This can be used to provide different probe parameters
+                            at the beginning of a Pod''s lifecycle, when it might
+                            take a long time to load data or warm a cache, than during
+                            steady-state operation. This cannot be updated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        stdin:
+                          description: Whether this container should allocate a buffer
+                            for stdin in the container runtime. If this is not set,
+                            reads from stdin in the container will always result in
+                            EOF. Default is false.
+                          type: boolean
+                        stdinOnce:
+                          description: Whether the container runtime should close
+                            the stdin channel after it has been opened by a single
+                            attach. When stdin is true the stdin stream will remain
+                            open across multiple attach sessions. If stdinOnce is
+                            set to true, stdin is opened on container start, is empty
+                            until the first client attaches to stdin, and then remains
+                            open and accepts data until the client disconnects, at
+                            which time stdin is closed and remains closed until the
+                            container is restarted. If this flag is false, a container
+                            processes that reads from stdin will never receive an
+                            EOF. Default is false
+                          type: boolean
+                        terminationMessagePath:
+                          description: 'Optional: Path at which the file to which
+                            the container''s termination message will be written is
+                            mounted into the container''s filesystem. Message written
+                            is intended to be brief final status, such as an assertion
+                            failure message. Will be truncated by the node if greater
+                            than 4096 bytes. The total message length across all containers
+                            will be limited to 12kb. Defaults to /dev/termination-log.
+                            Cannot be updated.'
+                          type: string
+                        terminationMessagePolicy:
+                          description: |-
+                            Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                            Possible enum values:
+                             - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                             - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                          type: string
+                        tty:
+                          description: Whether this container should allocate a TTY
+                            for itself, also requires 'stdin' to be true. Default
+                            is false.
+                          type: boolean
+                        volumeDevices:
+                          description: volumeDevices is the list of block devices
+                            to be used by the container.
+                          items:
+                            description: volumeDevice describes a mapping of a raw
+                              block device within a container.
+                            properties:
+                              devicePath:
+                                description: devicePath is the path inside of the
+                                  container that the device will be mapped to.
+                                type: string
+                              name:
+                                description: name must match the name of a persistentVolumeClaim
+                                  in the pod
+                                type: string
+                            required:
+                            - devicePath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - devicePath
+                          x-kubernetes-list-type: map
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                            Cannot be updated.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write
+                                  otherwise (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the
+                                  container's volume should be mounted. Defaults to
+                                  "" (volume's root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from
+                                  which the container's volume should be mounted.
+                                  Behaves similarly to SubPath but environment variable
+                                  references $(VAR_NAME) are expanded using the container's
+                                  environment. Defaults to "" (volume's root). SubPathExpr
+                                  and SubPath are mutually exclusive.
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - mountPath
+                          x-kubernetes-list-type: map
+                        workingDir:
+                          description: Container's working directory. If not specified,
+                            the container runtime's default will be used, which might
+                            be configured in the container image. Cannot be updated.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  nodeName:
+                    description: NodeName is a request to schedule this pod onto a
+                      specific node. If it is non-empty, the scheduler simply schedules
+                      this pod onto that node, assuming that it fits resource requirements.
+                    type: string
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'NodeSelector is a selector which must be true for
+                      the pod to fit on a node. Selector which must match a node''s
+                      labels for the pod to be scheduled on that node. More info:
+                      https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                    type: object
+                  os:
+                    description: |-
+                      Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set.
+
+                      If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions
+
+                      If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup
+                    properties:
+                      name:
+                        description: 'Name is the name of the operating system. The
+                          currently supported values are linux and windows. Additional
+                          value may be defined in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                          Clients should expect to handle additional values and treat
+                          unrecognized values in this field as os: null'
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  overhead:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Overhead represents the resource overhead associated
+                      with running a pod for a given RuntimeClass. This field will
+                      be autopopulated at admission time by the RuntimeClass admission
+                      controller. If the RuntimeClass admission controller is enabled,
+                      overhead must not be set in Pod create requests. The RuntimeClass
+                      admission controller will reject Pod create requests which have
+                      the overhead already set. If RuntimeClass is configured and
+                      selected in the PodSpec, Overhead will be set to the value defined
+                      in the corresponding RuntimeClass, otherwise it will remain
+                      unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
+                    type: object
+                  preemptionPolicy:
+                    description: PreemptionPolicy is the Policy for preempting pods
+                      with lower priority. One of Never, PreemptLowerPriority. Defaults
+                      to PreemptLowerPriority if unset.
+                    type: string
+                  priority:
+                    description: The priority value. Various system components use
+                      this field to find the priority of the pod. When Priority Admission
+                      Controller is enabled, it prevents users from setting this field.
+                      The admission controller populates this field from PriorityClassName.
+                      The higher the value, the higher the priority.
+                    format: int32
+                    type: integer
+                  priorityClassName:
+                    description: If specified, indicates the pod's priority. "system-node-critical"
+                      and "system-cluster-critical" are two special keywords which
+                      indicate the highest priorities with the former being the highest
+                      priority. Any other name must be defined by creating a PriorityClass
+                      object with that name. If not specified, the pod priority will
+                      be default or zero if there is no default.
+                    type: string
+                  readinessGates:
+                    description: 'If specified, all readiness gates will be evaluated
+                      for pod readiness. A pod is ready when all its containers are
+                      ready AND all conditions specified in the readiness gates have
+                      status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
+                    items:
+                      description: PodReadinessGate contains the reference to a pod
+                        condition
+                      properties:
+                        conditionType:
+                          description: ConditionType refers to a condition in the
+                            pod's condition list with matching type.
+                          type: string
+                      required:
+                      - conditionType
+                      type: object
+                    type: array
+                  restartPolicy:
+                    description: |-
+                      Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+
+                      Possible enum values:
+                       - `"Always"`
+                       - `"Never"`
+                       - `"OnFailure"`
+                    type: string
+                  runtimeClassName:
+                    description: 'RuntimeClassName refers to a RuntimeClass object
+                      in the node.k8s.io group, which should be used to run this pod.  If
+                      no RuntimeClass resource matches the named class, the pod will
+                      not be run. If unset or empty, the "legacy" RuntimeClass will
+                      be used, which is an implicit class with an empty definition
+                      that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
+                    type: string
+                  schedulerName:
+                    description: If specified, the pod will be dispatched by specified
+                      scheduler. If not specified, the pod will be dispatched by default
+                      scheduler.
+                    type: string
+                  securityContext:
+                    description: 'SecurityContext holds pod-level security attributes
+                      and common container settings. Optional: Defaults to empty.  See
+                      type description for default values of each field.'
+                    properties:
+                      fsGroup:
+                        description: |-
+                          A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
+                          1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
+                          If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      fsGroupChangePolicy:
+                        description: 'fsGroupChangePolicy defines behavior of changing
+                          ownership and permission of the volume before being exposed
+                          inside Pod. This field will only apply to volume types which
+                          support fsGroup based ownership(and permissions). It will
+                          have no effect on ephemeral volume types such as: secret,
+                          configmaps and emptydir. Valid values are "OnRootMismatch"
+                          and "Always". If not specified, "Always" is used. Note that
+                          this field cannot be set when spec.os.name is windows.'
+                        type: string
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence for that container. Note that this field
+                          cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in SecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in SecurityContext.  If set
+                          in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence for that container.
+                          Note that this field cannot be set when spec.os.name is
+                          windows.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to all containers.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          SecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence
+                          for that container. Note that this field cannot be set when
+                          spec.os.name is windows.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: The seccomp options to use by the containers
+                          in this pod. Note that this field cannot be set when spec.os.name
+                          is windows.
+                        properties:
+                          localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used. The profile must
+                              be preconfigured on the node to work. Must be a descending
+                              path, relative to the kubelet's configured seccomp profile
+                              location. Must only be set if type is "Localhost".
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                              Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                              Possible enum values:
+                               - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                               - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                               - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      supplementalGroups:
+                        description: A list of groups applied to the first process
+                          run in each container, in addition to the container's primary
+                          GID.  If unspecified, no groups will be added to any container.
+                          Note that this field cannot be set when spec.os.name is
+                          windows.
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      sysctls:
+                        description: Sysctls hold a list of namespaced sysctls used
+                          for the pod. Pods with unsupported sysctls (by the container
+                          runtime) might fail to launch. Note that this field cannot
+                          be set when spec.os.name is windows.
+                        items:
+                          description: Sysctl defines a kernel parameter to be set
+                          properties:
+                            name:
+                              description: Name of a property to set
+                              type: string
+                            value:
+                              description: Value of a property to set
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options within a container's
+                          SecurityContext will be used. If set in both SecurityContext
+                          and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence. Note that this field cannot be set when
+                          spec.os.name is linux.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: HostProcess determines if a container should
+                              be run as a 'Host Process' container. This field is
+                              alpha-level and will only be honored by components that
+                              enable the WindowsHostProcessContainers feature flag.
+                              Setting this field without the feature flag will result
+                              in errors when validating the Pod. All of a Pod's containers
+                              must have the same effective HostProcess value (it is
+                              not allowed to have a mix of HostProcess containers
+                              and non-HostProcess containers).  In addition, if HostProcess
+                              is true then HostNetwork must also be set to true.
+                            type: boolean
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  serviceAccount:
+                    description: 'DeprecatedServiceAccount is a depreciated alias
+                      for ServiceAccountName. Deprecated: Use serviceAccountName instead.'
+                    type: string
+                  serviceAccountName:
+                    description: 'ServiceAccountName is the name of the ServiceAccount
+                      to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                    type: string
+                  setHostnameAsFQDN:
+                    description: If true the pod's hostname will be configured as
+                      the pod's FQDN, rather than the leaf name (the default). In
+                      Linux containers, this means setting the FQDN in the hostname
+                      field of the kernel (the nodename field of struct utsname).
+                      In Windows containers, this means setting the registry value
+                      of hostname for the registry key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters
+                      to FQDN. If a pod does not have FQDN, this has no effect. Default
+                      to false.
+                    type: boolean
+                  shareProcessNamespace:
+                    description: 'Share a single process namespace between all of
+                      the containers in a pod. When this is set containers will be
+                      able to view and signal processes from other containers in the
+                      same pod, and the first process in each container will not be
+                      assigned PID 1. HostPID and ShareProcessNamespace cannot both
+                      be set. Optional: Default to false.'
+                    type: boolean
+                  subdomain:
+                    description: If specified, the fully qualified Pod hostname will
+                      be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+                      If not specified, the pod will not have a domainname at all.
+                    type: string
+                  terminationGracePeriodSeconds:
+                    description: Optional duration in seconds the pod needs to terminate
+                      gracefully. May be decreased in delete request. Value must be
+                      non-negative integer. The value zero indicates stop immediately
+                      via the kill signal (no opportunity to shut down). If this value
+                      is nil, the default grace period will be used instead. The grace
+                      period is the duration in seconds after the processes running
+                      in the pod are sent a termination signal and the time when the
+                      processes are forcibly halted with a kill signal. Set this value
+                      longer than the expected cleanup time for your process. Defaults
+                      to 30 seconds.
+                    format: int64
+                    type: integer
+                  tolerations:
+                    description: If specified, the pod's tolerations.
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using
+                        the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+                            Possible enum values:
+                             - `"NoExecute"` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+                             - `"NoSchedule"` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+                             - `"PreferNoSchedule"` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+
+                            Possible enum values:
+                             - `"Equal"`
+                             - `"Exists"`
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of
+                            time the toleration (which must be of effect NoExecute,
+                            otherwise this field is ignored) tolerates the taint.
+                            By default, it is not set, which means tolerate the taint
+                            forever (do not evict). Zero and negative values will
+                            be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  topologySpreadConstraints:
+                    description: TopologySpreadConstraints describes how a group of
+                      pods ought to spread across topology domains. Scheduler will
+                      schedule pods in a way which abides by the constraints. All
+                      topologySpreadConstraints are ANDed.
+                    items:
+                      description: TopologySpreadConstraint specifies how to spread
+                        matching pods among the given topology.
+                      properties:
+                        labelSelector:
+                          description: LabelSelector is used to find matching pods.
+                            Pods that match this label selector are counted to determine
+                            the number of pods in their corresponding topology domain.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        matchLabelKeys:
+                          description: MatchLabelKeys is a set of pod label keys to
+                            select the pods over which spreading will be calculated.
+                            The keys are used to lookup values from the incoming pod
+                            labels, those key-value labels are ANDed with labelSelector
+                            to select the group of existing pods over which spreading
+                            will be calculated for the incoming pod. Keys that don't
+                            exist in the incoming pod labels will be ignored. A null
+                            or empty list means only match against labelSelector.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        maxSkew:
+                          description: 'MaxSkew describes the degree to which pods
+                            may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                            it is the maximum permitted difference between the number
+                            of matching pods in the target topology and the global
+                            minimum. The global minimum is the minimum number of matching
+                            pods in an eligible domain or zero if the number of eligible
+                            domains is less than MinDomains. For example, in a 3-zone
+                            cluster, MaxSkew is set to 1, and pods with the same labelSelector
+                            spread as 2/2/1: In this case, the global minimum is 1.
+                            | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | -
+                            if MaxSkew is 1, incoming pod can only be scheduled to
+                            zone3 to become 2/2/2; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(3-1) on zone1(zone2) violate
+                            MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
+                            onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                            it is used to give higher precedence to topologies that
+                            satisfy it. It''s a required field. Default value is 1
+                            and 0 is not allowed.'
+                          format: int32
+                          type: integer
+                        minDomains:
+                          description: |-
+                            MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                            For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew.
+
+                            This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
+                          format: int32
+                          type: integer
+                        nodeAffinityPolicy:
+                          description: |-
+                            NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                            If this value is nil, the behavior is equivalent to the Honor policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                          type: string
+                        nodeTaintsPolicy:
+                          description: |-
+                            NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included.
+
+                            If this value is nil, the behavior is equivalent to the Ignore policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                          type: string
+                        topologyKey:
+                          description: TopologyKey is the key of node labels. Nodes
+                            that have a label with this key and identical values are
+                            considered to be in the same topology. We consider each
+                            <key, value> as a "bucket", and try to put balanced number
+                            of pods into each bucket. We define a domain as a particular
+                            instance of a topology. Also, we define an eligible domain
+                            as a domain whose nodes meet the requirements of nodeAffinityPolicy
+                            and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
+                            each Node is a domain of that topology. And, if TopologyKey
+                            is "topology.kubernetes.io/zone", each zone is a domain
+                            of that topology. It's a required field.
+                          type: string
+                        whenUnsatisfiable:
+                          description: |-
+                            WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                              but giving higher precedence to topologies that would help reduce the
+                              skew.
+                            A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
+
+                            Possible enum values:
+                             - `"DoNotSchedule"` instructs the scheduler not to schedule the pod when constraints are not satisfied.
+                             - `"ScheduleAnyway"` instructs the scheduler to schedule the pod even if constraints are not satisfied.
+                          type: string
+                      required:
+                      - maxSkew
+                      - topologyKey
+                      - whenUnsatisfiable
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - topologyKey
+                    - whenUnsatisfiable
+                    x-kubernetes-list-type: map
+                  volumes:
+                    description: 'List of volumes that can be mounted by containers
+                      belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                    items:
+                      description: Volume represents a named volume in a pod that
+                        may be accessed by any container in the pod.
+                      properties:
+                        awsElasticBlockStore:
+                          description: 'awsElasticBlockStore represents an AWS Disk
+                            resource that is attached to a kubelet''s host machine
+                            and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                          properties:
+                            fsType:
+                              description: 'fsType is the filesystem type of the volume
+                                that you want to mount. Tip: Ensure that the filesystem
+                                type is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              type: string
+                            partition:
+                              description: 'partition is the partition in the volume
+                                that you want to mount. If omitted, the default is
+                                to mount by volume name. Examples: For volume /dev/sda1,
+                                you specify the partition as "1". Similarly, the volume
+                                partition for /dev/sda is "0" (or you can leave the
+                                property empty).'
+                              format: int32
+                              type: integer
+                            readOnly:
+                              description: 'readOnly value true will force the readOnly
+                                setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              type: boolean
+                            volumeID:
+                              description: 'volumeID is unique ID of the persistent
+                                disk resource in AWS (Amazon EBS volume). More info:
+                                https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        azureDisk:
+                          description: azureDisk represents an Azure Data Disk mount
+                            on the host and bind mount to the pod.
+                          properties:
+                            cachingMode:
+                              description: 'cachingMode is the Host Caching mode:
+                                None, Read Only, Read Write.'
+                              type: string
+                            diskName:
+                              description: diskName is the Name of the data disk in
+                                the blob storage
+                              type: string
+                            diskURI:
+                              description: diskURI is the URI of data disk in the
+                                blob storage
+                              type: string
+                            fsType:
+                              description: fsType is Filesystem type to mount. Must
+                                be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified.
+                              type: string
+                            kind:
+                              description: 'kind expected values are Shared: multiple
+                                blob disks per storage account  Dedicated: single
+                                blob disk per storage account  Managed: azure managed
+                                data disk (only in managed availability set). defaults
+                                to shared'
+                              type: string
+                            readOnly:
+                              description: readOnly Defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                          required:
+                          - diskName
+                          - diskURI
+                          type: object
+                        azureFile:
+                          description: azureFile represents an Azure File Service
+                            mount on the host and bind mount to the pod.
+                          properties:
+                            readOnly:
+                              description: readOnly defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretName:
+                              description: secretName is the  name of secret that
+                                contains Azure Storage Account Name and Key
+                              type: string
+                            shareName:
+                              description: shareName is the azure share Name
+                              type: string
+                          required:
+                          - secretName
+                          - shareName
+                          type: object
+                        cephfs:
+                          description: cephFS represents a Ceph FS mount on the host
+                            that shares a pod's lifetime
+                          properties:
+                            monitors:
+                              description: 'monitors is Required: Monitors is a collection
+                                of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              items:
+                                type: string
+                              type: array
+                            path:
+                              description: 'path is Optional: Used as the mounted
+                                root, rather than the full Ceph tree, default is /'
+                              type: string
+                            readOnly:
+                              description: 'readOnly is Optional: Defaults to false
+                                (read/write). ReadOnly here will force the ReadOnly
+                                setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              type: boolean
+                            secretFile:
+                              description: 'secretFile is Optional: SecretFile is
+                                the path to key ring for User, default is /etc/ceph/user.secret
+                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              type: string
+                            secretRef:
+                              description: 'secretRef is Optional: SecretRef is reference
+                                to the authentication secret for User, default is
+                                empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            user:
+                              description: 'user is optional: User is the rados user
+                                name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              type: string
+                          required:
+                          - monitors
+                          type: object
+                        cinder:
+                          description: 'cinder represents a cinder volume attached
+                            and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                          properties:
+                            fsType:
+                              description: 'fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              type: string
+                            readOnly:
+                              description: 'readOnly defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              type: boolean
+                            secretRef:
+                              description: 'secretRef is optional: points to a secret
+                                object containing parameters used to connect to OpenStack.'
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            volumeID:
+                              description: 'volumeID used to identify the volume in
+                                cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        configMap:
+                          description: configMap represents a configMap that should
+                            populate this volume
+                          properties:
+                            defaultMode:
+                              description: 'defaultMode is optional: mode bits used
+                                to set permissions on created files by default. Must
+                                be an octal value between 0000 and 0777 or a decimal
+                                value between 0 and 511. YAML accepts both octal and
+                                decimal values, JSON requires decimal values for mode
+                                bits. Defaults to 0644. Directories within the path
+                                are not affected by this setting. This might be in
+                                conflict with other options that affect the file mode,
+                                like fsGroup, and the result can be other mode bits
+                                set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: items if unspecified, each key-value pair
+                                in the Data field of the referenced ConfigMap will
+                                be projected into the volume as a file whose name
+                                is the key and content is the value. If specified,
+                                the listed keys will be projected into the specified
+                                paths, and unlisted keys will not be present. If a
+                                key is specified which is not present in the ConfigMap,
+                                the volume setup will error unless it is marked optional.
+                                Paths must be relative and may not contain the '..'
+                                path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a
+                                  volume.
+                                properties:
+                                  key:
+                                    description: key is the key to project.
+                                    type: string
+                                  mode:
+                                    description: 'mode is Optional: mode bits used
+                                      to set permissions on this file. Must be an
+                                      octal value between 0000 and 0777 or a decimal
+                                      value between 0 and 511. YAML accepts both octal
+                                      and decimal values, JSON requires decimal values
+                                      for mode bits. If not specified, the volume
+                                      defaultMode will be used. This might be in conflict
+                                      with other options that affect the file mode,
+                                      like fsGroup, and the result can be other mode
+                                      bits set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: path is the relative path of the
+                                      file to map the key to. May not be an absolute
+                                      path. May not contain the path element '..'.
+                                      May not start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            optional:
+                              description: optional specify whether the ConfigMap
+                                or its keys must be defined
+                              type: boolean
+                          type: object
+                        csi:
+                          description: csi (Container Storage Interface) represents
+                            ephemeral storage that is handled by certain external
+                            CSI drivers (Beta feature).
+                          properties:
+                            driver:
+                              description: driver is the name of the CSI driver that
+                                handles this volume. Consult with your admin for the
+                                correct name as registered in the cluster.
+                              type: string
+                            fsType:
+                              description: fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                If not provided, the empty value is passed to the
+                                associated CSI driver which will determine the default
+                                filesystem to apply.
+                              type: string
+                            nodePublishSecretRef:
+                              description: nodePublishSecretRef is a reference to
+                                the secret object containing sensitive information
+                                to pass to the CSI driver to complete the CSI NodePublishVolume
+                                and NodeUnpublishVolume calls. This field is optional,
+                                and  may be empty if no secret is required. If the
+                                secret object contains more than one secret, all secret
+                                references are passed.
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            readOnly:
+                              description: readOnly specifies a read-only configuration
+                                for the volume. Defaults to false (read/write).
+                              type: boolean
+                            volumeAttributes:
+                              additionalProperties:
+                                type: string
+                              description: volumeAttributes stores driver-specific
+                                properties that are passed to the CSI driver. Consult
+                                your driver's documentation for supported values.
+                              type: object
+                          required:
+                          - driver
+                          type: object
+                        downwardAPI:
+                          description: downwardAPI represents downward API about the
+                            pod that should populate this volume
+                          properties:
+                            defaultMode:
+                              description: 'Optional: mode bits to use on created
+                                files by default. Must be a Optional: mode bits used
+                                to set permissions on created files by default. Must
+                                be an octal value between 0000 and 0777 or a decimal
+                                value between 0 and 511. YAML accepts both octal and
+                                decimal values, JSON requires decimal values for mode
+                                bits. Defaults to 0644. Directories within the path
+                                are not affected by this setting. This might be in
+                                conflict with other options that affect the file mode,
+                                like fsGroup, and the result can be other mode bits
+                                set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: Items is a list of downward API volume
+                                file
+                              items:
+                                description: DownwardAPIVolumeFile represents information
+                                  to create the file containing the pod field
+                                properties:
+                                  fieldRef:
+                                    description: 'Required: Selects a field of the
+                                      pod: only annotations, labels, name and namespace
+                                      are supported.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  mode:
+                                    description: 'Optional: mode bits used to set
+                                      permissions on this file, must be an octal value
+                                      between 0000 and 0777 or a decimal value between
+                                      0 and 511. YAML accepts both octal and decimal
+                                      values, JSON requires decimal values for mode
+                                      bits. If not specified, the volume defaultMode
+                                      will be used. This might be in conflict with
+                                      other options that affect the file mode, like
+                                      fsGroup, and the result can be other mode bits
+                                      set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: 'Required: Path is  the relative
+                                      path name of the file to be created. Must not
+                                      be absolute or contain the ''..'' path. Must
+                                      be utf-8 encoded. The first item of the relative
+                                      path must not start with ''..'''
+                                    type: string
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, requests.cpu and requests.memory)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                required:
+                                - path
+                                type: object
+                              type: array
+                          type: object
+                        emptyDir:
+                          description: 'emptyDir represents a temporary directory
+                            that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                          properties:
+                            medium:
+                              description: 'medium represents what type of storage
+                                medium should back this directory. The default is
+                                "" which means to use the node''s default medium.
+                                Must be an empty string (default) or Memory. More
+                                info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              type: string
+                            sizeLimit:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: 'sizeLimit is the total amount of local
+                                storage required for this EmptyDir volume. The size
+                                limit is also applicable for memory medium. The maximum
+                                usage on memory medium EmptyDir would be the minimum
+                                value between the SizeLimit specified here and the
+                                sum of memory limits of all containers in a pod. The
+                                default is nil which means that the limit is undefined.
+                                More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          type: object
+                        ephemeral:
+                          description: |-
+                            ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+
+                            Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+                               tracking are needed,
+                            c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+                               a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                               information on the connection between this volume type
+                               and PersistentVolumeClaim).
+
+                            Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+
+                            Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+
+                            A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+                          properties:
+                            volumeClaimTemplate:
+                              description: |-
+                                Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+
+                                An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+
+                                This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+
+                                Required, must not be nil.
+                              properties:
+                                metadata:
+                                  description: May contain labels and annotations
+                                    that will be copied into the PVC when creating
+                                    it. No other fields are allowed and will be rejected
+                                    during validation.
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                spec:
+                                  description: The specification for the PersistentVolumeClaim.
+                                    The entire content is copied unchanged into the
+                                    PVC that gets created from this template. The
+                                    same fields as in a PersistentVolumeClaim are
+                                    also valid here.
+                                  properties:
+                                    accessModes:
+                                      description: 'accessModes contains the desired
+                                        access modes the volume should have. More
+                                        info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                      items:
+                                        type: string
+                                      type: array
+                                    dataSource:
+                                      description: 'dataSource field can be used to
+                                        specify either: * An existing VolumeSnapshot
+                                        object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                        * An existing PVC (PersistentVolumeClaim)
+                                        If the provisioner or an external controller
+                                        can support the specified data source, it
+                                        will create a new volume based on the contents
+                                        of the specified data source. If the AnyVolumeDataSource
+                                        feature gate is enabled, this field will always
+                                        have the same contents as the DataSourceRef
+                                        field.'
+                                      properties:
+                                        apiGroup:
+                                          description: APIGroup is the group for the
+                                            resource being referenced. If APIGroup
+                                            is not specified, the specified Kind must
+                                            be in the core API group. For any other
+                                            third-party types, APIGroup is required.
+                                          type: string
+                                        kind:
+                                          description: Kind is the type of resource
+                                            being referenced
+                                          type: string
+                                        name:
+                                          description: Name is the name of resource
+                                            being referenced
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                    dataSourceRef:
+                                      description: |-
+                                        dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef
+                                          allows any non-core object, as well as PersistentVolumeClaim objects.
+                                        * While DataSource ignores disallowed values (dropping them), DataSourceRef
+                                          preserves all values, and generates an error if a disallowed value is
+                                          specified.
+                                        (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                      properties:
+                                        apiGroup:
+                                          description: APIGroup is the group for the
+                                            resource being referenced. If APIGroup
+                                            is not specified, the specified Kind must
+                                            be in the core API group. For any other
+                                            third-party types, APIGroup is required.
+                                          type: string
+                                        kind:
+                                          description: Kind is the type of resource
+                                            being referenced
+                                          type: string
+                                        name:
+                                          description: Name is the name of resource
+                                            being referenced
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                    resources:
+                                      description: 'resources represents the minimum
+                                        resources the volume should have. If RecoverVolumeExpansionFailure
+                                        feature is enabled users are allowed to specify
+                                        resource requirements that are lower than
+                                        previous value but must still be higher than
+                                        capacity recorded in the status field of the
+                                        claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Limits describes the maximum
+                                            amount of compute resources allowed. More
+                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Requests describes the minimum
+                                            amount of compute resources required.
+                                            If Requests is omitted for a container,
+                                            it defaults to Limits if that is explicitly
+                                            specified, otherwise to an implementation-defined
+                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                      type: object
+                                    selector:
+                                      description: selector is a label query over
+                                        volumes to consider for binding.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    storageClassName:
+                                      description: 'storageClassName is the name of
+                                        the StorageClass required by the claim. More
+                                        info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                      type: string
+                                    volumeMode:
+                                      description: volumeMode defines what type of
+                                        volume is required by the claim. Value of
+                                        Filesystem is implied when not included in
+                                        claim spec.
+                                      type: string
+                                    volumeName:
+                                      description: volumeName is the binding reference
+                                        to the PersistentVolume backing this claim.
+                                      type: string
+                                  type: object
+                              required:
+                              - spec
+                              type: object
+                          type: object
+                        fc:
+                          description: fc represents a Fibre Channel resource that
+                            is attached to a kubelet's host machine and then exposed
+                            to the pod.
+                          properties:
+                            fsType:
+                              description: fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified.
+                              type: string
+                            lun:
+                              description: 'lun is Optional: FC target lun number'
+                              format: int32
+                              type: integer
+                            readOnly:
+                              description: 'readOnly is Optional: Defaults to false
+                                (read/write). ReadOnly here will force the ReadOnly
+                                setting in VolumeMounts.'
+                              type: boolean
+                            targetWWNs:
+                              description: 'targetWWNs is Optional: FC target worldwide
+                                names (WWNs)'
+                              items:
+                                type: string
+                              type: array
+                            wwids:
+                              description: 'wwids Optional: FC volume world wide identifiers
+                                (wwids) Either wwids or combination of targetWWNs
+                                and lun must be set, but not both simultaneously.'
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        flexVolume:
+                          description: flexVolume represents a generic volume resource
+                            that is provisioned/attached using an exec based plugin.
+                          properties:
+                            driver:
+                              description: driver is the name of the driver to use
+                                for this volume.
+                              type: string
+                            fsType:
+                              description: fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". The default filesystem
+                                depends on FlexVolume script.
+                              type: string
+                            options:
+                              additionalProperties:
+                                type: string
+                              description: 'options is Optional: this field holds
+                                extra command options if any.'
+                              type: object
+                            readOnly:
+                              description: 'readOnly is Optional: defaults to false
+                                (read/write). ReadOnly here will force the ReadOnly
+                                setting in VolumeMounts.'
+                              type: boolean
+                            secretRef:
+                              description: 'secretRef is Optional: secretRef is reference
+                                to the secret object containing sensitive information
+                                to pass to the plugin scripts. This may be empty if
+                                no secret object is specified. If the secret object
+                                contains more than one secret, all secrets are passed
+                                to the plugin scripts.'
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                          required:
+                          - driver
+                          type: object
+                        flocker:
+                          description: flocker represents a Flocker volume attached
+                            to a kubelet's host machine. This depends on the Flocker
+                            control service being running
+                          properties:
+                            datasetName:
+                              description: datasetName is Name of the dataset stored
+                                as metadata -> name on the dataset for Flocker should
+                                be considered as deprecated
+                              type: string
+                            datasetUUID:
+                              description: datasetUUID is the UUID of the dataset.
+                                This is unique identifier of a Flocker dataset
+                              type: string
+                          type: object
+                        gcePersistentDisk:
+                          description: 'gcePersistentDisk represents a GCE Disk resource
+                            that is attached to a kubelet''s host machine and then
+                            exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                          properties:
+                            fsType:
+                              description: 'fsType is filesystem type of the volume
+                                that you want to mount. Tip: Ensure that the filesystem
+                                type is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              type: string
+                            partition:
+                              description: 'partition is the partition in the volume
+                                that you want to mount. If omitted, the default is
+                                to mount by volume name. Examples: For volume /dev/sda1,
+                                you specify the partition as "1". Similarly, the volume
+                                partition for /dev/sda is "0" (or you can leave the
+                                property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              format: int32
+                              type: integer
+                            pdName:
+                              description: 'pdName is unique name of the PD resource
+                                in GCE. Used to identify the disk in GCE. More info:
+                                https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              type: string
+                            readOnly:
+                              description: 'readOnly here will force the ReadOnly
+                                setting in VolumeMounts. Defaults to false. More info:
+                                https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              type: boolean
+                          required:
+                          - pdName
+                          type: object
+                        gitRepo:
+                          description: 'gitRepo represents a git repository at a particular
+                            revision. DEPRECATED: GitRepo is deprecated. To provision
+                            a container with a git repo, mount an EmptyDir into an
+                            InitContainer that clones the repo using git, then mount
+                            the EmptyDir into the Pod''s container.'
+                          properties:
+                            directory:
+                              description: directory is the target directory name.
+                                Must not contain or start with '..'.  If '.' is supplied,
+                                the volume directory will be the git repository.  Otherwise,
+                                if specified, the volume will contain the git repository
+                                in the subdirectory with the given name.
+                              type: string
+                            repository:
+                              description: repository is the URL
+                              type: string
+                            revision:
+                              description: revision is the commit hash for the specified
+                                revision.
+                              type: string
+                          required:
+                          - repository
+                          type: object
+                        glusterfs:
+                          description: 'glusterfs represents a Glusterfs mount on
+                            the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                          properties:
+                            endpoints:
+                              description: 'endpoints is the endpoint name that details
+                                Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                              type: string
+                            path:
+                              description: 'path is the Glusterfs volume path. More
+                                info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                              type: string
+                            readOnly:
+                              description: 'readOnly here will force the Glusterfs
+                                volume to be mounted with read-only permissions. Defaults
+                                to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                              type: boolean
+                          required:
+                          - endpoints
+                          - path
+                          type: object
+                        hostPath:
+                          description: 'hostPath represents a pre-existing file or
+                            directory on the host machine that is directly exposed
+                            to the container. This is generally used for system agents
+                            or other privileged things that are allowed to see the
+                            host machine. Most containers will NOT need this. More
+                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                          properties:
+                            path:
+                              description: 'path of the directory on the host. If
+                                the path is a symlink, it will follow the link to
+                                the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                              type: string
+                            type:
+                              description: 'type for HostPath Volume Defaults to ""
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        iscsi:
+                          description: 'iscsi represents an ISCSI Disk resource that
+                            is attached to a kubelet''s host machine and then exposed
+                            to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                          properties:
+                            chapAuthDiscovery:
+                              description: chapAuthDiscovery defines whether support
+                                iSCSI Discovery CHAP authentication
+                              type: boolean
+                            chapAuthSession:
+                              description: chapAuthSession defines whether support
+                                iSCSI Session CHAP authentication
+                              type: boolean
+                            fsType:
+                              description: 'fsType is the filesystem type of the volume
+                                that you want to mount. Tip: Ensure that the filesystem
+                                type is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                              type: string
+                            initiatorName:
+                              description: initiatorName is the custom iSCSI Initiator
+                                Name. If initiatorName is specified with iscsiInterface
+                                simultaneously, new iSCSI interface <target portal>:<volume
+                                name> will be created for the connection.
+                              type: string
+                            iqn:
+                              description: iqn is the target iSCSI Qualified Name.
+                              type: string
+                            iscsiInterface:
+                              description: iscsiInterface is the interface Name that
+                                uses an iSCSI transport. Defaults to 'default' (tcp).
+                              type: string
+                            lun:
+                              description: lun represents iSCSI Target Lun number.
+                              format: int32
+                              type: integer
+                            portals:
+                              description: portals is the iSCSI Target Portal List.
+                                The portal is either an IP or ip_addr:port if the
+                                port is other than default (typically TCP ports 860
+                                and 3260).
+                              items:
+                                type: string
+                              type: array
+                            readOnly:
+                              description: readOnly here will force the ReadOnly setting
+                                in VolumeMounts. Defaults to false.
+                              type: boolean
+                            secretRef:
+                              description: secretRef is the CHAP Secret for iSCSI
+                                target and initiator authentication
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            targetPortal:
+                              description: targetPortal is iSCSI Target Portal. The
+                                Portal is either an IP or ip_addr:port if the port
+                                is other than default (typically TCP ports 860 and
+                                3260).
+                              type: string
+                          required:
+                          - targetPortal
+                          - iqn
+                          - lun
+                          type: object
+                        name:
+                          description: 'name of the volume. Must be a DNS_LABEL and
+                            unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        nfs:
+                          description: 'nfs represents an NFS mount on the host that
+                            shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                          properties:
+                            path:
+                              description: 'path that is exported by the NFS server.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              type: string
+                            readOnly:
+                              description: 'readOnly here will force the NFS export
+                                to be mounted with read-only permissions. Defaults
+                                to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              type: boolean
+                            server:
+                              description: 'server is the hostname or IP address of
+                                the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              type: string
+                          required:
+                          - server
+                          - path
+                          type: object
+                        persistentVolumeClaim:
+                          description: 'persistentVolumeClaimVolumeSource represents
+                            a reference to a PersistentVolumeClaim in the same namespace.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          properties:
+                            claimName:
+                              description: 'claimName is the name of a PersistentVolumeClaim
+                                in the same namespace as the pod using this volume.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              type: string
+                            readOnly:
+                              description: readOnly Will force the ReadOnly setting
+                                in VolumeMounts. Default false.
+                              type: boolean
+                          required:
+                          - claimName
+                          type: object
+                        photonPersistentDisk:
+                          description: photonPersistentDisk represents a PhotonController
+                            persistent disk attached and mounted on kubelets host
+                            machine
+                          properties:
+                            fsType:
+                              description: fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified.
+                              type: string
+                            pdID:
+                              description: pdID is the ID that identifies Photon Controller
+                                persistent disk
+                              type: string
+                          required:
+                          - pdID
+                          type: object
+                        portworxVolume:
+                          description: portworxVolume represents a portworx volume
+                            attached and mounted on kubelets host machine
+                          properties:
+                            fsType:
+                              description: fSType represents the filesystem type to
+                                mount Must be a filesystem type supported by the host
+                                operating system. Ex. "ext4", "xfs". Implicitly inferred
+                                to be "ext4" if unspecified.
+                              type: string
+                            readOnly:
+                              description: readOnly defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            volumeID:
+                              description: volumeID uniquely identifies a Portworx
+                                volume
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        projected:
+                          description: projected items for all in one resources secrets,
+                            configmaps, and downward API
+                          properties:
+                            defaultMode:
+                              description: defaultMode are the mode bits used to set
+                                permissions on created files by default. Must be an
+                                octal value between 0000 and 0777 or a decimal value
+                                between 0 and 511. YAML accepts both octal and decimal
+                                values, JSON requires decimal values for mode bits.
+                                Directories within the path are not affected by this
+                                setting. This might be in conflict with other options
+                                that affect the file mode, like fsGroup, and the result
+                                can be other mode bits set.
+                              format: int32
+                              type: integer
+                            sources:
+                              description: sources is the list of volume projections
+                              items:
+                                description: Projection that may be projected along
+                                  with other supported volume types
+                                properties:
+                                  configMap:
+                                    description: configMap information about the configMap
+                                      data to project
+                                    properties:
+                                      items:
+                                        description: items if unspecified, each key-value
+                                          pair in the Data field of the referenced
+                                          ConfigMap will be projected into the volume
+                                          as a file whose name is the key and content
+                                          is the value. If specified, the listed keys
+                                          will be projected into the specified paths,
+                                          and unlisted keys will not be present. If
+                                          a key is specified which is not present
+                                          in the ConfigMap, the volume setup will
+                                          error unless it is marked optional. Paths
+                                          must be relative and may not contain the
+                                          '..' path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: key is the key to project.
+                                              type: string
+                                            mode:
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: path is the relative path
+                                                of the file to map the key to. May
+                                                not be an absolute path. May not contain
+                                                the path element '..'. May not start
+                                                with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: optional specify whether the
+                                          ConfigMap or its keys must be defined
+                                        type: boolean
+                                    type: object
+                                  downwardAPI:
+                                    description: downwardAPI information about the
+                                      downwardAPI data to project
+                                    properties:
+                                      items:
+                                        description: Items is a list of DownwardAPIVolume
+                                          file
+                                        items:
+                                          description: DownwardAPIVolumeFile represents
+                                            information to create the file containing
+                                            the pod field
+                                          properties:
+                                            fieldRef:
+                                              description: 'Required: Selects a field
+                                                of the pod: only annotations, labels,
+                                                name and namespace are supported.'
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                            mode:
+                                              description: 'Optional: mode bits used
+                                                to set permissions on this file, must
+                                                be an octal value between 0000 and
+                                                0777 or a decimal value between 0
+                                                and 511. YAML accepts both octal and
+                                                decimal values, JSON requires decimal
+                                                values for mode bits. If not specified,
+                                                the volume defaultMode will be used.
+                                                This might be in conflict with other
+                                                options that affect the file mode,
+                                                like fsGroup, and the result can be
+                                                other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: 'Required: Path is  the
+                                                relative path name of the file to
+                                                be created. Must not be absolute or
+                                                contain the ''..'' path. Must be utf-8
+                                                encoded. The first item of the relative
+                                                path must not start with ''..'''
+                                              type: string
+                                            resourceFieldRef:
+                                              description: 'Selects a resource of
+                                                the container: only resources limits
+                                                and requests (limits.cpu, limits.memory,
+                                                requests.cpu and requests.memory)
+                                                are currently supported.'
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                          required:
+                                          - path
+                                          type: object
+                                        type: array
+                                    type: object
+                                  secret:
+                                    description: secret information about the secret
+                                      data to project
+                                    properties:
+                                      items:
+                                        description: items if unspecified, each key-value
+                                          pair in the Data field of the referenced
+                                          Secret will be projected into the volume
+                                          as a file whose name is the key and content
+                                          is the value. If specified, the listed keys
+                                          will be projected into the specified paths,
+                                          and unlisted keys will not be present. If
+                                          a key is specified which is not present
+                                          in the Secret, the volume setup will error
+                                          unless it is marked optional. Paths must
+                                          be relative and may not contain the '..'
+                                          path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: key is the key to project.
+                                              type: string
+                                            mode:
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: path is the relative path
+                                                of the file to map the key to. May
+                                                not be an absolute path. May not contain
+                                                the path element '..'. May not start
+                                                with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: optional field specify whether
+                                          the Secret or its key must be defined
+                                        type: boolean
+                                    type: object
+                                  serviceAccountToken:
+                                    description: serviceAccountToken is information
+                                      about the serviceAccountToken data to project
+                                    properties:
+                                      audience:
+                                        description: audience is the intended audience
+                                          of the token. A recipient of a token must
+                                          identify itself with an identifier specified
+                                          in the audience of the token, and otherwise
+                                          should reject the token. The audience defaults
+                                          to the identifier of the apiserver.
+                                        type: string
+                                      expirationSeconds:
+                                        description: expirationSeconds is the requested
+                                          duration of validity of the service account
+                                          token. As the token approaches expiration,
+                                          the kubelet volume plugin will proactively
+                                          rotate the service account token. The kubelet
+                                          will start trying to rotate the token if
+                                          the token is older than 80 percent of its
+                                          time to live or if the token is older than
+                                          24 hours.Defaults to 1 hour and must be
+                                          at least 10 minutes.
+                                        format: int64
+                                        type: integer
+                                      path:
+                                        description: path is the path relative to
+                                          the mount point of the file to project the
+                                          token into.
+                                        type: string
+                                    required:
+                                    - path
+                                    type: object
+                                type: object
+                              type: array
+                          type: object
+                        quobyte:
+                          description: quobyte represents a Quobyte mount on the host
+                            that shares a pod's lifetime
+                          properties:
+                            group:
+                              description: group to map volume access to Default is
+                                no group
+                              type: string
+                            readOnly:
+                              description: readOnly here will force the Quobyte volume
+                                to be mounted with read-only permissions. Defaults
+                                to false.
+                              type: boolean
+                            registry:
+                              description: registry represents a single or multiple
+                                Quobyte Registry services specified as a string as
+                                host:port pair (multiple entries are separated with
+                                commas) which acts as the central registry for volumes
+                              type: string
+                            tenant:
+                              description: tenant owning the given Quobyte volume
+                                in the Backend Used with dynamically provisioned Quobyte
+                                volumes, value is set by the plugin
+                              type: string
+                            user:
+                              description: user to map volume access to Defaults to
+                                serivceaccount user
+                              type: string
+                            volume:
+                              description: volume is a string that references an already
+                                created Quobyte volume by name.
+                              type: string
+                          required:
+                          - registry
+                          - volume
+                          type: object
+                        rbd:
+                          description: 'rbd represents a Rados Block Device mount
+                            on the host that shares a pod''s lifetime. More info:
+                            https://examples.k8s.io/volumes/rbd/README.md'
+                          properties:
+                            fsType:
+                              description: 'fsType is the filesystem type of the volume
+                                that you want to mount. Tip: Ensure that the filesystem
+                                type is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                              type: string
+                            image:
+                              description: 'image is the rados image name. More info:
+                                https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: string
+                            keyring:
+                              description: 'keyring is the path to key ring for RBDUser.
+                                Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: string
+                            monitors:
+                              description: 'monitors is a collection of Ceph monitors.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              items:
+                                type: string
+                              type: array
+                            pool:
+                              description: 'pool is the rados pool name. Default is
+                                rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: string
+                            readOnly:
+                              description: 'readOnly here will force the ReadOnly
+                                setting in VolumeMounts. Defaults to false. More info:
+                                https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: boolean
+                            secretRef:
+                              description: 'secretRef is name of the authentication
+                                secret for RBDUser. If provided overrides keyring.
+                                Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            user:
+                              description: 'user is the rados user name. Default is
+                                admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: string
+                          required:
+                          - monitors
+                          - image
+                          type: object
+                        scaleIO:
+                          description: scaleIO represents a ScaleIO persistent volume
+                            attached and mounted on Kubernetes nodes.
+                          properties:
+                            fsType:
+                              description: fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                              type: string
+                            gateway:
+                              description: gateway is the host address of the ScaleIO
+                                API Gateway.
+                              type: string
+                            protectionDomain:
+                              description: protectionDomain is the name of the ScaleIO
+                                Protection Domain for the configured storage.
+                              type: string
+                            readOnly:
+                              description: readOnly Defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretRef:
+                              description: secretRef references to the secret for
+                                ScaleIO user and other sensitive information. If this
+                                is not provided, Login operation will fail.
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            sslEnabled:
+                              description: sslEnabled Flag enable/disable SSL communication
+                                with Gateway, default false
+                              type: boolean
+                            storageMode:
+                              description: storageMode indicates whether the storage
+                                for a volume should be ThickProvisioned or ThinProvisioned.
+                                Default is ThinProvisioned.
+                              type: string
+                            storagePool:
+                              description: storagePool is the ScaleIO Storage Pool
+                                associated with the protection domain.
+                              type: string
+                            system:
+                              description: system is the name of the storage system
+                                as configured in ScaleIO.
+                              type: string
+                            volumeName:
+                              description: volumeName is the name of a volume already
+                                created in the ScaleIO system that is associated with
+                                this volume source.
+                              type: string
+                          required:
+                          - gateway
+                          - system
+                          - secretRef
+                          type: object
+                        secret:
+                          description: 'secret represents a secret that should populate
+                            this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                          properties:
+                            defaultMode:
+                              description: 'defaultMode is Optional: mode bits used
+                                to set permissions on created files by default. Must
+                                be an octal value between 0000 and 0777 or a decimal
+                                value between 0 and 511. YAML accepts both octal and
+                                decimal values, JSON requires decimal values for mode
+                                bits. Defaults to 0644. Directories within the path
+                                are not affected by this setting. This might be in
+                                conflict with other options that affect the file mode,
+                                like fsGroup, and the result can be other mode bits
+                                set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: items If unspecified, each key-value pair
+                                in the Data field of the referenced Secret will be
+                                projected into the volume as a file whose name is
+                                the key and content is the value. If specified, the
+                                listed keys will be projected into the specified paths,
+                                and unlisted keys will not be present. If a key is
+                                specified which is not present in the Secret, the
+                                volume setup will error unless it is marked optional.
+                                Paths must be relative and may not contain the '..'
+                                path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a
+                                  volume.
+                                properties:
+                                  key:
+                                    description: key is the key to project.
+                                    type: string
+                                  mode:
+                                    description: 'mode is Optional: mode bits used
+                                      to set permissions on this file. Must be an
+                                      octal value between 0000 and 0777 or a decimal
+                                      value between 0 and 511. YAML accepts both octal
+                                      and decimal values, JSON requires decimal values
+                                      for mode bits. If not specified, the volume
+                                      defaultMode will be used. This might be in conflict
+                                      with other options that affect the file mode,
+                                      like fsGroup, and the result can be other mode
+                                      bits set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: path is the relative path of the
+                                      file to map the key to. May not be an absolute
+                                      path. May not contain the path element '..'.
+                                      May not start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                            optional:
+                              description: optional field specify whether the Secret
+                                or its keys must be defined
+                              type: boolean
+                            secretName:
+                              description: 'secretName is the name of the secret in
+                                the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              type: string
+                          type: object
+                        storageos:
+                          description: storageOS represents a StorageOS volume attached
+                            and mounted on Kubernetes nodes.
+                          properties:
+                            fsType:
+                              description: fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified.
+                              type: string
+                            readOnly:
+                              description: readOnly defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretRef:
+                              description: secretRef specifies the secret to use for
+                                obtaining the StorageOS API credentials.  If not specified,
+                                default values will be attempted.
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            volumeName:
+                              description: volumeName is the human-readable name of
+                                the StorageOS volume.  Volume names are only unique
+                                within a namespace.
+                              type: string
+                            volumeNamespace:
+                              description: volumeNamespace specifies the scope of
+                                the volume within StorageOS.  If no namespace is specified
+                                then the Pod's namespace will be used.  This allows
+                                the Kubernetes name scoping to be mirrored within
+                                StorageOS for tighter integration. Set VolumeName
+                                to any name to override the default behaviour. Set
+                                to "default" if you are not using namespaces within
+                                StorageOS. Namespaces that do not pre-exist within
+                                StorageOS will be created.
+                              type: string
+                          type: object
+                        vsphereVolume:
+                          description: vsphereVolume represents a vSphere volume attached
+                            and mounted on kubelets host machine
+                          properties:
+                            fsType:
+                              description: fsType is filesystem type to mount. Must
+                                be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified.
+                              type: string
+                            storagePolicyID:
+                              description: storagePolicyID is the storage Policy Based
+                                Management (SPBM) profile ID associated with the StoragePolicyName.
+                              type: string
+                            storagePolicyName:
+                              description: storagePolicyName is the storage Policy
+                                Based Management (SPBM) profile name.
+                              type: string
+                            volumePath:
+                              description: volumePath is the path that identifies
+                                vSphere volume vmdk
+                              type: string
+                          required:
+                          - volumePath
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                required:
+                - containers
+                type: object
+            type: object
+        required:
+        - selector
+        - template
+        type: object
+      status:
+        description: Most recently observed status of the Deployment.
+        properties:
+          availableReplicas:
+            description: Total number of available pods (ready for at least minReadySeconds)
+              targeted by this deployment.
+            format: int32
+            type: integer
+          collisionCount:
+            description: Count of hash collisions for the Deployment. The Deployment
+              controller uses this field as a collision avoidance mechanism when it
+              needs to create the name for the newest ReplicaSet.
+            format: int32
+            type: integer
+          conditions:
+            description: Represents the latest available observations of a deployment's
+              current state.
+            items:
+              description: DeploymentCondition describes the state of a deployment
+                at a certain point.
+              properties:
+                lastTransitionTime:
+                  description: Last time the condition transitioned from one status
+                    to another.
+                  format: date-time
+                  type: string
+                lastUpdateTime:
+                  description: The last time this condition was updated.
+                  format: date-time
+                  type: string
+                message:
+                  description: A human readable message indicating details about the
+                    transition.
+                  type: string
+                reason:
+                  description: The reason for the condition's last transition.
+                  type: string
+                status:
+                  description: Status of the condition, one of True, False, Unknown.
+                  type: string
+                type:
+                  description: Type of deployment condition.
+                  type: string
+              required:
+              - status
+              - type
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - type
+            x-kubernetes-list-type: map
+          observedGeneration:
+            description: The generation observed by the deployment controller.
+            format: int64
+            type: integer
+          readyReplicas:
+            description: readyReplicas is the number of pods targeted by this Deployment
+              with a Ready Condition.
+            format: int32
+            type: integer
+          replicas:
+            description: Total number of non-terminated pods targeted by this deployment
+              (their labels match the selector).
+            format: int32
+            type: integer
+          unavailableReplicas:
+            description: Total number of unavailable pods targeted by this deployment.
+              This is the total number of pods that are still required for the deployment
+              to have 100% available capacity. They may either be pods that are running
+              but not yet available or pods that still have not been created.
+            format: int32
+            type: integer
+          updatedReplicas:
+            description: Total number of non-terminated pods targeted by this deployment
+              that have the desired template spec.
+            format: int32
+            type: integer
+        type: object
+    type: object
+  plural: deployments
+  schemaUpdateStrategy: UpdateUnpublished
+  scope: Namespaced
+  shortNames:
+  - deploy
+  singular: deployment
+  subResources:
+  - name: scale
+  - name: status
+status:
+  conditions:
+  - lastTransitionTime: "2023-03-21T17:10:10Z"
+    status: "True"
+    type: Compatible

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/3-APIResourceImport-ingresses.kind.v1.networking.k8s.io.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/3-APIResourceImport-ingresses.kind.v1.networking.k8s.io.yaml
@@ -1,0 +1,356 @@
+apiVersion: apiresource.kcp.io/v1alpha1
+kind: APIResourceImport
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kcp-dev/kubernetes/pull/4
+    apiresource.kcp.io/apiVersion: networking.k8s.io/v1
+    kcp.io/cluster: br3qimk2t1o3jb70
+  creationTimestamp: "2023-03-21T17:10:10Z"
+  generation: 1
+  name: ingresses.kind.v1.networking.k8s.io
+  ownerReferences:
+  - apiVersion: workload.kcp.io/v1alpha1
+    controller: true
+    kind: SyncTarget
+    name: kind
+    uid: 8df305e7-f4f8-439f-9115-51054d519361
+  resourceVersion: "9154"
+  uid: 64009668-946b-4101-82a1-199cac106e65
+spec:
+  groupVersion:
+    group: networking.k8s.io
+    version: v1
+  kind: Ingress
+  listKind: IngressList
+  location: kind
+  openAPIV3Schema:
+    description: Ingress is a collection of rules that allow inbound connections to
+      reach the endpoints defined by a backend. An Ingress can be configured to give
+      services externally-reachable urls, load balance traffic, terminate SSL, offer
+      name based virtual hosting etc.
+    properties:
+      apiVersion:
+        description: 'APIVersion defines the versioned schema of this representation
+          of an object. Servers should convert recognized schemas to the latest internal
+          value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+        type: string
+      kind:
+        description: 'Kind is a string value representing the REST resource this object
+          represents. Servers may infer this from the endpoint the client submits
+          requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+        type: string
+      metadata:
+        type: object
+      spec:
+        description: 'Spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+        properties:
+          defaultBackend:
+            description: DefaultBackend is the backend that should handle requests
+              that don't match any rule. If Rules are not specified, DefaultBackend
+              must be specified. If DefaultBackend is not set, the handling of requests
+              that do not match any of the rules will be up to the Ingress controller.
+            properties:
+              resource:
+                description: Resource is an ObjectRef to another Kubernetes resource
+                  in the namespace of the Ingress object. If resource is specified,
+                  a service.Name and service.Port must not be specified. This is a
+                  mutually exclusive setting with "Service".
+                properties:
+                  apiGroup:
+                    description: APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in
+                      the core API group. For any other third-party types, APIGroup
+                      is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              service:
+                description: Service references a Service as a Backend. This is a
+                  mutually exclusive setting with "Resource".
+                properties:
+                  name:
+                    description: Name is the referenced service. The service must
+                      exist in the same namespace as the Ingress object.
+                    type: string
+                  port:
+                    description: Port of the referenced service. A port name or port
+                      number is required for a IngressServiceBackend.
+                    properties:
+                      name:
+                        description: Name is the name of the port on the Service.
+                          This is a mutually exclusive setting with "Number".
+                        type: string
+                      number:
+                        description: Number is the numerical port number (e.g. 80)
+                          on the Service. This is a mutually exclusive setting with
+                          "Name".
+                        format: int32
+                        type: integer
+                    type: object
+                required:
+                - name
+                type: object
+            type: object
+          ingressClassName:
+            description: IngressClassName is the name of an IngressClass cluster resource.
+              Ingress controller implementations use this field to know whether they
+              should be serving this Ingress resource, by a transitive connection
+              (controller -> IngressClass -> Ingress resource). Although the `kubernetes.io/ingress.class`
+              annotation (simple constant name) was never formally defined, it was
+              widely supported by Ingress controllers to create a direct binding between
+              Ingress controller and Ingress resources. Newly created Ingress resources
+              should prefer using the field. However, even though the annotation is
+              officially deprecated, for backwards compatibility reasons, ingress
+              controllers should still honor that annotation if present.
+            type: string
+          rules:
+            description: A list of host rules used to configure the Ingress. If unspecified,
+              or no rule matches, all traffic is sent to the default backend.
+            items:
+              description: IngressRule represents the rules mapping the paths under
+                a specified host to the related backend services. Incoming requests
+                are first evaluated for a host match, then routed to the backend associated
+                with the matching IngressRuleValue.
+              properties:
+                host:
+                  description: "Host is the fully qualified domain name of a network
+                    host, as defined by RFC 3986. Note the following deviations from
+                    the \"host\" part of the URI as defined in RFC 3986: 1. IPs are
+                    not allowed. Currently an IngressRuleValue can only apply to\n
+                    \  the IP in the Spec of the parent Ingress.\n2. The `:` delimiter
+                    is not respected because ports are not allowed.\n\t  Currently
+                    the port of an Ingress is implicitly :80 for http and\n\t  :443
+                    for https.\nBoth these may change in the future. Incoming requests
+                    are matched against the host before the IngressRuleValue. If the
+                    host is unspecified, the Ingress routes all traffic based on the
+                    specified IngressRuleValue.\n\nHost can be \"precise\" which is
+                    a domain name without the terminating dot of a network host (e.g.
+                    \"foo.bar.com\") or \"wildcard\", which is a domain name prefixed
+                    with a single wildcard label (e.g. \"*.foo.com\"). The wildcard
+                    character '*' must appear by itself as the first DNS label and
+                    matches only a single label. You cannot have a wildcard label
+                    by itself (e.g. Host == \"*\"). Requests will be matched against
+                    the Host field in the following way: 1. If Host is precise, the
+                    request matches this rule if the http host header is equal to
+                    Host. 2. If Host is a wildcard, then the request matches this
+                    rule if the http host header is to equal to the suffix (removing
+                    the first label) of the wildcard rule."
+                  type: string
+                http:
+                  description: 'HTTPIngressRuleValue is a list of http selectors pointing
+                    to backends. In the example: http://<host>/<path>?<searchpart>
+                    -> backend where where parts of the url correspond to RFC 3986,
+                    this resource will be used to match against everything after the
+                    last ''/'' and before the first ''?'' or ''#''.'
+                  properties:
+                    paths:
+                      description: A collection of paths that map requests to backends.
+                      items:
+                        description: HTTPIngressPath associates a path with a backend.
+                          Incoming urls matching the path are forwarded to the backend.
+                        properties:
+                          backend:
+                            description: Backend defines the referenced service endpoint
+                              to which the traffic will be forwarded to.
+                            properties:
+                              resource:
+                                description: Resource is an ObjectRef to another Kubernetes
+                                  resource in the namespace of the Ingress object.
+                                  If resource is specified, a service.Name and service.Port
+                                  must not be specified. This is a mutually exclusive
+                                  setting with "Service".
+                                properties:
+                                  apiGroup:
+                                    description: APIGroup is the group for the resource
+                                      being referenced. If APIGroup is not specified,
+                                      the specified Kind must be in the core API group.
+                                      For any other third-party types, APIGroup is
+                                      required.
+                                    type: string
+                                  kind:
+                                    description: Kind is the type of resource being
+                                      referenced
+                                    type: string
+                                  name:
+                                    description: Name is the name of resource being
+                                      referenced
+                                    type: string
+                                required:
+                                - kind
+                                - name
+                                type: object
+                              service:
+                                description: Service references a Service as a Backend.
+                                  This is a mutually exclusive setting with "Resource".
+                                properties:
+                                  name:
+                                    description: Name is the referenced service. The
+                                      service must exist in the same namespace as
+                                      the Ingress object.
+                                    type: string
+                                  port:
+                                    description: Port of the referenced service. A
+                                      port name or port number is required for a IngressServiceBackend.
+                                    properties:
+                                      name:
+                                        description: Name is the name of the port
+                                          on the Service. This is a mutually exclusive
+                                          setting with "Number".
+                                        type: string
+                                      number:
+                                        description: Number is the numerical port
+                                          number (e.g. 80) on the Service. This is
+                                          a mutually exclusive setting with "Name".
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                            type: object
+                          path:
+                            description: Path is matched against the path of an incoming
+                              request. Currently it can contain characters disallowed
+                              from the conventional "path" part of a URL as defined
+                              by RFC 3986. Paths must begin with a '/' and must be
+                              present when using PathType with value "Exact" or "Prefix".
+                            type: string
+                          pathType:
+                            description: |-
+                              PathType determines the interpretation of the Path matching. PathType can be one of the following values: * Exact: Matches the URL path exactly. * Prefix: Matches based on a URL path prefix split by '/'. Matching is
+                                done on a path element by element basis. A path element refers is the
+                                list of labels in the path split by the '/' separator. A request is a
+                                match for path p if every p is an element-wise prefix of p of the
+                                request path. Note that if the last element of the path is a substring
+                                of the last element in request path, it is not a match (e.g. /foo/bar
+                                matches /foo/bar/baz, but does not match /foo/barbaz).
+                              * ImplementationSpecific: Interpretation of the Path matching is up to
+                                the IngressClass. Implementations can treat this as a separate PathType
+                                or treat it identically to Prefix or Exact path types.
+                              Implementations are required to support all path types.
+                            type: string
+                        required:
+                        - pathType
+                        - backend
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  required:
+                  - paths
+                  type: object
+              type: object
+            type: array
+            x-kubernetes-list-type: atomic
+          tls:
+            description: TLS configuration. Currently the Ingress only supports a
+              single TLS port, 443. If multiple members of this list specify different
+              hosts, they will be multiplexed on the same port according to the hostname
+              specified through the SNI TLS extension, if the ingress controller fulfilling
+              the ingress supports SNI.
+            items:
+              description: IngressTLS describes the transport layer security associated
+                with an Ingress.
+              properties:
+                hosts:
+                  description: Hosts are a list of hosts included in the TLS certificate.
+                    The values in this list must match the name/s used in the tlsSecret.
+                    Defaults to the wildcard host setting for the loadbalancer controller
+                    fulfilling this Ingress, if left unspecified.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: atomic
+                secretName:
+                  description: SecretName is the name of the secret used to terminate
+                    TLS traffic on port 443. Field is left optional to allow TLS routing
+                    based on SNI hostname alone. If the SNI host in a listener conflicts
+                    with the "Host" header field used by an IngressRule, the SNI host
+                    is used for termination and value of the Host header is used for
+                    routing.
+                  type: string
+              type: object
+            type: array
+            x-kubernetes-list-type: atomic
+        type: object
+      status:
+        description: 'Status is the current state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+        properties:
+          loadBalancer:
+            description: LoadBalancer contains the current status of the load-balancer.
+            properties:
+              ingress:
+                description: Ingress is a list containing ingress points for the load-balancer.
+                  Traffic intended for the service should be sent to these ingress
+                  points.
+                items:
+                  description: 'LoadBalancerIngress represents the status of a load-balancer
+                    ingress point: traffic intended for the service should be sent
+                    to an ingress point.'
+                  properties:
+                    hostname:
+                      description: Hostname is set for load-balancer ingress points
+                        that are DNS based (typically AWS load-balancers)
+                      type: string
+                    ip:
+                      description: IP is set for load-balancer ingress points that
+                        are IP based (typically GCE or OpenStack load-balancers)
+                      type: string
+                    ports:
+                      description: Ports is a list of records of service ports If
+                        used, every port defined in the service should have an entry
+                        in it
+                      items:
+                        properties:
+                          error:
+                            description: |-
+                              Error is to record the problem with the service port The format of the error shall comply with the following rules: - built-in error values shall be specified in this file and those shall use
+                                CamelCase names
+                              - cloud provider specific error values must have names that comply with the
+                                format foo.example.com/CamelCase.
+                            type: string
+                          port:
+                            description: Port is the port number of the service port
+                              of which status is recorded here
+                            format: int32
+                            type: integer
+                          protocol:
+                            description: |-
+                              Protocol is the protocol of the service port of which status is recorded here The supported values are: "TCP", "UDP", "SCTP"
+
+                              Possible enum values:
+                               - `"SCTP"` is the SCTP protocol.
+                               - `"TCP"` is the TCP protocol.
+                               - `"UDP"` is the UDP protocol.
+                            type: string
+                        required:
+                        - port
+                        - protocol
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  type: object
+                type: array
+            type: object
+        type: object
+    type: object
+  plural: ingresses
+  schemaUpdateStrategy: UpdateUnpublished
+  scope: Namespaced
+  shortNames:
+  - ing
+  singular: ingress
+  subResources:
+  - name: status
+status:
+  conditions:
+  - lastTransitionTime: "2023-03-21T17:10:10Z"
+    status: "True"
+    type: Compatible

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/3-APIResourceImport-pods.kind.v1.core.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/3-APIResourceImport-pods.kind.v1.core.yaml
@@ -1,0 +1,7105 @@
+apiVersion: apiresource.kcp.io/v1alpha1
+kind: APIResourceImport
+metadata:
+  annotations:
+    apiresource.kcp.io/apiVersion: v1
+    kcp.io/cluster: br3qimk2t1o3jb70
+  creationTimestamp: "2023-03-21T17:10:09Z"
+  generation: 1
+  name: pods.kind.v1.core
+  ownerReferences:
+  - apiVersion: workload.kcp.io/v1alpha1
+    controller: true
+    kind: SyncTarget
+    name: kind
+    uid: 8df305e7-f4f8-439f-9115-51054d519361
+  resourceVersion: "9156"
+  uid: ae3bc872-30e7-4abf-9501-93142a390803
+spec:
+  categories:
+  - all
+  groupVersion:
+    version: v1
+  kind: Pod
+  listKind: PodList
+  location: kind
+  openAPIV3Schema:
+    description: Pod is a collection of containers that can run on a host. This resource
+      is created by clients and scheduled onto hosts.
+    properties:
+      apiVersion:
+        description: 'APIVersion defines the versioned schema of this representation
+          of an object. Servers should convert recognized schemas to the latest internal
+          value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+        type: string
+      kind:
+        description: 'Kind is a string value representing the REST resource this object
+          represents. Servers may infer this from the endpoint the client submits
+          requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+        type: string
+      metadata:
+        type: object
+      spec:
+        description: 'Specification of the desired behavior of the pod. More info:
+          https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+        properties:
+          activeDeadlineSeconds:
+            description: Optional duration in seconds the pod may be active on the
+              node relative to StartTime before the system will actively try to mark
+              it failed and kill associated containers. Value must be a positive integer.
+            format: int64
+            type: integer
+          affinity:
+            description: If specified, the pod's scheduling constraints
+            properties:
+              nodeAffinity:
+                description: Describes node affinity scheduling rules for the pod.
+                properties:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    description: The scheduler will prefer to schedule pods to nodes
+                      that satisfy the affinity expressions specified by this field,
+                      but it may choose a node that violates one or more of the expressions.
+                      The node that is most preferred is the one with the greatest
+                      sum of weights, i.e. for each node that meets all of the scheduling
+                      requirements (resource request, requiredDuringScheduling affinity
+                      expressions, etc.), compute a sum by iterating through the elements
+                      of this field and adding "weight" to the sum if the node matches
+                      the corresponding matchExpressions; the node(s) with the highest
+                      sum are the most preferred.
+                    items:
+                      description: An empty preferred scheduling term matches all
+                        objects with implicit weight 0 (i.e. it's a no-op). A null
+                        preferred scheduling term matches no objects (i.e. is also
+                        a no-op).
+                      properties:
+                        preference:
+                          description: A node selector term, associated with the corresponding
+                            weight.
+                          properties:
+                            matchExpressions:
+                              description: A list of node selector requirements by
+                                node's labels.
+                              items:
+                                description: A node selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: The label key that the selector applies
+                                      to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                      Possible enum values:
+                                       - `"DoesNotExist"`
+                                       - `"Exists"`
+                                       - `"Gt"`
+                                       - `"In"`
+                                       - `"Lt"`
+                                       - `"NotIn"`
+                                    type: string
+                                  values:
+                                    description: An array of string values. If the
+                                      operator is In or NotIn, the values array must
+                                      be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator
+                                      is Gt or Lt, the values array must have a single
+                                      element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchFields:
+                              description: A list of node selector requirements by
+                                node's fields.
+                              items:
+                                description: A node selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: The label key that the selector applies
+                                      to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                      Possible enum values:
+                                       - `"DoesNotExist"`
+                                       - `"Exists"`
+                                       - `"Gt"`
+                                       - `"In"`
+                                       - `"Lt"`
+                                       - `"NotIn"`
+                                    type: string
+                                  values:
+                                    description: An array of string values. If the
+                                      operator is In or NotIn, the values array must
+                                      be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator
+                                      is Gt or Lt, the values array must have a single
+                                      element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                          type: object
+                        weight:
+                          description: Weight associated with matching the corresponding
+                            nodeSelectorTerm, in the range 1-100.
+                          format: int32
+                          type: integer
+                      required:
+                      - weight
+                      - preference
+                      type: object
+                    type: array
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    description: If the affinity requirements specified by this field
+                      are not met at scheduling time, the pod will not be scheduled
+                      onto the node. If the affinity requirements specified by this
+                      field cease to be met at some point during pod execution (e.g.
+                      due to an update), the system may or may not try to eventually
+                      evict the pod from its node.
+                    properties:
+                      nodeSelectorTerms:
+                        description: Required. A list of node selector terms. The
+                          terms are ORed.
+                        items:
+                          description: A null or empty node selector term matches
+                            no objects. The requirements of them are ANDed. The TopologySelectorTerm
+                            type implements a subset of the NodeSelectorTerm.
+                          properties:
+                            matchExpressions:
+                              description: A list of node selector requirements by
+                                node's labels.
+                              items:
+                                description: A node selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: The label key that the selector applies
+                                      to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                      Possible enum values:
+                                       - `"DoesNotExist"`
+                                       - `"Exists"`
+                                       - `"Gt"`
+                                       - `"In"`
+                                       - `"Lt"`
+                                       - `"NotIn"`
+                                    type: string
+                                  values:
+                                    description: An array of string values. If the
+                                      operator is In or NotIn, the values array must
+                                      be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator
+                                      is Gt or Lt, the values array must have a single
+                                      element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchFields:
+                              description: A list of node selector requirements by
+                                node's fields.
+                              items:
+                                description: A node selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: The label key that the selector applies
+                                      to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                      Possible enum values:
+                                       - `"DoesNotExist"`
+                                       - `"Exists"`
+                                       - `"Gt"`
+                                       - `"In"`
+                                       - `"Lt"`
+                                       - `"NotIn"`
+                                    type: string
+                                  values:
+                                    description: An array of string values. If the
+                                      operator is In or NotIn, the values array must
+                                      be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator
+                                      is Gt or Lt, the values array must have a single
+                                      element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                          type: object
+                        type: array
+                    required:
+                    - nodeSelectorTerms
+                    type: object
+                type: object
+              podAffinity:
+                description: Describes pod affinity scheduling rules (e.g. co-locate
+                  this pod in the same node, zone, etc. as some other pod(s)).
+                properties:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    description: The scheduler will prefer to schedule pods to nodes
+                      that satisfy the affinity expressions specified by this field,
+                      but it may choose a node that violates one or more of the expressions.
+                      The node that is most preferred is the one with the greatest
+                      sum of weights, i.e. for each node that meets all of the scheduling
+                      requirements (resource request, requiredDuringScheduling affinity
+                      expressions, etc.), compute a sum by iterating through the elements
+                      of this field and adding "weight" to the sum if the node has
+                      pods which matches the corresponding podAffinityTerm; the node(s)
+                      with the highest sum are the most preferred.
+                    items:
+                      description: The weights of all of the matched WeightedPodAffinityTerm
+                        fields are added per-node to find the most preferred node(s)
+                      properties:
+                        podAffinityTerm:
+                          description: Required. A pod affinity term, associated with
+                            the corresponding weight.
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field. null selector
+                                and null or empty namespaces list means "this pod's
+                                namespace". An empty selector ({}) matches all namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector. null or
+                                empty namespaces list and null namespaceSelector means
+                                "this pod's namespace".
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        weight:
+                          description: weight associated with matching the corresponding
+                            podAffinityTerm, in the range 1-100.
+                          format: int32
+                          type: integer
+                      required:
+                      - weight
+                      - podAffinityTerm
+                      type: object
+                    type: array
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    description: If the affinity requirements specified by this field
+                      are not met at scheduling time, the pod will not be scheduled
+                      onto the node. If the affinity requirements specified by this
+                      field cease to be met at some point during pod execution (e.g.
+                      due to a pod label update), the system may or may not try to
+                      eventually evict the pod from its node. When there are multiple
+                      elements, the lists of nodes corresponding to each podAffinityTerm
+                      are intersected, i.e. all terms must be satisfied.
+                    items:
+                      description: Defines a set of pods (namely those matching the
+                        labelSelector relative to the given namespace(s)) that this
+                        pod should be co-located (affinity) or not co-located (anti-affinity)
+                        with, where co-located is defined as running on a node whose
+                        value of the label with key <topologyKey> matches that of
+                        any node on which a pod of the set of pods is running
+                      properties:
+                        labelSelector:
+                          description: A label query over a set of resources, in this
+                            case pods.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        namespaceSelector:
+                          description: A label query over the set of namespaces that
+                            the term applies to. The term is applied to the union
+                            of the namespaces selected by this field and the ones
+                            listed in the namespaces field. null selector and null
+                            or empty namespaces list means "this pod's namespace".
+                            An empty selector ({}) matches all namespaces.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        namespaces:
+                          description: namespaces specifies a static list of namespace
+                            names that the term applies to. The term is applied to
+                            the union of the namespaces listed in this field and the
+                            ones selected by namespaceSelector. null or empty namespaces
+                            list and null namespaceSelector means "this pod's namespace".
+                          items:
+                            type: string
+                          type: array
+                        topologyKey:
+                          description: This pod should be co-located (affinity) or
+                            not co-located (anti-affinity) with the pods matching
+                            the labelSelector in the specified namespaces, where co-located
+                            is defined as running on a node whose value of the label
+                            with key topologyKey matches that of any node on which
+                            any of the selected pods is running. Empty topologyKey
+                            is not allowed.
+                          type: string
+                      required:
+                      - topologyKey
+                      type: object
+                    type: array
+                type: object
+              podAntiAffinity:
+                description: Describes pod anti-affinity scheduling rules (e.g. avoid
+                  putting this pod in the same node, zone, etc. as some other pod(s)).
+                properties:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    description: The scheduler will prefer to schedule pods to nodes
+                      that satisfy the anti-affinity expressions specified by this
+                      field, but it may choose a node that violates one or more of
+                      the expressions. The node that is most preferred is the one
+                      with the greatest sum of weights, i.e. for each node that meets
+                      all of the scheduling requirements (resource request, requiredDuringScheduling
+                      anti-affinity expressions, etc.), compute a sum by iterating
+                      through the elements of this field and adding "weight" to the
+                      sum if the node has pods which matches the corresponding podAffinityTerm;
+                      the node(s) with the highest sum are the most preferred.
+                    items:
+                      description: The weights of all of the matched WeightedPodAffinityTerm
+                        fields are added per-node to find the most preferred node(s)
+                      properties:
+                        podAffinityTerm:
+                          description: Required. A pod affinity term, associated with
+                            the corresponding weight.
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field. null selector
+                                and null or empty namespaces list means "this pod's
+                                namespace". An empty selector ({}) matches all namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector. null or
+                                empty namespaces list and null namespaceSelector means
+                                "this pod's namespace".
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        weight:
+                          description: weight associated with matching the corresponding
+                            podAffinityTerm, in the range 1-100.
+                          format: int32
+                          type: integer
+                      required:
+                      - weight
+                      - podAffinityTerm
+                      type: object
+                    type: array
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    description: If the anti-affinity requirements specified by this
+                      field are not met at scheduling time, the pod will not be scheduled
+                      onto the node. If the anti-affinity requirements specified by
+                      this field cease to be met at some point during pod execution
+                      (e.g. due to a pod label update), the system may or may not
+                      try to eventually evict the pod from its node. When there are
+                      multiple elements, the lists of nodes corresponding to each
+                      podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                    items:
+                      description: Defines a set of pods (namely those matching the
+                        labelSelector relative to the given namespace(s)) that this
+                        pod should be co-located (affinity) or not co-located (anti-affinity)
+                        with, where co-located is defined as running on a node whose
+                        value of the label with key <topologyKey> matches that of
+                        any node on which a pod of the set of pods is running
+                      properties:
+                        labelSelector:
+                          description: A label query over a set of resources, in this
+                            case pods.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        namespaceSelector:
+                          description: A label query over the set of namespaces that
+                            the term applies to. The term is applied to the union
+                            of the namespaces selected by this field and the ones
+                            listed in the namespaces field. null selector and null
+                            or empty namespaces list means "this pod's namespace".
+                            An empty selector ({}) matches all namespaces.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        namespaces:
+                          description: namespaces specifies a static list of namespace
+                            names that the term applies to. The term is applied to
+                            the union of the namespaces listed in this field and the
+                            ones selected by namespaceSelector. null or empty namespaces
+                            list and null namespaceSelector means "this pod's namespace".
+                          items:
+                            type: string
+                          type: array
+                        topologyKey:
+                          description: This pod should be co-located (affinity) or
+                            not co-located (anti-affinity) with the pods matching
+                            the labelSelector in the specified namespaces, where co-located
+                            is defined as running on a node whose value of the label
+                            with key topologyKey matches that of any node on which
+                            any of the selected pods is running. Empty topologyKey
+                            is not allowed.
+                          type: string
+                      required:
+                      - topologyKey
+                      type: object
+                    type: array
+                type: object
+            type: object
+          automountServiceAccountToken:
+            description: AutomountServiceAccountToken indicates whether a service
+              account token should be automatically mounted.
+            type: boolean
+          containers:
+            description: List of containers belonging to the pod. Containers cannot
+              currently be added or removed. There must be at least one container
+              in a Pod. Cannot be updated.
+            items:
+              description: A single application container that you want to run within
+                a pod.
+              properties:
+                args:
+                  description: 'Arguments to the entrypoint. The container image''s
+                    CMD is used if this is not provided. Variable references $(VAR_NAME)
+                    are expanded using the container''s environment. If a variable
+                    cannot be resolved, the reference in the input string will be
+                    unchanged. Double $$ are reduced to a single $, which allows for
+                    escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                    the string literal "$(VAR_NAME)". Escaped references will never
+                    be expanded, regardless of whether the variable exists or not.
+                    Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                command:
+                  description: 'Entrypoint array. Not executed within a shell. The
+                    container image''s ENTRYPOINT is used if this is not provided.
+                    Variable references $(VAR_NAME) are expanded using the container''s
+                    environment. If a variable cannot be resolved, the reference in
+                    the input string will be unchanged. Double $$ are reduced to a
+                    single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                    Escaped references will never be expanded, regardless of whether
+                    the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                env:
+                  description: List of environment variables to set in the container.
+                    Cannot be updated.
+                  items:
+                    description: EnvVar represents an environment variable present
+                      in a Container.
+                    properties:
+                      name:
+                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        type: string
+                      value:
+                        description: 'Variable references $(VAR_NAME) are expanded
+                          using the previously defined environment variables in the
+                          container and any service environment variables. If a variable
+                          cannot be resolved, the reference in the input string will
+                          be unchanged. Double $$ are reduced to a single $, which
+                          allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                          will produce the string literal "$(VAR_NAME)". Escaped references
+                          will never be expanded, regardless of whether the variable
+                          exists or not. Defaults to "".'
+                        type: string
+                      valueFrom:
+                        description: Source for the environment variable's value.
+                          Cannot be used if value is not empty.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          fieldRef:
+                            description: 'Selects a field of the pod: supports metadata.name,
+                              metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                              spec.nodeName, spec.serviceAccountName, status.hostIP,
+                              status.podIP, status.podIPs.'
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                            - fieldPath
+                            type: object
+                          resourceFieldRef:
+                            description: 'Selects a resource of the container: only
+                              resources limits and requests (limits.cpu, limits.memory,
+                              limits.ephemeral-storage, requests.cpu, requests.memory
+                              and requests.ephemeral-storage) are currently supported.'
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Specifies the output format of the exposed
+                                  resources, defaults to "1"
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                            - resource
+                            type: object
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - name
+                  x-kubernetes-list-type: map
+                envFrom:
+                  description: List of sources to populate environment variables in
+                    the container. The keys defined within a source must be a C_IDENTIFIER.
+                    All invalid keys will be reported as an event when the container
+                    is starting. When a key exists in multiple sources, the value
+                    associated with the last source will take precedence. Values defined
+                    by an Env with a duplicate key will take precedence. Cannot be
+                    updated.
+                  items:
+                    description: EnvFromSource represents the source of a set of ConfigMaps
+                    properties:
+                      configMapRef:
+                        description: The ConfigMap to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the ConfigMap must be defined
+                            type: boolean
+                        type: object
+                      prefix:
+                        description: An optional identifier to prepend to each key
+                          in the ConfigMap. Must be a C_IDENTIFIER.
+                        type: string
+                      secretRef:
+                        description: The Secret to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret must be defined
+                            type: boolean
+                        type: object
+                    type: object
+                  type: array
+                image:
+                  description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                    This field is optional to allow higher level config management
+                    to default or override container images in workload controllers
+                    like Deployments and StatefulSets.'
+                  type: string
+                imagePullPolicy:
+                  description: |-
+                    Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                    Possible enum values:
+                     - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                     - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                     - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                  type: string
+                lifecycle:
+                  description: Actions that the management system should take in response
+                    to container lifecycle events. Cannot be updated.
+                  properties:
+                    postStart:
+                      description: 'PostStart is called immediately after a container
+                        is created. If the handler fails, the container is terminated
+                        and restarted according to its restart policy. Other management
+                        of the container blocks until the hook completes. More info:
+                        https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: |-
+                                Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                Possible enum values:
+                                 - `"HTTP"` means that the scheme used will be http://
+                                 - `"HTTPS"` means that the scheme used will be https://
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: Deprecated. TCPSocket is NOT supported as a
+                            LifecycleHandler and kept for the backward compatibility.
+                            There are no validation of this field and lifecycle hooks
+                            will fail in runtime when tcp handler is specified.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                    preStop:
+                      description: 'PreStop is called immediately before a container
+                        is terminated due to an API request or management event such
+                        as liveness/startup probe failure, preemption, resource contention,
+                        etc. The handler is not called if the container crashes or
+                        exits. The Pod''s termination grace period countdown begins
+                        before the PreStop hook is executed. Regardless of the outcome
+                        of the handler, the container will eventually terminate within
+                        the Pod''s termination grace period (unless delayed by finalizers).
+                        Other management of the container blocks until the hook completes
+                        or until the termination grace period is reached. More info:
+                        https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: |-
+                                Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                Possible enum values:
+                                 - `"HTTP"` means that the scheme used will be http://
+                                 - `"HTTPS"` means that the scheme used will be https://
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: Deprecated. TCPSocket is NOT supported as a
+                            LifecycleHandler and kept for the backward compatibility.
+                            There are no validation of this field and lifecycle hooks
+                            will fail in runtime when tcp handler is specified.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                  type: object
+                livenessProbe:
+                  description: 'Periodic probe of container liveness. Container will
+                    be restarted if the probe fails. Cannot be updated. More info:
+                    https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                name:
+                  description: Name of the container specified as a DNS_LABEL. Each
+                    container in a pod must have a unique name (DNS_LABEL). Cannot
+                    be updated.
+                  type: string
+                ports:
+                  description: List of ports to expose from the container. Not specifying
+                    a port here DOES NOT prevent that port from being exposed. Any
+                    port which is listening on the default "0.0.0.0" address inside
+                    a container will be accessible from the network. Modifying this
+                    array with strategic merge patch may corrupt the data. For more
+                    information See https://github.com/kubernetes/kubernetes/issues/108255.
+                    Cannot be updated.
+                  items:
+                    description: ContainerPort represents a network port in a single
+                      container.
+                    properties:
+                      containerPort:
+                        description: Number of port to expose on the pod's IP address.
+                          This must be a valid port number, 0 < x < 65536.
+                        format: int32
+                        type: integer
+                      hostIP:
+                        description: What host IP to bind the external port to.
+                        type: string
+                      hostPort:
+                        description: Number of port to expose on the host. If specified,
+                          this must be a valid port number, 0 < x < 65536. If HostNetwork
+                          is specified, this must match ContainerPort. Most containers
+                          do not need this.
+                        format: int32
+                        type: integer
+                      name:
+                        description: If specified, this must be an IANA_SVC_NAME and
+                          unique within the pod. Each named port in a pod must have
+                          a unique name. Name for the port that can be referred to
+                          by services.
+                        type: string
+                      protocol:
+                        default: TCP
+                        description: |-
+                          Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                          Possible enum values:
+                           - `"SCTP"` is the SCTP protocol.
+                           - `"TCP"` is the TCP protocol.
+                           - `"UDP"` is the UDP protocol.
+                        type: string
+                    required:
+                    - containerPort
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - containerPort
+                  - protocol
+                  x-kubernetes-list-type: map
+                readinessProbe:
+                  description: 'Periodic probe of container service readiness. Container
+                    will be removed from service endpoints if the probe fails. Cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                resources:
+                  description: 'Compute Resources required by this container. Cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                  type: object
+                securityContext:
+                  description: 'SecurityContext defines the security options the container
+                    should be run with. If set, the fields of SecurityContext override
+                    the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                  properties:
+                    allowPrivilegeEscalation:
+                      description: 'AllowPrivilegeEscalation controls whether a process
+                        can gain more privileges than its parent process. This bool
+                        directly controls if the no_new_privs flag will be set on
+                        the container process. AllowPrivilegeEscalation is true always
+                        when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
+                        Note that this field cannot be set when spec.os.name is windows.'
+                      type: boolean
+                    capabilities:
+                      description: The capabilities to add/drop when running containers.
+                        Defaults to the default set of capabilities granted by the
+                        container runtime. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      properties:
+                        add:
+                          description: Added capabilities
+                          items:
+                            type: string
+                          type: array
+                        drop:
+                          description: Removed capabilities
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    privileged:
+                      description: Run container in privileged mode. Processes in
+                        privileged containers are essentially equivalent to root on
+                        the host. Defaults to false. Note that this field cannot be
+                        set when spec.os.name is windows.
+                      type: boolean
+                    procMount:
+                      description: procMount denotes the type of proc mount to use
+                        for the containers. The default is DefaultProcMount which
+                        uses the container runtime defaults for readonly paths and
+                        masked paths. This requires the ProcMountType feature flag
+                        to be enabled. Note that this field cannot be set when spec.os.name
+                        is windows.
+                      type: string
+                    readOnlyRootFilesystem:
+                      description: Whether this container has a read-only root filesystem.
+                        Default is false. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      type: boolean
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container
+                        process. Uses runtime default if unset. May also be set in
+                        PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence. Note
+                        that this field cannot be set when spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to
+                        start the container if it does. If unset or false, no such
+                        validation will be performed. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container
+                        process. Defaults to user specified in image metadata if unspecified.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: The SELinux context to be applied to the container.
+                        If unspecified, the container runtime will allocate a random
+                        SELinux context for each container.  May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence. Note that this
+                        field cannot be set when spec.os.name is windows.
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
+                      type: object
+                    seccompProfile:
+                      description: The seccomp options to use by this container. If
+                        seccomp options are provided at both the pod & container level,
+                        the container options override the pod options. Note that
+                        this field cannot be set when spec.os.name is windows.
+                      properties:
+                        localhostProfile:
+                          description: localhostProfile indicates a profile defined
+                            in a file on the node should be used. The profile must
+                            be preconfigured on the node to work. Must be a descending
+                            path, relative to the kubelet's configured seccomp profile
+                            location. Must only be set if type is "Localhost".
+                          type: string
+                        type:
+                          description: |-
+                            type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                            Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                            Possible enum values:
+                             - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                             - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                             - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    windowsOptions:
+                      description: The Windows specific settings applied to all containers.
+                        If unspecified, the options from the PodSecurityContext will
+                        be used. If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence. Note
+                        that this field cannot be set when spec.os.name is linux.
+                      properties:
+                        gmsaCredentialSpec:
+                          description: GMSACredentialSpec is where the GMSA admission
+                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                            inlines the contents of the GMSA credential spec named
+                            by the GMSACredentialSpecName field.
+                          type: string
+                        gmsaCredentialSpecName:
+                          description: GMSACredentialSpecName is the name of the GMSA
+                            credential spec to use.
+                          type: string
+                        hostProcess:
+                          description: HostProcess determines if a container should
+                            be run as a 'Host Process' container. This field is alpha-level
+                            and will only be honored by components that enable the
+                            WindowsHostProcessContainers feature flag. Setting this
+                            field without the feature flag will result in errors when
+                            validating the Pod. All of a Pod's containers must have
+                            the same effective HostProcess value (it is not allowed
+                            to have a mix of HostProcess containers and non-HostProcess
+                            containers).  In addition, if HostProcess is true then
+                            HostNetwork must also be set to true.
+                          type: boolean
+                        runAsUserName:
+                          description: The UserName in Windows to run the entrypoint
+                            of the container process. Defaults to the user specified
+                            in image metadata if unspecified. May also be set in PodSecurityContext.
+                            If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence.
+                          type: string
+                      type: object
+                  type: object
+                startupProbe:
+                  description: 'StartupProbe indicates that the Pod has successfully
+                    initialized. If specified, no other probes are executed until
+                    this completes successfully. If this probe fails, the Pod will
+                    be restarted, just as if the livenessProbe failed. This can be
+                    used to provide different probe parameters at the beginning of
+                    a Pod''s lifecycle, when it might take a long time to load data
+                    or warm a cache, than during steady-state operation. This cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                stdin:
+                  description: Whether this container should allocate a buffer for
+                    stdin in the container runtime. If this is not set, reads from
+                    stdin in the container will always result in EOF. Default is false.
+                  type: boolean
+                stdinOnce:
+                  description: Whether the container runtime should close the stdin
+                    channel after it has been opened by a single attach. When stdin
+                    is true the stdin stream will remain open across multiple attach
+                    sessions. If stdinOnce is set to true, stdin is opened on container
+                    start, is empty until the first client attaches to stdin, and
+                    then remains open and accepts data until the client disconnects,
+                    at which time stdin is closed and remains closed until the container
+                    is restarted. If this flag is false, a container processes that
+                    reads from stdin will never receive an EOF. Default is false
+                  type: boolean
+                terminationMessagePath:
+                  description: 'Optional: Path at which the file to which the container''s
+                    termination message will be written is mounted into the container''s
+                    filesystem. Message written is intended to be brief final status,
+                    such as an assertion failure message. Will be truncated by the
+                    node if greater than 4096 bytes. The total message length across
+                    all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                    Cannot be updated.'
+                  type: string
+                terminationMessagePolicy:
+                  description: |-
+                    Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                    Possible enum values:
+                     - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                     - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                  type: string
+                tty:
+                  description: Whether this container should allocate a TTY for itself,
+                    also requires 'stdin' to be true. Default is false.
+                  type: boolean
+                volumeDevices:
+                  description: volumeDevices is the list of block devices to be used
+                    by the container.
+                  items:
+                    description: volumeDevice describes a mapping of a raw block device
+                      within a container.
+                    properties:
+                      devicePath:
+                        description: devicePath is the path inside of the container
+                          that the device will be mapped to.
+                        type: string
+                      name:
+                        description: name must match the name of a persistentVolumeClaim
+                          in the pod
+                        type: string
+                    required:
+                    - devicePath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - devicePath
+                  x-kubernetes-list-type: map
+                volumeMounts:
+                  description: Pod volumes to mount into the container's filesystem.
+                    Cannot be updated.
+                  items:
+                    description: VolumeMount describes a mounting of a Volume within
+                      a container.
+                    properties:
+                      mountPath:
+                        description: Path within the container at which the volume
+                          should be mounted.  Must not contain ':'.
+                        type: string
+                      mountPropagation:
+                        description: mountPropagation determines how mounts are propagated
+                          from the host to container and the other way around. When
+                          not set, MountPropagationNone is used. This field is beta
+                          in 1.10.
+                        type: string
+                      name:
+                        description: This must match the Name of a Volume.
+                        type: string
+                      readOnly:
+                        description: Mounted read-only if true, read-write otherwise
+                          (false or unspecified). Defaults to false.
+                        type: boolean
+                      subPath:
+                        description: Path within the volume from which the container's
+                          volume should be mounted. Defaults to "" (volume's root).
+                        type: string
+                      subPathExpr:
+                        description: Expanded path within the volume from which the
+                          container's volume should be mounted. Behaves similarly
+                          to SubPath but environment variable references $(VAR_NAME)
+                          are expanded using the container's environment. Defaults
+                          to "" (volume's root). SubPathExpr and SubPath are mutually
+                          exclusive.
+                        type: string
+                    required:
+                    - mountPath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - mountPath
+                  x-kubernetes-list-type: map
+                workingDir:
+                  description: Container's working directory. If not specified, the
+                    container runtime's default will be used, which might be configured
+                    in the container image. Cannot be updated.
+                  type: string
+              required:
+              - name
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - name
+            x-kubernetes-list-type: map
+          dnsConfig:
+            description: Specifies the DNS parameters of a pod. Parameters specified
+              here will be merged to the generated DNS configuration based on DNSPolicy.
+            properties:
+              nameservers:
+                description: A list of DNS name server IP addresses. This will be
+                  appended to the base nameservers generated from DNSPolicy. Duplicated
+                  nameservers will be removed.
+                items:
+                  type: string
+                type: array
+              options:
+                description: A list of DNS resolver options. This will be merged with
+                  the base options generated from DNSPolicy. Duplicated entries will
+                  be removed. Resolution options given in Options will override those
+                  that appear in the base DNSPolicy.
+                items:
+                  description: PodDNSConfigOption defines DNS resolver options of
+                    a pod.
+                  properties:
+                    name:
+                      description: Required.
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
+              searches:
+                description: A list of DNS search domains for host-name lookup. This
+                  will be appended to the base search paths generated from DNSPolicy.
+                  Duplicated search paths will be removed.
+                items:
+                  type: string
+                type: array
+            type: object
+          dnsPolicy:
+            description: |-
+              Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+
+              Possible enum values:
+               - `"ClusterFirst"` indicates that the pod should use cluster DNS first unless hostNetwork is true, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+               - `"ClusterFirstWithHostNet"` indicates that the pod should use cluster DNS first, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+               - `"Default"` indicates that the pod should use the default (as determined by kubelet) DNS settings.
+               - `"None"` indicates that the pod should use empty DNS settings. DNS parameters such as nameservers and search paths should be defined via DNSConfig.
+            type: string
+          enableServiceLinks:
+            description: 'EnableServiceLinks indicates whether information about services
+              should be injected into pod''s environment variables, matching the syntax
+              of Docker links. Optional: Defaults to true.'
+            type: boolean
+          ephemeralContainers:
+            description: List of ephemeral containers run in this pod. Ephemeral containers
+              may be run in an existing pod to perform user-initiated actions such
+              as debugging. This list cannot be specified when creating a pod, and
+              it cannot be modified by updating the pod spec. In order to add an ephemeral
+              container to an existing pod, use the pod's ephemeralcontainers subresource.
+            items:
+              description: |-
+                An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation.
+
+                To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.
+              properties:
+                args:
+                  description: 'Arguments to the entrypoint. The image''s CMD is used
+                    if this is not provided. Variable references $(VAR_NAME) are expanded
+                    using the container''s environment. If a variable cannot be resolved,
+                    the reference in the input string will be unchanged. Double $$
+                    are reduced to a single $, which allows for escaping the $(VAR_NAME)
+                    syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                    Escaped references will never be expanded, regardless of whether
+                    the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                command:
+                  description: 'Entrypoint array. Not executed within a shell. The
+                    image''s ENTRYPOINT is used if this is not provided. Variable
+                    references $(VAR_NAME) are expanded using the container''s environment.
+                    If a variable cannot be resolved, the reference in the input string
+                    will be unchanged. Double $$ are reduced to a single $, which
+                    allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                    will produce the string literal "$(VAR_NAME)". Escaped references
+                    will never be expanded, regardless of whether the variable exists
+                    or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                env:
+                  description: List of environment variables to set in the container.
+                    Cannot be updated.
+                  items:
+                    description: EnvVar represents an environment variable present
+                      in a Container.
+                    properties:
+                      name:
+                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        type: string
+                      value:
+                        description: 'Variable references $(VAR_NAME) are expanded
+                          using the previously defined environment variables in the
+                          container and any service environment variables. If a variable
+                          cannot be resolved, the reference in the input string will
+                          be unchanged. Double $$ are reduced to a single $, which
+                          allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                          will produce the string literal "$(VAR_NAME)". Escaped references
+                          will never be expanded, regardless of whether the variable
+                          exists or not. Defaults to "".'
+                        type: string
+                      valueFrom:
+                        description: Source for the environment variable's value.
+                          Cannot be used if value is not empty.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          fieldRef:
+                            description: 'Selects a field of the pod: supports metadata.name,
+                              metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                              spec.nodeName, spec.serviceAccountName, status.hostIP,
+                              status.podIP, status.podIPs.'
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                            - fieldPath
+                            type: object
+                          resourceFieldRef:
+                            description: 'Selects a resource of the container: only
+                              resources limits and requests (limits.cpu, limits.memory,
+                              limits.ephemeral-storage, requests.cpu, requests.memory
+                              and requests.ephemeral-storage) are currently supported.'
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Specifies the output format of the exposed
+                                  resources, defaults to "1"
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                            - resource
+                            type: object
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - name
+                  x-kubernetes-list-type: map
+                envFrom:
+                  description: List of sources to populate environment variables in
+                    the container. The keys defined within a source must be a C_IDENTIFIER.
+                    All invalid keys will be reported as an event when the container
+                    is starting. When a key exists in multiple sources, the value
+                    associated with the last source will take precedence. Values defined
+                    by an Env with a duplicate key will take precedence. Cannot be
+                    updated.
+                  items:
+                    description: EnvFromSource represents the source of a set of ConfigMaps
+                    properties:
+                      configMapRef:
+                        description: The ConfigMap to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the ConfigMap must be defined
+                            type: boolean
+                        type: object
+                      prefix:
+                        description: An optional identifier to prepend to each key
+                          in the ConfigMap. Must be a C_IDENTIFIER.
+                        type: string
+                      secretRef:
+                        description: The Secret to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret must be defined
+                            type: boolean
+                        type: object
+                    type: object
+                  type: array
+                image:
+                  description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                  type: string
+                imagePullPolicy:
+                  description: |-
+                    Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                    Possible enum values:
+                     - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                     - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                     - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                  type: string
+                lifecycle:
+                  description: Lifecycle is not allowed for ephemeral containers.
+                  properties:
+                    postStart:
+                      description: 'PostStart is called immediately after a container
+                        is created. If the handler fails, the container is terminated
+                        and restarted according to its restart policy. Other management
+                        of the container blocks until the hook completes. More info:
+                        https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: |-
+                                Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                Possible enum values:
+                                 - `"HTTP"` means that the scheme used will be http://
+                                 - `"HTTPS"` means that the scheme used will be https://
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: Deprecated. TCPSocket is NOT supported as a
+                            LifecycleHandler and kept for the backward compatibility.
+                            There are no validation of this field and lifecycle hooks
+                            will fail in runtime when tcp handler is specified.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                    preStop:
+                      description: 'PreStop is called immediately before a container
+                        is terminated due to an API request or management event such
+                        as liveness/startup probe failure, preemption, resource contention,
+                        etc. The handler is not called if the container crashes or
+                        exits. The Pod''s termination grace period countdown begins
+                        before the PreStop hook is executed. Regardless of the outcome
+                        of the handler, the container will eventually terminate within
+                        the Pod''s termination grace period (unless delayed by finalizers).
+                        Other management of the container blocks until the hook completes
+                        or until the termination grace period is reached. More info:
+                        https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: |-
+                                Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                Possible enum values:
+                                 - `"HTTP"` means that the scheme used will be http://
+                                 - `"HTTPS"` means that the scheme used will be https://
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: Deprecated. TCPSocket is NOT supported as a
+                            LifecycleHandler and kept for the backward compatibility.
+                            There are no validation of this field and lifecycle hooks
+                            will fail in runtime when tcp handler is specified.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                  type: object
+                livenessProbe:
+                  description: Probes are not allowed for ephemeral containers.
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                name:
+                  description: Name of the ephemeral container specified as a DNS_LABEL.
+                    This name must be unique among all containers, init containers
+                    and ephemeral containers.
+                  type: string
+                ports:
+                  description: Ports are not allowed for ephemeral containers.
+                  items:
+                    description: ContainerPort represents a network port in a single
+                      container.
+                    properties:
+                      containerPort:
+                        description: Number of port to expose on the pod's IP address.
+                          This must be a valid port number, 0 < x < 65536.
+                        format: int32
+                        type: integer
+                      hostIP:
+                        description: What host IP to bind the external port to.
+                        type: string
+                      hostPort:
+                        description: Number of port to expose on the host. If specified,
+                          this must be a valid port number, 0 < x < 65536. If HostNetwork
+                          is specified, this must match ContainerPort. Most containers
+                          do not need this.
+                        format: int32
+                        type: integer
+                      name:
+                        description: If specified, this must be an IANA_SVC_NAME and
+                          unique within the pod. Each named port in a pod must have
+                          a unique name. Name for the port that can be referred to
+                          by services.
+                        type: string
+                      protocol:
+                        default: TCP
+                        description: |-
+                          Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                          Possible enum values:
+                           - `"SCTP"` is the SCTP protocol.
+                           - `"TCP"` is the TCP protocol.
+                           - `"UDP"` is the UDP protocol.
+                        type: string
+                    required:
+                    - containerPort
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - containerPort
+                  - protocol
+                  x-kubernetes-list-type: map
+                readinessProbe:
+                  description: Probes are not allowed for ephemeral containers.
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                resources:
+                  description: Resources are not allowed for ephemeral containers.
+                    Ephemeral containers use spare resources already allocated to
+                    the pod.
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                  type: object
+                securityContext:
+                  description: 'Optional: SecurityContext defines the security options
+                    the ephemeral container should be run with. If set, the fields
+                    of SecurityContext override the equivalent fields of PodSecurityContext.'
+                  properties:
+                    allowPrivilegeEscalation:
+                      description: 'AllowPrivilegeEscalation controls whether a process
+                        can gain more privileges than its parent process. This bool
+                        directly controls if the no_new_privs flag will be set on
+                        the container process. AllowPrivilegeEscalation is true always
+                        when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
+                        Note that this field cannot be set when spec.os.name is windows.'
+                      type: boolean
+                    capabilities:
+                      description: The capabilities to add/drop when running containers.
+                        Defaults to the default set of capabilities granted by the
+                        container runtime. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      properties:
+                        add:
+                          description: Added capabilities
+                          items:
+                            type: string
+                          type: array
+                        drop:
+                          description: Removed capabilities
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    privileged:
+                      description: Run container in privileged mode. Processes in
+                        privileged containers are essentially equivalent to root on
+                        the host. Defaults to false. Note that this field cannot be
+                        set when spec.os.name is windows.
+                      type: boolean
+                    procMount:
+                      description: procMount denotes the type of proc mount to use
+                        for the containers. The default is DefaultProcMount which
+                        uses the container runtime defaults for readonly paths and
+                        masked paths. This requires the ProcMountType feature flag
+                        to be enabled. Note that this field cannot be set when spec.os.name
+                        is windows.
+                      type: string
+                    readOnlyRootFilesystem:
+                      description: Whether this container has a read-only root filesystem.
+                        Default is false. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      type: boolean
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container
+                        process. Uses runtime default if unset. May also be set in
+                        PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence. Note
+                        that this field cannot be set when spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to
+                        start the container if it does. If unset or false, no such
+                        validation will be performed. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container
+                        process. Defaults to user specified in image metadata if unspecified.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: The SELinux context to be applied to the container.
+                        If unspecified, the container runtime will allocate a random
+                        SELinux context for each container.  May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence. Note that this
+                        field cannot be set when spec.os.name is windows.
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
+                      type: object
+                    seccompProfile:
+                      description: The seccomp options to use by this container. If
+                        seccomp options are provided at both the pod & container level,
+                        the container options override the pod options. Note that
+                        this field cannot be set when spec.os.name is windows.
+                      properties:
+                        localhostProfile:
+                          description: localhostProfile indicates a profile defined
+                            in a file on the node should be used. The profile must
+                            be preconfigured on the node to work. Must be a descending
+                            path, relative to the kubelet's configured seccomp profile
+                            location. Must only be set if type is "Localhost".
+                          type: string
+                        type:
+                          description: |-
+                            type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                            Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                            Possible enum values:
+                             - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                             - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                             - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    windowsOptions:
+                      description: The Windows specific settings applied to all containers.
+                        If unspecified, the options from the PodSecurityContext will
+                        be used. If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence. Note
+                        that this field cannot be set when spec.os.name is linux.
+                      properties:
+                        gmsaCredentialSpec:
+                          description: GMSACredentialSpec is where the GMSA admission
+                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                            inlines the contents of the GMSA credential spec named
+                            by the GMSACredentialSpecName field.
+                          type: string
+                        gmsaCredentialSpecName:
+                          description: GMSACredentialSpecName is the name of the GMSA
+                            credential spec to use.
+                          type: string
+                        hostProcess:
+                          description: HostProcess determines if a container should
+                            be run as a 'Host Process' container. This field is alpha-level
+                            and will only be honored by components that enable the
+                            WindowsHostProcessContainers feature flag. Setting this
+                            field without the feature flag will result in errors when
+                            validating the Pod. All of a Pod's containers must have
+                            the same effective HostProcess value (it is not allowed
+                            to have a mix of HostProcess containers and non-HostProcess
+                            containers).  In addition, if HostProcess is true then
+                            HostNetwork must also be set to true.
+                          type: boolean
+                        runAsUserName:
+                          description: The UserName in Windows to run the entrypoint
+                            of the container process. Defaults to the user specified
+                            in image metadata if unspecified. May also be set in PodSecurityContext.
+                            If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence.
+                          type: string
+                      type: object
+                  type: object
+                startupProbe:
+                  description: Probes are not allowed for ephemeral containers.
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                stdin:
+                  description: Whether this container should allocate a buffer for
+                    stdin in the container runtime. If this is not set, reads from
+                    stdin in the container will always result in EOF. Default is false.
+                  type: boolean
+                stdinOnce:
+                  description: Whether the container runtime should close the stdin
+                    channel after it has been opened by a single attach. When stdin
+                    is true the stdin stream will remain open across multiple attach
+                    sessions. If stdinOnce is set to true, stdin is opened on container
+                    start, is empty until the first client attaches to stdin, and
+                    then remains open and accepts data until the client disconnects,
+                    at which time stdin is closed and remains closed until the container
+                    is restarted. If this flag is false, a container processes that
+                    reads from stdin will never receive an EOF. Default is false
+                  type: boolean
+                targetContainerName:
+                  description: |-
+                    If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+                    The container runtime must implement support for this feature. If the runtime does not support namespace targeting then the result of setting this field is undefined.
+                  type: string
+                terminationMessagePath:
+                  description: 'Optional: Path at which the file to which the container''s
+                    termination message will be written is mounted into the container''s
+                    filesystem. Message written is intended to be brief final status,
+                    such as an assertion failure message. Will be truncated by the
+                    node if greater than 4096 bytes. The total message length across
+                    all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                    Cannot be updated.'
+                  type: string
+                terminationMessagePolicy:
+                  description: |-
+                    Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                    Possible enum values:
+                     - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                     - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                  type: string
+                tty:
+                  description: Whether this container should allocate a TTY for itself,
+                    also requires 'stdin' to be true. Default is false.
+                  type: boolean
+                volumeDevices:
+                  description: volumeDevices is the list of block devices to be used
+                    by the container.
+                  items:
+                    description: volumeDevice describes a mapping of a raw block device
+                      within a container.
+                    properties:
+                      devicePath:
+                        description: devicePath is the path inside of the container
+                          that the device will be mapped to.
+                        type: string
+                      name:
+                        description: name must match the name of a persistentVolumeClaim
+                          in the pod
+                        type: string
+                    required:
+                    - devicePath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - devicePath
+                  x-kubernetes-list-type: map
+                volumeMounts:
+                  description: Pod volumes to mount into the container's filesystem.
+                    Subpath mounts are not allowed for ephemeral containers. Cannot
+                    be updated.
+                  items:
+                    description: VolumeMount describes a mounting of a Volume within
+                      a container.
+                    properties:
+                      mountPath:
+                        description: Path within the container at which the volume
+                          should be mounted.  Must not contain ':'.
+                        type: string
+                      mountPropagation:
+                        description: mountPropagation determines how mounts are propagated
+                          from the host to container and the other way around. When
+                          not set, MountPropagationNone is used. This field is beta
+                          in 1.10.
+                        type: string
+                      name:
+                        description: This must match the Name of a Volume.
+                        type: string
+                      readOnly:
+                        description: Mounted read-only if true, read-write otherwise
+                          (false or unspecified). Defaults to false.
+                        type: boolean
+                      subPath:
+                        description: Path within the volume from which the container's
+                          volume should be mounted. Defaults to "" (volume's root).
+                        type: string
+                      subPathExpr:
+                        description: Expanded path within the volume from which the
+                          container's volume should be mounted. Behaves similarly
+                          to SubPath but environment variable references $(VAR_NAME)
+                          are expanded using the container's environment. Defaults
+                          to "" (volume's root). SubPathExpr and SubPath are mutually
+                          exclusive.
+                        type: string
+                    required:
+                    - mountPath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - mountPath
+                  x-kubernetes-list-type: map
+                workingDir:
+                  description: Container's working directory. If not specified, the
+                    container runtime's default will be used, which might be configured
+                    in the container image. Cannot be updated.
+                  type: string
+              required:
+              - name
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - name
+            x-kubernetes-list-type: map
+          hostAliases:
+            description: HostAliases is an optional list of hosts and IPs that will
+              be injected into the pod's hosts file if specified. This is only valid
+              for non-hostNetwork pods.
+            items:
+              description: HostAlias holds the mapping between IP and hostnames that
+                will be injected as an entry in the pod's hosts file.
+              properties:
+                hostnames:
+                  description: Hostnames for the above IP address.
+                  items:
+                    type: string
+                  type: array
+                ip:
+                  description: IP address of the host file entry.
+                  type: string
+              required:
+              - ip
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - ip
+            x-kubernetes-list-type: map
+          hostIPC:
+            description: 'Use the host''s ipc namespace. Optional: Default to false.'
+            type: boolean
+          hostNetwork:
+            description: Host networking requested for this pod. Use the host's network
+              namespace. If this option is set, the ports that will be used must be
+              specified. Default to false.
+            type: boolean
+          hostPID:
+            description: 'Use the host''s pid namespace. Optional: Default to false.'
+            type: boolean
+          hostUsers:
+            description: 'Use the host''s user namespace. Optional: Default to true.
+              If set to true or not present, the pod will be run in the host user
+              namespace, useful for when the pod needs a feature only available to
+              the host user namespace, such as loading a kernel module with CAP_SYS_MODULE.
+              When set to false, a new userns is created for the pod. Setting false
+              is useful for mitigating container breakout vulnerabilities even allowing
+              users to run their containers as root without actually having root privileges
+              on the host. This field is alpha-level and is only honored by servers
+              that enable the UserNamespacesSupport feature.'
+            type: boolean
+          hostname:
+            description: Specifies the hostname of the Pod If not specified, the pod's
+              hostname will be set to a system-defined value.
+            type: string
+          imagePullSecrets:
+            description: 'ImagePullSecrets is an optional list of references to secrets
+              in the same namespace to use for pulling any of the images used by this
+              PodSpec. If specified, these secrets will be passed to individual puller
+              implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+            items:
+              description: LocalObjectReference contains enough information to let
+                you locate the referenced object inside the same namespace.
+              properties:
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+              required:
+              - name
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - name
+            x-kubernetes-list-type: map
+          initContainers:
+            description: 'List of initialization containers belonging to the pod.
+              Init containers are executed in order prior to containers being started.
+              If any init container fails, the pod is considered to have failed and
+              is handled according to its restartPolicy. The name for an init container
+              or normal container must be unique among all containers. Init containers
+              may not have Lifecycle actions, Readiness probes, Liveness probes, or
+              Startup probes. The resourceRequirements of an init container are taken
+              into account during scheduling by finding the highest request/limit
+              for each resource type, and then using the max of of that value or the
+              sum of the normal containers. Limits are applied to init containers
+              in a similar fashion. Init containers cannot currently be added or removed.
+              Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+            items:
+              description: A single application container that you want to run within
+                a pod.
+              properties:
+                args:
+                  description: 'Arguments to the entrypoint. The container image''s
+                    CMD is used if this is not provided. Variable references $(VAR_NAME)
+                    are expanded using the container''s environment. If a variable
+                    cannot be resolved, the reference in the input string will be
+                    unchanged. Double $$ are reduced to a single $, which allows for
+                    escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                    the string literal "$(VAR_NAME)". Escaped references will never
+                    be expanded, regardless of whether the variable exists or not.
+                    Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                command:
+                  description: 'Entrypoint array. Not executed within a shell. The
+                    container image''s ENTRYPOINT is used if this is not provided.
+                    Variable references $(VAR_NAME) are expanded using the container''s
+                    environment. If a variable cannot be resolved, the reference in
+                    the input string will be unchanged. Double $$ are reduced to a
+                    single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                    Escaped references will never be expanded, regardless of whether
+                    the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                env:
+                  description: List of environment variables to set in the container.
+                    Cannot be updated.
+                  items:
+                    description: EnvVar represents an environment variable present
+                      in a Container.
+                    properties:
+                      name:
+                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        type: string
+                      value:
+                        description: 'Variable references $(VAR_NAME) are expanded
+                          using the previously defined environment variables in the
+                          container and any service environment variables. If a variable
+                          cannot be resolved, the reference in the input string will
+                          be unchanged. Double $$ are reduced to a single $, which
+                          allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                          will produce the string literal "$(VAR_NAME)". Escaped references
+                          will never be expanded, regardless of whether the variable
+                          exists or not. Defaults to "".'
+                        type: string
+                      valueFrom:
+                        description: Source for the environment variable's value.
+                          Cannot be used if value is not empty.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          fieldRef:
+                            description: 'Selects a field of the pod: supports metadata.name,
+                              metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                              spec.nodeName, spec.serviceAccountName, status.hostIP,
+                              status.podIP, status.podIPs.'
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                            - fieldPath
+                            type: object
+                          resourceFieldRef:
+                            description: 'Selects a resource of the container: only
+                              resources limits and requests (limits.cpu, limits.memory,
+                              limits.ephemeral-storage, requests.cpu, requests.memory
+                              and requests.ephemeral-storage) are currently supported.'
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Specifies the output format of the exposed
+                                  resources, defaults to "1"
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                            - resource
+                            type: object
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - name
+                  x-kubernetes-list-type: map
+                envFrom:
+                  description: List of sources to populate environment variables in
+                    the container. The keys defined within a source must be a C_IDENTIFIER.
+                    All invalid keys will be reported as an event when the container
+                    is starting. When a key exists in multiple sources, the value
+                    associated with the last source will take precedence. Values defined
+                    by an Env with a duplicate key will take precedence. Cannot be
+                    updated.
+                  items:
+                    description: EnvFromSource represents the source of a set of ConfigMaps
+                    properties:
+                      configMapRef:
+                        description: The ConfigMap to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the ConfigMap must be defined
+                            type: boolean
+                        type: object
+                      prefix:
+                        description: An optional identifier to prepend to each key
+                          in the ConfigMap. Must be a C_IDENTIFIER.
+                        type: string
+                      secretRef:
+                        description: The Secret to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret must be defined
+                            type: boolean
+                        type: object
+                    type: object
+                  type: array
+                image:
+                  description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                    This field is optional to allow higher level config management
+                    to default or override container images in workload controllers
+                    like Deployments and StatefulSets.'
+                  type: string
+                imagePullPolicy:
+                  description: |-
+                    Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                    Possible enum values:
+                     - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                     - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                     - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                  type: string
+                lifecycle:
+                  description: Actions that the management system should take in response
+                    to container lifecycle events. Cannot be updated.
+                  properties:
+                    postStart:
+                      description: 'PostStart is called immediately after a container
+                        is created. If the handler fails, the container is terminated
+                        and restarted according to its restart policy. Other management
+                        of the container blocks until the hook completes. More info:
+                        https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: |-
+                                Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                Possible enum values:
+                                 - `"HTTP"` means that the scheme used will be http://
+                                 - `"HTTPS"` means that the scheme used will be https://
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: Deprecated. TCPSocket is NOT supported as a
+                            LifecycleHandler and kept for the backward compatibility.
+                            There are no validation of this field and lifecycle hooks
+                            will fail in runtime when tcp handler is specified.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                    preStop:
+                      description: 'PreStop is called immediately before a container
+                        is terminated due to an API request or management event such
+                        as liveness/startup probe failure, preemption, resource contention,
+                        etc. The handler is not called if the container crashes or
+                        exits. The Pod''s termination grace period countdown begins
+                        before the PreStop hook is executed. Regardless of the outcome
+                        of the handler, the container will eventually terminate within
+                        the Pod''s termination grace period (unless delayed by finalizers).
+                        Other management of the container blocks until the hook completes
+                        or until the termination grace period is reached. More info:
+                        https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: |-
+                                Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                Possible enum values:
+                                 - `"HTTP"` means that the scheme used will be http://
+                                 - `"HTTPS"` means that the scheme used will be https://
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: Deprecated. TCPSocket is NOT supported as a
+                            LifecycleHandler and kept for the backward compatibility.
+                            There are no validation of this field and lifecycle hooks
+                            will fail in runtime when tcp handler is specified.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                  type: object
+                livenessProbe:
+                  description: 'Periodic probe of container liveness. Container will
+                    be restarted if the probe fails. Cannot be updated. More info:
+                    https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                name:
+                  description: Name of the container specified as a DNS_LABEL. Each
+                    container in a pod must have a unique name (DNS_LABEL). Cannot
+                    be updated.
+                  type: string
+                ports:
+                  description: List of ports to expose from the container. Not specifying
+                    a port here DOES NOT prevent that port from being exposed. Any
+                    port which is listening on the default "0.0.0.0" address inside
+                    a container will be accessible from the network. Modifying this
+                    array with strategic merge patch may corrupt the data. For more
+                    information See https://github.com/kubernetes/kubernetes/issues/108255.
+                    Cannot be updated.
+                  items:
+                    description: ContainerPort represents a network port in a single
+                      container.
+                    properties:
+                      containerPort:
+                        description: Number of port to expose on the pod's IP address.
+                          This must be a valid port number, 0 < x < 65536.
+                        format: int32
+                        type: integer
+                      hostIP:
+                        description: What host IP to bind the external port to.
+                        type: string
+                      hostPort:
+                        description: Number of port to expose on the host. If specified,
+                          this must be a valid port number, 0 < x < 65536. If HostNetwork
+                          is specified, this must match ContainerPort. Most containers
+                          do not need this.
+                        format: int32
+                        type: integer
+                      name:
+                        description: If specified, this must be an IANA_SVC_NAME and
+                          unique within the pod. Each named port in a pod must have
+                          a unique name. Name for the port that can be referred to
+                          by services.
+                        type: string
+                      protocol:
+                        default: TCP
+                        description: |-
+                          Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                          Possible enum values:
+                           - `"SCTP"` is the SCTP protocol.
+                           - `"TCP"` is the TCP protocol.
+                           - `"UDP"` is the UDP protocol.
+                        type: string
+                    required:
+                    - containerPort
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - containerPort
+                  - protocol
+                  x-kubernetes-list-type: map
+                readinessProbe:
+                  description: 'Periodic probe of container service readiness. Container
+                    will be removed from service endpoints if the probe fails. Cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                resources:
+                  description: 'Compute Resources required by this container. Cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                  type: object
+                securityContext:
+                  description: 'SecurityContext defines the security options the container
+                    should be run with. If set, the fields of SecurityContext override
+                    the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                  properties:
+                    allowPrivilegeEscalation:
+                      description: 'AllowPrivilegeEscalation controls whether a process
+                        can gain more privileges than its parent process. This bool
+                        directly controls if the no_new_privs flag will be set on
+                        the container process. AllowPrivilegeEscalation is true always
+                        when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
+                        Note that this field cannot be set when spec.os.name is windows.'
+                      type: boolean
+                    capabilities:
+                      description: The capabilities to add/drop when running containers.
+                        Defaults to the default set of capabilities granted by the
+                        container runtime. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      properties:
+                        add:
+                          description: Added capabilities
+                          items:
+                            type: string
+                          type: array
+                        drop:
+                          description: Removed capabilities
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    privileged:
+                      description: Run container in privileged mode. Processes in
+                        privileged containers are essentially equivalent to root on
+                        the host. Defaults to false. Note that this field cannot be
+                        set when spec.os.name is windows.
+                      type: boolean
+                    procMount:
+                      description: procMount denotes the type of proc mount to use
+                        for the containers. The default is DefaultProcMount which
+                        uses the container runtime defaults for readonly paths and
+                        masked paths. This requires the ProcMountType feature flag
+                        to be enabled. Note that this field cannot be set when spec.os.name
+                        is windows.
+                      type: string
+                    readOnlyRootFilesystem:
+                      description: Whether this container has a read-only root filesystem.
+                        Default is false. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      type: boolean
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container
+                        process. Uses runtime default if unset. May also be set in
+                        PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence. Note
+                        that this field cannot be set when spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to
+                        start the container if it does. If unset or false, no such
+                        validation will be performed. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container
+                        process. Defaults to user specified in image metadata if unspecified.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: The SELinux context to be applied to the container.
+                        If unspecified, the container runtime will allocate a random
+                        SELinux context for each container.  May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence. Note that this
+                        field cannot be set when spec.os.name is windows.
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
+                      type: object
+                    seccompProfile:
+                      description: The seccomp options to use by this container. If
+                        seccomp options are provided at both the pod & container level,
+                        the container options override the pod options. Note that
+                        this field cannot be set when spec.os.name is windows.
+                      properties:
+                        localhostProfile:
+                          description: localhostProfile indicates a profile defined
+                            in a file on the node should be used. The profile must
+                            be preconfigured on the node to work. Must be a descending
+                            path, relative to the kubelet's configured seccomp profile
+                            location. Must only be set if type is "Localhost".
+                          type: string
+                        type:
+                          description: |-
+                            type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                            Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                            Possible enum values:
+                             - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                             - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                             - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    windowsOptions:
+                      description: The Windows specific settings applied to all containers.
+                        If unspecified, the options from the PodSecurityContext will
+                        be used. If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence. Note
+                        that this field cannot be set when spec.os.name is linux.
+                      properties:
+                        gmsaCredentialSpec:
+                          description: GMSACredentialSpec is where the GMSA admission
+                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                            inlines the contents of the GMSA credential spec named
+                            by the GMSACredentialSpecName field.
+                          type: string
+                        gmsaCredentialSpecName:
+                          description: GMSACredentialSpecName is the name of the GMSA
+                            credential spec to use.
+                          type: string
+                        hostProcess:
+                          description: HostProcess determines if a container should
+                            be run as a 'Host Process' container. This field is alpha-level
+                            and will only be honored by components that enable the
+                            WindowsHostProcessContainers feature flag. Setting this
+                            field without the feature flag will result in errors when
+                            validating the Pod. All of a Pod's containers must have
+                            the same effective HostProcess value (it is not allowed
+                            to have a mix of HostProcess containers and non-HostProcess
+                            containers).  In addition, if HostProcess is true then
+                            HostNetwork must also be set to true.
+                          type: boolean
+                        runAsUserName:
+                          description: The UserName in Windows to run the entrypoint
+                            of the container process. Defaults to the user specified
+                            in image metadata if unspecified. May also be set in PodSecurityContext.
+                            If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence.
+                          type: string
+                      type: object
+                  type: object
+                startupProbe:
+                  description: 'StartupProbe indicates that the Pod has successfully
+                    initialized. If specified, no other probes are executed until
+                    this completes successfully. If this probe fails, the Pod will
+                    be restarted, just as if the livenessProbe failed. This can be
+                    used to provide different probe parameters at the beginning of
+                    a Pod''s lifecycle, when it might take a long time to load data
+                    or warm a cache, than during steady-state operation. This cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                stdin:
+                  description: Whether this container should allocate a buffer for
+                    stdin in the container runtime. If this is not set, reads from
+                    stdin in the container will always result in EOF. Default is false.
+                  type: boolean
+                stdinOnce:
+                  description: Whether the container runtime should close the stdin
+                    channel after it has been opened by a single attach. When stdin
+                    is true the stdin stream will remain open across multiple attach
+                    sessions. If stdinOnce is set to true, stdin is opened on container
+                    start, is empty until the first client attaches to stdin, and
+                    then remains open and accepts data until the client disconnects,
+                    at which time stdin is closed and remains closed until the container
+                    is restarted. If this flag is false, a container processes that
+                    reads from stdin will never receive an EOF. Default is false
+                  type: boolean
+                terminationMessagePath:
+                  description: 'Optional: Path at which the file to which the container''s
+                    termination message will be written is mounted into the container''s
+                    filesystem. Message written is intended to be brief final status,
+                    such as an assertion failure message. Will be truncated by the
+                    node if greater than 4096 bytes. The total message length across
+                    all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                    Cannot be updated.'
+                  type: string
+                terminationMessagePolicy:
+                  description: |-
+                    Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                    Possible enum values:
+                     - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                     - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                  type: string
+                tty:
+                  description: Whether this container should allocate a TTY for itself,
+                    also requires 'stdin' to be true. Default is false.
+                  type: boolean
+                volumeDevices:
+                  description: volumeDevices is the list of block devices to be used
+                    by the container.
+                  items:
+                    description: volumeDevice describes a mapping of a raw block device
+                      within a container.
+                    properties:
+                      devicePath:
+                        description: devicePath is the path inside of the container
+                          that the device will be mapped to.
+                        type: string
+                      name:
+                        description: name must match the name of a persistentVolumeClaim
+                          in the pod
+                        type: string
+                    required:
+                    - devicePath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - devicePath
+                  x-kubernetes-list-type: map
+                volumeMounts:
+                  description: Pod volumes to mount into the container's filesystem.
+                    Cannot be updated.
+                  items:
+                    description: VolumeMount describes a mounting of a Volume within
+                      a container.
+                    properties:
+                      mountPath:
+                        description: Path within the container at which the volume
+                          should be mounted.  Must not contain ':'.
+                        type: string
+                      mountPropagation:
+                        description: mountPropagation determines how mounts are propagated
+                          from the host to container and the other way around. When
+                          not set, MountPropagationNone is used. This field is beta
+                          in 1.10.
+                        type: string
+                      name:
+                        description: This must match the Name of a Volume.
+                        type: string
+                      readOnly:
+                        description: Mounted read-only if true, read-write otherwise
+                          (false or unspecified). Defaults to false.
+                        type: boolean
+                      subPath:
+                        description: Path within the volume from which the container's
+                          volume should be mounted. Defaults to "" (volume's root).
+                        type: string
+                      subPathExpr:
+                        description: Expanded path within the volume from which the
+                          container's volume should be mounted. Behaves similarly
+                          to SubPath but environment variable references $(VAR_NAME)
+                          are expanded using the container's environment. Defaults
+                          to "" (volume's root). SubPathExpr and SubPath are mutually
+                          exclusive.
+                        type: string
+                    required:
+                    - mountPath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - mountPath
+                  x-kubernetes-list-type: map
+                workingDir:
+                  description: Container's working directory. If not specified, the
+                    container runtime's default will be used, which might be configured
+                    in the container image. Cannot be updated.
+                  type: string
+              required:
+              - name
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - name
+            x-kubernetes-list-type: map
+          nodeName:
+            description: NodeName is a request to schedule this pod onto a specific
+              node. If it is non-empty, the scheduler simply schedules this pod onto
+              that node, assuming that it fits resource requirements.
+            type: string
+          nodeSelector:
+            additionalProperties:
+              type: string
+            description: 'NodeSelector is a selector which must be true for the pod
+              to fit on a node. Selector which must match a node''s labels for the
+              pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+            type: object
+          os:
+            description: |-
+              Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set.
+
+              If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions
+
+              If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup
+            properties:
+              name:
+                description: 'Name is the name of the operating system. The currently
+                  supported values are linux and windows. Additional value may be
+                  defined in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                  Clients should expect to handle additional values and treat unrecognized
+                  values in this field as os: null'
+                type: string
+            required:
+            - name
+            type: object
+          overhead:
+            additionalProperties:
+              anyOf:
+              - type: integer
+              - type: string
+              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+              x-kubernetes-int-or-string: true
+            description: 'Overhead represents the resource overhead associated with
+              running a pod for a given RuntimeClass. This field will be autopopulated
+              at admission time by the RuntimeClass admission controller. If the RuntimeClass
+              admission controller is enabled, overhead must not be set in Pod create
+              requests. The RuntimeClass admission controller will reject Pod create
+              requests which have the overhead already set. If RuntimeClass is configured
+              and selected in the PodSpec, Overhead will be set to the value defined
+              in the corresponding RuntimeClass, otherwise it will remain unset and
+              treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
+            type: object
+          preemptionPolicy:
+            description: PreemptionPolicy is the Policy for preempting pods with lower
+              priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority
+              if unset.
+            type: string
+          priority:
+            description: The priority value. Various system components use this field
+              to find the priority of the pod. When Priority Admission Controller
+              is enabled, it prevents users from setting this field. The admission
+              controller populates this field from PriorityClassName. The higher the
+              value, the higher the priority.
+            format: int32
+            type: integer
+          priorityClassName:
+            description: If specified, indicates the pod's priority. "system-node-critical"
+              and "system-cluster-critical" are two special keywords which indicate
+              the highest priorities with the former being the highest priority. Any
+              other name must be defined by creating a PriorityClass object with that
+              name. If not specified, the pod priority will be default or zero if
+              there is no default.
+            type: string
+          readinessGates:
+            description: 'If specified, all readiness gates will be evaluated for
+              pod readiness. A pod is ready when all its containers are ready AND
+              all conditions specified in the readiness gates have status equal to
+              "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
+            items:
+              description: PodReadinessGate contains the reference to a pod condition
+              properties:
+                conditionType:
+                  description: ConditionType refers to a condition in the pod's condition
+                    list with matching type.
+                  type: string
+              required:
+              - conditionType
+              type: object
+            type: array
+          restartPolicy:
+            description: |-
+              Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+
+              Possible enum values:
+               - `"Always"`
+               - `"Never"`
+               - `"OnFailure"`
+            type: string
+          runtimeClassName:
+            description: 'RuntimeClassName refers to a RuntimeClass object in the
+              node.k8s.io group, which should be used to run this pod.  If no RuntimeClass
+              resource matches the named class, the pod will not be run. If unset
+              or empty, the "legacy" RuntimeClass will be used, which is an implicit
+              class with an empty definition that uses the default runtime handler.
+              More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
+            type: string
+          schedulerName:
+            description: If specified, the pod will be dispatched by specified scheduler.
+              If not specified, the pod will be dispatched by default scheduler.
+            type: string
+          securityContext:
+            description: 'SecurityContext holds pod-level security attributes and
+              common container settings. Optional: Defaults to empty.  See type description
+              for default values of each field.'
+            properties:
+              fsGroup:
+                description: |-
+                  A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
+                  1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
+                  If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.
+                format: int64
+                type: integer
+              fsGroupChangePolicy:
+                description: 'fsGroupChangePolicy defines behavior of changing ownership
+                  and permission of the volume before being exposed inside Pod. This
+                  field will only apply to volume types which support fsGroup based
+                  ownership(and permissions). It will have no effect on ephemeral
+                  volume types such as: secret, configmaps and emptydir. Valid values
+                  are "OnRootMismatch" and "Always". If not specified, "Always" is
+                  used. Note that this field cannot be set when spec.os.name is windows.'
+                type: string
+              runAsGroup:
+                description: The GID to run the entrypoint of the container process.
+                  Uses runtime default if unset. May also be set in SecurityContext.  If
+                  set in both SecurityContext and PodSecurityContext, the value specified
+                  in SecurityContext takes precedence for that container. Note that
+                  this field cannot be set when spec.os.name is windows.
+                format: int64
+                type: integer
+              runAsNonRoot:
+                description: Indicates that the container must run as a non-root user.
+                  If true, the Kubelet will validate the image at runtime to ensure
+                  that it does not run as UID 0 (root) and fail to start the container
+                  if it does. If unset or false, no such validation will be performed.
+                  May also be set in SecurityContext.  If set in both SecurityContext
+                  and PodSecurityContext, the value specified in SecurityContext takes
+                  precedence.
+                type: boolean
+              runAsUser:
+                description: The UID to run the entrypoint of the container process.
+                  Defaults to user specified in image metadata if unspecified. May
+                  also be set in SecurityContext.  If set in both SecurityContext
+                  and PodSecurityContext, the value specified in SecurityContext takes
+                  precedence for that container. Note that this field cannot be set
+                  when spec.os.name is windows.
+                format: int64
+                type: integer
+              seLinuxOptions:
+                description: The SELinux context to be applied to all containers.
+                  If unspecified, the container runtime will allocate a random SELinux
+                  context for each container.  May also be set in SecurityContext.  If
+                  set in both SecurityContext and PodSecurityContext, the value specified
+                  in SecurityContext takes precedence for that container. Note that
+                  this field cannot be set when spec.os.name is windows.
+                properties:
+                  level:
+                    description: Level is SELinux level label that applies to the
+                      container.
+                    type: string
+                  role:
+                    description: Role is a SELinux role label that applies to the
+                      container.
+                    type: string
+                  type:
+                    description: Type is a SELinux type label that applies to the
+                      container.
+                    type: string
+                  user:
+                    description: User is a SELinux user label that applies to the
+                      container.
+                    type: string
+                type: object
+              seccompProfile:
+                description: The seccomp options to use by the containers in this
+                  pod. Note that this field cannot be set when spec.os.name is windows.
+                properties:
+                  localhostProfile:
+                    description: localhostProfile indicates a profile defined in a
+                      file on the node should be used. The profile must be preconfigured
+                      on the node to work. Must be a descending path, relative to
+                      the kubelet's configured seccomp profile location. Must only
+                      be set if type is "Localhost".
+                    type: string
+                  type:
+                    description: |-
+                      type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                      Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                      Possible enum values:
+                       - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                       - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                       - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                    type: string
+                required:
+                - type
+                type: object
+              supplementalGroups:
+                description: A list of groups applied to the first process run in
+                  each container, in addition to the container's primary GID.  If
+                  unspecified, no groups will be added to any container. Note that
+                  this field cannot be set when spec.os.name is windows.
+                items:
+                  format: int64
+                  type: integer
+                type: array
+              sysctls:
+                description: Sysctls hold a list of namespaced sysctls used for the
+                  pod. Pods with unsupported sysctls (by the container runtime) might
+                  fail to launch. Note that this field cannot be set when spec.os.name
+                  is windows.
+                items:
+                  description: Sysctl defines a kernel parameter to be set
+                  properties:
+                    name:
+                      description: Name of a property to set
+                      type: string
+                    value:
+                      description: Value of a property to set
+                      type: string
+                  required:
+                  - name
+                  - value
+                  type: object
+                type: array
+              windowsOptions:
+                description: The Windows specific settings applied to all containers.
+                  If unspecified, the options within a container's SecurityContext
+                  will be used. If set in both SecurityContext and PodSecurityContext,
+                  the value specified in SecurityContext takes precedence. Note that
+                  this field cannot be set when spec.os.name is linux.
+                properties:
+                  gmsaCredentialSpec:
+                    description: GMSACredentialSpec is where the GMSA admission webhook
+                      (https://github.com/kubernetes-sigs/windows-gmsa) inlines the
+                      contents of the GMSA credential spec named by the GMSACredentialSpecName
+                      field.
+                    type: string
+                  gmsaCredentialSpecName:
+                    description: GMSACredentialSpecName is the name of the GMSA credential
+                      spec to use.
+                    type: string
+                  hostProcess:
+                    description: HostProcess determines if a container should be run
+                      as a 'Host Process' container. This field is alpha-level and
+                      will only be honored by components that enable the WindowsHostProcessContainers
+                      feature flag. Setting this field without the feature flag will
+                      result in errors when validating the Pod. All of a Pod's containers
+                      must have the same effective HostProcess value (it is not allowed
+                      to have a mix of HostProcess containers and non-HostProcess
+                      containers).  In addition, if HostProcess is true then HostNetwork
+                      must also be set to true.
+                    type: boolean
+                  runAsUserName:
+                    description: The UserName in Windows to run the entrypoint of
+                      the container process. Defaults to the user specified in image
+                      metadata if unspecified. May also be set in PodSecurityContext.
+                      If set in both SecurityContext and PodSecurityContext, the value
+                      specified in SecurityContext takes precedence.
+                    type: string
+                type: object
+            type: object
+          serviceAccount:
+            description: 'DeprecatedServiceAccount is a depreciated alias for ServiceAccountName.
+              Deprecated: Use serviceAccountName instead.'
+            type: string
+          serviceAccountName:
+            description: 'ServiceAccountName is the name of the ServiceAccount to
+              use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+            type: string
+          setHostnameAsFQDN:
+            description: If true the pod's hostname will be configured as the pod's
+              FQDN, rather than the leaf name (the default). In Linux containers,
+              this means setting the FQDN in the hostname field of the kernel (the
+              nodename field of struct utsname). In Windows containers, this means
+              setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters
+              to FQDN. If a pod does not have FQDN, this has no effect. Default to
+              false.
+            type: boolean
+          shareProcessNamespace:
+            description: 'Share a single process namespace between all of the containers
+              in a pod. When this is set containers will be able to view and signal
+              processes from other containers in the same pod, and the first process
+              in each container will not be assigned PID 1. HostPID and ShareProcessNamespace
+              cannot both be set. Optional: Default to false.'
+            type: boolean
+          subdomain:
+            description: If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod
+              namespace>.svc.<cluster domain>". If not specified, the pod will not
+              have a domainname at all.
+            type: string
+          terminationGracePeriodSeconds:
+            description: Optional duration in seconds the pod needs to terminate gracefully.
+              May be decreased in delete request. Value must be non-negative integer.
+              The value zero indicates stop immediately via the kill signal (no opportunity
+              to shut down). If this value is nil, the default grace period will be
+              used instead. The grace period is the duration in seconds after the
+              processes running in the pod are sent a termination signal and the time
+              when the processes are forcibly halted with a kill signal. Set this
+              value longer than the expected cleanup time for your process. Defaults
+              to 30 seconds.
+            format: int64
+            type: integer
+          tolerations:
+            description: If specified, the pod's tolerations.
+            items:
+              description: The pod this Toleration is attached to tolerates any taint
+                that matches the triple <key,value,effect> using the matching operator
+                <operator>.
+              properties:
+                effect:
+                  description: |-
+                    Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+                    Possible enum values:
+                     - `"NoExecute"` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+                     - `"NoSchedule"` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+                     - `"PreferNoSchedule"` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
+                  type: string
+                key:
+                  description: Key is the taint key that the toleration applies to.
+                    Empty means match all taint keys. If the key is empty, operator
+                    must be Exists; this combination means to match all values and
+                    all keys.
+                  type: string
+                operator:
+                  description: |-
+                    Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+
+                    Possible enum values:
+                     - `"Equal"`
+                     - `"Exists"`
+                  type: string
+                tolerationSeconds:
+                  description: TolerationSeconds represents the period of time the
+                    toleration (which must be of effect NoExecute, otherwise this
+                    field is ignored) tolerates the taint. By default, it is not set,
+                    which means tolerate the taint forever (do not evict). Zero and
+                    negative values will be treated as 0 (evict immediately) by the
+                    system.
+                  format: int64
+                  type: integer
+                value:
+                  description: Value is the taint value the toleration matches to.
+                    If the operator is Exists, the value should be empty, otherwise
+                    just a regular string.
+                  type: string
+              type: object
+            type: array
+          topologySpreadConstraints:
+            description: TopologySpreadConstraints describes how a group of pods ought
+              to spread across topology domains. Scheduler will schedule pods in a
+              way which abides by the constraints. All topologySpreadConstraints are
+              ANDed.
+            items:
+              description: TopologySpreadConstraint specifies how to spread matching
+                pods among the given topology.
+              properties:
+                labelSelector:
+                  description: LabelSelector is used to find matching pods. Pods that
+                    match this label selector are counted to determine the number
+                    of pods in their corresponding topology domain.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                matchLabelKeys:
+                  description: MatchLabelKeys is a set of pod label keys to select
+                    the pods over which spreading will be calculated. The keys are
+                    used to lookup values from the incoming pod labels, those key-value
+                    labels are ANDed with labelSelector to select the group of existing
+                    pods over which spreading will be calculated for the incoming
+                    pod. Keys that don't exist in the incoming pod labels will be
+                    ignored. A null or empty list means only match against labelSelector.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: atomic
+                maxSkew:
+                  description: 'MaxSkew describes the degree to which pods may be
+                    unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                    it is the maximum permitted difference between the number of matching
+                    pods in the target topology and the global minimum. The global
+                    minimum is the minimum number of matching pods in an eligible
+                    domain or zero if the number of eligible domains is less than
+                    MinDomains. For example, in a 3-zone cluster, MaxSkew is set to
+                    1, and pods with the same labelSelector spread as 2/2/1: In this
+                    case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P
+                    P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only
+                    be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2)
+                    would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1).
+                    - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                    When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher
+                    precedence to topologies that satisfy it. It''s a required field.
+                    Default value is 1 and 0 is not allowed.'
+                  format: int32
+                  type: integer
+                minDomains:
+                  description: |-
+                    MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                    For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew.
+
+                    This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
+                  format: int32
+                  type: integer
+                nodeAffinityPolicy:
+                  description: |-
+                    NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                    If this value is nil, the behavior is equivalent to the Honor policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                  type: string
+                nodeTaintsPolicy:
+                  description: |-
+                    NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included.
+
+                    If this value is nil, the behavior is equivalent to the Ignore policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                  type: string
+                topologyKey:
+                  description: TopologyKey is the key of node labels. Nodes that have
+                    a label with this key and identical values are considered to be
+                    in the same topology. We consider each <key, value> as a "bucket",
+                    and try to put balanced number of pods into each bucket. We define
+                    a domain as a particular instance of a topology. Also, we define
+                    an eligible domain as a domain whose nodes meet the requirements
+                    of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey
+                    is "kubernetes.io/hostname", each Node is a domain of that topology.
+                    And, if TopologyKey is "topology.kubernetes.io/zone", each zone
+                    is a domain of that topology. It's a required field.
+                  type: string
+                whenUnsatisfiable:
+                  description: |-
+                    WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                      but giving higher precedence to topologies that would help reduce the
+                      skew.
+                    A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
+
+                    Possible enum values:
+                     - `"DoNotSchedule"` instructs the scheduler not to schedule the pod when constraints are not satisfied.
+                     - `"ScheduleAnyway"` instructs the scheduler to schedule the pod even if constraints are not satisfied.
+                  type: string
+              required:
+              - maxSkew
+              - topologyKey
+              - whenUnsatisfiable
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - topologyKey
+            - whenUnsatisfiable
+            x-kubernetes-list-type: map
+          volumes:
+            description: 'List of volumes that can be mounted by containers belonging
+              to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+            items:
+              description: Volume represents a named volume in a pod that may be accessed
+                by any container in the pod.
+              properties:
+                awsElasticBlockStore:
+                  description: 'awsElasticBlockStore represents an AWS Disk resource
+                    that is attached to a kubelet''s host machine and then exposed
+                    to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                  properties:
+                    fsType:
+                      description: 'fsType is the filesystem type of the volume that
+                        you want to mount. Tip: Ensure that the filesystem type is
+                        supported by the host operating system. Examples: "ext4",
+                        "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                      type: string
+                    partition:
+                      description: 'partition is the partition in the volume that
+                        you want to mount. If omitted, the default is to mount by
+                        volume name. Examples: For volume /dev/sda1, you specify the
+                        partition as "1". Similarly, the volume partition for /dev/sda
+                        is "0" (or you can leave the property empty).'
+                      format: int32
+                      type: integer
+                    readOnly:
+                      description: 'readOnly value true will force the readOnly setting
+                        in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                      type: boolean
+                    volumeID:
+                      description: 'volumeID is unique ID of the persistent disk resource
+                        in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                      type: string
+                  required:
+                  - volumeID
+                  type: object
+                azureDisk:
+                  description: azureDisk represents an Azure Data Disk mount on the
+                    host and bind mount to the pod.
+                  properties:
+                    cachingMode:
+                      description: 'cachingMode is the Host Caching mode: None, Read
+                        Only, Read Write.'
+                      type: string
+                    diskName:
+                      description: diskName is the Name of the data disk in the blob
+                        storage
+                      type: string
+                    diskURI:
+                      description: diskURI is the URI of data disk in the blob storage
+                      type: string
+                    fsType:
+                      description: fsType is Filesystem type to mount. Must be a filesystem
+                        type supported by the host operating system. Ex. "ext4", "xfs",
+                        "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                      type: string
+                    kind:
+                      description: 'kind expected values are Shared: multiple blob
+                        disks per storage account  Dedicated: single blob disk per
+                        storage account  Managed: azure managed data disk (only in
+                        managed availability set). defaults to shared'
+                      type: string
+                    readOnly:
+                      description: readOnly Defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts.
+                      type: boolean
+                  required:
+                  - diskName
+                  - diskURI
+                  type: object
+                azureFile:
+                  description: azureFile represents an Azure File Service mount on
+                    the host and bind mount to the pod.
+                  properties:
+                    readOnly:
+                      description: readOnly defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts.
+                      type: boolean
+                    secretName:
+                      description: secretName is the  name of secret that contains
+                        Azure Storage Account Name and Key
+                      type: string
+                    shareName:
+                      description: shareName is the azure share Name
+                      type: string
+                  required:
+                  - secretName
+                  - shareName
+                  type: object
+                cephfs:
+                  description: cephFS represents a Ceph FS mount on the host that
+                    shares a pod's lifetime
+                  properties:
+                    monitors:
+                      description: 'monitors is Required: Monitors is a collection
+                        of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                      items:
+                        type: string
+                      type: array
+                    path:
+                      description: 'path is Optional: Used as the mounted root, rather
+                        than the full Ceph tree, default is /'
+                      type: string
+                    readOnly:
+                      description: 'readOnly is Optional: Defaults to false (read/write).
+                        ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                      type: boolean
+                    secretFile:
+                      description: 'secretFile is Optional: SecretFile is the path
+                        to key ring for User, default is /etc/ceph/user.secret More
+                        info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                      type: string
+                    secretRef:
+                      description: 'secretRef is Optional: SecretRef is reference
+                        to the authentication secret for User, default is empty. More
+                        info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    user:
+                      description: 'user is optional: User is the rados user name,
+                        default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                      type: string
+                  required:
+                  - monitors
+                  type: object
+                cinder:
+                  description: 'cinder represents a cinder volume attached and mounted
+                    on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                  properties:
+                    fsType:
+                      description: 'fsType is the filesystem type to mount. Must be
+                        a filesystem type supported by the host operating system.
+                        Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be
+                        "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                      type: string
+                    readOnly:
+                      description: 'readOnly defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts. More
+                        info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                      type: boolean
+                    secretRef:
+                      description: 'secretRef is optional: points to a secret object
+                        containing parameters used to connect to OpenStack.'
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    volumeID:
+                      description: 'volumeID used to identify the volume in cinder.
+                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                      type: string
+                  required:
+                  - volumeID
+                  type: object
+                configMap:
+                  description: configMap represents a configMap that should populate
+                    this volume
+                  properties:
+                    defaultMode:
+                      description: 'defaultMode is optional: mode bits used to set
+                        permissions on created files by default. Must be an octal
+                        value between 0000 and 0777 or a decimal value between 0 and
+                        511. YAML accepts both octal and decimal values, JSON requires
+                        decimal values for mode bits. Defaults to 0644. Directories
+                        within the path are not affected by this setting. This might
+                        be in conflict with other options that affect the file mode,
+                        like fsGroup, and the result can be other mode bits set.'
+                      format: int32
+                      type: integer
+                    items:
+                      description: items if unspecified, each key-value pair in the
+                        Data field of the referenced ConfigMap will be projected into
+                        the volume as a file whose name is the key and content is
+                        the value. If specified, the listed keys will be projected
+                        into the specified paths, and unlisted keys will not be present.
+                        If a key is specified which is not present in the ConfigMap,
+                        the volume setup will error unless it is marked optional.
+                        Paths must be relative and may not contain the '..' path or
+                        start with '..'.
+                      items:
+                        description: Maps a string key to a path within a volume.
+                        properties:
+                          key:
+                            description: key is the key to project.
+                            type: string
+                          mode:
+                            description: 'mode is Optional: mode bits used to set
+                              permissions on this file. Must be an octal value between
+                              0000 and 0777 or a decimal value between 0 and 511.
+                              YAML accepts both octal and decimal values, JSON requires
+                              decimal values for mode bits. If not specified, the
+                              volume defaultMode will be used. This might be in conflict
+                              with other options that affect the file mode, like fsGroup,
+                              and the result can be other mode bits set.'
+                            format: int32
+                            type: integer
+                          path:
+                            description: path is the relative path of the file to
+                              map the key to. May not be an absolute path. May not
+                              contain the path element '..'. May not start with the
+                              string '..'.
+                            type: string
+                        required:
+                        - key
+                        - path
+                        type: object
+                      type: array
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    optional:
+                      description: optional specify whether the ConfigMap or its keys
+                        must be defined
+                      type: boolean
+                  type: object
+                csi:
+                  description: csi (Container Storage Interface) represents ephemeral
+                    storage that is handled by certain external CSI drivers (Beta
+                    feature).
+                  properties:
+                    driver:
+                      description: driver is the name of the CSI driver that handles
+                        this volume. Consult with your admin for the correct name
+                        as registered in the cluster.
+                      type: string
+                    fsType:
+                      description: fsType to mount. Ex. "ext4", "xfs", "ntfs". If
+                        not provided, the empty value is passed to the associated
+                        CSI driver which will determine the default filesystem to
+                        apply.
+                      type: string
+                    nodePublishSecretRef:
+                      description: nodePublishSecretRef is a reference to the secret
+                        object containing sensitive information to pass to the CSI
+                        driver to complete the CSI NodePublishVolume and NodeUnpublishVolume
+                        calls. This field is optional, and  may be empty if no secret
+                        is required. If the secret object contains more than one secret,
+                        all secret references are passed.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    readOnly:
+                      description: readOnly specifies a read-only configuration for
+                        the volume. Defaults to false (read/write).
+                      type: boolean
+                    volumeAttributes:
+                      additionalProperties:
+                        type: string
+                      description: volumeAttributes stores driver-specific properties
+                        that are passed to the CSI driver. Consult your driver's documentation
+                        for supported values.
+                      type: object
+                  required:
+                  - driver
+                  type: object
+                downwardAPI:
+                  description: downwardAPI represents downward API about the pod that
+                    should populate this volume
+                  properties:
+                    defaultMode:
+                      description: 'Optional: mode bits to use on created files by
+                        default. Must be a Optional: mode bits used to set permissions
+                        on created files by default. Must be an octal value between
+                        0000 and 0777 or a decimal value between 0 and 511. YAML accepts
+                        both octal and decimal values, JSON requires decimal values
+                        for mode bits. Defaults to 0644. Directories within the path
+                        are not affected by this setting. This might be in conflict
+                        with other options that affect the file mode, like fsGroup,
+                        and the result can be other mode bits set.'
+                      format: int32
+                      type: integer
+                    items:
+                      description: Items is a list of downward API volume file
+                      items:
+                        description: DownwardAPIVolumeFile represents information
+                          to create the file containing the pod field
+                        properties:
+                          fieldRef:
+                            description: 'Required: Selects a field of the pod: only
+                              annotations, labels, name and namespace are supported.'
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                            - fieldPath
+                            type: object
+                          mode:
+                            description: 'Optional: mode bits used to set permissions
+                              on this file, must be an octal value between 0000 and
+                              0777 or a decimal value between 0 and 511. YAML accepts
+                              both octal and decimal values, JSON requires decimal
+                              values for mode bits. If not specified, the volume defaultMode
+                              will be used. This might be in conflict with other options
+                              that affect the file mode, like fsGroup, and the result
+                              can be other mode bits set.'
+                            format: int32
+                            type: integer
+                          path:
+                            description: 'Required: Path is  the relative path name
+                              of the file to be created. Must not be absolute or contain
+                              the ''..'' path. Must be utf-8 encoded. The first item
+                              of the relative path must not start with ''..'''
+                            type: string
+                          resourceFieldRef:
+                            description: 'Selects a resource of the container: only
+                              resources limits and requests (limits.cpu, limits.memory,
+                              requests.cpu and requests.memory) are currently supported.'
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Specifies the output format of the exposed
+                                  resources, defaults to "1"
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                            - resource
+                            type: object
+                        required:
+                        - path
+                        type: object
+                      type: array
+                  type: object
+                emptyDir:
+                  description: 'emptyDir represents a temporary directory that shares
+                    a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                  properties:
+                    medium:
+                      description: 'medium represents what type of storage medium
+                        should back this directory. The default is "" which means
+                        to use the node''s default medium. Must be an empty string
+                        (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                      type: string
+                    sizeLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: 'sizeLimit is the total amount of local storage
+                        required for this EmptyDir volume. The size limit is also
+                        applicable for memory medium. The maximum usage on memory
+                        medium EmptyDir would be the minimum value between the SizeLimit
+                        specified here and the sum of memory limits of all containers
+                        in a pod. The default is nil which means that the limit is
+                        undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  type: object
+                ephemeral:
+                  description: |-
+                    ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+
+                    Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+                       tracking are needed,
+                    c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+                       a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                       information on the connection between this volume type
+                       and PersistentVolumeClaim).
+
+                    Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+
+                    Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+
+                    A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+                  properties:
+                    volumeClaimTemplate:
+                      description: |-
+                        Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+
+                        An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+
+                        This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+
+                        Required, must not be nil.
+                      properties:
+                        metadata:
+                          description: May contain labels and annotations that will
+                            be copied into the PVC when creating it. No other fields
+                            are allowed and will be rejected during validation.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        spec:
+                          description: The specification for the PersistentVolumeClaim.
+                            The entire content is copied unchanged into the PVC that
+                            gets created from this template. The same fields as in
+                            a PersistentVolumeClaim are also valid here.
+                          properties:
+                            accessModes:
+                              description: 'accessModes contains the desired access
+                                modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                              items:
+                                type: string
+                              type: array
+                            dataSource:
+                              description: 'dataSource field can be used to specify
+                                either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                * An existing PVC (PersistentVolumeClaim) If the provisioner
+                                or an external controller can support the specified
+                                data source, it will create a new volume based on
+                                the contents of the specified data source. If the
+                                AnyVolumeDataSource feature gate is enabled, this
+                                field will always have the same contents as the DataSourceRef
+                                field.'
+                              properties:
+                                apiGroup:
+                                  description: APIGroup is the group for the resource
+                                    being referenced. If APIGroup is not specified,
+                                    the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being
+                                    referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being
+                                    referenced
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            dataSourceRef:
+                              description: |-
+                                dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef
+                                  allows any non-core object, as well as PersistentVolumeClaim objects.
+                                * While DataSource ignores disallowed values (dropping them), DataSourceRef
+                                  preserves all values, and generates an error if a disallowed value is
+                                  specified.
+                                (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                              properties:
+                                apiGroup:
+                                  description: APIGroup is the group for the resource
+                                    being referenced. If APIGroup is not specified,
+                                    the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being
+                                    referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being
+                                    referenced
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            resources:
+                              description: 'resources represents the minimum resources
+                                the volume should have. If RecoverVolumeExpansionFailure
+                                feature is enabled users are allowed to specify resource
+                                requirements that are lower than previous value but
+                                must still be higher than capacity recorded in the
+                                status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                              type: object
+                            selector:
+                              description: selector is a label query over volumes
+                                to consider for binding.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            storageClassName:
+                              description: 'storageClassName is the name of the StorageClass
+                                required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                              type: string
+                            volumeMode:
+                              description: volumeMode defines what type of volume
+                                is required by the claim. Value of Filesystem is implied
+                                when not included in claim spec.
+                              type: string
+                            volumeName:
+                              description: volumeName is the binding reference to
+                                the PersistentVolume backing this claim.
+                              type: string
+                          type: object
+                      required:
+                      - spec
+                      type: object
+                  type: object
+                fc:
+                  description: fc represents a Fibre Channel resource that is attached
+                    to a kubelet's host machine and then exposed to the pod.
+                  properties:
+                    fsType:
+                      description: fsType is the filesystem type to mount. Must be
+                        a filesystem type supported by the host operating system.
+                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                        if unspecified.
+                      type: string
+                    lun:
+                      description: 'lun is Optional: FC target lun number'
+                      format: int32
+                      type: integer
+                    readOnly:
+                      description: 'readOnly is Optional: Defaults to false (read/write).
+                        ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                      type: boolean
+                    targetWWNs:
+                      description: 'targetWWNs is Optional: FC target worldwide names
+                        (WWNs)'
+                      items:
+                        type: string
+                      type: array
+                    wwids:
+                      description: 'wwids Optional: FC volume world wide identifiers
+                        (wwids) Either wwids or combination of targetWWNs and lun
+                        must be set, but not both simultaneously.'
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                flexVolume:
+                  description: flexVolume represents a generic volume resource that
+                    is provisioned/attached using an exec based plugin.
+                  properties:
+                    driver:
+                      description: driver is the name of the driver to use for this
+                        volume.
+                      type: string
+                    fsType:
+                      description: fsType is the filesystem type to mount. Must be
+                        a filesystem type supported by the host operating system.
+                        Ex. "ext4", "xfs", "ntfs". The default filesystem depends
+                        on FlexVolume script.
+                      type: string
+                    options:
+                      additionalProperties:
+                        type: string
+                      description: 'options is Optional: this field holds extra command
+                        options if any.'
+                      type: object
+                    readOnly:
+                      description: 'readOnly is Optional: defaults to false (read/write).
+                        ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                      type: boolean
+                    secretRef:
+                      description: 'secretRef is Optional: secretRef is reference
+                        to the secret object containing sensitive information to pass
+                        to the plugin scripts. This may be empty if no secret object
+                        is specified. If the secret object contains more than one
+                        secret, all secrets are passed to the plugin scripts.'
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                  required:
+                  - driver
+                  type: object
+                flocker:
+                  description: flocker represents a Flocker volume attached to a kubelet's
+                    host machine. This depends on the Flocker control service being
+                    running
+                  properties:
+                    datasetName:
+                      description: datasetName is Name of the dataset stored as metadata
+                        -> name on the dataset for Flocker should be considered as
+                        deprecated
+                      type: string
+                    datasetUUID:
+                      description: datasetUUID is the UUID of the dataset. This is
+                        unique identifier of a Flocker dataset
+                      type: string
+                  type: object
+                gcePersistentDisk:
+                  description: 'gcePersistentDisk represents a GCE Disk resource that
+                    is attached to a kubelet''s host machine and then exposed to the
+                    pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                  properties:
+                    fsType:
+                      description: 'fsType is filesystem type of the volume that you
+                        want to mount. Tip: Ensure that the filesystem type is supported
+                        by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                        Implicitly inferred to be "ext4" if unspecified. More info:
+                        https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                      type: string
+                    partition:
+                      description: 'partition is the partition in the volume that
+                        you want to mount. If omitted, the default is to mount by
+                        volume name. Examples: For volume /dev/sda1, you specify the
+                        partition as "1". Similarly, the volume partition for /dev/sda
+                        is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                      format: int32
+                      type: integer
+                    pdName:
+                      description: 'pdName is unique name of the PD resource in GCE.
+                        Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                      type: string
+                    readOnly:
+                      description: 'readOnly here will force the ReadOnly setting
+                        in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                      type: boolean
+                  required:
+                  - pdName
+                  type: object
+                gitRepo:
+                  description: 'gitRepo represents a git repository at a particular
+                    revision. DEPRECATED: GitRepo is deprecated. To provision a container
+                    with a git repo, mount an EmptyDir into an InitContainer that
+                    clones the repo using git, then mount the EmptyDir into the Pod''s
+                    container.'
+                  properties:
+                    directory:
+                      description: directory is the target directory name. Must not
+                        contain or start with '..'.  If '.' is supplied, the volume
+                        directory will be the git repository.  Otherwise, if specified,
+                        the volume will contain the git repository in the subdirectory
+                        with the given name.
+                      type: string
+                    repository:
+                      description: repository is the URL
+                      type: string
+                    revision:
+                      description: revision is the commit hash for the specified revision.
+                      type: string
+                  required:
+                  - repository
+                  type: object
+                glusterfs:
+                  description: 'glusterfs represents a Glusterfs mount on the host
+                    that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                  properties:
+                    endpoints:
+                      description: 'endpoints is the endpoint name that details Glusterfs
+                        topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                      type: string
+                    path:
+                      description: 'path is the Glusterfs volume path. More info:
+                        https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                      type: string
+                    readOnly:
+                      description: 'readOnly here will force the Glusterfs volume
+                        to be mounted with read-only permissions. Defaults to false.
+                        More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                      type: boolean
+                  required:
+                  - endpoints
+                  - path
+                  type: object
+                hostPath:
+                  description: 'hostPath represents a pre-existing file or directory
+                    on the host machine that is directly exposed to the container.
+                    This is generally used for system agents or other privileged things
+                    that are allowed to see the host machine. Most containers will
+                    NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                  properties:
+                    path:
+                      description: 'path of the directory on the host. If the path
+                        is a symlink, it will follow the link to the real path. More
+                        info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                      type: string
+                    type:
+                      description: 'type for HostPath Volume Defaults to "" More info:
+                        https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                      type: string
+                  required:
+                  - path
+                  type: object
+                iscsi:
+                  description: 'iscsi represents an ISCSI Disk resource that is attached
+                    to a kubelet''s host machine and then exposed to the pod. More
+                    info: https://examples.k8s.io/volumes/iscsi/README.md'
+                  properties:
+                    chapAuthDiscovery:
+                      description: chapAuthDiscovery defines whether support iSCSI
+                        Discovery CHAP authentication
+                      type: boolean
+                    chapAuthSession:
+                      description: chapAuthSession defines whether support iSCSI Session
+                        CHAP authentication
+                      type: boolean
+                    fsType:
+                      description: 'fsType is the filesystem type of the volume that
+                        you want to mount. Tip: Ensure that the filesystem type is
+                        supported by the host operating system. Examples: "ext4",
+                        "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                      type: string
+                    initiatorName:
+                      description: initiatorName is the custom iSCSI Initiator Name.
+                        If initiatorName is specified with iscsiInterface simultaneously,
+                        new iSCSI interface <target portal>:<volume name> will be
+                        created for the connection.
+                      type: string
+                    iqn:
+                      description: iqn is the target iSCSI Qualified Name.
+                      type: string
+                    iscsiInterface:
+                      description: iscsiInterface is the interface Name that uses
+                        an iSCSI transport. Defaults to 'default' (tcp).
+                      type: string
+                    lun:
+                      description: lun represents iSCSI Target Lun number.
+                      format: int32
+                      type: integer
+                    portals:
+                      description: portals is the iSCSI Target Portal List. The portal
+                        is either an IP or ip_addr:port if the port is other than
+                        default (typically TCP ports 860 and 3260).
+                      items:
+                        type: string
+                      type: array
+                    readOnly:
+                      description: readOnly here will force the ReadOnly setting in
+                        VolumeMounts. Defaults to false.
+                      type: boolean
+                    secretRef:
+                      description: secretRef is the CHAP Secret for iSCSI target and
+                        initiator authentication
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    targetPortal:
+                      description: targetPortal is iSCSI Target Portal. The Portal
+                        is either an IP or ip_addr:port if the port is other than
+                        default (typically TCP ports 860 and 3260).
+                      type: string
+                  required:
+                  - targetPortal
+                  - iqn
+                  - lun
+                  type: object
+                name:
+                  description: 'name of the volume. Must be a DNS_LABEL and unique
+                    within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                nfs:
+                  description: 'nfs represents an NFS mount on the host that shares
+                    a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                  properties:
+                    path:
+                      description: 'path that is exported by the NFS server. More
+                        info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                      type: string
+                    readOnly:
+                      description: 'readOnly here will force the NFS export to be
+                        mounted with read-only permissions. Defaults to false. More
+                        info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                      type: boolean
+                    server:
+                      description: 'server is the hostname or IP address of the NFS
+                        server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                      type: string
+                  required:
+                  - server
+                  - path
+                  type: object
+                persistentVolumeClaim:
+                  description: 'persistentVolumeClaimVolumeSource represents a reference
+                    to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                  properties:
+                    claimName:
+                      description: 'claimName is the name of a PersistentVolumeClaim
+                        in the same namespace as the pod using this volume. More info:
+                        https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                      type: string
+                    readOnly:
+                      description: readOnly Will force the ReadOnly setting in VolumeMounts.
+                        Default false.
+                      type: boolean
+                  required:
+                  - claimName
+                  type: object
+                photonPersistentDisk:
+                  description: photonPersistentDisk represents a PhotonController
+                    persistent disk attached and mounted on kubelets host machine
+                  properties:
+                    fsType:
+                      description: fsType is the filesystem type to mount. Must be
+                        a filesystem type supported by the host operating system.
+                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                        if unspecified.
+                      type: string
+                    pdID:
+                      description: pdID is the ID that identifies Photon Controller
+                        persistent disk
+                      type: string
+                  required:
+                  - pdID
+                  type: object
+                portworxVolume:
+                  description: portworxVolume represents a portworx volume attached
+                    and mounted on kubelets host machine
+                  properties:
+                    fsType:
+                      description: fSType represents the filesystem type to mount
+                        Must be a filesystem type supported by the host operating
+                        system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
+                        if unspecified.
+                      type: string
+                    readOnly:
+                      description: readOnly defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts.
+                      type: boolean
+                    volumeID:
+                      description: volumeID uniquely identifies a Portworx volume
+                      type: string
+                  required:
+                  - volumeID
+                  type: object
+                projected:
+                  description: projected items for all in one resources secrets, configmaps,
+                    and downward API
+                  properties:
+                    defaultMode:
+                      description: defaultMode are the mode bits used to set permissions
+                        on created files by default. Must be an octal value between
+                        0000 and 0777 or a decimal value between 0 and 511. YAML accepts
+                        both octal and decimal values, JSON requires decimal values
+                        for mode bits. Directories within the path are not affected
+                        by this setting. This might be in conflict with other options
+                        that affect the file mode, like fsGroup, and the result can
+                        be other mode bits set.
+                      format: int32
+                      type: integer
+                    sources:
+                      description: sources is the list of volume projections
+                      items:
+                        description: Projection that may be projected along with other
+                          supported volume types
+                        properties:
+                          configMap:
+                            description: configMap information about the configMap
+                              data to project
+                            properties:
+                              items:
+                                description: items if unspecified, each key-value
+                                  pair in the Data field of the referenced ConfigMap
+                                  will be projected into the volume as a file whose
+                                  name is the key and content is the value. If specified,
+                                  the listed keys will be projected into the specified
+                                  paths, and unlisted keys will not be present. If
+                                  a key is specified which is not present in the ConfigMap,
+                                  the volume setup will error unless it is marked
+                                  optional. Paths must be relative and may not contain
+                                  the '..' path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: 'mode is Optional: mode bits used
+                                        to set permissions on this file. Must be an
+                                        octal value between 0000 and 0777 or a decimal
+                                        value between 0 and 511. YAML accepts both
+                                        octal and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: path is the relative path of the
+                                        file to map the key to. May not be an absolute
+                                        path. May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: optional specify whether the ConfigMap
+                                  or its keys must be defined
+                                type: boolean
+                            type: object
+                          downwardAPI:
+                            description: downwardAPI information about the downwardAPI
+                              data to project
+                            properties:
+                              items:
+                                description: Items is a list of DownwardAPIVolume
+                                  file
+                                items:
+                                  description: DownwardAPIVolumeFile represents information
+                                    to create the file containing the pod field
+                                  properties:
+                                    fieldRef:
+                                      description: 'Required: Selects a field of the
+                                        pod: only annotations, labels, name and namespace
+                                        are supported.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    mode:
+                                      description: 'Optional: mode bits used to set
+                                        permissions on this file, must be an octal
+                                        value between 0000 and 0777 or a decimal value
+                                        between 0 and 511. YAML accepts both octal
+                                        and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: 'Required: Path is  the relative
+                                        path name of the file to be created. Must
+                                        not be absolute or contain the ''..'' path.
+                                        Must be utf-8 encoded. The first item of the
+                                        relative path must not start with ''..'''
+                                      type: string
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, requests.cpu and requests.memory)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                  required:
+                                  - path
+                                  type: object
+                                type: array
+                            type: object
+                          secret:
+                            description: secret information about the secret data
+                              to project
+                            properties:
+                              items:
+                                description: items if unspecified, each key-value
+                                  pair in the Data field of the referenced Secret
+                                  will be projected into the volume as a file whose
+                                  name is the key and content is the value. If specified,
+                                  the listed keys will be projected into the specified
+                                  paths, and unlisted keys will not be present. If
+                                  a key is specified which is not present in the Secret,
+                                  the volume setup will error unless it is marked
+                                  optional. Paths must be relative and may not contain
+                                  the '..' path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: 'mode is Optional: mode bits used
+                                        to set permissions on this file. Must be an
+                                        octal value between 0000 and 0777 or a decimal
+                                        value between 0 and 511. YAML accepts both
+                                        octal and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: path is the relative path of the
+                                        file to map the key to. May not be an absolute
+                                        path. May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: optional field specify whether the Secret
+                                  or its key must be defined
+                                type: boolean
+                            type: object
+                          serviceAccountToken:
+                            description: serviceAccountToken is information about
+                              the serviceAccountToken data to project
+                            properties:
+                              audience:
+                                description: audience is the intended audience of
+                                  the token. A recipient of a token must identify
+                                  itself with an identifier specified in the audience
+                                  of the token, and otherwise should reject the token.
+                                  The audience defaults to the identifier of the apiserver.
+                                type: string
+                              expirationSeconds:
+                                description: expirationSeconds is the requested duration
+                                  of validity of the service account token. As the
+                                  token approaches expiration, the kubelet volume
+                                  plugin will proactively rotate the service account
+                                  token. The kubelet will start trying to rotate the
+                                  token if the token is older than 80 percent of its
+                                  time to live or if the token is older than 24 hours.Defaults
+                                  to 1 hour and must be at least 10 minutes.
+                                format: int64
+                                type: integer
+                              path:
+                                description: path is the path relative to the mount
+                                  point of the file to project the token into.
+                                type: string
+                            required:
+                            - path
+                            type: object
+                        type: object
+                      type: array
+                  type: object
+                quobyte:
+                  description: quobyte represents a Quobyte mount on the host that
+                    shares a pod's lifetime
+                  properties:
+                    group:
+                      description: group to map volume access to Default is no group
+                      type: string
+                    readOnly:
+                      description: readOnly here will force the Quobyte volume to
+                        be mounted with read-only permissions. Defaults to false.
+                      type: boolean
+                    registry:
+                      description: registry represents a single or multiple Quobyte
+                        Registry services specified as a string as host:port pair
+                        (multiple entries are separated with commas) which acts as
+                        the central registry for volumes
+                      type: string
+                    tenant:
+                      description: tenant owning the given Quobyte volume in the Backend
+                        Used with dynamically provisioned Quobyte volumes, value is
+                        set by the plugin
+                      type: string
+                    user:
+                      description: user to map volume access to Defaults to serivceaccount
+                        user
+                      type: string
+                    volume:
+                      description: volume is a string that references an already created
+                        Quobyte volume by name.
+                      type: string
+                  required:
+                  - registry
+                  - volume
+                  type: object
+                rbd:
+                  description: 'rbd represents a Rados Block Device mount on the host
+                    that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                  properties:
+                    fsType:
+                      description: 'fsType is the filesystem type of the volume that
+                        you want to mount. Tip: Ensure that the filesystem type is
+                        supported by the host operating system. Examples: "ext4",
+                        "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                      type: string
+                    image:
+                      description: 'image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      type: string
+                    keyring:
+                      description: 'keyring is the path to key ring for RBDUser. Default
+                        is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      type: string
+                    monitors:
+                      description: 'monitors is a collection of Ceph monitors. More
+                        info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      items:
+                        type: string
+                      type: array
+                    pool:
+                      description: 'pool is the rados pool name. Default is rbd. More
+                        info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      type: string
+                    readOnly:
+                      description: 'readOnly here will force the ReadOnly setting
+                        in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      type: boolean
+                    secretRef:
+                      description: 'secretRef is name of the authentication secret
+                        for RBDUser. If provided overrides keyring. Default is nil.
+                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    user:
+                      description: 'user is the rados user name. Default is admin.
+                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      type: string
+                  required:
+                  - monitors
+                  - image
+                  type: object
+                scaleIO:
+                  description: scaleIO represents a ScaleIO persistent volume attached
+                    and mounted on Kubernetes nodes.
+                  properties:
+                    fsType:
+                      description: fsType is the filesystem type to mount. Must be
+                        a filesystem type supported by the host operating system.
+                        Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                      type: string
+                    gateway:
+                      description: gateway is the host address of the ScaleIO API
+                        Gateway.
+                      type: string
+                    protectionDomain:
+                      description: protectionDomain is the name of the ScaleIO Protection
+                        Domain for the configured storage.
+                      type: string
+                    readOnly:
+                      description: readOnly Defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts.
+                      type: boolean
+                    secretRef:
+                      description: secretRef references to the secret for ScaleIO
+                        user and other sensitive information. If this is not provided,
+                        Login operation will fail.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    sslEnabled:
+                      description: sslEnabled Flag enable/disable SSL communication
+                        with Gateway, default false
+                      type: boolean
+                    storageMode:
+                      description: storageMode indicates whether the storage for a
+                        volume should be ThickProvisioned or ThinProvisioned. Default
+                        is ThinProvisioned.
+                      type: string
+                    storagePool:
+                      description: storagePool is the ScaleIO Storage Pool associated
+                        with the protection domain.
+                      type: string
+                    system:
+                      description: system is the name of the storage system as configured
+                        in ScaleIO.
+                      type: string
+                    volumeName:
+                      description: volumeName is the name of a volume already created
+                        in the ScaleIO system that is associated with this volume
+                        source.
+                      type: string
+                  required:
+                  - gateway
+                  - system
+                  - secretRef
+                  type: object
+                secret:
+                  description: 'secret represents a secret that should populate this
+                    volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                  properties:
+                    defaultMode:
+                      description: 'defaultMode is Optional: mode bits used to set
+                        permissions on created files by default. Must be an octal
+                        value between 0000 and 0777 or a decimal value between 0 and
+                        511. YAML accepts both octal and decimal values, JSON requires
+                        decimal values for mode bits. Defaults to 0644. Directories
+                        within the path are not affected by this setting. This might
+                        be in conflict with other options that affect the file mode,
+                        like fsGroup, and the result can be other mode bits set.'
+                      format: int32
+                      type: integer
+                    items:
+                      description: items If unspecified, each key-value pair in the
+                        Data field of the referenced Secret will be projected into
+                        the volume as a file whose name is the key and content is
+                        the value. If specified, the listed keys will be projected
+                        into the specified paths, and unlisted keys will not be present.
+                        If a key is specified which is not present in the Secret,
+                        the volume setup will error unless it is marked optional.
+                        Paths must be relative and may not contain the '..' path or
+                        start with '..'.
+                      items:
+                        description: Maps a string key to a path within a volume.
+                        properties:
+                          key:
+                            description: key is the key to project.
+                            type: string
+                          mode:
+                            description: 'mode is Optional: mode bits used to set
+                              permissions on this file. Must be an octal value between
+                              0000 and 0777 or a decimal value between 0 and 511.
+                              YAML accepts both octal and decimal values, JSON requires
+                              decimal values for mode bits. If not specified, the
+                              volume defaultMode will be used. This might be in conflict
+                              with other options that affect the file mode, like fsGroup,
+                              and the result can be other mode bits set.'
+                            format: int32
+                            type: integer
+                          path:
+                            description: path is the relative path of the file to
+                              map the key to. May not be an absolute path. May not
+                              contain the path element '..'. May not start with the
+                              string '..'.
+                            type: string
+                        required:
+                        - key
+                        - path
+                        type: object
+                      type: array
+                    optional:
+                      description: optional field specify whether the Secret or its
+                        keys must be defined
+                      type: boolean
+                    secretName:
+                      description: 'secretName is the name of the secret in the pod''s
+                        namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                      type: string
+                  type: object
+                storageos:
+                  description: storageOS represents a StorageOS volume attached and
+                    mounted on Kubernetes nodes.
+                  properties:
+                    fsType:
+                      description: fsType is the filesystem type to mount. Must be
+                        a filesystem type supported by the host operating system.
+                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                        if unspecified.
+                      type: string
+                    readOnly:
+                      description: readOnly defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts.
+                      type: boolean
+                    secretRef:
+                      description: secretRef specifies the secret to use for obtaining
+                        the StorageOS API credentials.  If not specified, default
+                        values will be attempted.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    volumeName:
+                      description: volumeName is the human-readable name of the StorageOS
+                        volume.  Volume names are only unique within a namespace.
+                      type: string
+                    volumeNamespace:
+                      description: volumeNamespace specifies the scope of the volume
+                        within StorageOS.  If no namespace is specified then the Pod's
+                        namespace will be used.  This allows the Kubernetes name scoping
+                        to be mirrored within StorageOS for tighter integration. Set
+                        VolumeName to any name to override the default behaviour.
+                        Set to "default" if you are not using namespaces within StorageOS.
+                        Namespaces that do not pre-exist within StorageOS will be
+                        created.
+                      type: string
+                  type: object
+                vsphereVolume:
+                  description: vsphereVolume represents a vSphere volume attached
+                    and mounted on kubelets host machine
+                  properties:
+                    fsType:
+                      description: fsType is filesystem type to mount. Must be a filesystem
+                        type supported by the host operating system. Ex. "ext4", "xfs",
+                        "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                      type: string
+                    storagePolicyID:
+                      description: storagePolicyID is the storage Policy Based Management
+                        (SPBM) profile ID associated with the StoragePolicyName.
+                      type: string
+                    storagePolicyName:
+                      description: storagePolicyName is the storage Policy Based Management
+                        (SPBM) profile name.
+                      type: string
+                    volumePath:
+                      description: volumePath is the path that identifies vSphere
+                        volume vmdk
+                      type: string
+                  required:
+                  - volumePath
+                  type: object
+              required:
+              - name
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - name
+            x-kubernetes-list-type: map
+        required:
+        - containers
+        type: object
+      status:
+        description: 'Most recently observed status of the pod. This data may not
+          be up to date. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+        properties:
+          conditions:
+            description: 'Current service state of pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions'
+            items:
+              description: PodCondition contains details for the current condition
+                of this pod.
+              properties:
+                lastProbeTime:
+                  description: Last time we probed the condition.
+                  format: date-time
+                  type: string
+                lastTransitionTime:
+                  description: Last time the condition transitioned from one status
+                    to another.
+                  format: date-time
+                  type: string
+                message:
+                  description: Human-readable message indicating details about last
+                    transition.
+                  type: string
+                reason:
+                  description: Unique, one-word, CamelCase reason for the condition's
+                    last transition.
+                  type: string
+                status:
+                  description: 'Status is the status of the condition. Can be True,
+                    False, Unknown. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions'
+                  type: string
+                type:
+                  description: 'Type is the type of the condition. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions'
+                  type: string
+              required:
+              - status
+              - type
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - type
+            x-kubernetes-list-type: map
+          containerStatuses:
+            description: 'The list has one entry per container in the manifest. More
+              info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status'
+            items:
+              description: ContainerStatus contains details for the current status
+                of this container.
+              properties:
+                containerID:
+                  description: Container's ID in the format '<type>://<container_id>'.
+                  type: string
+                image:
+                  description: 'The image the container is running. More info: https://kubernetes.io/docs/concepts/containers/images.'
+                  type: string
+                imageID:
+                  description: ImageID of the container's image.
+                  type: string
+                lastState:
+                  description: Details about the container's last termination condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format '<type>://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+                name:
+                  description: This must be a DNS_LABEL. Each container in a pod must
+                    have a unique name. Cannot be updated.
+                  type: string
+                ready:
+                  description: Specifies whether the container has passed its readiness
+                    probe.
+                  type: boolean
+                restartCount:
+                  description: The number of times the container has been restarted.
+                  format: int32
+                  type: integer
+                started:
+                  description: Specifies whether the container has passed its startup
+                    probe. Initialized as false, becomes true after startupProbe is
+                    considered successful. Resets to false when the container is restarted,
+                    or if kubelet loses state temporarily. Is always true when no
+                    startupProbe is defined.
+                  type: boolean
+                state:
+                  description: Details about the container's current condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format '<type>://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+              required:
+              - name
+              - ready
+              - restartCount
+              - image
+              - imageID
+              type: object
+            type: array
+          ephemeralContainerStatuses:
+            description: Status for any ephemeral containers that have run in this
+              pod.
+            items:
+              description: ContainerStatus contains details for the current status
+                of this container.
+              properties:
+                containerID:
+                  description: Container's ID in the format '<type>://<container_id>'.
+                  type: string
+                image:
+                  description: 'The image the container is running. More info: https://kubernetes.io/docs/concepts/containers/images.'
+                  type: string
+                imageID:
+                  description: ImageID of the container's image.
+                  type: string
+                lastState:
+                  description: Details about the container's last termination condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format '<type>://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+                name:
+                  description: This must be a DNS_LABEL. Each container in a pod must
+                    have a unique name. Cannot be updated.
+                  type: string
+                ready:
+                  description: Specifies whether the container has passed its readiness
+                    probe.
+                  type: boolean
+                restartCount:
+                  description: The number of times the container has been restarted.
+                  format: int32
+                  type: integer
+                started:
+                  description: Specifies whether the container has passed its startup
+                    probe. Initialized as false, becomes true after startupProbe is
+                    considered successful. Resets to false when the container is restarted,
+                    or if kubelet loses state temporarily. Is always true when no
+                    startupProbe is defined.
+                  type: boolean
+                state:
+                  description: Details about the container's current condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format '<type>://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+              required:
+              - name
+              - ready
+              - restartCount
+              - image
+              - imageID
+              type: object
+            type: array
+          hostIP:
+            description: IP address of the host to which the pod is assigned. Empty
+              if not yet scheduled.
+            type: string
+          initContainerStatuses:
+            description: 'The list has one entry per init container in the manifest.
+              The most recent successful init container will have ready = true, the
+              most recently started container will have startTime set. More info:
+              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status'
+            items:
+              description: ContainerStatus contains details for the current status
+                of this container.
+              properties:
+                containerID:
+                  description: Container's ID in the format '<type>://<container_id>'.
+                  type: string
+                image:
+                  description: 'The image the container is running. More info: https://kubernetes.io/docs/concepts/containers/images.'
+                  type: string
+                imageID:
+                  description: ImageID of the container's image.
+                  type: string
+                lastState:
+                  description: Details about the container's last termination condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format '<type>://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+                name:
+                  description: This must be a DNS_LABEL. Each container in a pod must
+                    have a unique name. Cannot be updated.
+                  type: string
+                ready:
+                  description: Specifies whether the container has passed its readiness
+                    probe.
+                  type: boolean
+                restartCount:
+                  description: The number of times the container has been restarted.
+                  format: int32
+                  type: integer
+                started:
+                  description: Specifies whether the container has passed its startup
+                    probe. Initialized as false, becomes true after startupProbe is
+                    considered successful. Resets to false when the container is restarted,
+                    or if kubelet loses state temporarily. Is always true when no
+                    startupProbe is defined.
+                  type: boolean
+                state:
+                  description: Details about the container's current condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format '<type>://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+              required:
+              - name
+              - ready
+              - restartCount
+              - image
+              - imageID
+              type: object
+            type: array
+          message:
+            description: A human readable message indicating details about why the
+              pod is in this condition.
+            type: string
+          nominatedNodeName:
+            description: nominatedNodeName is set only when this pod preempts other
+              pods on the node, but it cannot be scheduled right away as preemption
+              victims receive their graceful termination periods. This field does
+              not guarantee that the pod will be scheduled on this node. Scheduler
+              may decide to place the pod elsewhere if other nodes become available
+              sooner. Scheduler may also decide to give the resources on this node
+              to a higher priority pod that is created after preemption. As a result,
+              this field may be different than PodSpec.nodeName when the pod is scheduled.
+            type: string
+          phase:
+            description: |-
+              The phase of a Pod is a simple, high-level summary of where the Pod is in its lifecycle. The conditions array, the reason and message fields, and the individual container status arrays contain more detail about the pod's status. There are five possible phase values:
+
+              Pending: The pod has been accepted by the Kubernetes system, but one or more of the container images has not been created. This includes time before being scheduled as well as time spent downloading images over the network, which could take a while. Running: The pod has been bound to a node, and all of the containers have been created. At least one container is still running, or is in the process of starting or restarting. Succeeded: All containers in the pod have terminated in success, and will not be restarted. Failed: All containers in the pod have terminated, and at least one container has terminated in failure. The container either exited with non-zero status or was terminated by the system. Unknown: For some reason the state of the pod could not be obtained, typically due to an error in communicating with the host of the pod.
+
+              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-phase
+
+              Possible enum values:
+               - `"Failed"` means that all containers in the pod have terminated, and at least one container has terminated in a failure (exited with a non-zero exit code or was stopped by the system).
+               - `"Pending"` means the pod has been accepted by the system, but one or more of the containers has not been started. This includes time before being bound to a node, as well as time spent pulling images onto the host.
+               - `"Running"` means the pod has been bound to a node and all of the containers have been started. At least one container is still running or is in the process of being restarted.
+               - `"Succeeded"` means that all containers in the pod have voluntarily terminated with a container exit code of 0, and the system is not going to restart any of these containers.
+               - `"Unknown"` means that for some reason the state of the pod could not be obtained, typically due to an error in communicating with the host of the pod. Deprecated: It isn't being set since 2015 (74da3b14b0c0f658b3bb8d2def5094686d0e9095)
+            type: string
+          podIP:
+            description: IP address allocated to the pod. Routable at least within
+              the cluster. Empty if not yet allocated.
+            type: string
+          podIPs:
+            description: podIPs holds the IP addresses allocated to the pod. If this
+              field is specified, the 0th entry must match the podIP field. Pods may
+              be allocated at most 1 value for each of IPv4 and IPv6. This list is
+              empty if no IPs have been allocated yet.
+            items:
+              description: "IP address information for entries in the (plural) PodIPs
+                field. Each entry includes:\n\n\tIP: An IP address allocated to the
+                pod. Routable at least within the cluster."
+              properties:
+                ip:
+                  description: ip is an IP address (IPv4 or IPv6) assigned to the
+                    pod
+                  type: string
+              required:
+              - ip
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - ip
+            x-kubernetes-list-type: map
+          qosClass:
+            description: |-
+              The Quality of Service (QOS) classification assigned to the pod based on resource requirements See PodQOSClass type for available QOS classes More info: https://git.k8s.io/community/contributors/design-proposals/node/resource-qos.md
+
+              Possible enum values:
+               - `"BestEffort"` is the BestEffort qos class.
+               - `"Burstable"` is the Burstable qos class.
+               - `"Guaranteed"` is the Guaranteed qos class.
+            type: string
+          reason:
+            description: A brief CamelCase message indicating details about why the
+              pod is in this state. e.g. 'Evicted'
+            type: string
+          startTime:
+            description: RFC 3339 date and time at which the object was acknowledged
+              by the Kubelet. This is before the Kubelet pulled the container image(s)
+              for the pod.
+            format: date-time
+            type: string
+        type: object
+    type: object
+  plural: pods
+  schemaUpdateStrategy: UpdateUnpublished
+  scope: Namespaced
+  shortNames:
+  - po
+  singular: pod
+  subResources:
+  - name: status
+status:
+  conditions:
+  - lastTransitionTime: "2023-03-21T17:10:10Z"
+    status: "True"
+    type: Compatible

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/3-APIResourceImport-services.kind.v1.core.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/3-APIResourceImport-services.kind.v1.core.yaml
@@ -1,0 +1,429 @@
+apiVersion: apiresource.kcp.io/v1alpha1
+kind: APIResourceImport
+metadata:
+  annotations:
+    apiresource.kcp.io/apiVersion: v1
+    kcp.io/cluster: br3qimk2t1o3jb70
+  creationTimestamp: "2023-03-21T17:10:09Z"
+  generation: 1
+  name: services.kind.v1.core
+  ownerReferences:
+  - apiVersion: workload.kcp.io/v1alpha1
+    controller: true
+    kind: SyncTarget
+    name: kind
+    uid: 8df305e7-f4f8-439f-9115-51054d519361
+  resourceVersion: "9143"
+  uid: 5f801853-c70e-47ac-9585-b497fd42e65d
+spec:
+  categories:
+  - all
+  groupVersion:
+    version: v1
+  kind: Service
+  listKind: ServiceList
+  location: kind
+  openAPIV3Schema:
+    description: Service is a named abstraction of software service (for example,
+      mysql) consisting of local port (for example 3306) that the proxy listens on,
+      and the selector that determines which pods will answer requests sent through
+      the proxy.
+    properties:
+      apiVersion:
+        description: 'APIVersion defines the versioned schema of this representation
+          of an object. Servers should convert recognized schemas to the latest internal
+          value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+        type: string
+      kind:
+        description: 'Kind is a string value representing the REST resource this object
+          represents. Servers may infer this from the endpoint the client submits
+          requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+        type: string
+      metadata:
+        type: object
+      spec:
+        description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        properties:
+          allocateLoadBalancerNodePorts:
+            description: allocateLoadBalancerNodePorts defines if NodePorts will be
+              automatically allocated for services with type LoadBalancer.  Default
+              is "true". It may be set to "false" if the cluster load-balancer does
+              not rely on NodePorts.  If the caller requests specific NodePorts (by
+              specifying a value), those requests will be respected, regardless of
+              this field. This field may only be set for services with type LoadBalancer
+              and will be cleared if the type is changed to any other type.
+            type: boolean
+          clusterIP:
+            description: 'clusterIP is the IP address of the service and is usually
+              assigned randomly. If an address is specified manually, is in-range
+              (as per system configuration), and is not in use, it will be allocated
+              to the service; otherwise creation of the service will fail. This field
+              may not be changed through updates unless the type field is also being
+              changed to ExternalName (which requires this field to be blank) or the
+              type field is being changed from ExternalName (in which case this field
+              may optionally be specified, as describe above).  Valid values are "None",
+              empty string (""), or a valid IP address. Setting this to "None" makes
+              a "headless service" (no virtual IP), which is useful when direct endpoint
+              connections are preferred and proxying is not required.  Only applies
+              to types ClusterIP, NodePort, and LoadBalancer. If this field is specified
+              when creating a Service of type ExternalName, creation will fail. This
+              field will be wiped when updating a Service to type ExternalName. More
+              info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+            type: string
+          clusterIPs:
+            description: |-
+              ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address.  Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value.
+
+              This field may hold a maximum of two entries (dual-stack IPs, in either order). These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+            items:
+              type: string
+            type: array
+            x-kubernetes-list-type: atomic
+          externalIPs:
+            description: externalIPs is a list of IP addresses for which nodes in
+              the cluster will also accept traffic for this service.  These IPs are
+              not managed by Kubernetes.  The user is responsible for ensuring that
+              traffic arrives at a node with this IP.  A common example is external
+              load-balancers that are not part of the Kubernetes system.
+            items:
+              type: string
+            type: array
+          externalName:
+            description: externalName is the external reference that discovery mechanisms
+              will return as an alias for this service (e.g. a DNS CNAME record).
+              No proxying will be involved.  Must be a lowercase RFC-1123 hostname
+              (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
+            type: string
+          externalTrafficPolicy:
+            description: |-
+              externalTrafficPolicy describes how nodes distribute service traffic they receive on one of the Service's "externally-facing" addresses (NodePorts, ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure the service in a way that assumes that external load balancers will take care of balancing the service traffic between nodes, and so each node will deliver traffic only to the node-local endpoints of the service, without masquerading the client source IP. (Traffic mistakenly sent to a node with no endpoints will be dropped.) The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features). Note that traffic sent to an External IP or LoadBalancer IP from within the cluster will always get "Cluster" semantics, but clients sending to a NodePort from within the cluster may need to take traffic policy into account when picking a node.
+
+              Possible enum values:
+               - `"Cluster"` routes traffic to all endpoints.
+               - `"Local"` preserves the source IP of the traffic by routing only to endpoints on the same node as the traffic was received on (dropping the traffic if there are no local endpoints).
+            type: string
+          healthCheckNodePort:
+            description: healthCheckNodePort specifies the healthcheck nodePort for
+              the service. This only applies when type is set to LoadBalancer and
+              externalTrafficPolicy is set to Local. If a value is specified, is in-range,
+              and is not in use, it will be used.  If not specified, a value will
+              be automatically allocated.  External systems (e.g. load-balancers)
+              can use this port to determine if a given node holds endpoints for this
+              service or not.  If this field is specified when creating a Service
+              which does not need it, creation will fail. This field will be wiped
+              when updating a Service to no longer need it (e.g. changing type). This
+              field cannot be updated once set.
+            format: int32
+            type: integer
+          internalTrafficPolicy:
+            description: InternalTrafficPolicy describes how nodes distribute service
+              traffic they receive on the ClusterIP. If set to "Local", the proxy
+              will assume that pods only want to talk to endpoints of the service
+              on the same node as the pod, dropping the traffic if there are no local
+              endpoints. The default value, "Cluster", uses the standard behavior
+              of routing to all endpoints evenly (possibly modified by topology and
+              other features).
+            type: string
+          ipFamilies:
+            description: |-
+              IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service. This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail. This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service. Valid values are "IPv4" and "IPv6".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to "headless" services. This field will be wiped when updating a Service to type ExternalName.
+
+              This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field.
+            items:
+              type: string
+            type: array
+            x-kubernetes-list-type: atomic
+          ipFamilyPolicy:
+            description: IPFamilyPolicy represents the dual-stack-ness requested or
+              required by this Service. If there is no value provided, then this field
+              will be set to SingleStack. Services can be "SingleStack" (a single
+              IP family), "PreferDualStack" (two IP families on dual-stack configured
+              clusters or a single IP family on single-stack clusters), or "RequireDualStack"
+              (two IP families on dual-stack configured clusters, otherwise fail).
+              The ipFamilies and clusterIPs fields depend on the value of this field.
+              This field will be wiped when updating a service to type ExternalName.
+            type: string
+          loadBalancerClass:
+            description: loadBalancerClass is the class of the load balancer implementation
+              this Service belongs to. If specified, the value of this field must
+              be a label-style identifier, with an optional prefix, e.g. "internal-vip"
+              or "example.com/internal-vip". Unprefixed names are reserved for end-users.
+              This field can only be set when the Service type is 'LoadBalancer'.
+              If not set, the default load balancer implementation is used, today
+              this is typically done through the cloud provider integration, but should
+              apply for any default implementation. If set, it is assumed that a load
+              balancer implementation is watching for Services with a matching class.
+              Any default load balancer implementation (e.g. cloud providers) should
+              ignore Services that set this field. This field can only be set when
+              creating or updating a Service to type 'LoadBalancer'. Once set, it
+              can not be changed. This field will be wiped when a service is updated
+              to a non 'LoadBalancer' type.
+            type: string
+          loadBalancerIP:
+            description: 'Only applies to Service Type: LoadBalancer. This feature
+              depends on whether the underlying cloud-provider supports specifying
+              the loadBalancerIP when a load balancer is created. This field will
+              be ignored if the cloud-provider does not support the feature. Deprecated:
+              This field was under-specified and its meaning varies across implementations,
+              and it cannot support dual-stack. As of Kubernetes v1.24, users are
+              encouraged to use implementation-specific annotations when available.
+              This field may be removed in a future API version.'
+            type: string
+          loadBalancerSourceRanges:
+            description: 'If specified and supported by the platform, this will restrict
+              traffic through the cloud-provider load-balancer will be restricted
+              to the specified client IPs. This field will be ignored if the cloud-provider
+              does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/'
+            items:
+              type: string
+            type: array
+          ports:
+            description: 'The list of ports that are exposed by this service. More
+              info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+            items:
+              description: ServicePort contains information on service's port.
+              properties:
+                appProtocol:
+                  description: The application protocol for this port. This field
+                    follows standard Kubernetes label syntax. Un-prefixed names are
+                    reserved for IANA standard service names (as per RFC-6335 and
+                    https://www.iana.org/assignments/service-names). Non-standard
+                    protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+                  type: string
+                name:
+                  description: The name of this port within the service. This must
+                    be a DNS_LABEL. All ports within a ServiceSpec must have unique
+                    names. When considering the endpoints for a Service, this must
+                    match the 'name' field in the EndpointPort. Optional if only one
+                    ServicePort is defined on this service.
+                  type: string
+                nodePort:
+                  description: 'The port on each node on which this service is exposed
+                    when type is NodePort or LoadBalancer.  Usually assigned by the
+                    system. If a value is specified, in-range, and not in use it will
+                    be used, otherwise the operation will fail.  If not specified,
+                    a port will be allocated if this Service requires one.  If this
+                    field is specified when creating a Service which does not need
+                    it, creation will fail. This field will be wiped when updating
+                    a Service to no longer need it (e.g. changing type from NodePort
+                    to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                  format: int32
+                  type: integer
+                port:
+                  description: The port that will be exposed by this service.
+                  format: int32
+                  type: integer
+                protocol:
+                  default: TCP
+                  description: |-
+                    The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+
+                    Possible enum values:
+                     - `"SCTP"` is the SCTP protocol.
+                     - `"TCP"` is the TCP protocol.
+                     - `"UDP"` is the UDP protocol.
+                  type: string
+                targetPort:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: 'Number or name of the port to access on the pods targeted
+                    by the service. Number must be in the range 1 to 65535. Name must
+                    be an IANA_SVC_NAME. If this is a string, it will be looked up
+                    as a named port in the target Pod''s container ports. If this
+                    is not specified, the value of the ''port'' field is used (an
+                    identity map). This field is ignored for services with clusterIP=None,
+                    and should be omitted or set equal to the ''port'' field. More
+                    info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                  x-kubernetes-int-or-string: true
+              required:
+              - port
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - port
+            - protocol
+            x-kubernetes-list-type: map
+          publishNotReadyAddresses:
+            description: publishNotReadyAddresses indicates that any agent which deals
+              with endpoints for this Service should disregard any indications of
+              ready/not-ready. The primary use case for setting this field is for
+              a StatefulSet's Headless Service to propagate SRV DNS records for its
+              Pods for the purpose of peer discovery. The Kubernetes controllers that
+              generate Endpoints and EndpointSlice resources for Services interpret
+              this to mean that all endpoints are considered "ready" even if the Pods
+              themselves are not. Agents which consume only Kubernetes generated endpoints
+              through the Endpoints or EndpointSlice resources can safely assume this
+              behavior.
+            type: boolean
+          selector:
+            additionalProperties:
+              type: string
+            description: 'Route service traffic to pods with label keys and values
+              matching this selector. If empty or not present, the service is assumed
+              to have an external process managing its endpoints, which Kubernetes
+              will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer.
+              Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+            type: object
+          sessionAffinity:
+            description: |-
+              Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+
+              Possible enum values:
+               - `"ClientIP"` is the Client IP based.
+               - `"None"` - no session affinity.
+            type: string
+          sessionAffinityConfig:
+            description: sessionAffinityConfig contains the configurations of session
+              affinity.
+            properties:
+              clientIP:
+                description: clientIP contains the configurations of Client IP based
+                  session affinity.
+                properties:
+                  timeoutSeconds:
+                    description: timeoutSeconds specifies the seconds of ClientIP
+                      type session sticky time. The value must be >0 && <=86400(for
+                      1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for
+                      3 hours).
+                    format: int32
+                    type: integer
+                type: object
+            type: object
+          type:
+            description: |-
+              type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+
+              Possible enum values:
+               - `"ClusterIP"` means a service will only be accessible inside the cluster, via the cluster IP.
+               - `"ExternalName"` means a service consists of only a reference to an external name that kubedns or equivalent will return as a CNAME record, with no exposing or proxying of any pods involved.
+               - `"LoadBalancer"` means a service will be exposed via an external load balancer (if the cloud provider supports it), in addition to 'NodePort' type.
+               - `"NodePort"` means a service will be exposed on one port of every node, in addition to 'ClusterIP' type.
+            type: string
+        type: object
+      status:
+        description: 'Most recently observed status of the service. Populated by the
+          system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+        properties:
+          conditions:
+            description: Current service state
+            items:
+              description: Condition contains details for one aspect of the current
+                state of this API Resource.
+              properties:
+                lastTransitionTime:
+                  description: lastTransitionTime is the last time the condition transitioned
+                    from one status to another. This should be when the underlying
+                    condition changed.  If that is not known, then using the time
+                    when the API field changed is acceptable.
+                  format: date-time
+                  type: string
+                message:
+                  description: message is a human readable message indicating details
+                    about the transition. This may be an empty string.
+                  type: string
+                observedGeneration:
+                  description: observedGeneration represents the .metadata.generation
+                    that the condition was set based upon. For instance, if .metadata.generation
+                    is currently 12, but the .status.conditions[x].observedGeneration
+                    is 9, the condition is out of date with respect to the current
+                    state of the instance.
+                  format: int64
+                  type: integer
+                reason:
+                  description: reason contains a programmatic identifier indicating
+                    the reason for the condition's last transition. Producers of specific
+                    condition types may define expected values and meanings for this
+                    field, and whether the values are considered a guaranteed API.
+                    The value should be a CamelCase string. This field may not be
+                    empty.
+                  type: string
+                status:
+                  description: status of the condition, one of True, False, Unknown.
+                  type: string
+                type:
+                  description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                  type: string
+              required:
+              - lastTransitionTime
+              - message
+              - reason
+              - status
+              - type
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - type
+            x-kubernetes-list-type: map
+          loadBalancer:
+            description: LoadBalancer contains the current status of the load-balancer,
+              if one is present.
+            properties:
+              ingress:
+                description: Ingress is a list containing ingress points for the load-balancer.
+                  Traffic intended for the service should be sent to these ingress
+                  points.
+                items:
+                  description: 'LoadBalancerIngress represents the status of a load-balancer
+                    ingress point: traffic intended for the service should be sent
+                    to an ingress point.'
+                  properties:
+                    hostname:
+                      description: Hostname is set for load-balancer ingress points
+                        that are DNS based (typically AWS load-balancers)
+                      type: string
+                    ip:
+                      description: IP is set for load-balancer ingress points that
+                        are IP based (typically GCE or OpenStack load-balancers)
+                      type: string
+                    ports:
+                      description: Ports is a list of records of service ports If
+                        used, every port defined in the service should have an entry
+                        in it
+                      items:
+                        properties:
+                          error:
+                            description: |-
+                              Error is to record the problem with the service port The format of the error shall comply with the following rules: - built-in error values shall be specified in this file and those shall use
+                                CamelCase names
+                              - cloud provider specific error values must have names that comply with the
+                                format foo.example.com/CamelCase.
+                            type: string
+                          port:
+                            description: Port is the port number of the service port
+                              of which status is recorded here
+                            format: int32
+                            type: integer
+                          protocol:
+                            description: |-
+                              Protocol is the protocol of the service port of which status is recorded here The supported values are: "TCP", "UDP", "SCTP"
+
+                              Possible enum values:
+                               - `"SCTP"` is the SCTP protocol.
+                               - `"TCP"` is the TCP protocol.
+                               - `"UDP"` is the UDP protocol.
+                            type: string
+                        required:
+                        - port
+                        - protocol
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  type: object
+                type: array
+            type: object
+        type: object
+    type: object
+  plural: services
+  schemaUpdateStrategy: UpdateUnpublished
+  scope: Namespaced
+  shortNames:
+  - svc
+  singular: service
+  subResources:
+  - name: status
+status:
+  conditions:
+  - lastTransitionTime: "2023-03-21T17:10:09Z"
+    status: "True"
+    type: Compatible

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/3-NegotiatedAPIResource-deployments.v1.apps.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/3-NegotiatedAPIResource-deployments.v1.apps.yaml
@@ -1,0 +1,7119 @@
+apiVersion: apiresource.kcp.io/v1alpha1
+kind: NegotiatedAPIResource
+metadata:
+  annotations:
+    apiresource.kcp.io/apiVersion: apps/v1
+    kcp.io/cluster: br3qimk2t1o3jb70
+  creationTimestamp: "2023-03-21T17:10:10Z"
+  generation: 1
+  name: deployments.v1.apps
+  resourceVersion: "9151"
+  uid: fbd66449-8b09-4438-92f6-eb9091b980c2
+spec:
+  categories:
+  - all
+  groupVersion:
+    group: apps
+    version: v1
+  kind: Deployment
+  listKind: DeploymentList
+  openAPIV3Schema:
+    description: Deployment enables declarative updates for Pods and ReplicaSets.
+    properties:
+      apiVersion:
+        description: 'APIVersion defines the versioned schema of this representation
+          of an object. Servers should convert recognized schemas to the latest internal
+          value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+        type: string
+      kind:
+        description: 'Kind is a string value representing the REST resource this object
+          represents. Servers may infer this from the endpoint the client submits
+          requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+        type: string
+      metadata:
+        type: object
+      spec:
+        description: Specification of the desired behavior of the Deployment.
+        properties:
+          minReadySeconds:
+            description: Minimum number of seconds for which a newly created pod should
+              be ready without any of its container crashing, for it to be considered
+              available. Defaults to 0 (pod will be considered available as soon as
+              it is ready)
+            format: int32
+            type: integer
+          paused:
+            description: Indicates that the deployment is paused.
+            type: boolean
+          progressDeadlineSeconds:
+            description: The maximum time in seconds for a deployment to make progress
+              before it is considered to be failed. The deployment controller will
+              continue to process failed deployments and a condition with a ProgressDeadlineExceeded
+              reason will be surfaced in the deployment status. Note that progress
+              will not be estimated during the time a deployment is paused. Defaults
+              to 600s.
+            format: int32
+            type: integer
+          replicas:
+            description: Number of desired pods. This is a pointer to distinguish
+              between explicit zero and not specified. Defaults to 1.
+            format: int32
+            type: integer
+          revisionHistoryLimit:
+            description: The number of old ReplicaSets to retain to allow rollback.
+              This is a pointer to distinguish between explicit zero and not specified.
+              Defaults to 10.
+            format: int32
+            type: integer
+          selector:
+            description: Label selector for pods. Existing ReplicaSets whose pods
+              are selected by this will be the ones affected by this deployment. It
+              must match the pod template's labels.
+            properties:
+              matchExpressions:
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
+                items:
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
+                  properties:
+                    key:
+                      description: key is the label key that the selector applies
+                        to.
+                      type: string
+                    operator:
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      type: string
+                    values:
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - key
+                  - operator
+                  type: object
+                type: array
+              matchLabels:
+                additionalProperties:
+                  type: string
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
+                type: object
+            type: object
+          strategy:
+            description: The deployment strategy to use to replace existing pods with
+              new ones.
+            properties:
+              rollingUpdate:
+                description: Rolling update config params. Present only if DeploymentStrategyType
+                  = RollingUpdate.
+                properties:
+                  maxSurge:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'The maximum number of pods that can be scheduled
+                      above the desired number of pods. Value can be an absolute number
+                      (ex: 5) or a percentage of desired pods (ex: 10%). This can
+                      not be 0 if MaxUnavailable is 0. Absolute number is calculated
+                      from percentage by rounding up. Defaults to 25%. Example: when
+                      this is set to 30%, the new ReplicaSet can be scaled up immediately
+                      when the rolling update starts, such that the total number of
+                      old and new pods do not exceed 130% of desired pods. Once old
+                      pods have been killed, new ReplicaSet can be scaled up further,
+                      ensuring that total number of pods running at any time during
+                      the update is at most 130% of desired pods.'
+                    x-kubernetes-int-or-string: true
+                  maxUnavailable:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'The maximum number of pods that can be unavailable
+                      during the update. Value can be an absolute number (ex: 5) or
+                      a percentage of desired pods (ex: 10%). Absolute number is calculated
+                      from percentage by rounding down. This can not be 0 if MaxSurge
+                      is 0. Defaults to 25%. Example: when this is set to 30%, the
+                      old ReplicaSet can be scaled down to 70% of desired pods immediately
+                      when the rolling update starts. Once new pods are ready, old
+                      ReplicaSet can be scaled down further, followed by scaling up
+                      the new ReplicaSet, ensuring that the total number of pods available
+                      at all times during the update is at least 70% of desired pods.'
+                    x-kubernetes-int-or-string: true
+                type: object
+              type:
+                description: |-
+                  Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+
+                  Possible enum values:
+                   - `"Recreate"` Kill all existing pods before creating new ones.
+                   - `"RollingUpdate"` Replace the old ReplicaSets by new one using rolling update i.e gradually scale down the old ReplicaSets and scale up the new one.
+                type: string
+            type: object
+          template:
+            description: Template describes the pods that will be created.
+            properties:
+              metadata:
+                description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              spec:
+                description: 'Specification of the desired behavior of the pod. More
+                  info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                properties:
+                  activeDeadlineSeconds:
+                    description: Optional duration in seconds the pod may be active
+                      on the node relative to StartTime before the system will actively
+                      try to mark it failed and kill associated containers. Value
+                      must be a positive integer.
+                    format: int64
+                    type: integer
+                  affinity:
+                    description: If specified, the pod's scheduling constraints
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for
+                          the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node matches the corresponding matchExpressions;
+                              the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches
+                                all objects with implicit weight 0 (i.e. it's a no-op).
+                                A null preferred scheduling term matches no objects
+                                (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                              Possible enum values:
+                                               - `"DoesNotExist"`
+                                               - `"Exists"`
+                                               - `"Gt"`
+                                               - `"In"`
+                                               - `"Lt"`
+                                               - `"NotIn"`
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                              Possible enum values:
+                                               - `"DoesNotExist"`
+                                               - `"Exists"`
+                                               - `"Gt"`
+                                               - `"In"`
+                                               - `"Lt"`
+                                               - `"NotIn"`
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the
+                                    corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - weight
+                              - preference
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by
+                              this field are not met at scheduling time, the pod will
+                              not be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from
+                              its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term
+                                    matches no objects. The requirements of them are
+                                    ANDed. The TopologySelectorTerm type implements
+                                    a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                              Possible enum values:
+                                               - `"DoesNotExist"`
+                                               - `"Exists"`
+                                               - `"Gt"`
+                                               - `"In"`
+                                               - `"Lt"`
+                                               - `"NotIn"`
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                              Possible enum values:
+                                               - `"DoesNotExist"`
+                                               - `"Exists"`
+                                               - `"Gt"`
+                                               - `"In"`
+                                               - `"Lt"`
+                                               - `"NotIn"`
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g.
+                          co-locate this pod in the same node, zone, etc. as some
+                          other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node has pods which matches the corresponding
+                              podAffinityTerm; the node(s) with the highest sum are
+                              the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the
+                                    corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - weight
+                              - podAffinityTerm
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by
+                              this field are not met at scheduling time, the pod will
+                              not be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to a pod label update),
+                              the system may or may not try to eventually evict the
+                              pod from its node. When there are multiple elements,
+                              the lists of nodes corresponding to each podAffinityTerm
+                              are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located
+                                is defined as running on a node whose value of the
+                                label with key <topologyKey> matches that of any node
+                                on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules
+                          (e.g. avoid putting this pod in the same node, zone, etc.
+                          as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the anti-affinity expressions
+                              specified by this field, but it may choose a node that
+                              violates one or more of the expressions. The node that
+                              is most preferred is the one with the greatest sum of
+                              weights, i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              anti-affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node has pods which matches the corresponding
+                              podAffinityTerm; the node(s) with the highest sum are
+                              the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the
+                                    corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - weight
+                              - podAffinityTerm
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified
+                              by this field are not met at scheduling time, the pod
+                              will not be scheduled onto the node. If the anti-affinity
+                              requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod
+                              label update), the system may or may not try to eventually
+                              evict the pod from its node. When there are multiple
+                              elements, the lists of nodes corresponding to each podAffinityTerm
+                              are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located
+                                is defined as running on a node whose value of the
+                                label with key <topologyKey> matches that of any node
+                                on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  automountServiceAccountToken:
+                    description: AutomountServiceAccountToken indicates whether a
+                      service account token should be automatically mounted.
+                    type: boolean
+                  containers:
+                    description: List of containers belonging to the pod. Containers
+                      cannot currently be added or removed. There must be at least
+                      one container in a Pod. Cannot be updated.
+                    items:
+                      description: A single application container that you want to
+                        run within a pod.
+                      properties:
+                        args:
+                          description: 'Arguments to the entrypoint. The container
+                            image''s CMD is used if this is not provided. Variable
+                            references $(VAR_NAME) are expanded using the container''s
+                            environment. If a variable cannot be resolved, the reference
+                            in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME)
+                            syntax: i.e. "$$(VAR_NAME)" will produce the string literal
+                            "$(VAR_NAME)". Escaped references will never be expanded,
+                            regardless of whether the variable exists or not. Cannot
+                            be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: 'Entrypoint array. Not executed within a shell.
+                            The container image''s ENTRYPOINT is used if this is not
+                            provided. Variable references $(VAR_NAME) are expanded
+                            using the container''s environment. If a variable cannot
+                            be resolved, the reference in the input string will be
+                            unchanged. Double $$ are reduced to a single $, which
+                            allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                            will produce the string literal "$(VAR_NAME)". Escaped
+                            references will never be expanded, regardless of whether
+                            the variable exists or not. Cannot be updated. More info:
+                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the
+                            container. Cannot be updated.
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previously defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  Double $$ are reduced to a single $, which allows
+                                  for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                  will produce the string literal "$(VAR_NAME)". Escaped
+                                  references will never be expanded, regardless of
+                                  whether the variable exists or not. Defaults to
+                                  "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's
+                                  value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container. The keys defined within a source must
+                            be a C_IDENTIFIER. All invalid keys will be reported as
+                            an event when the container is starting. When a key exists
+                            in multiple sources, the value associated with the last
+                            source will take precedence. Values defined by an Env
+                            with a duplicate key will take precedence. Cannot be updated.
+                          items:
+                            description: EnvFromSource represents the source of a
+                              set of ConfigMaps
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must
+                                      be defined
+                                    type: boolean
+                                type: object
+                              prefix:
+                                description: An optional identifier to prepend to
+                                  each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be
+                                      defined
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                            This field is optional to allow higher level config management
+                            to default or override container images in workload controllers
+                            like Deployments and StatefulSets.'
+                          type: string
+                        imagePullPolicy:
+                          description: |-
+                            Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                            Possible enum values:
+                             - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                             - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                             - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                          type: string
+                        lifecycle:
+                          description: Actions that the management system should take
+                            in response to container lifecycle events. Cannot be updated.
+                          properties:
+                            postStart:
+                              description: 'PostStart is called immediately after
+                                a container is created. If the handler fails, the
+                                container is terminated and restarted according to
+                                its restart policy. Other management of the container
+                                blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            preStop:
+                              description: 'PreStop is called immediately before a
+                                container is terminated due to an API request or management
+                                event such as liveness/startup probe failure, preemption,
+                                resource contention, etc. The handler is not called
+                                if the container crashes or exits. The Pod''s termination
+                                grace period countdown begins before the PreStop hook
+                                is executed. Regardless of the outcome of the handler,
+                                the container will eventually terminate within the
+                                Pod''s termination grace period (unless delayed by
+                                finalizers). Other management of the container blocks
+                                until the hook completes or until the termination
+                                grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                          type: object
+                        livenessProbe:
+                          description: 'Periodic probe of container liveness. Container
+                            will be restarted if the probe fails. Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: Name of the container specified as a DNS_LABEL.
+                            Each container in a pod must have a unique name (DNS_LABEL).
+                            Cannot be updated.
+                          type: string
+                        ports:
+                          description: List of ports to expose from the container.
+                            Not specifying a port here DOES NOT prevent that port
+                            from being exposed. Any port which is listening on the
+                            default "0.0.0.0" address inside a container will be accessible
+                            from the network. Modifying this array with strategic
+                            merge patch may corrupt the data. For more information
+                            See https://github.com/kubernetes/kubernetes/issues/108255.
+                            Cannot be updated.
+                          items:
+                            description: ContainerPort represents a network port in
+                              a single container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's
+                                  IP address. This must be a valid port number, 0
+                                  < x < 65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port
+                                  to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host.
+                                  If specified, this must be a valid port number,
+                                  0 < x < 65536. If HostNetwork is specified, this
+                                  must match ContainerPort. Most containers do not
+                                  need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a
+                                  pod must have a unique name. Name for the port that
+                                  can be referred to by services.
+                                type: string
+                              protocol:
+                                default: TCP
+                                description: |-
+                                  Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                  Possible enum values:
+                                   - `"SCTP"` is the SCTP protocol.
+                                   - `"TCP"` is the TCP protocol.
+                                   - `"UDP"` is the UDP protocol.
+                                type: string
+                            required:
+                            - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - containerPort
+                          - protocol
+                          x-kubernetes-list-type: map
+                        readinessProbe:
+                          description: 'Periodic probe of container service readiness.
+                            Container will be removed from service endpoints if the
+                            probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          description: 'Compute Resources required by this container.
+                            Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        securityContext:
+                          description: 'SecurityContext defines the security options
+                            the container should be run with. If set, the fields of
+                            SecurityContext override the equivalent fields of PodSecurityContext.
+                            More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                          properties:
+                            allowPrivilegeEscalation:
+                              description: 'AllowPrivilegeEscalation controls whether
+                                a process can gain more privileges than its parent
+                                process. This bool directly controls if the no_new_privs
+                                flag will be set on the container process. AllowPrivilegeEscalation
+                                is true always when the container is: 1) run as Privileged
+                                2) has CAP_SYS_ADMIN Note that this field cannot be
+                                set when spec.os.name is windows.'
+                              type: boolean
+                            capabilities:
+                              description: The capabilities to add/drop when running
+                                containers. Defaults to the default set of capabilities
+                                granted by the container runtime. Note that this field
+                                cannot be set when spec.os.name is windows.
+                              properties:
+                                add:
+                                  description: Added capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                                drop:
+                                  description: Removed capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            privileged:
+                              description: Run container in privileged mode. Processes
+                                in privileged containers are essentially equivalent
+                                to root on the host. Defaults to false. Note that
+                                this field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            procMount:
+                              description: procMount denotes the type of proc mount
+                                to use for the containers. The default is DefaultProcMount
+                                which uses the container runtime defaults for readonly
+                                paths and masked paths. This requires the ProcMountType
+                                feature flag to be enabled. Note that this field cannot
+                                be set when spec.os.name is windows.
+                              type: string
+                            readOnlyRootFilesystem:
+                              description: Whether this container has a read-only
+                                root filesystem. Default is false. Note that this
+                                field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            runAsGroup:
+                              description: The GID to run the entrypoint of the container
+                                process. Uses runtime default if unset. May also be
+                                set in PodSecurityContext.  If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is windows.
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              description: Indicates that the container must run as
+                                a non-root user. If true, the Kubelet will validate
+                                the image at runtime to ensure that it does not run
+                                as UID 0 (root) and fail to start the container if
+                                it does. If unset or false, no such validation will
+                                be performed. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                              type: boolean
+                            runAsUser:
+                              description: The UID to run the entrypoint of the container
+                                process. Defaults to user specified in image metadata
+                                if unspecified. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name
+                                is windows.
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              description: The SELinux context to be applied to the
+                                container. If unspecified, the container runtime will
+                                allocate a random SELinux context for each container.  May
+                                also be set in PodSecurityContext.  If set in both
+                                SecurityContext and PodSecurityContext, the value
+                                specified in SecurityContext takes precedence. Note
+                                that this field cannot be set when spec.os.name is
+                                windows.
+                              properties:
+                                level:
+                                  description: Level is SELinux level label that applies
+                                    to the container.
+                                  type: string
+                                role:
+                                  description: Role is a SELinux role label that applies
+                                    to the container.
+                                  type: string
+                                type:
+                                  description: Type is a SELinux type label that applies
+                                    to the container.
+                                  type: string
+                                user:
+                                  description: User is a SELinux user label that applies
+                                    to the container.
+                                  type: string
+                              type: object
+                            seccompProfile:
+                              description: The seccomp options to use by this container.
+                                If seccomp options are provided at both the pod &
+                                container level, the container options override the
+                                pod options. Note that this field cannot be set when
+                                spec.os.name is windows.
+                              properties:
+                                localhostProfile:
+                                  description: localhostProfile indicates a profile
+                                    defined in a file on the node should be used.
+                                    The profile must be preconfigured on the node
+                                    to work. Must be a descending path, relative to
+                                    the kubelet's configured seccomp profile location.
+                                    Must only be set if type is "Localhost".
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                    Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                    Possible enum values:
+                                     - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                     - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                     - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            windowsOptions:
+                              description: The Windows specific settings applied to
+                                all containers. If unspecified, the options from the
+                                PodSecurityContext will be used. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is linux.
+                              properties:
+                                gmsaCredentialSpec:
+                                  description: GMSACredentialSpec is where the GMSA
+                                    admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                    inlines the contents of the GMSA credential spec
+                                    named by the GMSACredentialSpecName field.
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  description: GMSACredentialSpecName is the name
+                                    of the GMSA credential spec to use.
+                                  type: string
+                                hostProcess:
+                                  description: HostProcess determines if a container
+                                    should be run as a 'Host Process' container. This
+                                    field is alpha-level and will only be honored
+                                    by components that enable the WindowsHostProcessContainers
+                                    feature flag. Setting this field without the feature
+                                    flag will result in errors when validating the
+                                    Pod. All of a Pod's containers must have the same
+                                    effective HostProcess value (it is not allowed
+                                    to have a mix of HostProcess containers and non-HostProcess
+                                    containers).  In addition, if HostProcess is true
+                                    then HostNetwork must also be set to true.
+                                  type: boolean
+                                runAsUserName:
+                                  description: The UserName in Windows to run the
+                                    entrypoint of the container process. Defaults
+                                    to the user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  type: string
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: 'StartupProbe indicates that the Pod has successfully
+                            initialized. If specified, no other probes are executed
+                            until this completes successfully. If this probe fails,
+                            the Pod will be restarted, just as if the livenessProbe
+                            failed. This can be used to provide different probe parameters
+                            at the beginning of a Pod''s lifecycle, when it might
+                            take a long time to load data or warm a cache, than during
+                            steady-state operation. This cannot be updated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        stdin:
+                          description: Whether this container should allocate a buffer
+                            for stdin in the container runtime. If this is not set,
+                            reads from stdin in the container will always result in
+                            EOF. Default is false.
+                          type: boolean
+                        stdinOnce:
+                          description: Whether the container runtime should close
+                            the stdin channel after it has been opened by a single
+                            attach. When stdin is true the stdin stream will remain
+                            open across multiple attach sessions. If stdinOnce is
+                            set to true, stdin is opened on container start, is empty
+                            until the first client attaches to stdin, and then remains
+                            open and accepts data until the client disconnects, at
+                            which time stdin is closed and remains closed until the
+                            container is restarted. If this flag is false, a container
+                            processes that reads from stdin will never receive an
+                            EOF. Default is false
+                          type: boolean
+                        terminationMessagePath:
+                          description: 'Optional: Path at which the file to which
+                            the container''s termination message will be written is
+                            mounted into the container''s filesystem. Message written
+                            is intended to be brief final status, such as an assertion
+                            failure message. Will be truncated by the node if greater
+                            than 4096 bytes. The total message length across all containers
+                            will be limited to 12kb. Defaults to /dev/termination-log.
+                            Cannot be updated.'
+                          type: string
+                        terminationMessagePolicy:
+                          description: |-
+                            Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                            Possible enum values:
+                             - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                             - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                          type: string
+                        tty:
+                          description: Whether this container should allocate a TTY
+                            for itself, also requires 'stdin' to be true. Default
+                            is false.
+                          type: boolean
+                        volumeDevices:
+                          description: volumeDevices is the list of block devices
+                            to be used by the container.
+                          items:
+                            description: volumeDevice describes a mapping of a raw
+                              block device within a container.
+                            properties:
+                              devicePath:
+                                description: devicePath is the path inside of the
+                                  container that the device will be mapped to.
+                                type: string
+                              name:
+                                description: name must match the name of a persistentVolumeClaim
+                                  in the pod
+                                type: string
+                            required:
+                            - devicePath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - devicePath
+                          x-kubernetes-list-type: map
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                            Cannot be updated.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write
+                                  otherwise (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the
+                                  container's volume should be mounted. Defaults to
+                                  "" (volume's root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from
+                                  which the container's volume should be mounted.
+                                  Behaves similarly to SubPath but environment variable
+                                  references $(VAR_NAME) are expanded using the container's
+                                  environment. Defaults to "" (volume's root). SubPathExpr
+                                  and SubPath are mutually exclusive.
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - mountPath
+                          x-kubernetes-list-type: map
+                        workingDir:
+                          description: Container's working directory. If not specified,
+                            the container runtime's default will be used, which might
+                            be configured in the container image. Cannot be updated.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  dnsConfig:
+                    description: Specifies the DNS parameters of a pod. Parameters
+                      specified here will be merged to the generated DNS configuration
+                      based on DNSPolicy.
+                    properties:
+                      nameservers:
+                        description: A list of DNS name server IP addresses. This
+                          will be appended to the base nameservers generated from
+                          DNSPolicy. Duplicated nameservers will be removed.
+                        items:
+                          type: string
+                        type: array
+                      options:
+                        description: A list of DNS resolver options. This will be
+                          merged with the base options generated from DNSPolicy. Duplicated
+                          entries will be removed. Resolution options given in Options
+                          will override those that appear in the base DNSPolicy.
+                        items:
+                          description: PodDNSConfigOption defines DNS resolver options
+                            of a pod.
+                          properties:
+                            name:
+                              description: Required.
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                      searches:
+                        description: A list of DNS search domains for host-name lookup.
+                          This will be appended to the base search paths generated
+                          from DNSPolicy. Duplicated search paths will be removed.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  dnsPolicy:
+                    description: |-
+                      Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+
+                      Possible enum values:
+                       - `"ClusterFirst"` indicates that the pod should use cluster DNS first unless hostNetwork is true, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                       - `"ClusterFirstWithHostNet"` indicates that the pod should use cluster DNS first, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                       - `"Default"` indicates that the pod should use the default (as determined by kubelet) DNS settings.
+                       - `"None"` indicates that the pod should use empty DNS settings. DNS parameters such as nameservers and search paths should be defined via DNSConfig.
+                    type: string
+                  enableServiceLinks:
+                    description: 'EnableServiceLinks indicates whether information
+                      about services should be injected into pod''s environment variables,
+                      matching the syntax of Docker links. Optional: Defaults to true.'
+                    type: boolean
+                  ephemeralContainers:
+                    description: List of ephemeral containers run in this pod. Ephemeral
+                      containers may be run in an existing pod to perform user-initiated
+                      actions such as debugging. This list cannot be specified when
+                      creating a pod, and it cannot be modified by updating the pod
+                      spec. In order to add an ephemeral container to an existing
+                      pod, use the pod's ephemeralcontainers subresource.
+                    items:
+                      description: |-
+                        An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation.
+
+                        To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.
+                      properties:
+                        args:
+                          description: 'Arguments to the entrypoint. The image''s
+                            CMD is used if this is not provided. Variable references
+                            $(VAR_NAME) are expanded using the container''s environment.
+                            If a variable cannot be resolved, the reference in the
+                            input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME)
+                            syntax: i.e. "$$(VAR_NAME)" will produce the string literal
+                            "$(VAR_NAME)". Escaped references will never be expanded,
+                            regardless of whether the variable exists or not. Cannot
+                            be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: 'Entrypoint array. Not executed within a shell.
+                            The image''s ENTRYPOINT is used if this is not provided.
+                            Variable references $(VAR_NAME) are expanded using the
+                            container''s environment. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double
+                            $$ are reduced to a single $, which allows for escaping
+                            the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                            the string literal "$(VAR_NAME)". Escaped references will
+                            never be expanded, regardless of whether the variable
+                            exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the
+                            container. Cannot be updated.
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previously defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  Double $$ are reduced to a single $, which allows
+                                  for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                  will produce the string literal "$(VAR_NAME)". Escaped
+                                  references will never be expanded, regardless of
+                                  whether the variable exists or not. Defaults to
+                                  "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's
+                                  value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container. The keys defined within a source must
+                            be a C_IDENTIFIER. All invalid keys will be reported as
+                            an event when the container is starting. When a key exists
+                            in multiple sources, the value associated with the last
+                            source will take precedence. Values defined by an Env
+                            with a duplicate key will take precedence. Cannot be updated.
+                          items:
+                            description: EnvFromSource represents the source of a
+                              set of ConfigMaps
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must
+                                      be defined
+                                    type: boolean
+                                type: object
+                              prefix:
+                                description: An optional identifier to prepend to
+                                  each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be
+                                      defined
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                          type: string
+                        imagePullPolicy:
+                          description: |-
+                            Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                            Possible enum values:
+                             - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                             - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                             - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                          type: string
+                        lifecycle:
+                          description: Lifecycle is not allowed for ephemeral containers.
+                          properties:
+                            postStart:
+                              description: 'PostStart is called immediately after
+                                a container is created. If the handler fails, the
+                                container is terminated and restarted according to
+                                its restart policy. Other management of the container
+                                blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            preStop:
+                              description: 'PreStop is called immediately before a
+                                container is terminated due to an API request or management
+                                event such as liveness/startup probe failure, preemption,
+                                resource contention, etc. The handler is not called
+                                if the container crashes or exits. The Pod''s termination
+                                grace period countdown begins before the PreStop hook
+                                is executed. Regardless of the outcome of the handler,
+                                the container will eventually terminate within the
+                                Pod''s termination grace period (unless delayed by
+                                finalizers). Other management of the container blocks
+                                until the hook completes or until the termination
+                                grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                          type: object
+                        livenessProbe:
+                          description: Probes are not allowed for ephemeral containers.
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: Name of the ephemeral container specified as
+                            a DNS_LABEL. This name must be unique among all containers,
+                            init containers and ephemeral containers.
+                          type: string
+                        ports:
+                          description: Ports are not allowed for ephemeral containers.
+                          items:
+                            description: ContainerPort represents a network port in
+                              a single container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's
+                                  IP address. This must be a valid port number, 0
+                                  < x < 65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port
+                                  to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host.
+                                  If specified, this must be a valid port number,
+                                  0 < x < 65536. If HostNetwork is specified, this
+                                  must match ContainerPort. Most containers do not
+                                  need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a
+                                  pod must have a unique name. Name for the port that
+                                  can be referred to by services.
+                                type: string
+                              protocol:
+                                default: TCP
+                                description: |-
+                                  Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                  Possible enum values:
+                                   - `"SCTP"` is the SCTP protocol.
+                                   - `"TCP"` is the TCP protocol.
+                                   - `"UDP"` is the UDP protocol.
+                                type: string
+                            required:
+                            - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - containerPort
+                          - protocol
+                          x-kubernetes-list-type: map
+                        readinessProbe:
+                          description: Probes are not allowed for ephemeral containers.
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          description: Resources are not allowed for ephemeral containers.
+                            Ephemeral containers use spare resources already allocated
+                            to the pod.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        securityContext:
+                          description: 'Optional: SecurityContext defines the security
+                            options the ephemeral container should be run with. If
+                            set, the fields of SecurityContext override the equivalent
+                            fields of PodSecurityContext.'
+                          properties:
+                            allowPrivilegeEscalation:
+                              description: 'AllowPrivilegeEscalation controls whether
+                                a process can gain more privileges than its parent
+                                process. This bool directly controls if the no_new_privs
+                                flag will be set on the container process. AllowPrivilegeEscalation
+                                is true always when the container is: 1) run as Privileged
+                                2) has CAP_SYS_ADMIN Note that this field cannot be
+                                set when spec.os.name is windows.'
+                              type: boolean
+                            capabilities:
+                              description: The capabilities to add/drop when running
+                                containers. Defaults to the default set of capabilities
+                                granted by the container runtime. Note that this field
+                                cannot be set when spec.os.name is windows.
+                              properties:
+                                add:
+                                  description: Added capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                                drop:
+                                  description: Removed capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            privileged:
+                              description: Run container in privileged mode. Processes
+                                in privileged containers are essentially equivalent
+                                to root on the host. Defaults to false. Note that
+                                this field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            procMount:
+                              description: procMount denotes the type of proc mount
+                                to use for the containers. The default is DefaultProcMount
+                                which uses the container runtime defaults for readonly
+                                paths and masked paths. This requires the ProcMountType
+                                feature flag to be enabled. Note that this field cannot
+                                be set when spec.os.name is windows.
+                              type: string
+                            readOnlyRootFilesystem:
+                              description: Whether this container has a read-only
+                                root filesystem. Default is false. Note that this
+                                field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            runAsGroup:
+                              description: The GID to run the entrypoint of the container
+                                process. Uses runtime default if unset. May also be
+                                set in PodSecurityContext.  If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is windows.
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              description: Indicates that the container must run as
+                                a non-root user. If true, the Kubelet will validate
+                                the image at runtime to ensure that it does not run
+                                as UID 0 (root) and fail to start the container if
+                                it does. If unset or false, no such validation will
+                                be performed. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                              type: boolean
+                            runAsUser:
+                              description: The UID to run the entrypoint of the container
+                                process. Defaults to user specified in image metadata
+                                if unspecified. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name
+                                is windows.
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              description: The SELinux context to be applied to the
+                                container. If unspecified, the container runtime will
+                                allocate a random SELinux context for each container.  May
+                                also be set in PodSecurityContext.  If set in both
+                                SecurityContext and PodSecurityContext, the value
+                                specified in SecurityContext takes precedence. Note
+                                that this field cannot be set when spec.os.name is
+                                windows.
+                              properties:
+                                level:
+                                  description: Level is SELinux level label that applies
+                                    to the container.
+                                  type: string
+                                role:
+                                  description: Role is a SELinux role label that applies
+                                    to the container.
+                                  type: string
+                                type:
+                                  description: Type is a SELinux type label that applies
+                                    to the container.
+                                  type: string
+                                user:
+                                  description: User is a SELinux user label that applies
+                                    to the container.
+                                  type: string
+                              type: object
+                            seccompProfile:
+                              description: The seccomp options to use by this container.
+                                If seccomp options are provided at both the pod &
+                                container level, the container options override the
+                                pod options. Note that this field cannot be set when
+                                spec.os.name is windows.
+                              properties:
+                                localhostProfile:
+                                  description: localhostProfile indicates a profile
+                                    defined in a file on the node should be used.
+                                    The profile must be preconfigured on the node
+                                    to work. Must be a descending path, relative to
+                                    the kubelet's configured seccomp profile location.
+                                    Must only be set if type is "Localhost".
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                    Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                    Possible enum values:
+                                     - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                     - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                     - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            windowsOptions:
+                              description: The Windows specific settings applied to
+                                all containers. If unspecified, the options from the
+                                PodSecurityContext will be used. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is linux.
+                              properties:
+                                gmsaCredentialSpec:
+                                  description: GMSACredentialSpec is where the GMSA
+                                    admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                    inlines the contents of the GMSA credential spec
+                                    named by the GMSACredentialSpecName field.
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  description: GMSACredentialSpecName is the name
+                                    of the GMSA credential spec to use.
+                                  type: string
+                                hostProcess:
+                                  description: HostProcess determines if a container
+                                    should be run as a 'Host Process' container. This
+                                    field is alpha-level and will only be honored
+                                    by components that enable the WindowsHostProcessContainers
+                                    feature flag. Setting this field without the feature
+                                    flag will result in errors when validating the
+                                    Pod. All of a Pod's containers must have the same
+                                    effective HostProcess value (it is not allowed
+                                    to have a mix of HostProcess containers and non-HostProcess
+                                    containers).  In addition, if HostProcess is true
+                                    then HostNetwork must also be set to true.
+                                  type: boolean
+                                runAsUserName:
+                                  description: The UserName in Windows to run the
+                                    entrypoint of the container process. Defaults
+                                    to the user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  type: string
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: Probes are not allowed for ephemeral containers.
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        stdin:
+                          description: Whether this container should allocate a buffer
+                            for stdin in the container runtime. If this is not set,
+                            reads from stdin in the container will always result in
+                            EOF. Default is false.
+                          type: boolean
+                        stdinOnce:
+                          description: Whether the container runtime should close
+                            the stdin channel after it has been opened by a single
+                            attach. When stdin is true the stdin stream will remain
+                            open across multiple attach sessions. If stdinOnce is
+                            set to true, stdin is opened on container start, is empty
+                            until the first client attaches to stdin, and then remains
+                            open and accepts data until the client disconnects, at
+                            which time stdin is closed and remains closed until the
+                            container is restarted. If this flag is false, a container
+                            processes that reads from stdin will never receive an
+                            EOF. Default is false
+                          type: boolean
+                        targetContainerName:
+                          description: |-
+                            If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+                            The container runtime must implement support for this feature. If the runtime does not support namespace targeting then the result of setting this field is undefined.
+                          type: string
+                        terminationMessagePath:
+                          description: 'Optional: Path at which the file to which
+                            the container''s termination message will be written is
+                            mounted into the container''s filesystem. Message written
+                            is intended to be brief final status, such as an assertion
+                            failure message. Will be truncated by the node if greater
+                            than 4096 bytes. The total message length across all containers
+                            will be limited to 12kb. Defaults to /dev/termination-log.
+                            Cannot be updated.'
+                          type: string
+                        terminationMessagePolicy:
+                          description: |-
+                            Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                            Possible enum values:
+                             - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                             - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                          type: string
+                        tty:
+                          description: Whether this container should allocate a TTY
+                            for itself, also requires 'stdin' to be true. Default
+                            is false.
+                          type: boolean
+                        volumeDevices:
+                          description: volumeDevices is the list of block devices
+                            to be used by the container.
+                          items:
+                            description: volumeDevice describes a mapping of a raw
+                              block device within a container.
+                            properties:
+                              devicePath:
+                                description: devicePath is the path inside of the
+                                  container that the device will be mapped to.
+                                type: string
+                              name:
+                                description: name must match the name of a persistentVolumeClaim
+                                  in the pod
+                                type: string
+                            required:
+                            - devicePath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - devicePath
+                          x-kubernetes-list-type: map
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                            Subpath mounts are not allowed for ephemeral containers.
+                            Cannot be updated.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write
+                                  otherwise (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the
+                                  container's volume should be mounted. Defaults to
+                                  "" (volume's root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from
+                                  which the container's volume should be mounted.
+                                  Behaves similarly to SubPath but environment variable
+                                  references $(VAR_NAME) are expanded using the container's
+                                  environment. Defaults to "" (volume's root). SubPathExpr
+                                  and SubPath are mutually exclusive.
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - mountPath
+                          x-kubernetes-list-type: map
+                        workingDir:
+                          description: Container's working directory. If not specified,
+                            the container runtime's default will be used, which might
+                            be configured in the container image. Cannot be updated.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  hostAliases:
+                    description: HostAliases is an optional list of hosts and IPs
+                      that will be injected into the pod's hosts file if specified.
+                      This is only valid for non-hostNetwork pods.
+                    items:
+                      description: HostAlias holds the mapping between IP and hostnames
+                        that will be injected as an entry in the pod's hosts file.
+                      properties:
+                        hostnames:
+                          description: Hostnames for the above IP address.
+                          items:
+                            type: string
+                          type: array
+                        ip:
+                          description: IP address of the host file entry.
+                          type: string
+                      required:
+                      - ip
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - ip
+                    x-kubernetes-list-type: map
+                  hostIPC:
+                    description: 'Use the host''s ipc namespace. Optional: Default
+                      to false.'
+                    type: boolean
+                  hostNetwork:
+                    description: Host networking requested for this pod. Use the host's
+                      network namespace. If this option is set, the ports that will
+                      be used must be specified. Default to false.
+                    type: boolean
+                  hostPID:
+                    description: 'Use the host''s pid namespace. Optional: Default
+                      to false.'
+                    type: boolean
+                  hostUsers:
+                    description: 'Use the host''s user namespace. Optional: Default
+                      to true. If set to true or not present, the pod will be run
+                      in the host user namespace, useful for when the pod needs a
+                      feature only available to the host user namespace, such as loading
+                      a kernel module with CAP_SYS_MODULE. When set to false, a new
+                      userns is created for the pod. Setting false is useful for mitigating
+                      container breakout vulnerabilities even allowing users to run
+                      their containers as root without actually having root privileges
+                      on the host. This field is alpha-level and is only honored by
+                      servers that enable the UserNamespacesSupport feature.'
+                    type: boolean
+                  hostname:
+                    description: Specifies the hostname of the Pod If not specified,
+                      the pod's hostname will be set to a system-defined value.
+                    type: string
+                  imagePullSecrets:
+                    description: 'ImagePullSecrets is an optional list of references
+                      to secrets in the same namespace to use for pulling any of the
+                      images used by this PodSpec. If specified, these secrets will
+                      be passed to individual puller implementations for them to use.
+                      More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                    items:
+                      description: LocalObjectReference contains enough information
+                        to let you locate the referenced object inside the same namespace.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  initContainers:
+                    description: 'List of initialization containers belonging to the
+                      pod. Init containers are executed in order prior to containers
+                      being started. If any init container fails, the pod is considered
+                      to have failed and is handled according to its restartPolicy.
+                      The name for an init container or normal container must be unique
+                      among all containers. Init containers may not have Lifecycle
+                      actions, Readiness probes, Liveness probes, or Startup probes.
+                      The resourceRequirements of an init container are taken into
+                      account during scheduling by finding the highest request/limit
+                      for each resource type, and then using the max of of that value
+                      or the sum of the normal containers. Limits are applied to init
+                      containers in a similar fashion. Init containers cannot currently
+                      be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                    items:
+                      description: A single application container that you want to
+                        run within a pod.
+                      properties:
+                        args:
+                          description: 'Arguments to the entrypoint. The container
+                            image''s CMD is used if this is not provided. Variable
+                            references $(VAR_NAME) are expanded using the container''s
+                            environment. If a variable cannot be resolved, the reference
+                            in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME)
+                            syntax: i.e. "$$(VAR_NAME)" will produce the string literal
+                            "$(VAR_NAME)". Escaped references will never be expanded,
+                            regardless of whether the variable exists or not. Cannot
+                            be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: 'Entrypoint array. Not executed within a shell.
+                            The container image''s ENTRYPOINT is used if this is not
+                            provided. Variable references $(VAR_NAME) are expanded
+                            using the container''s environment. If a variable cannot
+                            be resolved, the reference in the input string will be
+                            unchanged. Double $$ are reduced to a single $, which
+                            allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                            will produce the string literal "$(VAR_NAME)". Escaped
+                            references will never be expanded, regardless of whether
+                            the variable exists or not. Cannot be updated. More info:
+                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the
+                            container. Cannot be updated.
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previously defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  Double $$ are reduced to a single $, which allows
+                                  for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                  will produce the string literal "$(VAR_NAME)". Escaped
+                                  references will never be expanded, regardless of
+                                  whether the variable exists or not. Defaults to
+                                  "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's
+                                  value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container. The keys defined within a source must
+                            be a C_IDENTIFIER. All invalid keys will be reported as
+                            an event when the container is starting. When a key exists
+                            in multiple sources, the value associated with the last
+                            source will take precedence. Values defined by an Env
+                            with a duplicate key will take precedence. Cannot be updated.
+                          items:
+                            description: EnvFromSource represents the source of a
+                              set of ConfigMaps
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must
+                                      be defined
+                                    type: boolean
+                                type: object
+                              prefix:
+                                description: An optional identifier to prepend to
+                                  each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be
+                                      defined
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                            This field is optional to allow higher level config management
+                            to default or override container images in workload controllers
+                            like Deployments and StatefulSets.'
+                          type: string
+                        imagePullPolicy:
+                          description: |-
+                            Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                            Possible enum values:
+                             - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                             - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                             - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                          type: string
+                        lifecycle:
+                          description: Actions that the management system should take
+                            in response to container lifecycle events. Cannot be updated.
+                          properties:
+                            postStart:
+                              description: 'PostStart is called immediately after
+                                a container is created. If the handler fails, the
+                                container is terminated and restarted according to
+                                its restart policy. Other management of the container
+                                blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            preStop:
+                              description: 'PreStop is called immediately before a
+                                container is terminated due to an API request or management
+                                event such as liveness/startup probe failure, preemption,
+                                resource contention, etc. The handler is not called
+                                if the container crashes or exits. The Pod''s termination
+                                grace period countdown begins before the PreStop hook
+                                is executed. Regardless of the outcome of the handler,
+                                the container will eventually terminate within the
+                                Pod''s termination grace period (unless delayed by
+                                finalizers). Other management of the container blocks
+                                until the hook completes or until the termination
+                                grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                          type: object
+                        livenessProbe:
+                          description: 'Periodic probe of container liveness. Container
+                            will be restarted if the probe fails. Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: Name of the container specified as a DNS_LABEL.
+                            Each container in a pod must have a unique name (DNS_LABEL).
+                            Cannot be updated.
+                          type: string
+                        ports:
+                          description: List of ports to expose from the container.
+                            Not specifying a port here DOES NOT prevent that port
+                            from being exposed. Any port which is listening on the
+                            default "0.0.0.0" address inside a container will be accessible
+                            from the network. Modifying this array with strategic
+                            merge patch may corrupt the data. For more information
+                            See https://github.com/kubernetes/kubernetes/issues/108255.
+                            Cannot be updated.
+                          items:
+                            description: ContainerPort represents a network port in
+                              a single container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's
+                                  IP address. This must be a valid port number, 0
+                                  < x < 65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port
+                                  to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host.
+                                  If specified, this must be a valid port number,
+                                  0 < x < 65536. If HostNetwork is specified, this
+                                  must match ContainerPort. Most containers do not
+                                  need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a
+                                  pod must have a unique name. Name for the port that
+                                  can be referred to by services.
+                                type: string
+                              protocol:
+                                default: TCP
+                                description: |-
+                                  Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                  Possible enum values:
+                                   - `"SCTP"` is the SCTP protocol.
+                                   - `"TCP"` is the TCP protocol.
+                                   - `"UDP"` is the UDP protocol.
+                                type: string
+                            required:
+                            - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - containerPort
+                          - protocol
+                          x-kubernetes-list-type: map
+                        readinessProbe:
+                          description: 'Periodic probe of container service readiness.
+                            Container will be removed from service endpoints if the
+                            probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          description: 'Compute Resources required by this container.
+                            Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        securityContext:
+                          description: 'SecurityContext defines the security options
+                            the container should be run with. If set, the fields of
+                            SecurityContext override the equivalent fields of PodSecurityContext.
+                            More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                          properties:
+                            allowPrivilegeEscalation:
+                              description: 'AllowPrivilegeEscalation controls whether
+                                a process can gain more privileges than its parent
+                                process. This bool directly controls if the no_new_privs
+                                flag will be set on the container process. AllowPrivilegeEscalation
+                                is true always when the container is: 1) run as Privileged
+                                2) has CAP_SYS_ADMIN Note that this field cannot be
+                                set when spec.os.name is windows.'
+                              type: boolean
+                            capabilities:
+                              description: The capabilities to add/drop when running
+                                containers. Defaults to the default set of capabilities
+                                granted by the container runtime. Note that this field
+                                cannot be set when spec.os.name is windows.
+                              properties:
+                                add:
+                                  description: Added capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                                drop:
+                                  description: Removed capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            privileged:
+                              description: Run container in privileged mode. Processes
+                                in privileged containers are essentially equivalent
+                                to root on the host. Defaults to false. Note that
+                                this field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            procMount:
+                              description: procMount denotes the type of proc mount
+                                to use for the containers. The default is DefaultProcMount
+                                which uses the container runtime defaults for readonly
+                                paths and masked paths. This requires the ProcMountType
+                                feature flag to be enabled. Note that this field cannot
+                                be set when spec.os.name is windows.
+                              type: string
+                            readOnlyRootFilesystem:
+                              description: Whether this container has a read-only
+                                root filesystem. Default is false. Note that this
+                                field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            runAsGroup:
+                              description: The GID to run the entrypoint of the container
+                                process. Uses runtime default if unset. May also be
+                                set in PodSecurityContext.  If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is windows.
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              description: Indicates that the container must run as
+                                a non-root user. If true, the Kubelet will validate
+                                the image at runtime to ensure that it does not run
+                                as UID 0 (root) and fail to start the container if
+                                it does. If unset or false, no such validation will
+                                be performed. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                              type: boolean
+                            runAsUser:
+                              description: The UID to run the entrypoint of the container
+                                process. Defaults to user specified in image metadata
+                                if unspecified. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name
+                                is windows.
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              description: The SELinux context to be applied to the
+                                container. If unspecified, the container runtime will
+                                allocate a random SELinux context for each container.  May
+                                also be set in PodSecurityContext.  If set in both
+                                SecurityContext and PodSecurityContext, the value
+                                specified in SecurityContext takes precedence. Note
+                                that this field cannot be set when spec.os.name is
+                                windows.
+                              properties:
+                                level:
+                                  description: Level is SELinux level label that applies
+                                    to the container.
+                                  type: string
+                                role:
+                                  description: Role is a SELinux role label that applies
+                                    to the container.
+                                  type: string
+                                type:
+                                  description: Type is a SELinux type label that applies
+                                    to the container.
+                                  type: string
+                                user:
+                                  description: User is a SELinux user label that applies
+                                    to the container.
+                                  type: string
+                              type: object
+                            seccompProfile:
+                              description: The seccomp options to use by this container.
+                                If seccomp options are provided at both the pod &
+                                container level, the container options override the
+                                pod options. Note that this field cannot be set when
+                                spec.os.name is windows.
+                              properties:
+                                localhostProfile:
+                                  description: localhostProfile indicates a profile
+                                    defined in a file on the node should be used.
+                                    The profile must be preconfigured on the node
+                                    to work. Must be a descending path, relative to
+                                    the kubelet's configured seccomp profile location.
+                                    Must only be set if type is "Localhost".
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                    Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                    Possible enum values:
+                                     - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                     - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                     - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            windowsOptions:
+                              description: The Windows specific settings applied to
+                                all containers. If unspecified, the options from the
+                                PodSecurityContext will be used. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is linux.
+                              properties:
+                                gmsaCredentialSpec:
+                                  description: GMSACredentialSpec is where the GMSA
+                                    admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                    inlines the contents of the GMSA credential spec
+                                    named by the GMSACredentialSpecName field.
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  description: GMSACredentialSpecName is the name
+                                    of the GMSA credential spec to use.
+                                  type: string
+                                hostProcess:
+                                  description: HostProcess determines if a container
+                                    should be run as a 'Host Process' container. This
+                                    field is alpha-level and will only be honored
+                                    by components that enable the WindowsHostProcessContainers
+                                    feature flag. Setting this field without the feature
+                                    flag will result in errors when validating the
+                                    Pod. All of a Pod's containers must have the same
+                                    effective HostProcess value (it is not allowed
+                                    to have a mix of HostProcess containers and non-HostProcess
+                                    containers).  In addition, if HostProcess is true
+                                    then HostNetwork must also be set to true.
+                                  type: boolean
+                                runAsUserName:
+                                  description: The UserName in Windows to run the
+                                    entrypoint of the container process. Defaults
+                                    to the user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  type: string
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: 'StartupProbe indicates that the Pod has successfully
+                            initialized. If specified, no other probes are executed
+                            until this completes successfully. If this probe fails,
+                            the Pod will be restarted, just as if the livenessProbe
+                            failed. This can be used to provide different probe parameters
+                            at the beginning of a Pod''s lifecycle, when it might
+                            take a long time to load data or warm a cache, than during
+                            steady-state operation. This cannot be updated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        stdin:
+                          description: Whether this container should allocate a buffer
+                            for stdin in the container runtime. If this is not set,
+                            reads from stdin in the container will always result in
+                            EOF. Default is false.
+                          type: boolean
+                        stdinOnce:
+                          description: Whether the container runtime should close
+                            the stdin channel after it has been opened by a single
+                            attach. When stdin is true the stdin stream will remain
+                            open across multiple attach sessions. If stdinOnce is
+                            set to true, stdin is opened on container start, is empty
+                            until the first client attaches to stdin, and then remains
+                            open and accepts data until the client disconnects, at
+                            which time stdin is closed and remains closed until the
+                            container is restarted. If this flag is false, a container
+                            processes that reads from stdin will never receive an
+                            EOF. Default is false
+                          type: boolean
+                        terminationMessagePath:
+                          description: 'Optional: Path at which the file to which
+                            the container''s termination message will be written is
+                            mounted into the container''s filesystem. Message written
+                            is intended to be brief final status, such as an assertion
+                            failure message. Will be truncated by the node if greater
+                            than 4096 bytes. The total message length across all containers
+                            will be limited to 12kb. Defaults to /dev/termination-log.
+                            Cannot be updated.'
+                          type: string
+                        terminationMessagePolicy:
+                          description: |-
+                            Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                            Possible enum values:
+                             - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                             - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                          type: string
+                        tty:
+                          description: Whether this container should allocate a TTY
+                            for itself, also requires 'stdin' to be true. Default
+                            is false.
+                          type: boolean
+                        volumeDevices:
+                          description: volumeDevices is the list of block devices
+                            to be used by the container.
+                          items:
+                            description: volumeDevice describes a mapping of a raw
+                              block device within a container.
+                            properties:
+                              devicePath:
+                                description: devicePath is the path inside of the
+                                  container that the device will be mapped to.
+                                type: string
+                              name:
+                                description: name must match the name of a persistentVolumeClaim
+                                  in the pod
+                                type: string
+                            required:
+                            - devicePath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - devicePath
+                          x-kubernetes-list-type: map
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                            Cannot be updated.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write
+                                  otherwise (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the
+                                  container's volume should be mounted. Defaults to
+                                  "" (volume's root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from
+                                  which the container's volume should be mounted.
+                                  Behaves similarly to SubPath but environment variable
+                                  references $(VAR_NAME) are expanded using the container's
+                                  environment. Defaults to "" (volume's root). SubPathExpr
+                                  and SubPath are mutually exclusive.
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - mountPath
+                          x-kubernetes-list-type: map
+                        workingDir:
+                          description: Container's working directory. If not specified,
+                            the container runtime's default will be used, which might
+                            be configured in the container image. Cannot be updated.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  nodeName:
+                    description: NodeName is a request to schedule this pod onto a
+                      specific node. If it is non-empty, the scheduler simply schedules
+                      this pod onto that node, assuming that it fits resource requirements.
+                    type: string
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'NodeSelector is a selector which must be true for
+                      the pod to fit on a node. Selector which must match a node''s
+                      labels for the pod to be scheduled on that node. More info:
+                      https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                    type: object
+                  os:
+                    description: |-
+                      Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set.
+
+                      If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions
+
+                      If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup
+                    properties:
+                      name:
+                        description: 'Name is the name of the operating system. The
+                          currently supported values are linux and windows. Additional
+                          value may be defined in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                          Clients should expect to handle additional values and treat
+                          unrecognized values in this field as os: null'
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  overhead:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Overhead represents the resource overhead associated
+                      with running a pod for a given RuntimeClass. This field will
+                      be autopopulated at admission time by the RuntimeClass admission
+                      controller. If the RuntimeClass admission controller is enabled,
+                      overhead must not be set in Pod create requests. The RuntimeClass
+                      admission controller will reject Pod create requests which have
+                      the overhead already set. If RuntimeClass is configured and
+                      selected in the PodSpec, Overhead will be set to the value defined
+                      in the corresponding RuntimeClass, otherwise it will remain
+                      unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
+                    type: object
+                  preemptionPolicy:
+                    description: PreemptionPolicy is the Policy for preempting pods
+                      with lower priority. One of Never, PreemptLowerPriority. Defaults
+                      to PreemptLowerPriority if unset.
+                    type: string
+                  priority:
+                    description: The priority value. Various system components use
+                      this field to find the priority of the pod. When Priority Admission
+                      Controller is enabled, it prevents users from setting this field.
+                      The admission controller populates this field from PriorityClassName.
+                      The higher the value, the higher the priority.
+                    format: int32
+                    type: integer
+                  priorityClassName:
+                    description: If specified, indicates the pod's priority. "system-node-critical"
+                      and "system-cluster-critical" are two special keywords which
+                      indicate the highest priorities with the former being the highest
+                      priority. Any other name must be defined by creating a PriorityClass
+                      object with that name. If not specified, the pod priority will
+                      be default or zero if there is no default.
+                    type: string
+                  readinessGates:
+                    description: 'If specified, all readiness gates will be evaluated
+                      for pod readiness. A pod is ready when all its containers are
+                      ready AND all conditions specified in the readiness gates have
+                      status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
+                    items:
+                      description: PodReadinessGate contains the reference to a pod
+                        condition
+                      properties:
+                        conditionType:
+                          description: ConditionType refers to a condition in the
+                            pod's condition list with matching type.
+                          type: string
+                      required:
+                      - conditionType
+                      type: object
+                    type: array
+                  restartPolicy:
+                    description: |-
+                      Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+
+                      Possible enum values:
+                       - `"Always"`
+                       - `"Never"`
+                       - `"OnFailure"`
+                    type: string
+                  runtimeClassName:
+                    description: 'RuntimeClassName refers to a RuntimeClass object
+                      in the node.k8s.io group, which should be used to run this pod.  If
+                      no RuntimeClass resource matches the named class, the pod will
+                      not be run. If unset or empty, the "legacy" RuntimeClass will
+                      be used, which is an implicit class with an empty definition
+                      that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
+                    type: string
+                  schedulerName:
+                    description: If specified, the pod will be dispatched by specified
+                      scheduler. If not specified, the pod will be dispatched by default
+                      scheduler.
+                    type: string
+                  securityContext:
+                    description: 'SecurityContext holds pod-level security attributes
+                      and common container settings. Optional: Defaults to empty.  See
+                      type description for default values of each field.'
+                    properties:
+                      fsGroup:
+                        description: |-
+                          A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
+                          1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
+                          If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      fsGroupChangePolicy:
+                        description: 'fsGroupChangePolicy defines behavior of changing
+                          ownership and permission of the volume before being exposed
+                          inside Pod. This field will only apply to volume types which
+                          support fsGroup based ownership(and permissions). It will
+                          have no effect on ephemeral volume types such as: secret,
+                          configmaps and emptydir. Valid values are "OnRootMismatch"
+                          and "Always". If not specified, "Always" is used. Note that
+                          this field cannot be set when spec.os.name is windows.'
+                        type: string
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence for that container. Note that this field
+                          cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in SecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in SecurityContext.  If set
+                          in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence for that container.
+                          Note that this field cannot be set when spec.os.name is
+                          windows.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to all containers.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          SecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence
+                          for that container. Note that this field cannot be set when
+                          spec.os.name is windows.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: The seccomp options to use by the containers
+                          in this pod. Note that this field cannot be set when spec.os.name
+                          is windows.
+                        properties:
+                          localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used. The profile must
+                              be preconfigured on the node to work. Must be a descending
+                              path, relative to the kubelet's configured seccomp profile
+                              location. Must only be set if type is "Localhost".
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                              Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                              Possible enum values:
+                               - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                               - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                               - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      supplementalGroups:
+                        description: A list of groups applied to the first process
+                          run in each container, in addition to the container's primary
+                          GID.  If unspecified, no groups will be added to any container.
+                          Note that this field cannot be set when spec.os.name is
+                          windows.
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      sysctls:
+                        description: Sysctls hold a list of namespaced sysctls used
+                          for the pod. Pods with unsupported sysctls (by the container
+                          runtime) might fail to launch. Note that this field cannot
+                          be set when spec.os.name is windows.
+                        items:
+                          description: Sysctl defines a kernel parameter to be set
+                          properties:
+                            name:
+                              description: Name of a property to set
+                              type: string
+                            value:
+                              description: Value of a property to set
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options within a container's
+                          SecurityContext will be used. If set in both SecurityContext
+                          and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence. Note that this field cannot be set when
+                          spec.os.name is linux.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: HostProcess determines if a container should
+                              be run as a 'Host Process' container. This field is
+                              alpha-level and will only be honored by components that
+                              enable the WindowsHostProcessContainers feature flag.
+                              Setting this field without the feature flag will result
+                              in errors when validating the Pod. All of a Pod's containers
+                              must have the same effective HostProcess value (it is
+                              not allowed to have a mix of HostProcess containers
+                              and non-HostProcess containers).  In addition, if HostProcess
+                              is true then HostNetwork must also be set to true.
+                            type: boolean
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  serviceAccount:
+                    description: 'DeprecatedServiceAccount is a depreciated alias
+                      for ServiceAccountName. Deprecated: Use serviceAccountName instead.'
+                    type: string
+                  serviceAccountName:
+                    description: 'ServiceAccountName is the name of the ServiceAccount
+                      to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                    type: string
+                  setHostnameAsFQDN:
+                    description: If true the pod's hostname will be configured as
+                      the pod's FQDN, rather than the leaf name (the default). In
+                      Linux containers, this means setting the FQDN in the hostname
+                      field of the kernel (the nodename field of struct utsname).
+                      In Windows containers, this means setting the registry value
+                      of hostname for the registry key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters
+                      to FQDN. If a pod does not have FQDN, this has no effect. Default
+                      to false.
+                    type: boolean
+                  shareProcessNamespace:
+                    description: 'Share a single process namespace between all of
+                      the containers in a pod. When this is set containers will be
+                      able to view and signal processes from other containers in the
+                      same pod, and the first process in each container will not be
+                      assigned PID 1. HostPID and ShareProcessNamespace cannot both
+                      be set. Optional: Default to false.'
+                    type: boolean
+                  subdomain:
+                    description: If specified, the fully qualified Pod hostname will
+                      be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+                      If not specified, the pod will not have a domainname at all.
+                    type: string
+                  terminationGracePeriodSeconds:
+                    description: Optional duration in seconds the pod needs to terminate
+                      gracefully. May be decreased in delete request. Value must be
+                      non-negative integer. The value zero indicates stop immediately
+                      via the kill signal (no opportunity to shut down). If this value
+                      is nil, the default grace period will be used instead. The grace
+                      period is the duration in seconds after the processes running
+                      in the pod are sent a termination signal and the time when the
+                      processes are forcibly halted with a kill signal. Set this value
+                      longer than the expected cleanup time for your process. Defaults
+                      to 30 seconds.
+                    format: int64
+                    type: integer
+                  tolerations:
+                    description: If specified, the pod's tolerations.
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using
+                        the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+                            Possible enum values:
+                             - `"NoExecute"` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+                             - `"NoSchedule"` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+                             - `"PreferNoSchedule"` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+
+                            Possible enum values:
+                             - `"Equal"`
+                             - `"Exists"`
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of
+                            time the toleration (which must be of effect NoExecute,
+                            otherwise this field is ignored) tolerates the taint.
+                            By default, it is not set, which means tolerate the taint
+                            forever (do not evict). Zero and negative values will
+                            be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  topologySpreadConstraints:
+                    description: TopologySpreadConstraints describes how a group of
+                      pods ought to spread across topology domains. Scheduler will
+                      schedule pods in a way which abides by the constraints. All
+                      topologySpreadConstraints are ANDed.
+                    items:
+                      description: TopologySpreadConstraint specifies how to spread
+                        matching pods among the given topology.
+                      properties:
+                        labelSelector:
+                          description: LabelSelector is used to find matching pods.
+                            Pods that match this label selector are counted to determine
+                            the number of pods in their corresponding topology domain.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        matchLabelKeys:
+                          description: MatchLabelKeys is a set of pod label keys to
+                            select the pods over which spreading will be calculated.
+                            The keys are used to lookup values from the incoming pod
+                            labels, those key-value labels are ANDed with labelSelector
+                            to select the group of existing pods over which spreading
+                            will be calculated for the incoming pod. Keys that don't
+                            exist in the incoming pod labels will be ignored. A null
+                            or empty list means only match against labelSelector.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        maxSkew:
+                          description: 'MaxSkew describes the degree to which pods
+                            may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                            it is the maximum permitted difference between the number
+                            of matching pods in the target topology and the global
+                            minimum. The global minimum is the minimum number of matching
+                            pods in an eligible domain or zero if the number of eligible
+                            domains is less than MinDomains. For example, in a 3-zone
+                            cluster, MaxSkew is set to 1, and pods with the same labelSelector
+                            spread as 2/2/1: In this case, the global minimum is 1.
+                            | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | -
+                            if MaxSkew is 1, incoming pod can only be scheduled to
+                            zone3 to become 2/2/2; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(3-1) on zone1(zone2) violate
+                            MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
+                            onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                            it is used to give higher precedence to topologies that
+                            satisfy it. It''s a required field. Default value is 1
+                            and 0 is not allowed.'
+                          format: int32
+                          type: integer
+                        minDomains:
+                          description: |-
+                            MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                            For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew.
+
+                            This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
+                          format: int32
+                          type: integer
+                        nodeAffinityPolicy:
+                          description: |-
+                            NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                            If this value is nil, the behavior is equivalent to the Honor policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                          type: string
+                        nodeTaintsPolicy:
+                          description: |-
+                            NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included.
+
+                            If this value is nil, the behavior is equivalent to the Ignore policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                          type: string
+                        topologyKey:
+                          description: TopologyKey is the key of node labels. Nodes
+                            that have a label with this key and identical values are
+                            considered to be in the same topology. We consider each
+                            <key, value> as a "bucket", and try to put balanced number
+                            of pods into each bucket. We define a domain as a particular
+                            instance of a topology. Also, we define an eligible domain
+                            as a domain whose nodes meet the requirements of nodeAffinityPolicy
+                            and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
+                            each Node is a domain of that topology. And, if TopologyKey
+                            is "topology.kubernetes.io/zone", each zone is a domain
+                            of that topology. It's a required field.
+                          type: string
+                        whenUnsatisfiable:
+                          description: |-
+                            WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                              but giving higher precedence to topologies that would help reduce the
+                              skew.
+                            A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
+
+                            Possible enum values:
+                             - `"DoNotSchedule"` instructs the scheduler not to schedule the pod when constraints are not satisfied.
+                             - `"ScheduleAnyway"` instructs the scheduler to schedule the pod even if constraints are not satisfied.
+                          type: string
+                      required:
+                      - maxSkew
+                      - topologyKey
+                      - whenUnsatisfiable
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - topologyKey
+                    - whenUnsatisfiable
+                    x-kubernetes-list-type: map
+                  volumes:
+                    description: 'List of volumes that can be mounted by containers
+                      belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                    items:
+                      description: Volume represents a named volume in a pod that
+                        may be accessed by any container in the pod.
+                      properties:
+                        awsElasticBlockStore:
+                          description: 'awsElasticBlockStore represents an AWS Disk
+                            resource that is attached to a kubelet''s host machine
+                            and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                          properties:
+                            fsType:
+                              description: 'fsType is the filesystem type of the volume
+                                that you want to mount. Tip: Ensure that the filesystem
+                                type is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              type: string
+                            partition:
+                              description: 'partition is the partition in the volume
+                                that you want to mount. If omitted, the default is
+                                to mount by volume name. Examples: For volume /dev/sda1,
+                                you specify the partition as "1". Similarly, the volume
+                                partition for /dev/sda is "0" (or you can leave the
+                                property empty).'
+                              format: int32
+                              type: integer
+                            readOnly:
+                              description: 'readOnly value true will force the readOnly
+                                setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              type: boolean
+                            volumeID:
+                              description: 'volumeID is unique ID of the persistent
+                                disk resource in AWS (Amazon EBS volume). More info:
+                                https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        azureDisk:
+                          description: azureDisk represents an Azure Data Disk mount
+                            on the host and bind mount to the pod.
+                          properties:
+                            cachingMode:
+                              description: 'cachingMode is the Host Caching mode:
+                                None, Read Only, Read Write.'
+                              type: string
+                            diskName:
+                              description: diskName is the Name of the data disk in
+                                the blob storage
+                              type: string
+                            diskURI:
+                              description: diskURI is the URI of data disk in the
+                                blob storage
+                              type: string
+                            fsType:
+                              description: fsType is Filesystem type to mount. Must
+                                be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified.
+                              type: string
+                            kind:
+                              description: 'kind expected values are Shared: multiple
+                                blob disks per storage account  Dedicated: single
+                                blob disk per storage account  Managed: azure managed
+                                data disk (only in managed availability set). defaults
+                                to shared'
+                              type: string
+                            readOnly:
+                              description: readOnly Defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                          required:
+                          - diskName
+                          - diskURI
+                          type: object
+                        azureFile:
+                          description: azureFile represents an Azure File Service
+                            mount on the host and bind mount to the pod.
+                          properties:
+                            readOnly:
+                              description: readOnly defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretName:
+                              description: secretName is the  name of secret that
+                                contains Azure Storage Account Name and Key
+                              type: string
+                            shareName:
+                              description: shareName is the azure share Name
+                              type: string
+                          required:
+                          - secretName
+                          - shareName
+                          type: object
+                        cephfs:
+                          description: cephFS represents a Ceph FS mount on the host
+                            that shares a pod's lifetime
+                          properties:
+                            monitors:
+                              description: 'monitors is Required: Monitors is a collection
+                                of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              items:
+                                type: string
+                              type: array
+                            path:
+                              description: 'path is Optional: Used as the mounted
+                                root, rather than the full Ceph tree, default is /'
+                              type: string
+                            readOnly:
+                              description: 'readOnly is Optional: Defaults to false
+                                (read/write). ReadOnly here will force the ReadOnly
+                                setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              type: boolean
+                            secretFile:
+                              description: 'secretFile is Optional: SecretFile is
+                                the path to key ring for User, default is /etc/ceph/user.secret
+                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              type: string
+                            secretRef:
+                              description: 'secretRef is Optional: SecretRef is reference
+                                to the authentication secret for User, default is
+                                empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            user:
+                              description: 'user is optional: User is the rados user
+                                name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              type: string
+                          required:
+                          - monitors
+                          type: object
+                        cinder:
+                          description: 'cinder represents a cinder volume attached
+                            and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                          properties:
+                            fsType:
+                              description: 'fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              type: string
+                            readOnly:
+                              description: 'readOnly defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              type: boolean
+                            secretRef:
+                              description: 'secretRef is optional: points to a secret
+                                object containing parameters used to connect to OpenStack.'
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            volumeID:
+                              description: 'volumeID used to identify the volume in
+                                cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        configMap:
+                          description: configMap represents a configMap that should
+                            populate this volume
+                          properties:
+                            defaultMode:
+                              description: 'defaultMode is optional: mode bits used
+                                to set permissions on created files by default. Must
+                                be an octal value between 0000 and 0777 or a decimal
+                                value between 0 and 511. YAML accepts both octal and
+                                decimal values, JSON requires decimal values for mode
+                                bits. Defaults to 0644. Directories within the path
+                                are not affected by this setting. This might be in
+                                conflict with other options that affect the file mode,
+                                like fsGroup, and the result can be other mode bits
+                                set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: items if unspecified, each key-value pair
+                                in the Data field of the referenced ConfigMap will
+                                be projected into the volume as a file whose name
+                                is the key and content is the value. If specified,
+                                the listed keys will be projected into the specified
+                                paths, and unlisted keys will not be present. If a
+                                key is specified which is not present in the ConfigMap,
+                                the volume setup will error unless it is marked optional.
+                                Paths must be relative and may not contain the '..'
+                                path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a
+                                  volume.
+                                properties:
+                                  key:
+                                    description: key is the key to project.
+                                    type: string
+                                  mode:
+                                    description: 'mode is Optional: mode bits used
+                                      to set permissions on this file. Must be an
+                                      octal value between 0000 and 0777 or a decimal
+                                      value between 0 and 511. YAML accepts both octal
+                                      and decimal values, JSON requires decimal values
+                                      for mode bits. If not specified, the volume
+                                      defaultMode will be used. This might be in conflict
+                                      with other options that affect the file mode,
+                                      like fsGroup, and the result can be other mode
+                                      bits set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: path is the relative path of the
+                                      file to map the key to. May not be an absolute
+                                      path. May not contain the path element '..'.
+                                      May not start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            optional:
+                              description: optional specify whether the ConfigMap
+                                or its keys must be defined
+                              type: boolean
+                          type: object
+                        csi:
+                          description: csi (Container Storage Interface) represents
+                            ephemeral storage that is handled by certain external
+                            CSI drivers (Beta feature).
+                          properties:
+                            driver:
+                              description: driver is the name of the CSI driver that
+                                handles this volume. Consult with your admin for the
+                                correct name as registered in the cluster.
+                              type: string
+                            fsType:
+                              description: fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                If not provided, the empty value is passed to the
+                                associated CSI driver which will determine the default
+                                filesystem to apply.
+                              type: string
+                            nodePublishSecretRef:
+                              description: nodePublishSecretRef is a reference to
+                                the secret object containing sensitive information
+                                to pass to the CSI driver to complete the CSI NodePublishVolume
+                                and NodeUnpublishVolume calls. This field is optional,
+                                and  may be empty if no secret is required. If the
+                                secret object contains more than one secret, all secret
+                                references are passed.
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            readOnly:
+                              description: readOnly specifies a read-only configuration
+                                for the volume. Defaults to false (read/write).
+                              type: boolean
+                            volumeAttributes:
+                              additionalProperties:
+                                type: string
+                              description: volumeAttributes stores driver-specific
+                                properties that are passed to the CSI driver. Consult
+                                your driver's documentation for supported values.
+                              type: object
+                          required:
+                          - driver
+                          type: object
+                        downwardAPI:
+                          description: downwardAPI represents downward API about the
+                            pod that should populate this volume
+                          properties:
+                            defaultMode:
+                              description: 'Optional: mode bits to use on created
+                                files by default. Must be a Optional: mode bits used
+                                to set permissions on created files by default. Must
+                                be an octal value between 0000 and 0777 or a decimal
+                                value between 0 and 511. YAML accepts both octal and
+                                decimal values, JSON requires decimal values for mode
+                                bits. Defaults to 0644. Directories within the path
+                                are not affected by this setting. This might be in
+                                conflict with other options that affect the file mode,
+                                like fsGroup, and the result can be other mode bits
+                                set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: Items is a list of downward API volume
+                                file
+                              items:
+                                description: DownwardAPIVolumeFile represents information
+                                  to create the file containing the pod field
+                                properties:
+                                  fieldRef:
+                                    description: 'Required: Selects a field of the
+                                      pod: only annotations, labels, name and namespace
+                                      are supported.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  mode:
+                                    description: 'Optional: mode bits used to set
+                                      permissions on this file, must be an octal value
+                                      between 0000 and 0777 or a decimal value between
+                                      0 and 511. YAML accepts both octal and decimal
+                                      values, JSON requires decimal values for mode
+                                      bits. If not specified, the volume defaultMode
+                                      will be used. This might be in conflict with
+                                      other options that affect the file mode, like
+                                      fsGroup, and the result can be other mode bits
+                                      set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: 'Required: Path is  the relative
+                                      path name of the file to be created. Must not
+                                      be absolute or contain the ''..'' path. Must
+                                      be utf-8 encoded. The first item of the relative
+                                      path must not start with ''..'''
+                                    type: string
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, requests.cpu and requests.memory)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                required:
+                                - path
+                                type: object
+                              type: array
+                          type: object
+                        emptyDir:
+                          description: 'emptyDir represents a temporary directory
+                            that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                          properties:
+                            medium:
+                              description: 'medium represents what type of storage
+                                medium should back this directory. The default is
+                                "" which means to use the node''s default medium.
+                                Must be an empty string (default) or Memory. More
+                                info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              type: string
+                            sizeLimit:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: 'sizeLimit is the total amount of local
+                                storage required for this EmptyDir volume. The size
+                                limit is also applicable for memory medium. The maximum
+                                usage on memory medium EmptyDir would be the minimum
+                                value between the SizeLimit specified here and the
+                                sum of memory limits of all containers in a pod. The
+                                default is nil which means that the limit is undefined.
+                                More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          type: object
+                        ephemeral:
+                          description: |-
+                            ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+
+                            Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+                               tracking are needed,
+                            c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+                               a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                               information on the connection between this volume type
+                               and PersistentVolumeClaim).
+
+                            Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+
+                            Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+
+                            A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+                          properties:
+                            volumeClaimTemplate:
+                              description: |-
+                                Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+
+                                An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+
+                                This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+
+                                Required, must not be nil.
+                              properties:
+                                metadata:
+                                  description: May contain labels and annotations
+                                    that will be copied into the PVC when creating
+                                    it. No other fields are allowed and will be rejected
+                                    during validation.
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                spec:
+                                  description: The specification for the PersistentVolumeClaim.
+                                    The entire content is copied unchanged into the
+                                    PVC that gets created from this template. The
+                                    same fields as in a PersistentVolumeClaim are
+                                    also valid here.
+                                  properties:
+                                    accessModes:
+                                      description: 'accessModes contains the desired
+                                        access modes the volume should have. More
+                                        info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                      items:
+                                        type: string
+                                      type: array
+                                    dataSource:
+                                      description: 'dataSource field can be used to
+                                        specify either: * An existing VolumeSnapshot
+                                        object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                        * An existing PVC (PersistentVolumeClaim)
+                                        If the provisioner or an external controller
+                                        can support the specified data source, it
+                                        will create a new volume based on the contents
+                                        of the specified data source. If the AnyVolumeDataSource
+                                        feature gate is enabled, this field will always
+                                        have the same contents as the DataSourceRef
+                                        field.'
+                                      properties:
+                                        apiGroup:
+                                          description: APIGroup is the group for the
+                                            resource being referenced. If APIGroup
+                                            is not specified, the specified Kind must
+                                            be in the core API group. For any other
+                                            third-party types, APIGroup is required.
+                                          type: string
+                                        kind:
+                                          description: Kind is the type of resource
+                                            being referenced
+                                          type: string
+                                        name:
+                                          description: Name is the name of resource
+                                            being referenced
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                    dataSourceRef:
+                                      description: |-
+                                        dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef
+                                          allows any non-core object, as well as PersistentVolumeClaim objects.
+                                        * While DataSource ignores disallowed values (dropping them), DataSourceRef
+                                          preserves all values, and generates an error if a disallowed value is
+                                          specified.
+                                        (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                      properties:
+                                        apiGroup:
+                                          description: APIGroup is the group for the
+                                            resource being referenced. If APIGroup
+                                            is not specified, the specified Kind must
+                                            be in the core API group. For any other
+                                            third-party types, APIGroup is required.
+                                          type: string
+                                        kind:
+                                          description: Kind is the type of resource
+                                            being referenced
+                                          type: string
+                                        name:
+                                          description: Name is the name of resource
+                                            being referenced
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                    resources:
+                                      description: 'resources represents the minimum
+                                        resources the volume should have. If RecoverVolumeExpansionFailure
+                                        feature is enabled users are allowed to specify
+                                        resource requirements that are lower than
+                                        previous value but must still be higher than
+                                        capacity recorded in the status field of the
+                                        claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Limits describes the maximum
+                                            amount of compute resources allowed. More
+                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Requests describes the minimum
+                                            amount of compute resources required.
+                                            If Requests is omitted for a container,
+                                            it defaults to Limits if that is explicitly
+                                            specified, otherwise to an implementation-defined
+                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                      type: object
+                                    selector:
+                                      description: selector is a label query over
+                                        volumes to consider for binding.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    storageClassName:
+                                      description: 'storageClassName is the name of
+                                        the StorageClass required by the claim. More
+                                        info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                      type: string
+                                    volumeMode:
+                                      description: volumeMode defines what type of
+                                        volume is required by the claim. Value of
+                                        Filesystem is implied when not included in
+                                        claim spec.
+                                      type: string
+                                    volumeName:
+                                      description: volumeName is the binding reference
+                                        to the PersistentVolume backing this claim.
+                                      type: string
+                                  type: object
+                              required:
+                              - spec
+                              type: object
+                          type: object
+                        fc:
+                          description: fc represents a Fibre Channel resource that
+                            is attached to a kubelet's host machine and then exposed
+                            to the pod.
+                          properties:
+                            fsType:
+                              description: fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified.
+                              type: string
+                            lun:
+                              description: 'lun is Optional: FC target lun number'
+                              format: int32
+                              type: integer
+                            readOnly:
+                              description: 'readOnly is Optional: Defaults to false
+                                (read/write). ReadOnly here will force the ReadOnly
+                                setting in VolumeMounts.'
+                              type: boolean
+                            targetWWNs:
+                              description: 'targetWWNs is Optional: FC target worldwide
+                                names (WWNs)'
+                              items:
+                                type: string
+                              type: array
+                            wwids:
+                              description: 'wwids Optional: FC volume world wide identifiers
+                                (wwids) Either wwids or combination of targetWWNs
+                                and lun must be set, but not both simultaneously.'
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        flexVolume:
+                          description: flexVolume represents a generic volume resource
+                            that is provisioned/attached using an exec based plugin.
+                          properties:
+                            driver:
+                              description: driver is the name of the driver to use
+                                for this volume.
+                              type: string
+                            fsType:
+                              description: fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". The default filesystem
+                                depends on FlexVolume script.
+                              type: string
+                            options:
+                              additionalProperties:
+                                type: string
+                              description: 'options is Optional: this field holds
+                                extra command options if any.'
+                              type: object
+                            readOnly:
+                              description: 'readOnly is Optional: defaults to false
+                                (read/write). ReadOnly here will force the ReadOnly
+                                setting in VolumeMounts.'
+                              type: boolean
+                            secretRef:
+                              description: 'secretRef is Optional: secretRef is reference
+                                to the secret object containing sensitive information
+                                to pass to the plugin scripts. This may be empty if
+                                no secret object is specified. If the secret object
+                                contains more than one secret, all secrets are passed
+                                to the plugin scripts.'
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                          required:
+                          - driver
+                          type: object
+                        flocker:
+                          description: flocker represents a Flocker volume attached
+                            to a kubelet's host machine. This depends on the Flocker
+                            control service being running
+                          properties:
+                            datasetName:
+                              description: datasetName is Name of the dataset stored
+                                as metadata -> name on the dataset for Flocker should
+                                be considered as deprecated
+                              type: string
+                            datasetUUID:
+                              description: datasetUUID is the UUID of the dataset.
+                                This is unique identifier of a Flocker dataset
+                              type: string
+                          type: object
+                        gcePersistentDisk:
+                          description: 'gcePersistentDisk represents a GCE Disk resource
+                            that is attached to a kubelet''s host machine and then
+                            exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                          properties:
+                            fsType:
+                              description: 'fsType is filesystem type of the volume
+                                that you want to mount. Tip: Ensure that the filesystem
+                                type is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              type: string
+                            partition:
+                              description: 'partition is the partition in the volume
+                                that you want to mount. If omitted, the default is
+                                to mount by volume name. Examples: For volume /dev/sda1,
+                                you specify the partition as "1". Similarly, the volume
+                                partition for /dev/sda is "0" (or you can leave the
+                                property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              format: int32
+                              type: integer
+                            pdName:
+                              description: 'pdName is unique name of the PD resource
+                                in GCE. Used to identify the disk in GCE. More info:
+                                https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              type: string
+                            readOnly:
+                              description: 'readOnly here will force the ReadOnly
+                                setting in VolumeMounts. Defaults to false. More info:
+                                https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              type: boolean
+                          required:
+                          - pdName
+                          type: object
+                        gitRepo:
+                          description: 'gitRepo represents a git repository at a particular
+                            revision. DEPRECATED: GitRepo is deprecated. To provision
+                            a container with a git repo, mount an EmptyDir into an
+                            InitContainer that clones the repo using git, then mount
+                            the EmptyDir into the Pod''s container.'
+                          properties:
+                            directory:
+                              description: directory is the target directory name.
+                                Must not contain or start with '..'.  If '.' is supplied,
+                                the volume directory will be the git repository.  Otherwise,
+                                if specified, the volume will contain the git repository
+                                in the subdirectory with the given name.
+                              type: string
+                            repository:
+                              description: repository is the URL
+                              type: string
+                            revision:
+                              description: revision is the commit hash for the specified
+                                revision.
+                              type: string
+                          required:
+                          - repository
+                          type: object
+                        glusterfs:
+                          description: 'glusterfs represents a Glusterfs mount on
+                            the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                          properties:
+                            endpoints:
+                              description: 'endpoints is the endpoint name that details
+                                Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                              type: string
+                            path:
+                              description: 'path is the Glusterfs volume path. More
+                                info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                              type: string
+                            readOnly:
+                              description: 'readOnly here will force the Glusterfs
+                                volume to be mounted with read-only permissions. Defaults
+                                to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                              type: boolean
+                          required:
+                          - endpoints
+                          - path
+                          type: object
+                        hostPath:
+                          description: 'hostPath represents a pre-existing file or
+                            directory on the host machine that is directly exposed
+                            to the container. This is generally used for system agents
+                            or other privileged things that are allowed to see the
+                            host machine. Most containers will NOT need this. More
+                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                          properties:
+                            path:
+                              description: 'path of the directory on the host. If
+                                the path is a symlink, it will follow the link to
+                                the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                              type: string
+                            type:
+                              description: 'type for HostPath Volume Defaults to ""
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        iscsi:
+                          description: 'iscsi represents an ISCSI Disk resource that
+                            is attached to a kubelet''s host machine and then exposed
+                            to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                          properties:
+                            chapAuthDiscovery:
+                              description: chapAuthDiscovery defines whether support
+                                iSCSI Discovery CHAP authentication
+                              type: boolean
+                            chapAuthSession:
+                              description: chapAuthSession defines whether support
+                                iSCSI Session CHAP authentication
+                              type: boolean
+                            fsType:
+                              description: 'fsType is the filesystem type of the volume
+                                that you want to mount. Tip: Ensure that the filesystem
+                                type is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                              type: string
+                            initiatorName:
+                              description: initiatorName is the custom iSCSI Initiator
+                                Name. If initiatorName is specified with iscsiInterface
+                                simultaneously, new iSCSI interface <target portal>:<volume
+                                name> will be created for the connection.
+                              type: string
+                            iqn:
+                              description: iqn is the target iSCSI Qualified Name.
+                              type: string
+                            iscsiInterface:
+                              description: iscsiInterface is the interface Name that
+                                uses an iSCSI transport. Defaults to 'default' (tcp).
+                              type: string
+                            lun:
+                              description: lun represents iSCSI Target Lun number.
+                              format: int32
+                              type: integer
+                            portals:
+                              description: portals is the iSCSI Target Portal List.
+                                The portal is either an IP or ip_addr:port if the
+                                port is other than default (typically TCP ports 860
+                                and 3260).
+                              items:
+                                type: string
+                              type: array
+                            readOnly:
+                              description: readOnly here will force the ReadOnly setting
+                                in VolumeMounts. Defaults to false.
+                              type: boolean
+                            secretRef:
+                              description: secretRef is the CHAP Secret for iSCSI
+                                target and initiator authentication
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            targetPortal:
+                              description: targetPortal is iSCSI Target Portal. The
+                                Portal is either an IP or ip_addr:port if the port
+                                is other than default (typically TCP ports 860 and
+                                3260).
+                              type: string
+                          required:
+                          - targetPortal
+                          - iqn
+                          - lun
+                          type: object
+                        name:
+                          description: 'name of the volume. Must be a DNS_LABEL and
+                            unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        nfs:
+                          description: 'nfs represents an NFS mount on the host that
+                            shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                          properties:
+                            path:
+                              description: 'path that is exported by the NFS server.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              type: string
+                            readOnly:
+                              description: 'readOnly here will force the NFS export
+                                to be mounted with read-only permissions. Defaults
+                                to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              type: boolean
+                            server:
+                              description: 'server is the hostname or IP address of
+                                the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              type: string
+                          required:
+                          - server
+                          - path
+                          type: object
+                        persistentVolumeClaim:
+                          description: 'persistentVolumeClaimVolumeSource represents
+                            a reference to a PersistentVolumeClaim in the same namespace.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          properties:
+                            claimName:
+                              description: 'claimName is the name of a PersistentVolumeClaim
+                                in the same namespace as the pod using this volume.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              type: string
+                            readOnly:
+                              description: readOnly Will force the ReadOnly setting
+                                in VolumeMounts. Default false.
+                              type: boolean
+                          required:
+                          - claimName
+                          type: object
+                        photonPersistentDisk:
+                          description: photonPersistentDisk represents a PhotonController
+                            persistent disk attached and mounted on kubelets host
+                            machine
+                          properties:
+                            fsType:
+                              description: fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified.
+                              type: string
+                            pdID:
+                              description: pdID is the ID that identifies Photon Controller
+                                persistent disk
+                              type: string
+                          required:
+                          - pdID
+                          type: object
+                        portworxVolume:
+                          description: portworxVolume represents a portworx volume
+                            attached and mounted on kubelets host machine
+                          properties:
+                            fsType:
+                              description: fSType represents the filesystem type to
+                                mount Must be a filesystem type supported by the host
+                                operating system. Ex. "ext4", "xfs". Implicitly inferred
+                                to be "ext4" if unspecified.
+                              type: string
+                            readOnly:
+                              description: readOnly defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            volumeID:
+                              description: volumeID uniquely identifies a Portworx
+                                volume
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        projected:
+                          description: projected items for all in one resources secrets,
+                            configmaps, and downward API
+                          properties:
+                            defaultMode:
+                              description: defaultMode are the mode bits used to set
+                                permissions on created files by default. Must be an
+                                octal value between 0000 and 0777 or a decimal value
+                                between 0 and 511. YAML accepts both octal and decimal
+                                values, JSON requires decimal values for mode bits.
+                                Directories within the path are not affected by this
+                                setting. This might be in conflict with other options
+                                that affect the file mode, like fsGroup, and the result
+                                can be other mode bits set.
+                              format: int32
+                              type: integer
+                            sources:
+                              description: sources is the list of volume projections
+                              items:
+                                description: Projection that may be projected along
+                                  with other supported volume types
+                                properties:
+                                  configMap:
+                                    description: configMap information about the configMap
+                                      data to project
+                                    properties:
+                                      items:
+                                        description: items if unspecified, each key-value
+                                          pair in the Data field of the referenced
+                                          ConfigMap will be projected into the volume
+                                          as a file whose name is the key and content
+                                          is the value. If specified, the listed keys
+                                          will be projected into the specified paths,
+                                          and unlisted keys will not be present. If
+                                          a key is specified which is not present
+                                          in the ConfigMap, the volume setup will
+                                          error unless it is marked optional. Paths
+                                          must be relative and may not contain the
+                                          '..' path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: key is the key to project.
+                                              type: string
+                                            mode:
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: path is the relative path
+                                                of the file to map the key to. May
+                                                not be an absolute path. May not contain
+                                                the path element '..'. May not start
+                                                with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: optional specify whether the
+                                          ConfigMap or its keys must be defined
+                                        type: boolean
+                                    type: object
+                                  downwardAPI:
+                                    description: downwardAPI information about the
+                                      downwardAPI data to project
+                                    properties:
+                                      items:
+                                        description: Items is a list of DownwardAPIVolume
+                                          file
+                                        items:
+                                          description: DownwardAPIVolumeFile represents
+                                            information to create the file containing
+                                            the pod field
+                                          properties:
+                                            fieldRef:
+                                              description: 'Required: Selects a field
+                                                of the pod: only annotations, labels,
+                                                name and namespace are supported.'
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                            mode:
+                                              description: 'Optional: mode bits used
+                                                to set permissions on this file, must
+                                                be an octal value between 0000 and
+                                                0777 or a decimal value between 0
+                                                and 511. YAML accepts both octal and
+                                                decimal values, JSON requires decimal
+                                                values for mode bits. If not specified,
+                                                the volume defaultMode will be used.
+                                                This might be in conflict with other
+                                                options that affect the file mode,
+                                                like fsGroup, and the result can be
+                                                other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: 'Required: Path is  the
+                                                relative path name of the file to
+                                                be created. Must not be absolute or
+                                                contain the ''..'' path. Must be utf-8
+                                                encoded. The first item of the relative
+                                                path must not start with ''..'''
+                                              type: string
+                                            resourceFieldRef:
+                                              description: 'Selects a resource of
+                                                the container: only resources limits
+                                                and requests (limits.cpu, limits.memory,
+                                                requests.cpu and requests.memory)
+                                                are currently supported.'
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                          required:
+                                          - path
+                                          type: object
+                                        type: array
+                                    type: object
+                                  secret:
+                                    description: secret information about the secret
+                                      data to project
+                                    properties:
+                                      items:
+                                        description: items if unspecified, each key-value
+                                          pair in the Data field of the referenced
+                                          Secret will be projected into the volume
+                                          as a file whose name is the key and content
+                                          is the value. If specified, the listed keys
+                                          will be projected into the specified paths,
+                                          and unlisted keys will not be present. If
+                                          a key is specified which is not present
+                                          in the Secret, the volume setup will error
+                                          unless it is marked optional. Paths must
+                                          be relative and may not contain the '..'
+                                          path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: key is the key to project.
+                                              type: string
+                                            mode:
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: path is the relative path
+                                                of the file to map the key to. May
+                                                not be an absolute path. May not contain
+                                                the path element '..'. May not start
+                                                with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: optional field specify whether
+                                          the Secret or its key must be defined
+                                        type: boolean
+                                    type: object
+                                  serviceAccountToken:
+                                    description: serviceAccountToken is information
+                                      about the serviceAccountToken data to project
+                                    properties:
+                                      audience:
+                                        description: audience is the intended audience
+                                          of the token. A recipient of a token must
+                                          identify itself with an identifier specified
+                                          in the audience of the token, and otherwise
+                                          should reject the token. The audience defaults
+                                          to the identifier of the apiserver.
+                                        type: string
+                                      expirationSeconds:
+                                        description: expirationSeconds is the requested
+                                          duration of validity of the service account
+                                          token. As the token approaches expiration,
+                                          the kubelet volume plugin will proactively
+                                          rotate the service account token. The kubelet
+                                          will start trying to rotate the token if
+                                          the token is older than 80 percent of its
+                                          time to live or if the token is older than
+                                          24 hours.Defaults to 1 hour and must be
+                                          at least 10 minutes.
+                                        format: int64
+                                        type: integer
+                                      path:
+                                        description: path is the path relative to
+                                          the mount point of the file to project the
+                                          token into.
+                                        type: string
+                                    required:
+                                    - path
+                                    type: object
+                                type: object
+                              type: array
+                          type: object
+                        quobyte:
+                          description: quobyte represents a Quobyte mount on the host
+                            that shares a pod's lifetime
+                          properties:
+                            group:
+                              description: group to map volume access to Default is
+                                no group
+                              type: string
+                            readOnly:
+                              description: readOnly here will force the Quobyte volume
+                                to be mounted with read-only permissions. Defaults
+                                to false.
+                              type: boolean
+                            registry:
+                              description: registry represents a single or multiple
+                                Quobyte Registry services specified as a string as
+                                host:port pair (multiple entries are separated with
+                                commas) which acts as the central registry for volumes
+                              type: string
+                            tenant:
+                              description: tenant owning the given Quobyte volume
+                                in the Backend Used with dynamically provisioned Quobyte
+                                volumes, value is set by the plugin
+                              type: string
+                            user:
+                              description: user to map volume access to Defaults to
+                                serivceaccount user
+                              type: string
+                            volume:
+                              description: volume is a string that references an already
+                                created Quobyte volume by name.
+                              type: string
+                          required:
+                          - registry
+                          - volume
+                          type: object
+                        rbd:
+                          description: 'rbd represents a Rados Block Device mount
+                            on the host that shares a pod''s lifetime. More info:
+                            https://examples.k8s.io/volumes/rbd/README.md'
+                          properties:
+                            fsType:
+                              description: 'fsType is the filesystem type of the volume
+                                that you want to mount. Tip: Ensure that the filesystem
+                                type is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                              type: string
+                            image:
+                              description: 'image is the rados image name. More info:
+                                https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: string
+                            keyring:
+                              description: 'keyring is the path to key ring for RBDUser.
+                                Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: string
+                            monitors:
+                              description: 'monitors is a collection of Ceph monitors.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              items:
+                                type: string
+                              type: array
+                            pool:
+                              description: 'pool is the rados pool name. Default is
+                                rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: string
+                            readOnly:
+                              description: 'readOnly here will force the ReadOnly
+                                setting in VolumeMounts. Defaults to false. More info:
+                                https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: boolean
+                            secretRef:
+                              description: 'secretRef is name of the authentication
+                                secret for RBDUser. If provided overrides keyring.
+                                Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            user:
+                              description: 'user is the rados user name. Default is
+                                admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: string
+                          required:
+                          - monitors
+                          - image
+                          type: object
+                        scaleIO:
+                          description: scaleIO represents a ScaleIO persistent volume
+                            attached and mounted on Kubernetes nodes.
+                          properties:
+                            fsType:
+                              description: fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                              type: string
+                            gateway:
+                              description: gateway is the host address of the ScaleIO
+                                API Gateway.
+                              type: string
+                            protectionDomain:
+                              description: protectionDomain is the name of the ScaleIO
+                                Protection Domain for the configured storage.
+                              type: string
+                            readOnly:
+                              description: readOnly Defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretRef:
+                              description: secretRef references to the secret for
+                                ScaleIO user and other sensitive information. If this
+                                is not provided, Login operation will fail.
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            sslEnabled:
+                              description: sslEnabled Flag enable/disable SSL communication
+                                with Gateway, default false
+                              type: boolean
+                            storageMode:
+                              description: storageMode indicates whether the storage
+                                for a volume should be ThickProvisioned or ThinProvisioned.
+                                Default is ThinProvisioned.
+                              type: string
+                            storagePool:
+                              description: storagePool is the ScaleIO Storage Pool
+                                associated with the protection domain.
+                              type: string
+                            system:
+                              description: system is the name of the storage system
+                                as configured in ScaleIO.
+                              type: string
+                            volumeName:
+                              description: volumeName is the name of a volume already
+                                created in the ScaleIO system that is associated with
+                                this volume source.
+                              type: string
+                          required:
+                          - gateway
+                          - system
+                          - secretRef
+                          type: object
+                        secret:
+                          description: 'secret represents a secret that should populate
+                            this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                          properties:
+                            defaultMode:
+                              description: 'defaultMode is Optional: mode bits used
+                                to set permissions on created files by default. Must
+                                be an octal value between 0000 and 0777 or a decimal
+                                value between 0 and 511. YAML accepts both octal and
+                                decimal values, JSON requires decimal values for mode
+                                bits. Defaults to 0644. Directories within the path
+                                are not affected by this setting. This might be in
+                                conflict with other options that affect the file mode,
+                                like fsGroup, and the result can be other mode bits
+                                set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: items If unspecified, each key-value pair
+                                in the Data field of the referenced Secret will be
+                                projected into the volume as a file whose name is
+                                the key and content is the value. If specified, the
+                                listed keys will be projected into the specified paths,
+                                and unlisted keys will not be present. If a key is
+                                specified which is not present in the Secret, the
+                                volume setup will error unless it is marked optional.
+                                Paths must be relative and may not contain the '..'
+                                path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a
+                                  volume.
+                                properties:
+                                  key:
+                                    description: key is the key to project.
+                                    type: string
+                                  mode:
+                                    description: 'mode is Optional: mode bits used
+                                      to set permissions on this file. Must be an
+                                      octal value between 0000 and 0777 or a decimal
+                                      value between 0 and 511. YAML accepts both octal
+                                      and decimal values, JSON requires decimal values
+                                      for mode bits. If not specified, the volume
+                                      defaultMode will be used. This might be in conflict
+                                      with other options that affect the file mode,
+                                      like fsGroup, and the result can be other mode
+                                      bits set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: path is the relative path of the
+                                      file to map the key to. May not be an absolute
+                                      path. May not contain the path element '..'.
+                                      May not start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                            optional:
+                              description: optional field specify whether the Secret
+                                or its keys must be defined
+                              type: boolean
+                            secretName:
+                              description: 'secretName is the name of the secret in
+                                the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              type: string
+                          type: object
+                        storageos:
+                          description: storageOS represents a StorageOS volume attached
+                            and mounted on Kubernetes nodes.
+                          properties:
+                            fsType:
+                              description: fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified.
+                              type: string
+                            readOnly:
+                              description: readOnly defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretRef:
+                              description: secretRef specifies the secret to use for
+                                obtaining the StorageOS API credentials.  If not specified,
+                                default values will be attempted.
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            volumeName:
+                              description: volumeName is the human-readable name of
+                                the StorageOS volume.  Volume names are only unique
+                                within a namespace.
+                              type: string
+                            volumeNamespace:
+                              description: volumeNamespace specifies the scope of
+                                the volume within StorageOS.  If no namespace is specified
+                                then the Pod's namespace will be used.  This allows
+                                the Kubernetes name scoping to be mirrored within
+                                StorageOS for tighter integration. Set VolumeName
+                                to any name to override the default behaviour. Set
+                                to "default" if you are not using namespaces within
+                                StorageOS. Namespaces that do not pre-exist within
+                                StorageOS will be created.
+                              type: string
+                          type: object
+                        vsphereVolume:
+                          description: vsphereVolume represents a vSphere volume attached
+                            and mounted on kubelets host machine
+                          properties:
+                            fsType:
+                              description: fsType is filesystem type to mount. Must
+                                be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified.
+                              type: string
+                            storagePolicyID:
+                              description: storagePolicyID is the storage Policy Based
+                                Management (SPBM) profile ID associated with the StoragePolicyName.
+                              type: string
+                            storagePolicyName:
+                              description: storagePolicyName is the storage Policy
+                                Based Management (SPBM) profile name.
+                              type: string
+                            volumePath:
+                              description: volumePath is the path that identifies
+                                vSphere volume vmdk
+                              type: string
+                          required:
+                          - volumePath
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                required:
+                - containers
+                type: object
+            type: object
+        required:
+        - selector
+        - template
+        type: object
+      status:
+        description: Most recently observed status of the Deployment.
+        properties:
+          availableReplicas:
+            description: Total number of available pods (ready for at least minReadySeconds)
+              targeted by this deployment.
+            format: int32
+            type: integer
+          collisionCount:
+            description: Count of hash collisions for the Deployment. The Deployment
+              controller uses this field as a collision avoidance mechanism when it
+              needs to create the name for the newest ReplicaSet.
+            format: int32
+            type: integer
+          conditions:
+            description: Represents the latest available observations of a deployment's
+              current state.
+            items:
+              description: DeploymentCondition describes the state of a deployment
+                at a certain point.
+              properties:
+                lastTransitionTime:
+                  description: Last time the condition transitioned from one status
+                    to another.
+                  format: date-time
+                  type: string
+                lastUpdateTime:
+                  description: The last time this condition was updated.
+                  format: date-time
+                  type: string
+                message:
+                  description: A human readable message indicating details about the
+                    transition.
+                  type: string
+                reason:
+                  description: The reason for the condition's last transition.
+                  type: string
+                status:
+                  description: Status of the condition, one of True, False, Unknown.
+                  type: string
+                type:
+                  description: Type of deployment condition.
+                  type: string
+              required:
+              - status
+              - type
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - type
+            x-kubernetes-list-type: map
+          observedGeneration:
+            description: The generation observed by the deployment controller.
+            format: int64
+            type: integer
+          readyReplicas:
+            description: readyReplicas is the number of pods targeted by this Deployment
+              with a Ready Condition.
+            format: int32
+            type: integer
+          replicas:
+            description: Total number of non-terminated pods targeted by this deployment
+              (their labels match the selector).
+            format: int32
+            type: integer
+          unavailableReplicas:
+            description: Total number of unavailable pods targeted by this deployment.
+              This is the total number of pods that are still required for the deployment
+              to have 100% available capacity. They may either be pods that are running
+              but not yet available or pods that still have not been created.
+            format: int32
+            type: integer
+          updatedReplicas:
+            description: Total number of non-terminated pods targeted by this deployment
+              that have the desired template spec.
+            format: int32
+            type: integer
+        type: object
+    type: object
+  plural: deployments
+  scope: Namespaced
+  shortNames:
+  - deploy
+  singular: deployment
+  subResources:
+  - name: scale
+  - name: status

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/3-NegotiatedAPIResource-ingresses.v1.networking.k8s.io.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/3-NegotiatedAPIResource-ingresses.v1.networking.k8s.io.yaml
@@ -1,0 +1,343 @@
+apiVersion: apiresource.kcp.io/v1alpha1
+kind: NegotiatedAPIResource
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kcp-dev/kubernetes/pull/4
+    apiresource.kcp.io/apiVersion: networking.k8s.io/v1
+    kcp.io/cluster: br3qimk2t1o3jb70
+  creationTimestamp: "2023-03-21T17:10:10Z"
+  generation: 1
+  name: ingresses.v1.networking.k8s.io
+  resourceVersion: "9152"
+  uid: 2e87e262-ba6b-4de5-8df0-a6fa1bc7368f
+spec:
+  groupVersion:
+    group: networking.k8s.io
+    version: v1
+  kind: Ingress
+  listKind: IngressList
+  openAPIV3Schema:
+    description: Ingress is a collection of rules that allow inbound connections to
+      reach the endpoints defined by a backend. An Ingress can be configured to give
+      services externally-reachable urls, load balance traffic, terminate SSL, offer
+      name based virtual hosting etc.
+    properties:
+      apiVersion:
+        description: 'APIVersion defines the versioned schema of this representation
+          of an object. Servers should convert recognized schemas to the latest internal
+          value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+        type: string
+      kind:
+        description: 'Kind is a string value representing the REST resource this object
+          represents. Servers may infer this from the endpoint the client submits
+          requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+        type: string
+      metadata:
+        type: object
+      spec:
+        description: 'Spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+        properties:
+          defaultBackend:
+            description: DefaultBackend is the backend that should handle requests
+              that don't match any rule. If Rules are not specified, DefaultBackend
+              must be specified. If DefaultBackend is not set, the handling of requests
+              that do not match any of the rules will be up to the Ingress controller.
+            properties:
+              resource:
+                description: Resource is an ObjectRef to another Kubernetes resource
+                  in the namespace of the Ingress object. If resource is specified,
+                  a service.Name and service.Port must not be specified. This is a
+                  mutually exclusive setting with "Service".
+                properties:
+                  apiGroup:
+                    description: APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in
+                      the core API group. For any other third-party types, APIGroup
+                      is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              service:
+                description: Service references a Service as a Backend. This is a
+                  mutually exclusive setting with "Resource".
+                properties:
+                  name:
+                    description: Name is the referenced service. The service must
+                      exist in the same namespace as the Ingress object.
+                    type: string
+                  port:
+                    description: Port of the referenced service. A port name or port
+                      number is required for a IngressServiceBackend.
+                    properties:
+                      name:
+                        description: Name is the name of the port on the Service.
+                          This is a mutually exclusive setting with "Number".
+                        type: string
+                      number:
+                        description: Number is the numerical port number (e.g. 80)
+                          on the Service. This is a mutually exclusive setting with
+                          "Name".
+                        format: int32
+                        type: integer
+                    type: object
+                required:
+                - name
+                type: object
+            type: object
+          ingressClassName:
+            description: IngressClassName is the name of an IngressClass cluster resource.
+              Ingress controller implementations use this field to know whether they
+              should be serving this Ingress resource, by a transitive connection
+              (controller -> IngressClass -> Ingress resource). Although the `kubernetes.io/ingress.class`
+              annotation (simple constant name) was never formally defined, it was
+              widely supported by Ingress controllers to create a direct binding between
+              Ingress controller and Ingress resources. Newly created Ingress resources
+              should prefer using the field. However, even though the annotation is
+              officially deprecated, for backwards compatibility reasons, ingress
+              controllers should still honor that annotation if present.
+            type: string
+          rules:
+            description: A list of host rules used to configure the Ingress. If unspecified,
+              or no rule matches, all traffic is sent to the default backend.
+            items:
+              description: IngressRule represents the rules mapping the paths under
+                a specified host to the related backend services. Incoming requests
+                are first evaluated for a host match, then routed to the backend associated
+                with the matching IngressRuleValue.
+              properties:
+                host:
+                  description: "Host is the fully qualified domain name of a network
+                    host, as defined by RFC 3986. Note the following deviations from
+                    the \"host\" part of the URI as defined in RFC 3986: 1. IPs are
+                    not allowed. Currently an IngressRuleValue can only apply to\n
+                    \  the IP in the Spec of the parent Ingress.\n2. The `:` delimiter
+                    is not respected because ports are not allowed.\n\t  Currently
+                    the port of an Ingress is implicitly :80 for http and\n\t  :443
+                    for https.\nBoth these may change in the future. Incoming requests
+                    are matched against the host before the IngressRuleValue. If the
+                    host is unspecified, the Ingress routes all traffic based on the
+                    specified IngressRuleValue.\n\nHost can be \"precise\" which is
+                    a domain name without the terminating dot of a network host (e.g.
+                    \"foo.bar.com\") or \"wildcard\", which is a domain name prefixed
+                    with a single wildcard label (e.g. \"*.foo.com\"). The wildcard
+                    character '*' must appear by itself as the first DNS label and
+                    matches only a single label. You cannot have a wildcard label
+                    by itself (e.g. Host == \"*\"). Requests will be matched against
+                    the Host field in the following way: 1. If Host is precise, the
+                    request matches this rule if the http host header is equal to
+                    Host. 2. If Host is a wildcard, then the request matches this
+                    rule if the http host header is to equal to the suffix (removing
+                    the first label) of the wildcard rule."
+                  type: string
+                http:
+                  description: 'HTTPIngressRuleValue is a list of http selectors pointing
+                    to backends. In the example: http://<host>/<path>?<searchpart>
+                    -> backend where where parts of the url correspond to RFC 3986,
+                    this resource will be used to match against everything after the
+                    last ''/'' and before the first ''?'' or ''#''.'
+                  properties:
+                    paths:
+                      description: A collection of paths that map requests to backends.
+                      items:
+                        description: HTTPIngressPath associates a path with a backend.
+                          Incoming urls matching the path are forwarded to the backend.
+                        properties:
+                          backend:
+                            description: Backend defines the referenced service endpoint
+                              to which the traffic will be forwarded to.
+                            properties:
+                              resource:
+                                description: Resource is an ObjectRef to another Kubernetes
+                                  resource in the namespace of the Ingress object.
+                                  If resource is specified, a service.Name and service.Port
+                                  must not be specified. This is a mutually exclusive
+                                  setting with "Service".
+                                properties:
+                                  apiGroup:
+                                    description: APIGroup is the group for the resource
+                                      being referenced. If APIGroup is not specified,
+                                      the specified Kind must be in the core API group.
+                                      For any other third-party types, APIGroup is
+                                      required.
+                                    type: string
+                                  kind:
+                                    description: Kind is the type of resource being
+                                      referenced
+                                    type: string
+                                  name:
+                                    description: Name is the name of resource being
+                                      referenced
+                                    type: string
+                                required:
+                                - kind
+                                - name
+                                type: object
+                              service:
+                                description: Service references a Service as a Backend.
+                                  This is a mutually exclusive setting with "Resource".
+                                properties:
+                                  name:
+                                    description: Name is the referenced service. The
+                                      service must exist in the same namespace as
+                                      the Ingress object.
+                                    type: string
+                                  port:
+                                    description: Port of the referenced service. A
+                                      port name or port number is required for a IngressServiceBackend.
+                                    properties:
+                                      name:
+                                        description: Name is the name of the port
+                                          on the Service. This is a mutually exclusive
+                                          setting with "Number".
+                                        type: string
+                                      number:
+                                        description: Number is the numerical port
+                                          number (e.g. 80) on the Service. This is
+                                          a mutually exclusive setting with "Name".
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                            type: object
+                          path:
+                            description: Path is matched against the path of an incoming
+                              request. Currently it can contain characters disallowed
+                              from the conventional "path" part of a URL as defined
+                              by RFC 3986. Paths must begin with a '/' and must be
+                              present when using PathType with value "Exact" or "Prefix".
+                            type: string
+                          pathType:
+                            description: |-
+                              PathType determines the interpretation of the Path matching. PathType can be one of the following values: * Exact: Matches the URL path exactly. * Prefix: Matches based on a URL path prefix split by '/'. Matching is
+                                done on a path element by element basis. A path element refers is the
+                                list of labels in the path split by the '/' separator. A request is a
+                                match for path p if every p is an element-wise prefix of p of the
+                                request path. Note that if the last element of the path is a substring
+                                of the last element in request path, it is not a match (e.g. /foo/bar
+                                matches /foo/bar/baz, but does not match /foo/barbaz).
+                              * ImplementationSpecific: Interpretation of the Path matching is up to
+                                the IngressClass. Implementations can treat this as a separate PathType
+                                or treat it identically to Prefix or Exact path types.
+                              Implementations are required to support all path types.
+                            type: string
+                        required:
+                        - pathType
+                        - backend
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  required:
+                  - paths
+                  type: object
+              type: object
+            type: array
+            x-kubernetes-list-type: atomic
+          tls:
+            description: TLS configuration. Currently the Ingress only supports a
+              single TLS port, 443. If multiple members of this list specify different
+              hosts, they will be multiplexed on the same port according to the hostname
+              specified through the SNI TLS extension, if the ingress controller fulfilling
+              the ingress supports SNI.
+            items:
+              description: IngressTLS describes the transport layer security associated
+                with an Ingress.
+              properties:
+                hosts:
+                  description: Hosts are a list of hosts included in the TLS certificate.
+                    The values in this list must match the name/s used in the tlsSecret.
+                    Defaults to the wildcard host setting for the loadbalancer controller
+                    fulfilling this Ingress, if left unspecified.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: atomic
+                secretName:
+                  description: SecretName is the name of the secret used to terminate
+                    TLS traffic on port 443. Field is left optional to allow TLS routing
+                    based on SNI hostname alone. If the SNI host in a listener conflicts
+                    with the "Host" header field used by an IngressRule, the SNI host
+                    is used for termination and value of the Host header is used for
+                    routing.
+                  type: string
+              type: object
+            type: array
+            x-kubernetes-list-type: atomic
+        type: object
+      status:
+        description: 'Status is the current state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+        properties:
+          loadBalancer:
+            description: LoadBalancer contains the current status of the load-balancer.
+            properties:
+              ingress:
+                description: Ingress is a list containing ingress points for the load-balancer.
+                  Traffic intended for the service should be sent to these ingress
+                  points.
+                items:
+                  description: 'LoadBalancerIngress represents the status of a load-balancer
+                    ingress point: traffic intended for the service should be sent
+                    to an ingress point.'
+                  properties:
+                    hostname:
+                      description: Hostname is set for load-balancer ingress points
+                        that are DNS based (typically AWS load-balancers)
+                      type: string
+                    ip:
+                      description: IP is set for load-balancer ingress points that
+                        are IP based (typically GCE or OpenStack load-balancers)
+                      type: string
+                    ports:
+                      description: Ports is a list of records of service ports If
+                        used, every port defined in the service should have an entry
+                        in it
+                      items:
+                        properties:
+                          error:
+                            description: |-
+                              Error is to record the problem with the service port The format of the error shall comply with the following rules: - built-in error values shall be specified in this file and those shall use
+                                CamelCase names
+                              - cloud provider specific error values must have names that comply with the
+                                format foo.example.com/CamelCase.
+                            type: string
+                          port:
+                            description: Port is the port number of the service port
+                              of which status is recorded here
+                            format: int32
+                            type: integer
+                          protocol:
+                            description: |-
+                              Protocol is the protocol of the service port of which status is recorded here The supported values are: "TCP", "UDP", "SCTP"
+
+                              Possible enum values:
+                               - `"SCTP"` is the SCTP protocol.
+                               - `"TCP"` is the TCP protocol.
+                               - `"UDP"` is the UDP protocol.
+                            type: string
+                        required:
+                        - port
+                        - protocol
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  type: object
+                type: array
+            type: object
+        type: object
+    type: object
+  plural: ingresses
+  scope: Namespaced
+  shortNames:
+  - ing
+  singular: ingress
+  subResources:
+  - name: status

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/3-NegotiatedAPIResource-pods.v1.core.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/3-NegotiatedAPIResource-pods.v1.core.yaml
@@ -1,0 +1,7092 @@
+apiVersion: apiresource.kcp.io/v1alpha1
+kind: NegotiatedAPIResource
+metadata:
+  annotations:
+    apiresource.kcp.io/apiVersion: v1
+    kcp.io/cluster: br3qimk2t1o3jb70
+  creationTimestamp: "2023-03-21T17:10:10Z"
+  generation: 1
+  name: pods.v1.core
+  resourceVersion: "9148"
+  uid: 83dcb300-05ce-4975-8a94-b30afec3a458
+spec:
+  categories:
+  - all
+  groupVersion:
+    version: v1
+  kind: Pod
+  listKind: PodList
+  openAPIV3Schema:
+    description: Pod is a collection of containers that can run on a host. This resource
+      is created by clients and scheduled onto hosts.
+    properties:
+      apiVersion:
+        description: 'APIVersion defines the versioned schema of this representation
+          of an object. Servers should convert recognized schemas to the latest internal
+          value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+        type: string
+      kind:
+        description: 'Kind is a string value representing the REST resource this object
+          represents. Servers may infer this from the endpoint the client submits
+          requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+        type: string
+      metadata:
+        type: object
+      spec:
+        description: 'Specification of the desired behavior of the pod. More info:
+          https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+        properties:
+          activeDeadlineSeconds:
+            description: Optional duration in seconds the pod may be active on the
+              node relative to StartTime before the system will actively try to mark
+              it failed and kill associated containers. Value must be a positive integer.
+            format: int64
+            type: integer
+          affinity:
+            description: If specified, the pod's scheduling constraints
+            properties:
+              nodeAffinity:
+                description: Describes node affinity scheduling rules for the pod.
+                properties:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    description: The scheduler will prefer to schedule pods to nodes
+                      that satisfy the affinity expressions specified by this field,
+                      but it may choose a node that violates one or more of the expressions.
+                      The node that is most preferred is the one with the greatest
+                      sum of weights, i.e. for each node that meets all of the scheduling
+                      requirements (resource request, requiredDuringScheduling affinity
+                      expressions, etc.), compute a sum by iterating through the elements
+                      of this field and adding "weight" to the sum if the node matches
+                      the corresponding matchExpressions; the node(s) with the highest
+                      sum are the most preferred.
+                    items:
+                      description: An empty preferred scheduling term matches all
+                        objects with implicit weight 0 (i.e. it's a no-op). A null
+                        preferred scheduling term matches no objects (i.e. is also
+                        a no-op).
+                      properties:
+                        preference:
+                          description: A node selector term, associated with the corresponding
+                            weight.
+                          properties:
+                            matchExpressions:
+                              description: A list of node selector requirements by
+                                node's labels.
+                              items:
+                                description: A node selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: The label key that the selector applies
+                                      to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                      Possible enum values:
+                                       - `"DoesNotExist"`
+                                       - `"Exists"`
+                                       - `"Gt"`
+                                       - `"In"`
+                                       - `"Lt"`
+                                       - `"NotIn"`
+                                    type: string
+                                  values:
+                                    description: An array of string values. If the
+                                      operator is In or NotIn, the values array must
+                                      be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator
+                                      is Gt or Lt, the values array must have a single
+                                      element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchFields:
+                              description: A list of node selector requirements by
+                                node's fields.
+                              items:
+                                description: A node selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: The label key that the selector applies
+                                      to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                      Possible enum values:
+                                       - `"DoesNotExist"`
+                                       - `"Exists"`
+                                       - `"Gt"`
+                                       - `"In"`
+                                       - `"Lt"`
+                                       - `"NotIn"`
+                                    type: string
+                                  values:
+                                    description: An array of string values. If the
+                                      operator is In or NotIn, the values array must
+                                      be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator
+                                      is Gt or Lt, the values array must have a single
+                                      element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                          type: object
+                        weight:
+                          description: Weight associated with matching the corresponding
+                            nodeSelectorTerm, in the range 1-100.
+                          format: int32
+                          type: integer
+                      required:
+                      - weight
+                      - preference
+                      type: object
+                    type: array
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    description: If the affinity requirements specified by this field
+                      are not met at scheduling time, the pod will not be scheduled
+                      onto the node. If the affinity requirements specified by this
+                      field cease to be met at some point during pod execution (e.g.
+                      due to an update), the system may or may not try to eventually
+                      evict the pod from its node.
+                    properties:
+                      nodeSelectorTerms:
+                        description: Required. A list of node selector terms. The
+                          terms are ORed.
+                        items:
+                          description: A null or empty node selector term matches
+                            no objects. The requirements of them are ANDed. The TopologySelectorTerm
+                            type implements a subset of the NodeSelectorTerm.
+                          properties:
+                            matchExpressions:
+                              description: A list of node selector requirements by
+                                node's labels.
+                              items:
+                                description: A node selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: The label key that the selector applies
+                                      to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                      Possible enum values:
+                                       - `"DoesNotExist"`
+                                       - `"Exists"`
+                                       - `"Gt"`
+                                       - `"In"`
+                                       - `"Lt"`
+                                       - `"NotIn"`
+                                    type: string
+                                  values:
+                                    description: An array of string values. If the
+                                      operator is In or NotIn, the values array must
+                                      be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator
+                                      is Gt or Lt, the values array must have a single
+                                      element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchFields:
+                              description: A list of node selector requirements by
+                                node's fields.
+                              items:
+                                description: A node selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: The label key that the selector applies
+                                      to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                      Possible enum values:
+                                       - `"DoesNotExist"`
+                                       - `"Exists"`
+                                       - `"Gt"`
+                                       - `"In"`
+                                       - `"Lt"`
+                                       - `"NotIn"`
+                                    type: string
+                                  values:
+                                    description: An array of string values. If the
+                                      operator is In or NotIn, the values array must
+                                      be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator
+                                      is Gt or Lt, the values array must have a single
+                                      element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                          type: object
+                        type: array
+                    required:
+                    - nodeSelectorTerms
+                    type: object
+                type: object
+              podAffinity:
+                description: Describes pod affinity scheduling rules (e.g. co-locate
+                  this pod in the same node, zone, etc. as some other pod(s)).
+                properties:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    description: The scheduler will prefer to schedule pods to nodes
+                      that satisfy the affinity expressions specified by this field,
+                      but it may choose a node that violates one or more of the expressions.
+                      The node that is most preferred is the one with the greatest
+                      sum of weights, i.e. for each node that meets all of the scheduling
+                      requirements (resource request, requiredDuringScheduling affinity
+                      expressions, etc.), compute a sum by iterating through the elements
+                      of this field and adding "weight" to the sum if the node has
+                      pods which matches the corresponding podAffinityTerm; the node(s)
+                      with the highest sum are the most preferred.
+                    items:
+                      description: The weights of all of the matched WeightedPodAffinityTerm
+                        fields are added per-node to find the most preferred node(s)
+                      properties:
+                        podAffinityTerm:
+                          description: Required. A pod affinity term, associated with
+                            the corresponding weight.
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field. null selector
+                                and null or empty namespaces list means "this pod's
+                                namespace". An empty selector ({}) matches all namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector. null or
+                                empty namespaces list and null namespaceSelector means
+                                "this pod's namespace".
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        weight:
+                          description: weight associated with matching the corresponding
+                            podAffinityTerm, in the range 1-100.
+                          format: int32
+                          type: integer
+                      required:
+                      - weight
+                      - podAffinityTerm
+                      type: object
+                    type: array
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    description: If the affinity requirements specified by this field
+                      are not met at scheduling time, the pod will not be scheduled
+                      onto the node. If the affinity requirements specified by this
+                      field cease to be met at some point during pod execution (e.g.
+                      due to a pod label update), the system may or may not try to
+                      eventually evict the pod from its node. When there are multiple
+                      elements, the lists of nodes corresponding to each podAffinityTerm
+                      are intersected, i.e. all terms must be satisfied.
+                    items:
+                      description: Defines a set of pods (namely those matching the
+                        labelSelector relative to the given namespace(s)) that this
+                        pod should be co-located (affinity) or not co-located (anti-affinity)
+                        with, where co-located is defined as running on a node whose
+                        value of the label with key <topologyKey> matches that of
+                        any node on which a pod of the set of pods is running
+                      properties:
+                        labelSelector:
+                          description: A label query over a set of resources, in this
+                            case pods.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        namespaceSelector:
+                          description: A label query over the set of namespaces that
+                            the term applies to. The term is applied to the union
+                            of the namespaces selected by this field and the ones
+                            listed in the namespaces field. null selector and null
+                            or empty namespaces list means "this pod's namespace".
+                            An empty selector ({}) matches all namespaces.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        namespaces:
+                          description: namespaces specifies a static list of namespace
+                            names that the term applies to. The term is applied to
+                            the union of the namespaces listed in this field and the
+                            ones selected by namespaceSelector. null or empty namespaces
+                            list and null namespaceSelector means "this pod's namespace".
+                          items:
+                            type: string
+                          type: array
+                        topologyKey:
+                          description: This pod should be co-located (affinity) or
+                            not co-located (anti-affinity) with the pods matching
+                            the labelSelector in the specified namespaces, where co-located
+                            is defined as running on a node whose value of the label
+                            with key topologyKey matches that of any node on which
+                            any of the selected pods is running. Empty topologyKey
+                            is not allowed.
+                          type: string
+                      required:
+                      - topologyKey
+                      type: object
+                    type: array
+                type: object
+              podAntiAffinity:
+                description: Describes pod anti-affinity scheduling rules (e.g. avoid
+                  putting this pod in the same node, zone, etc. as some other pod(s)).
+                properties:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    description: The scheduler will prefer to schedule pods to nodes
+                      that satisfy the anti-affinity expressions specified by this
+                      field, but it may choose a node that violates one or more of
+                      the expressions. The node that is most preferred is the one
+                      with the greatest sum of weights, i.e. for each node that meets
+                      all of the scheduling requirements (resource request, requiredDuringScheduling
+                      anti-affinity expressions, etc.), compute a sum by iterating
+                      through the elements of this field and adding "weight" to the
+                      sum if the node has pods which matches the corresponding podAffinityTerm;
+                      the node(s) with the highest sum are the most preferred.
+                    items:
+                      description: The weights of all of the matched WeightedPodAffinityTerm
+                        fields are added per-node to find the most preferred node(s)
+                      properties:
+                        podAffinityTerm:
+                          description: Required. A pod affinity term, associated with
+                            the corresponding weight.
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field. null selector
+                                and null or empty namespaces list means "this pod's
+                                namespace". An empty selector ({}) matches all namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector. null or
+                                empty namespaces list and null namespaceSelector means
+                                "this pod's namespace".
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        weight:
+                          description: weight associated with matching the corresponding
+                            podAffinityTerm, in the range 1-100.
+                          format: int32
+                          type: integer
+                      required:
+                      - weight
+                      - podAffinityTerm
+                      type: object
+                    type: array
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    description: If the anti-affinity requirements specified by this
+                      field are not met at scheduling time, the pod will not be scheduled
+                      onto the node. If the anti-affinity requirements specified by
+                      this field cease to be met at some point during pod execution
+                      (e.g. due to a pod label update), the system may or may not
+                      try to eventually evict the pod from its node. When there are
+                      multiple elements, the lists of nodes corresponding to each
+                      podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                    items:
+                      description: Defines a set of pods (namely those matching the
+                        labelSelector relative to the given namespace(s)) that this
+                        pod should be co-located (affinity) or not co-located (anti-affinity)
+                        with, where co-located is defined as running on a node whose
+                        value of the label with key <topologyKey> matches that of
+                        any node on which a pod of the set of pods is running
+                      properties:
+                        labelSelector:
+                          description: A label query over a set of resources, in this
+                            case pods.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        namespaceSelector:
+                          description: A label query over the set of namespaces that
+                            the term applies to. The term is applied to the union
+                            of the namespaces selected by this field and the ones
+                            listed in the namespaces field. null selector and null
+                            or empty namespaces list means "this pod's namespace".
+                            An empty selector ({}) matches all namespaces.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        namespaces:
+                          description: namespaces specifies a static list of namespace
+                            names that the term applies to. The term is applied to
+                            the union of the namespaces listed in this field and the
+                            ones selected by namespaceSelector. null or empty namespaces
+                            list and null namespaceSelector means "this pod's namespace".
+                          items:
+                            type: string
+                          type: array
+                        topologyKey:
+                          description: This pod should be co-located (affinity) or
+                            not co-located (anti-affinity) with the pods matching
+                            the labelSelector in the specified namespaces, where co-located
+                            is defined as running on a node whose value of the label
+                            with key topologyKey matches that of any node on which
+                            any of the selected pods is running. Empty topologyKey
+                            is not allowed.
+                          type: string
+                      required:
+                      - topologyKey
+                      type: object
+                    type: array
+                type: object
+            type: object
+          automountServiceAccountToken:
+            description: AutomountServiceAccountToken indicates whether a service
+              account token should be automatically mounted.
+            type: boolean
+          containers:
+            description: List of containers belonging to the pod. Containers cannot
+              currently be added or removed. There must be at least one container
+              in a Pod. Cannot be updated.
+            items:
+              description: A single application container that you want to run within
+                a pod.
+              properties:
+                args:
+                  description: 'Arguments to the entrypoint. The container image''s
+                    CMD is used if this is not provided. Variable references $(VAR_NAME)
+                    are expanded using the container''s environment. If a variable
+                    cannot be resolved, the reference in the input string will be
+                    unchanged. Double $$ are reduced to a single $, which allows for
+                    escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                    the string literal "$(VAR_NAME)". Escaped references will never
+                    be expanded, regardless of whether the variable exists or not.
+                    Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                command:
+                  description: 'Entrypoint array. Not executed within a shell. The
+                    container image''s ENTRYPOINT is used if this is not provided.
+                    Variable references $(VAR_NAME) are expanded using the container''s
+                    environment. If a variable cannot be resolved, the reference in
+                    the input string will be unchanged. Double $$ are reduced to a
+                    single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                    Escaped references will never be expanded, regardless of whether
+                    the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                env:
+                  description: List of environment variables to set in the container.
+                    Cannot be updated.
+                  items:
+                    description: EnvVar represents an environment variable present
+                      in a Container.
+                    properties:
+                      name:
+                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        type: string
+                      value:
+                        description: 'Variable references $(VAR_NAME) are expanded
+                          using the previously defined environment variables in the
+                          container and any service environment variables. If a variable
+                          cannot be resolved, the reference in the input string will
+                          be unchanged. Double $$ are reduced to a single $, which
+                          allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                          will produce the string literal "$(VAR_NAME)". Escaped references
+                          will never be expanded, regardless of whether the variable
+                          exists or not. Defaults to "".'
+                        type: string
+                      valueFrom:
+                        description: Source for the environment variable's value.
+                          Cannot be used if value is not empty.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          fieldRef:
+                            description: 'Selects a field of the pod: supports metadata.name,
+                              metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                              spec.nodeName, spec.serviceAccountName, status.hostIP,
+                              status.podIP, status.podIPs.'
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                            - fieldPath
+                            type: object
+                          resourceFieldRef:
+                            description: 'Selects a resource of the container: only
+                              resources limits and requests (limits.cpu, limits.memory,
+                              limits.ephemeral-storage, requests.cpu, requests.memory
+                              and requests.ephemeral-storage) are currently supported.'
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Specifies the output format of the exposed
+                                  resources, defaults to "1"
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                            - resource
+                            type: object
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - name
+                  x-kubernetes-list-type: map
+                envFrom:
+                  description: List of sources to populate environment variables in
+                    the container. The keys defined within a source must be a C_IDENTIFIER.
+                    All invalid keys will be reported as an event when the container
+                    is starting. When a key exists in multiple sources, the value
+                    associated with the last source will take precedence. Values defined
+                    by an Env with a duplicate key will take precedence. Cannot be
+                    updated.
+                  items:
+                    description: EnvFromSource represents the source of a set of ConfigMaps
+                    properties:
+                      configMapRef:
+                        description: The ConfigMap to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the ConfigMap must be defined
+                            type: boolean
+                        type: object
+                      prefix:
+                        description: An optional identifier to prepend to each key
+                          in the ConfigMap. Must be a C_IDENTIFIER.
+                        type: string
+                      secretRef:
+                        description: The Secret to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret must be defined
+                            type: boolean
+                        type: object
+                    type: object
+                  type: array
+                image:
+                  description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                    This field is optional to allow higher level config management
+                    to default or override container images in workload controllers
+                    like Deployments and StatefulSets.'
+                  type: string
+                imagePullPolicy:
+                  description: |-
+                    Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                    Possible enum values:
+                     - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                     - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                     - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                  type: string
+                lifecycle:
+                  description: Actions that the management system should take in response
+                    to container lifecycle events. Cannot be updated.
+                  properties:
+                    postStart:
+                      description: 'PostStart is called immediately after a container
+                        is created. If the handler fails, the container is terminated
+                        and restarted according to its restart policy. Other management
+                        of the container blocks until the hook completes. More info:
+                        https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: |-
+                                Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                Possible enum values:
+                                 - `"HTTP"` means that the scheme used will be http://
+                                 - `"HTTPS"` means that the scheme used will be https://
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: Deprecated. TCPSocket is NOT supported as a
+                            LifecycleHandler and kept for the backward compatibility.
+                            There are no validation of this field and lifecycle hooks
+                            will fail in runtime when tcp handler is specified.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                    preStop:
+                      description: 'PreStop is called immediately before a container
+                        is terminated due to an API request or management event such
+                        as liveness/startup probe failure, preemption, resource contention,
+                        etc. The handler is not called if the container crashes or
+                        exits. The Pod''s termination grace period countdown begins
+                        before the PreStop hook is executed. Regardless of the outcome
+                        of the handler, the container will eventually terminate within
+                        the Pod''s termination grace period (unless delayed by finalizers).
+                        Other management of the container blocks until the hook completes
+                        or until the termination grace period is reached. More info:
+                        https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: |-
+                                Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                Possible enum values:
+                                 - `"HTTP"` means that the scheme used will be http://
+                                 - `"HTTPS"` means that the scheme used will be https://
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: Deprecated. TCPSocket is NOT supported as a
+                            LifecycleHandler and kept for the backward compatibility.
+                            There are no validation of this field and lifecycle hooks
+                            will fail in runtime when tcp handler is specified.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                  type: object
+                livenessProbe:
+                  description: 'Periodic probe of container liveness. Container will
+                    be restarted if the probe fails. Cannot be updated. More info:
+                    https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                name:
+                  description: Name of the container specified as a DNS_LABEL. Each
+                    container in a pod must have a unique name (DNS_LABEL). Cannot
+                    be updated.
+                  type: string
+                ports:
+                  description: List of ports to expose from the container. Not specifying
+                    a port here DOES NOT prevent that port from being exposed. Any
+                    port which is listening on the default "0.0.0.0" address inside
+                    a container will be accessible from the network. Modifying this
+                    array with strategic merge patch may corrupt the data. For more
+                    information See https://github.com/kubernetes/kubernetes/issues/108255.
+                    Cannot be updated.
+                  items:
+                    description: ContainerPort represents a network port in a single
+                      container.
+                    properties:
+                      containerPort:
+                        description: Number of port to expose on the pod's IP address.
+                          This must be a valid port number, 0 < x < 65536.
+                        format: int32
+                        type: integer
+                      hostIP:
+                        description: What host IP to bind the external port to.
+                        type: string
+                      hostPort:
+                        description: Number of port to expose on the host. If specified,
+                          this must be a valid port number, 0 < x < 65536. If HostNetwork
+                          is specified, this must match ContainerPort. Most containers
+                          do not need this.
+                        format: int32
+                        type: integer
+                      name:
+                        description: If specified, this must be an IANA_SVC_NAME and
+                          unique within the pod. Each named port in a pod must have
+                          a unique name. Name for the port that can be referred to
+                          by services.
+                        type: string
+                      protocol:
+                        default: TCP
+                        description: |-
+                          Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                          Possible enum values:
+                           - `"SCTP"` is the SCTP protocol.
+                           - `"TCP"` is the TCP protocol.
+                           - `"UDP"` is the UDP protocol.
+                        type: string
+                    required:
+                    - containerPort
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - containerPort
+                  - protocol
+                  x-kubernetes-list-type: map
+                readinessProbe:
+                  description: 'Periodic probe of container service readiness. Container
+                    will be removed from service endpoints if the probe fails. Cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                resources:
+                  description: 'Compute Resources required by this container. Cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                  type: object
+                securityContext:
+                  description: 'SecurityContext defines the security options the container
+                    should be run with. If set, the fields of SecurityContext override
+                    the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                  properties:
+                    allowPrivilegeEscalation:
+                      description: 'AllowPrivilegeEscalation controls whether a process
+                        can gain more privileges than its parent process. This bool
+                        directly controls if the no_new_privs flag will be set on
+                        the container process. AllowPrivilegeEscalation is true always
+                        when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
+                        Note that this field cannot be set when spec.os.name is windows.'
+                      type: boolean
+                    capabilities:
+                      description: The capabilities to add/drop when running containers.
+                        Defaults to the default set of capabilities granted by the
+                        container runtime. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      properties:
+                        add:
+                          description: Added capabilities
+                          items:
+                            type: string
+                          type: array
+                        drop:
+                          description: Removed capabilities
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    privileged:
+                      description: Run container in privileged mode. Processes in
+                        privileged containers are essentially equivalent to root on
+                        the host. Defaults to false. Note that this field cannot be
+                        set when spec.os.name is windows.
+                      type: boolean
+                    procMount:
+                      description: procMount denotes the type of proc mount to use
+                        for the containers. The default is DefaultProcMount which
+                        uses the container runtime defaults for readonly paths and
+                        masked paths. This requires the ProcMountType feature flag
+                        to be enabled. Note that this field cannot be set when spec.os.name
+                        is windows.
+                      type: string
+                    readOnlyRootFilesystem:
+                      description: Whether this container has a read-only root filesystem.
+                        Default is false. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      type: boolean
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container
+                        process. Uses runtime default if unset. May also be set in
+                        PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence. Note
+                        that this field cannot be set when spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to
+                        start the container if it does. If unset or false, no such
+                        validation will be performed. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container
+                        process. Defaults to user specified in image metadata if unspecified.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: The SELinux context to be applied to the container.
+                        If unspecified, the container runtime will allocate a random
+                        SELinux context for each container.  May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence. Note that this
+                        field cannot be set when spec.os.name is windows.
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
+                      type: object
+                    seccompProfile:
+                      description: The seccomp options to use by this container. If
+                        seccomp options are provided at both the pod & container level,
+                        the container options override the pod options. Note that
+                        this field cannot be set when spec.os.name is windows.
+                      properties:
+                        localhostProfile:
+                          description: localhostProfile indicates a profile defined
+                            in a file on the node should be used. The profile must
+                            be preconfigured on the node to work. Must be a descending
+                            path, relative to the kubelet's configured seccomp profile
+                            location. Must only be set if type is "Localhost".
+                          type: string
+                        type:
+                          description: |-
+                            type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                            Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                            Possible enum values:
+                             - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                             - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                             - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    windowsOptions:
+                      description: The Windows specific settings applied to all containers.
+                        If unspecified, the options from the PodSecurityContext will
+                        be used. If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence. Note
+                        that this field cannot be set when spec.os.name is linux.
+                      properties:
+                        gmsaCredentialSpec:
+                          description: GMSACredentialSpec is where the GMSA admission
+                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                            inlines the contents of the GMSA credential spec named
+                            by the GMSACredentialSpecName field.
+                          type: string
+                        gmsaCredentialSpecName:
+                          description: GMSACredentialSpecName is the name of the GMSA
+                            credential spec to use.
+                          type: string
+                        hostProcess:
+                          description: HostProcess determines if a container should
+                            be run as a 'Host Process' container. This field is alpha-level
+                            and will only be honored by components that enable the
+                            WindowsHostProcessContainers feature flag. Setting this
+                            field without the feature flag will result in errors when
+                            validating the Pod. All of a Pod's containers must have
+                            the same effective HostProcess value (it is not allowed
+                            to have a mix of HostProcess containers and non-HostProcess
+                            containers).  In addition, if HostProcess is true then
+                            HostNetwork must also be set to true.
+                          type: boolean
+                        runAsUserName:
+                          description: The UserName in Windows to run the entrypoint
+                            of the container process. Defaults to the user specified
+                            in image metadata if unspecified. May also be set in PodSecurityContext.
+                            If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence.
+                          type: string
+                      type: object
+                  type: object
+                startupProbe:
+                  description: 'StartupProbe indicates that the Pod has successfully
+                    initialized. If specified, no other probes are executed until
+                    this completes successfully. If this probe fails, the Pod will
+                    be restarted, just as if the livenessProbe failed. This can be
+                    used to provide different probe parameters at the beginning of
+                    a Pod''s lifecycle, when it might take a long time to load data
+                    or warm a cache, than during steady-state operation. This cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                stdin:
+                  description: Whether this container should allocate a buffer for
+                    stdin in the container runtime. If this is not set, reads from
+                    stdin in the container will always result in EOF. Default is false.
+                  type: boolean
+                stdinOnce:
+                  description: Whether the container runtime should close the stdin
+                    channel after it has been opened by a single attach. When stdin
+                    is true the stdin stream will remain open across multiple attach
+                    sessions. If stdinOnce is set to true, stdin is opened on container
+                    start, is empty until the first client attaches to stdin, and
+                    then remains open and accepts data until the client disconnects,
+                    at which time stdin is closed and remains closed until the container
+                    is restarted. If this flag is false, a container processes that
+                    reads from stdin will never receive an EOF. Default is false
+                  type: boolean
+                terminationMessagePath:
+                  description: 'Optional: Path at which the file to which the container''s
+                    termination message will be written is mounted into the container''s
+                    filesystem. Message written is intended to be brief final status,
+                    such as an assertion failure message. Will be truncated by the
+                    node if greater than 4096 bytes. The total message length across
+                    all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                    Cannot be updated.'
+                  type: string
+                terminationMessagePolicy:
+                  description: |-
+                    Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                    Possible enum values:
+                     - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                     - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                  type: string
+                tty:
+                  description: Whether this container should allocate a TTY for itself,
+                    also requires 'stdin' to be true. Default is false.
+                  type: boolean
+                volumeDevices:
+                  description: volumeDevices is the list of block devices to be used
+                    by the container.
+                  items:
+                    description: volumeDevice describes a mapping of a raw block device
+                      within a container.
+                    properties:
+                      devicePath:
+                        description: devicePath is the path inside of the container
+                          that the device will be mapped to.
+                        type: string
+                      name:
+                        description: name must match the name of a persistentVolumeClaim
+                          in the pod
+                        type: string
+                    required:
+                    - devicePath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - devicePath
+                  x-kubernetes-list-type: map
+                volumeMounts:
+                  description: Pod volumes to mount into the container's filesystem.
+                    Cannot be updated.
+                  items:
+                    description: VolumeMount describes a mounting of a Volume within
+                      a container.
+                    properties:
+                      mountPath:
+                        description: Path within the container at which the volume
+                          should be mounted.  Must not contain ':'.
+                        type: string
+                      mountPropagation:
+                        description: mountPropagation determines how mounts are propagated
+                          from the host to container and the other way around. When
+                          not set, MountPropagationNone is used. This field is beta
+                          in 1.10.
+                        type: string
+                      name:
+                        description: This must match the Name of a Volume.
+                        type: string
+                      readOnly:
+                        description: Mounted read-only if true, read-write otherwise
+                          (false or unspecified). Defaults to false.
+                        type: boolean
+                      subPath:
+                        description: Path within the volume from which the container's
+                          volume should be mounted. Defaults to "" (volume's root).
+                        type: string
+                      subPathExpr:
+                        description: Expanded path within the volume from which the
+                          container's volume should be mounted. Behaves similarly
+                          to SubPath but environment variable references $(VAR_NAME)
+                          are expanded using the container's environment. Defaults
+                          to "" (volume's root). SubPathExpr and SubPath are mutually
+                          exclusive.
+                        type: string
+                    required:
+                    - mountPath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - mountPath
+                  x-kubernetes-list-type: map
+                workingDir:
+                  description: Container's working directory. If not specified, the
+                    container runtime's default will be used, which might be configured
+                    in the container image. Cannot be updated.
+                  type: string
+              required:
+              - name
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - name
+            x-kubernetes-list-type: map
+          dnsConfig:
+            description: Specifies the DNS parameters of a pod. Parameters specified
+              here will be merged to the generated DNS configuration based on DNSPolicy.
+            properties:
+              nameservers:
+                description: A list of DNS name server IP addresses. This will be
+                  appended to the base nameservers generated from DNSPolicy. Duplicated
+                  nameservers will be removed.
+                items:
+                  type: string
+                type: array
+              options:
+                description: A list of DNS resolver options. This will be merged with
+                  the base options generated from DNSPolicy. Duplicated entries will
+                  be removed. Resolution options given in Options will override those
+                  that appear in the base DNSPolicy.
+                items:
+                  description: PodDNSConfigOption defines DNS resolver options of
+                    a pod.
+                  properties:
+                    name:
+                      description: Required.
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
+              searches:
+                description: A list of DNS search domains for host-name lookup. This
+                  will be appended to the base search paths generated from DNSPolicy.
+                  Duplicated search paths will be removed.
+                items:
+                  type: string
+                type: array
+            type: object
+          dnsPolicy:
+            description: |-
+              Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+
+              Possible enum values:
+               - `"ClusterFirst"` indicates that the pod should use cluster DNS first unless hostNetwork is true, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+               - `"ClusterFirstWithHostNet"` indicates that the pod should use cluster DNS first, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+               - `"Default"` indicates that the pod should use the default (as determined by kubelet) DNS settings.
+               - `"None"` indicates that the pod should use empty DNS settings. DNS parameters such as nameservers and search paths should be defined via DNSConfig.
+            type: string
+          enableServiceLinks:
+            description: 'EnableServiceLinks indicates whether information about services
+              should be injected into pod''s environment variables, matching the syntax
+              of Docker links. Optional: Defaults to true.'
+            type: boolean
+          ephemeralContainers:
+            description: List of ephemeral containers run in this pod. Ephemeral containers
+              may be run in an existing pod to perform user-initiated actions such
+              as debugging. This list cannot be specified when creating a pod, and
+              it cannot be modified by updating the pod spec. In order to add an ephemeral
+              container to an existing pod, use the pod's ephemeralcontainers subresource.
+            items:
+              description: |-
+                An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation.
+
+                To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.
+              properties:
+                args:
+                  description: 'Arguments to the entrypoint. The image''s CMD is used
+                    if this is not provided. Variable references $(VAR_NAME) are expanded
+                    using the container''s environment. If a variable cannot be resolved,
+                    the reference in the input string will be unchanged. Double $$
+                    are reduced to a single $, which allows for escaping the $(VAR_NAME)
+                    syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                    Escaped references will never be expanded, regardless of whether
+                    the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                command:
+                  description: 'Entrypoint array. Not executed within a shell. The
+                    image''s ENTRYPOINT is used if this is not provided. Variable
+                    references $(VAR_NAME) are expanded using the container''s environment.
+                    If a variable cannot be resolved, the reference in the input string
+                    will be unchanged. Double $$ are reduced to a single $, which
+                    allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                    will produce the string literal "$(VAR_NAME)". Escaped references
+                    will never be expanded, regardless of whether the variable exists
+                    or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                env:
+                  description: List of environment variables to set in the container.
+                    Cannot be updated.
+                  items:
+                    description: EnvVar represents an environment variable present
+                      in a Container.
+                    properties:
+                      name:
+                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        type: string
+                      value:
+                        description: 'Variable references $(VAR_NAME) are expanded
+                          using the previously defined environment variables in the
+                          container and any service environment variables. If a variable
+                          cannot be resolved, the reference in the input string will
+                          be unchanged. Double $$ are reduced to a single $, which
+                          allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                          will produce the string literal "$(VAR_NAME)". Escaped references
+                          will never be expanded, regardless of whether the variable
+                          exists or not. Defaults to "".'
+                        type: string
+                      valueFrom:
+                        description: Source for the environment variable's value.
+                          Cannot be used if value is not empty.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          fieldRef:
+                            description: 'Selects a field of the pod: supports metadata.name,
+                              metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                              spec.nodeName, spec.serviceAccountName, status.hostIP,
+                              status.podIP, status.podIPs.'
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                            - fieldPath
+                            type: object
+                          resourceFieldRef:
+                            description: 'Selects a resource of the container: only
+                              resources limits and requests (limits.cpu, limits.memory,
+                              limits.ephemeral-storage, requests.cpu, requests.memory
+                              and requests.ephemeral-storage) are currently supported.'
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Specifies the output format of the exposed
+                                  resources, defaults to "1"
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                            - resource
+                            type: object
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - name
+                  x-kubernetes-list-type: map
+                envFrom:
+                  description: List of sources to populate environment variables in
+                    the container. The keys defined within a source must be a C_IDENTIFIER.
+                    All invalid keys will be reported as an event when the container
+                    is starting. When a key exists in multiple sources, the value
+                    associated with the last source will take precedence. Values defined
+                    by an Env with a duplicate key will take precedence. Cannot be
+                    updated.
+                  items:
+                    description: EnvFromSource represents the source of a set of ConfigMaps
+                    properties:
+                      configMapRef:
+                        description: The ConfigMap to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the ConfigMap must be defined
+                            type: boolean
+                        type: object
+                      prefix:
+                        description: An optional identifier to prepend to each key
+                          in the ConfigMap. Must be a C_IDENTIFIER.
+                        type: string
+                      secretRef:
+                        description: The Secret to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret must be defined
+                            type: boolean
+                        type: object
+                    type: object
+                  type: array
+                image:
+                  description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                  type: string
+                imagePullPolicy:
+                  description: |-
+                    Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                    Possible enum values:
+                     - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                     - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                     - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                  type: string
+                lifecycle:
+                  description: Lifecycle is not allowed for ephemeral containers.
+                  properties:
+                    postStart:
+                      description: 'PostStart is called immediately after a container
+                        is created. If the handler fails, the container is terminated
+                        and restarted according to its restart policy. Other management
+                        of the container blocks until the hook completes. More info:
+                        https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: |-
+                                Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                Possible enum values:
+                                 - `"HTTP"` means that the scheme used will be http://
+                                 - `"HTTPS"` means that the scheme used will be https://
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: Deprecated. TCPSocket is NOT supported as a
+                            LifecycleHandler and kept for the backward compatibility.
+                            There are no validation of this field and lifecycle hooks
+                            will fail in runtime when tcp handler is specified.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                    preStop:
+                      description: 'PreStop is called immediately before a container
+                        is terminated due to an API request or management event such
+                        as liveness/startup probe failure, preemption, resource contention,
+                        etc. The handler is not called if the container crashes or
+                        exits. The Pod''s termination grace period countdown begins
+                        before the PreStop hook is executed. Regardless of the outcome
+                        of the handler, the container will eventually terminate within
+                        the Pod''s termination grace period (unless delayed by finalizers).
+                        Other management of the container blocks until the hook completes
+                        or until the termination grace period is reached. More info:
+                        https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: |-
+                                Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                Possible enum values:
+                                 - `"HTTP"` means that the scheme used will be http://
+                                 - `"HTTPS"` means that the scheme used will be https://
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: Deprecated. TCPSocket is NOT supported as a
+                            LifecycleHandler and kept for the backward compatibility.
+                            There are no validation of this field and lifecycle hooks
+                            will fail in runtime when tcp handler is specified.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                  type: object
+                livenessProbe:
+                  description: Probes are not allowed for ephemeral containers.
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                name:
+                  description: Name of the ephemeral container specified as a DNS_LABEL.
+                    This name must be unique among all containers, init containers
+                    and ephemeral containers.
+                  type: string
+                ports:
+                  description: Ports are not allowed for ephemeral containers.
+                  items:
+                    description: ContainerPort represents a network port in a single
+                      container.
+                    properties:
+                      containerPort:
+                        description: Number of port to expose on the pod's IP address.
+                          This must be a valid port number, 0 < x < 65536.
+                        format: int32
+                        type: integer
+                      hostIP:
+                        description: What host IP to bind the external port to.
+                        type: string
+                      hostPort:
+                        description: Number of port to expose on the host. If specified,
+                          this must be a valid port number, 0 < x < 65536. If HostNetwork
+                          is specified, this must match ContainerPort. Most containers
+                          do not need this.
+                        format: int32
+                        type: integer
+                      name:
+                        description: If specified, this must be an IANA_SVC_NAME and
+                          unique within the pod. Each named port in a pod must have
+                          a unique name. Name for the port that can be referred to
+                          by services.
+                        type: string
+                      protocol:
+                        default: TCP
+                        description: |-
+                          Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                          Possible enum values:
+                           - `"SCTP"` is the SCTP protocol.
+                           - `"TCP"` is the TCP protocol.
+                           - `"UDP"` is the UDP protocol.
+                        type: string
+                    required:
+                    - containerPort
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - containerPort
+                  - protocol
+                  x-kubernetes-list-type: map
+                readinessProbe:
+                  description: Probes are not allowed for ephemeral containers.
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                resources:
+                  description: Resources are not allowed for ephemeral containers.
+                    Ephemeral containers use spare resources already allocated to
+                    the pod.
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                  type: object
+                securityContext:
+                  description: 'Optional: SecurityContext defines the security options
+                    the ephemeral container should be run with. If set, the fields
+                    of SecurityContext override the equivalent fields of PodSecurityContext.'
+                  properties:
+                    allowPrivilegeEscalation:
+                      description: 'AllowPrivilegeEscalation controls whether a process
+                        can gain more privileges than its parent process. This bool
+                        directly controls if the no_new_privs flag will be set on
+                        the container process. AllowPrivilegeEscalation is true always
+                        when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
+                        Note that this field cannot be set when spec.os.name is windows.'
+                      type: boolean
+                    capabilities:
+                      description: The capabilities to add/drop when running containers.
+                        Defaults to the default set of capabilities granted by the
+                        container runtime. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      properties:
+                        add:
+                          description: Added capabilities
+                          items:
+                            type: string
+                          type: array
+                        drop:
+                          description: Removed capabilities
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    privileged:
+                      description: Run container in privileged mode. Processes in
+                        privileged containers are essentially equivalent to root on
+                        the host. Defaults to false. Note that this field cannot be
+                        set when spec.os.name is windows.
+                      type: boolean
+                    procMount:
+                      description: procMount denotes the type of proc mount to use
+                        for the containers. The default is DefaultProcMount which
+                        uses the container runtime defaults for readonly paths and
+                        masked paths. This requires the ProcMountType feature flag
+                        to be enabled. Note that this field cannot be set when spec.os.name
+                        is windows.
+                      type: string
+                    readOnlyRootFilesystem:
+                      description: Whether this container has a read-only root filesystem.
+                        Default is false. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      type: boolean
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container
+                        process. Uses runtime default if unset. May also be set in
+                        PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence. Note
+                        that this field cannot be set when spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to
+                        start the container if it does. If unset or false, no such
+                        validation will be performed. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container
+                        process. Defaults to user specified in image metadata if unspecified.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: The SELinux context to be applied to the container.
+                        If unspecified, the container runtime will allocate a random
+                        SELinux context for each container.  May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence. Note that this
+                        field cannot be set when spec.os.name is windows.
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
+                      type: object
+                    seccompProfile:
+                      description: The seccomp options to use by this container. If
+                        seccomp options are provided at both the pod & container level,
+                        the container options override the pod options. Note that
+                        this field cannot be set when spec.os.name is windows.
+                      properties:
+                        localhostProfile:
+                          description: localhostProfile indicates a profile defined
+                            in a file on the node should be used. The profile must
+                            be preconfigured on the node to work. Must be a descending
+                            path, relative to the kubelet's configured seccomp profile
+                            location. Must only be set if type is "Localhost".
+                          type: string
+                        type:
+                          description: |-
+                            type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                            Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                            Possible enum values:
+                             - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                             - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                             - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    windowsOptions:
+                      description: The Windows specific settings applied to all containers.
+                        If unspecified, the options from the PodSecurityContext will
+                        be used. If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence. Note
+                        that this field cannot be set when spec.os.name is linux.
+                      properties:
+                        gmsaCredentialSpec:
+                          description: GMSACredentialSpec is where the GMSA admission
+                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                            inlines the contents of the GMSA credential spec named
+                            by the GMSACredentialSpecName field.
+                          type: string
+                        gmsaCredentialSpecName:
+                          description: GMSACredentialSpecName is the name of the GMSA
+                            credential spec to use.
+                          type: string
+                        hostProcess:
+                          description: HostProcess determines if a container should
+                            be run as a 'Host Process' container. This field is alpha-level
+                            and will only be honored by components that enable the
+                            WindowsHostProcessContainers feature flag. Setting this
+                            field without the feature flag will result in errors when
+                            validating the Pod. All of a Pod's containers must have
+                            the same effective HostProcess value (it is not allowed
+                            to have a mix of HostProcess containers and non-HostProcess
+                            containers).  In addition, if HostProcess is true then
+                            HostNetwork must also be set to true.
+                          type: boolean
+                        runAsUserName:
+                          description: The UserName in Windows to run the entrypoint
+                            of the container process. Defaults to the user specified
+                            in image metadata if unspecified. May also be set in PodSecurityContext.
+                            If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence.
+                          type: string
+                      type: object
+                  type: object
+                startupProbe:
+                  description: Probes are not allowed for ephemeral containers.
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                stdin:
+                  description: Whether this container should allocate a buffer for
+                    stdin in the container runtime. If this is not set, reads from
+                    stdin in the container will always result in EOF. Default is false.
+                  type: boolean
+                stdinOnce:
+                  description: Whether the container runtime should close the stdin
+                    channel after it has been opened by a single attach. When stdin
+                    is true the stdin stream will remain open across multiple attach
+                    sessions. If stdinOnce is set to true, stdin is opened on container
+                    start, is empty until the first client attaches to stdin, and
+                    then remains open and accepts data until the client disconnects,
+                    at which time stdin is closed and remains closed until the container
+                    is restarted. If this flag is false, a container processes that
+                    reads from stdin will never receive an EOF. Default is false
+                  type: boolean
+                targetContainerName:
+                  description: |-
+                    If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+                    The container runtime must implement support for this feature. If the runtime does not support namespace targeting then the result of setting this field is undefined.
+                  type: string
+                terminationMessagePath:
+                  description: 'Optional: Path at which the file to which the container''s
+                    termination message will be written is mounted into the container''s
+                    filesystem. Message written is intended to be brief final status,
+                    such as an assertion failure message. Will be truncated by the
+                    node if greater than 4096 bytes. The total message length across
+                    all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                    Cannot be updated.'
+                  type: string
+                terminationMessagePolicy:
+                  description: |-
+                    Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                    Possible enum values:
+                     - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                     - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                  type: string
+                tty:
+                  description: Whether this container should allocate a TTY for itself,
+                    also requires 'stdin' to be true. Default is false.
+                  type: boolean
+                volumeDevices:
+                  description: volumeDevices is the list of block devices to be used
+                    by the container.
+                  items:
+                    description: volumeDevice describes a mapping of a raw block device
+                      within a container.
+                    properties:
+                      devicePath:
+                        description: devicePath is the path inside of the container
+                          that the device will be mapped to.
+                        type: string
+                      name:
+                        description: name must match the name of a persistentVolumeClaim
+                          in the pod
+                        type: string
+                    required:
+                    - devicePath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - devicePath
+                  x-kubernetes-list-type: map
+                volumeMounts:
+                  description: Pod volumes to mount into the container's filesystem.
+                    Subpath mounts are not allowed for ephemeral containers. Cannot
+                    be updated.
+                  items:
+                    description: VolumeMount describes a mounting of a Volume within
+                      a container.
+                    properties:
+                      mountPath:
+                        description: Path within the container at which the volume
+                          should be mounted.  Must not contain ':'.
+                        type: string
+                      mountPropagation:
+                        description: mountPropagation determines how mounts are propagated
+                          from the host to container and the other way around. When
+                          not set, MountPropagationNone is used. This field is beta
+                          in 1.10.
+                        type: string
+                      name:
+                        description: This must match the Name of a Volume.
+                        type: string
+                      readOnly:
+                        description: Mounted read-only if true, read-write otherwise
+                          (false or unspecified). Defaults to false.
+                        type: boolean
+                      subPath:
+                        description: Path within the volume from which the container's
+                          volume should be mounted. Defaults to "" (volume's root).
+                        type: string
+                      subPathExpr:
+                        description: Expanded path within the volume from which the
+                          container's volume should be mounted. Behaves similarly
+                          to SubPath but environment variable references $(VAR_NAME)
+                          are expanded using the container's environment. Defaults
+                          to "" (volume's root). SubPathExpr and SubPath are mutually
+                          exclusive.
+                        type: string
+                    required:
+                    - mountPath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - mountPath
+                  x-kubernetes-list-type: map
+                workingDir:
+                  description: Container's working directory. If not specified, the
+                    container runtime's default will be used, which might be configured
+                    in the container image. Cannot be updated.
+                  type: string
+              required:
+              - name
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - name
+            x-kubernetes-list-type: map
+          hostAliases:
+            description: HostAliases is an optional list of hosts and IPs that will
+              be injected into the pod's hosts file if specified. This is only valid
+              for non-hostNetwork pods.
+            items:
+              description: HostAlias holds the mapping between IP and hostnames that
+                will be injected as an entry in the pod's hosts file.
+              properties:
+                hostnames:
+                  description: Hostnames for the above IP address.
+                  items:
+                    type: string
+                  type: array
+                ip:
+                  description: IP address of the host file entry.
+                  type: string
+              required:
+              - ip
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - ip
+            x-kubernetes-list-type: map
+          hostIPC:
+            description: 'Use the host''s ipc namespace. Optional: Default to false.'
+            type: boolean
+          hostNetwork:
+            description: Host networking requested for this pod. Use the host's network
+              namespace. If this option is set, the ports that will be used must be
+              specified. Default to false.
+            type: boolean
+          hostPID:
+            description: 'Use the host''s pid namespace. Optional: Default to false.'
+            type: boolean
+          hostUsers:
+            description: 'Use the host''s user namespace. Optional: Default to true.
+              If set to true or not present, the pod will be run in the host user
+              namespace, useful for when the pod needs a feature only available to
+              the host user namespace, such as loading a kernel module with CAP_SYS_MODULE.
+              When set to false, a new userns is created for the pod. Setting false
+              is useful for mitigating container breakout vulnerabilities even allowing
+              users to run their containers as root without actually having root privileges
+              on the host. This field is alpha-level and is only honored by servers
+              that enable the UserNamespacesSupport feature.'
+            type: boolean
+          hostname:
+            description: Specifies the hostname of the Pod If not specified, the pod's
+              hostname will be set to a system-defined value.
+            type: string
+          imagePullSecrets:
+            description: 'ImagePullSecrets is an optional list of references to secrets
+              in the same namespace to use for pulling any of the images used by this
+              PodSpec. If specified, these secrets will be passed to individual puller
+              implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+            items:
+              description: LocalObjectReference contains enough information to let
+                you locate the referenced object inside the same namespace.
+              properties:
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+              required:
+              - name
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - name
+            x-kubernetes-list-type: map
+          initContainers:
+            description: 'List of initialization containers belonging to the pod.
+              Init containers are executed in order prior to containers being started.
+              If any init container fails, the pod is considered to have failed and
+              is handled according to its restartPolicy. The name for an init container
+              or normal container must be unique among all containers. Init containers
+              may not have Lifecycle actions, Readiness probes, Liveness probes, or
+              Startup probes. The resourceRequirements of an init container are taken
+              into account during scheduling by finding the highest request/limit
+              for each resource type, and then using the max of of that value or the
+              sum of the normal containers. Limits are applied to init containers
+              in a similar fashion. Init containers cannot currently be added or removed.
+              Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+            items:
+              description: A single application container that you want to run within
+                a pod.
+              properties:
+                args:
+                  description: 'Arguments to the entrypoint. The container image''s
+                    CMD is used if this is not provided. Variable references $(VAR_NAME)
+                    are expanded using the container''s environment. If a variable
+                    cannot be resolved, the reference in the input string will be
+                    unchanged. Double $$ are reduced to a single $, which allows for
+                    escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                    the string literal "$(VAR_NAME)". Escaped references will never
+                    be expanded, regardless of whether the variable exists or not.
+                    Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                command:
+                  description: 'Entrypoint array. Not executed within a shell. The
+                    container image''s ENTRYPOINT is used if this is not provided.
+                    Variable references $(VAR_NAME) are expanded using the container''s
+                    environment. If a variable cannot be resolved, the reference in
+                    the input string will be unchanged. Double $$ are reduced to a
+                    single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                    Escaped references will never be expanded, regardless of whether
+                    the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                env:
+                  description: List of environment variables to set in the container.
+                    Cannot be updated.
+                  items:
+                    description: EnvVar represents an environment variable present
+                      in a Container.
+                    properties:
+                      name:
+                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        type: string
+                      value:
+                        description: 'Variable references $(VAR_NAME) are expanded
+                          using the previously defined environment variables in the
+                          container and any service environment variables. If a variable
+                          cannot be resolved, the reference in the input string will
+                          be unchanged. Double $$ are reduced to a single $, which
+                          allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                          will produce the string literal "$(VAR_NAME)". Escaped references
+                          will never be expanded, regardless of whether the variable
+                          exists or not. Defaults to "".'
+                        type: string
+                      valueFrom:
+                        description: Source for the environment variable's value.
+                          Cannot be used if value is not empty.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          fieldRef:
+                            description: 'Selects a field of the pod: supports metadata.name,
+                              metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                              spec.nodeName, spec.serviceAccountName, status.hostIP,
+                              status.podIP, status.podIPs.'
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                            - fieldPath
+                            type: object
+                          resourceFieldRef:
+                            description: 'Selects a resource of the container: only
+                              resources limits and requests (limits.cpu, limits.memory,
+                              limits.ephemeral-storage, requests.cpu, requests.memory
+                              and requests.ephemeral-storage) are currently supported.'
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Specifies the output format of the exposed
+                                  resources, defaults to "1"
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                            - resource
+                            type: object
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - name
+                  x-kubernetes-list-type: map
+                envFrom:
+                  description: List of sources to populate environment variables in
+                    the container. The keys defined within a source must be a C_IDENTIFIER.
+                    All invalid keys will be reported as an event when the container
+                    is starting. When a key exists in multiple sources, the value
+                    associated with the last source will take precedence. Values defined
+                    by an Env with a duplicate key will take precedence. Cannot be
+                    updated.
+                  items:
+                    description: EnvFromSource represents the source of a set of ConfigMaps
+                    properties:
+                      configMapRef:
+                        description: The ConfigMap to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the ConfigMap must be defined
+                            type: boolean
+                        type: object
+                      prefix:
+                        description: An optional identifier to prepend to each key
+                          in the ConfigMap. Must be a C_IDENTIFIER.
+                        type: string
+                      secretRef:
+                        description: The Secret to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret must be defined
+                            type: boolean
+                        type: object
+                    type: object
+                  type: array
+                image:
+                  description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                    This field is optional to allow higher level config management
+                    to default or override container images in workload controllers
+                    like Deployments and StatefulSets.'
+                  type: string
+                imagePullPolicy:
+                  description: |-
+                    Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                    Possible enum values:
+                     - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                     - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                     - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                  type: string
+                lifecycle:
+                  description: Actions that the management system should take in response
+                    to container lifecycle events. Cannot be updated.
+                  properties:
+                    postStart:
+                      description: 'PostStart is called immediately after a container
+                        is created. If the handler fails, the container is terminated
+                        and restarted according to its restart policy. Other management
+                        of the container blocks until the hook completes. More info:
+                        https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: |-
+                                Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                Possible enum values:
+                                 - `"HTTP"` means that the scheme used will be http://
+                                 - `"HTTPS"` means that the scheme used will be https://
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: Deprecated. TCPSocket is NOT supported as a
+                            LifecycleHandler and kept for the backward compatibility.
+                            There are no validation of this field and lifecycle hooks
+                            will fail in runtime when tcp handler is specified.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                    preStop:
+                      description: 'PreStop is called immediately before a container
+                        is terminated due to an API request or management event such
+                        as liveness/startup probe failure, preemption, resource contention,
+                        etc. The handler is not called if the container crashes or
+                        exits. The Pod''s termination grace period countdown begins
+                        before the PreStop hook is executed. Regardless of the outcome
+                        of the handler, the container will eventually terminate within
+                        the Pod''s termination grace period (unless delayed by finalizers).
+                        Other management of the container blocks until the hook completes
+                        or until the termination grace period is reached. More info:
+                        https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: |-
+                                Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                Possible enum values:
+                                 - `"HTTP"` means that the scheme used will be http://
+                                 - `"HTTPS"` means that the scheme used will be https://
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: Deprecated. TCPSocket is NOT supported as a
+                            LifecycleHandler and kept for the backward compatibility.
+                            There are no validation of this field and lifecycle hooks
+                            will fail in runtime when tcp handler is specified.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                  type: object
+                livenessProbe:
+                  description: 'Periodic probe of container liveness. Container will
+                    be restarted if the probe fails. Cannot be updated. More info:
+                    https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                name:
+                  description: Name of the container specified as a DNS_LABEL. Each
+                    container in a pod must have a unique name (DNS_LABEL). Cannot
+                    be updated.
+                  type: string
+                ports:
+                  description: List of ports to expose from the container. Not specifying
+                    a port here DOES NOT prevent that port from being exposed. Any
+                    port which is listening on the default "0.0.0.0" address inside
+                    a container will be accessible from the network. Modifying this
+                    array with strategic merge patch may corrupt the data. For more
+                    information See https://github.com/kubernetes/kubernetes/issues/108255.
+                    Cannot be updated.
+                  items:
+                    description: ContainerPort represents a network port in a single
+                      container.
+                    properties:
+                      containerPort:
+                        description: Number of port to expose on the pod's IP address.
+                          This must be a valid port number, 0 < x < 65536.
+                        format: int32
+                        type: integer
+                      hostIP:
+                        description: What host IP to bind the external port to.
+                        type: string
+                      hostPort:
+                        description: Number of port to expose on the host. If specified,
+                          this must be a valid port number, 0 < x < 65536. If HostNetwork
+                          is specified, this must match ContainerPort. Most containers
+                          do not need this.
+                        format: int32
+                        type: integer
+                      name:
+                        description: If specified, this must be an IANA_SVC_NAME and
+                          unique within the pod. Each named port in a pod must have
+                          a unique name. Name for the port that can be referred to
+                          by services.
+                        type: string
+                      protocol:
+                        default: TCP
+                        description: |-
+                          Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                          Possible enum values:
+                           - `"SCTP"` is the SCTP protocol.
+                           - `"TCP"` is the TCP protocol.
+                           - `"UDP"` is the UDP protocol.
+                        type: string
+                    required:
+                    - containerPort
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - containerPort
+                  - protocol
+                  x-kubernetes-list-type: map
+                readinessProbe:
+                  description: 'Periodic probe of container service readiness. Container
+                    will be removed from service endpoints if the probe fails. Cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                resources:
+                  description: 'Compute Resources required by this container. Cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                  type: object
+                securityContext:
+                  description: 'SecurityContext defines the security options the container
+                    should be run with. If set, the fields of SecurityContext override
+                    the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                  properties:
+                    allowPrivilegeEscalation:
+                      description: 'AllowPrivilegeEscalation controls whether a process
+                        can gain more privileges than its parent process. This bool
+                        directly controls if the no_new_privs flag will be set on
+                        the container process. AllowPrivilegeEscalation is true always
+                        when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
+                        Note that this field cannot be set when spec.os.name is windows.'
+                      type: boolean
+                    capabilities:
+                      description: The capabilities to add/drop when running containers.
+                        Defaults to the default set of capabilities granted by the
+                        container runtime. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      properties:
+                        add:
+                          description: Added capabilities
+                          items:
+                            type: string
+                          type: array
+                        drop:
+                          description: Removed capabilities
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    privileged:
+                      description: Run container in privileged mode. Processes in
+                        privileged containers are essentially equivalent to root on
+                        the host. Defaults to false. Note that this field cannot be
+                        set when spec.os.name is windows.
+                      type: boolean
+                    procMount:
+                      description: procMount denotes the type of proc mount to use
+                        for the containers. The default is DefaultProcMount which
+                        uses the container runtime defaults for readonly paths and
+                        masked paths. This requires the ProcMountType feature flag
+                        to be enabled. Note that this field cannot be set when spec.os.name
+                        is windows.
+                      type: string
+                    readOnlyRootFilesystem:
+                      description: Whether this container has a read-only root filesystem.
+                        Default is false. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      type: boolean
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container
+                        process. Uses runtime default if unset. May also be set in
+                        PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence. Note
+                        that this field cannot be set when spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to
+                        start the container if it does. If unset or false, no such
+                        validation will be performed. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container
+                        process. Defaults to user specified in image metadata if unspecified.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: The SELinux context to be applied to the container.
+                        If unspecified, the container runtime will allocate a random
+                        SELinux context for each container.  May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence. Note that this
+                        field cannot be set when spec.os.name is windows.
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
+                      type: object
+                    seccompProfile:
+                      description: The seccomp options to use by this container. If
+                        seccomp options are provided at both the pod & container level,
+                        the container options override the pod options. Note that
+                        this field cannot be set when spec.os.name is windows.
+                      properties:
+                        localhostProfile:
+                          description: localhostProfile indicates a profile defined
+                            in a file on the node should be used. The profile must
+                            be preconfigured on the node to work. Must be a descending
+                            path, relative to the kubelet's configured seccomp profile
+                            location. Must only be set if type is "Localhost".
+                          type: string
+                        type:
+                          description: |-
+                            type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                            Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                            Possible enum values:
+                             - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                             - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                             - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    windowsOptions:
+                      description: The Windows specific settings applied to all containers.
+                        If unspecified, the options from the PodSecurityContext will
+                        be used. If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence. Note
+                        that this field cannot be set when spec.os.name is linux.
+                      properties:
+                        gmsaCredentialSpec:
+                          description: GMSACredentialSpec is where the GMSA admission
+                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                            inlines the contents of the GMSA credential spec named
+                            by the GMSACredentialSpecName field.
+                          type: string
+                        gmsaCredentialSpecName:
+                          description: GMSACredentialSpecName is the name of the GMSA
+                            credential spec to use.
+                          type: string
+                        hostProcess:
+                          description: HostProcess determines if a container should
+                            be run as a 'Host Process' container. This field is alpha-level
+                            and will only be honored by components that enable the
+                            WindowsHostProcessContainers feature flag. Setting this
+                            field without the feature flag will result in errors when
+                            validating the Pod. All of a Pod's containers must have
+                            the same effective HostProcess value (it is not allowed
+                            to have a mix of HostProcess containers and non-HostProcess
+                            containers).  In addition, if HostProcess is true then
+                            HostNetwork must also be set to true.
+                          type: boolean
+                        runAsUserName:
+                          description: The UserName in Windows to run the entrypoint
+                            of the container process. Defaults to the user specified
+                            in image metadata if unspecified. May also be set in PodSecurityContext.
+                            If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence.
+                          type: string
+                      type: object
+                  type: object
+                startupProbe:
+                  description: 'StartupProbe indicates that the Pod has successfully
+                    initialized. If specified, no other probes are executed until
+                    this completes successfully. If this probe fails, the Pod will
+                    be restarted, just as if the livenessProbe failed. This can be
+                    used to provide different probe parameters at the beginning of
+                    a Pod''s lifecycle, when it might take a long time to load data
+                    or warm a cache, than during steady-state operation. This cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                stdin:
+                  description: Whether this container should allocate a buffer for
+                    stdin in the container runtime. If this is not set, reads from
+                    stdin in the container will always result in EOF. Default is false.
+                  type: boolean
+                stdinOnce:
+                  description: Whether the container runtime should close the stdin
+                    channel after it has been opened by a single attach. When stdin
+                    is true the stdin stream will remain open across multiple attach
+                    sessions. If stdinOnce is set to true, stdin is opened on container
+                    start, is empty until the first client attaches to stdin, and
+                    then remains open and accepts data until the client disconnects,
+                    at which time stdin is closed and remains closed until the container
+                    is restarted. If this flag is false, a container processes that
+                    reads from stdin will never receive an EOF. Default is false
+                  type: boolean
+                terminationMessagePath:
+                  description: 'Optional: Path at which the file to which the container''s
+                    termination message will be written is mounted into the container''s
+                    filesystem. Message written is intended to be brief final status,
+                    such as an assertion failure message. Will be truncated by the
+                    node if greater than 4096 bytes. The total message length across
+                    all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                    Cannot be updated.'
+                  type: string
+                terminationMessagePolicy:
+                  description: |-
+                    Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                    Possible enum values:
+                     - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                     - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                  type: string
+                tty:
+                  description: Whether this container should allocate a TTY for itself,
+                    also requires 'stdin' to be true. Default is false.
+                  type: boolean
+                volumeDevices:
+                  description: volumeDevices is the list of block devices to be used
+                    by the container.
+                  items:
+                    description: volumeDevice describes a mapping of a raw block device
+                      within a container.
+                    properties:
+                      devicePath:
+                        description: devicePath is the path inside of the container
+                          that the device will be mapped to.
+                        type: string
+                      name:
+                        description: name must match the name of a persistentVolumeClaim
+                          in the pod
+                        type: string
+                    required:
+                    - devicePath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - devicePath
+                  x-kubernetes-list-type: map
+                volumeMounts:
+                  description: Pod volumes to mount into the container's filesystem.
+                    Cannot be updated.
+                  items:
+                    description: VolumeMount describes a mounting of a Volume within
+                      a container.
+                    properties:
+                      mountPath:
+                        description: Path within the container at which the volume
+                          should be mounted.  Must not contain ':'.
+                        type: string
+                      mountPropagation:
+                        description: mountPropagation determines how mounts are propagated
+                          from the host to container and the other way around. When
+                          not set, MountPropagationNone is used. This field is beta
+                          in 1.10.
+                        type: string
+                      name:
+                        description: This must match the Name of a Volume.
+                        type: string
+                      readOnly:
+                        description: Mounted read-only if true, read-write otherwise
+                          (false or unspecified). Defaults to false.
+                        type: boolean
+                      subPath:
+                        description: Path within the volume from which the container's
+                          volume should be mounted. Defaults to "" (volume's root).
+                        type: string
+                      subPathExpr:
+                        description: Expanded path within the volume from which the
+                          container's volume should be mounted. Behaves similarly
+                          to SubPath but environment variable references $(VAR_NAME)
+                          are expanded using the container's environment. Defaults
+                          to "" (volume's root). SubPathExpr and SubPath are mutually
+                          exclusive.
+                        type: string
+                    required:
+                    - mountPath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - mountPath
+                  x-kubernetes-list-type: map
+                workingDir:
+                  description: Container's working directory. If not specified, the
+                    container runtime's default will be used, which might be configured
+                    in the container image. Cannot be updated.
+                  type: string
+              required:
+              - name
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - name
+            x-kubernetes-list-type: map
+          nodeName:
+            description: NodeName is a request to schedule this pod onto a specific
+              node. If it is non-empty, the scheduler simply schedules this pod onto
+              that node, assuming that it fits resource requirements.
+            type: string
+          nodeSelector:
+            additionalProperties:
+              type: string
+            description: 'NodeSelector is a selector which must be true for the pod
+              to fit on a node. Selector which must match a node''s labels for the
+              pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+            type: object
+          os:
+            description: |-
+              Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set.
+
+              If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions
+
+              If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup
+            properties:
+              name:
+                description: 'Name is the name of the operating system. The currently
+                  supported values are linux and windows. Additional value may be
+                  defined in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                  Clients should expect to handle additional values and treat unrecognized
+                  values in this field as os: null'
+                type: string
+            required:
+            - name
+            type: object
+          overhead:
+            additionalProperties:
+              anyOf:
+              - type: integer
+              - type: string
+              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+              x-kubernetes-int-or-string: true
+            description: 'Overhead represents the resource overhead associated with
+              running a pod for a given RuntimeClass. This field will be autopopulated
+              at admission time by the RuntimeClass admission controller. If the RuntimeClass
+              admission controller is enabled, overhead must not be set in Pod create
+              requests. The RuntimeClass admission controller will reject Pod create
+              requests which have the overhead already set. If RuntimeClass is configured
+              and selected in the PodSpec, Overhead will be set to the value defined
+              in the corresponding RuntimeClass, otherwise it will remain unset and
+              treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
+            type: object
+          preemptionPolicy:
+            description: PreemptionPolicy is the Policy for preempting pods with lower
+              priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority
+              if unset.
+            type: string
+          priority:
+            description: The priority value. Various system components use this field
+              to find the priority of the pod. When Priority Admission Controller
+              is enabled, it prevents users from setting this field. The admission
+              controller populates this field from PriorityClassName. The higher the
+              value, the higher the priority.
+            format: int32
+            type: integer
+          priorityClassName:
+            description: If specified, indicates the pod's priority. "system-node-critical"
+              and "system-cluster-critical" are two special keywords which indicate
+              the highest priorities with the former being the highest priority. Any
+              other name must be defined by creating a PriorityClass object with that
+              name. If not specified, the pod priority will be default or zero if
+              there is no default.
+            type: string
+          readinessGates:
+            description: 'If specified, all readiness gates will be evaluated for
+              pod readiness. A pod is ready when all its containers are ready AND
+              all conditions specified in the readiness gates have status equal to
+              "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
+            items:
+              description: PodReadinessGate contains the reference to a pod condition
+              properties:
+                conditionType:
+                  description: ConditionType refers to a condition in the pod's condition
+                    list with matching type.
+                  type: string
+              required:
+              - conditionType
+              type: object
+            type: array
+          restartPolicy:
+            description: |-
+              Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+
+              Possible enum values:
+               - `"Always"`
+               - `"Never"`
+               - `"OnFailure"`
+            type: string
+          runtimeClassName:
+            description: 'RuntimeClassName refers to a RuntimeClass object in the
+              node.k8s.io group, which should be used to run this pod.  If no RuntimeClass
+              resource matches the named class, the pod will not be run. If unset
+              or empty, the "legacy" RuntimeClass will be used, which is an implicit
+              class with an empty definition that uses the default runtime handler.
+              More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
+            type: string
+          schedulerName:
+            description: If specified, the pod will be dispatched by specified scheduler.
+              If not specified, the pod will be dispatched by default scheduler.
+            type: string
+          securityContext:
+            description: 'SecurityContext holds pod-level security attributes and
+              common container settings. Optional: Defaults to empty.  See type description
+              for default values of each field.'
+            properties:
+              fsGroup:
+                description: |-
+                  A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
+                  1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
+                  If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.
+                format: int64
+                type: integer
+              fsGroupChangePolicy:
+                description: 'fsGroupChangePolicy defines behavior of changing ownership
+                  and permission of the volume before being exposed inside Pod. This
+                  field will only apply to volume types which support fsGroup based
+                  ownership(and permissions). It will have no effect on ephemeral
+                  volume types such as: secret, configmaps and emptydir. Valid values
+                  are "OnRootMismatch" and "Always". If not specified, "Always" is
+                  used. Note that this field cannot be set when spec.os.name is windows.'
+                type: string
+              runAsGroup:
+                description: The GID to run the entrypoint of the container process.
+                  Uses runtime default if unset. May also be set in SecurityContext.  If
+                  set in both SecurityContext and PodSecurityContext, the value specified
+                  in SecurityContext takes precedence for that container. Note that
+                  this field cannot be set when spec.os.name is windows.
+                format: int64
+                type: integer
+              runAsNonRoot:
+                description: Indicates that the container must run as a non-root user.
+                  If true, the Kubelet will validate the image at runtime to ensure
+                  that it does not run as UID 0 (root) and fail to start the container
+                  if it does. If unset or false, no such validation will be performed.
+                  May also be set in SecurityContext.  If set in both SecurityContext
+                  and PodSecurityContext, the value specified in SecurityContext takes
+                  precedence.
+                type: boolean
+              runAsUser:
+                description: The UID to run the entrypoint of the container process.
+                  Defaults to user specified in image metadata if unspecified. May
+                  also be set in SecurityContext.  If set in both SecurityContext
+                  and PodSecurityContext, the value specified in SecurityContext takes
+                  precedence for that container. Note that this field cannot be set
+                  when spec.os.name is windows.
+                format: int64
+                type: integer
+              seLinuxOptions:
+                description: The SELinux context to be applied to all containers.
+                  If unspecified, the container runtime will allocate a random SELinux
+                  context for each container.  May also be set in SecurityContext.  If
+                  set in both SecurityContext and PodSecurityContext, the value specified
+                  in SecurityContext takes precedence for that container. Note that
+                  this field cannot be set when spec.os.name is windows.
+                properties:
+                  level:
+                    description: Level is SELinux level label that applies to the
+                      container.
+                    type: string
+                  role:
+                    description: Role is a SELinux role label that applies to the
+                      container.
+                    type: string
+                  type:
+                    description: Type is a SELinux type label that applies to the
+                      container.
+                    type: string
+                  user:
+                    description: User is a SELinux user label that applies to the
+                      container.
+                    type: string
+                type: object
+              seccompProfile:
+                description: The seccomp options to use by the containers in this
+                  pod. Note that this field cannot be set when spec.os.name is windows.
+                properties:
+                  localhostProfile:
+                    description: localhostProfile indicates a profile defined in a
+                      file on the node should be used. The profile must be preconfigured
+                      on the node to work. Must be a descending path, relative to
+                      the kubelet's configured seccomp profile location. Must only
+                      be set if type is "Localhost".
+                    type: string
+                  type:
+                    description: |-
+                      type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                      Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                      Possible enum values:
+                       - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                       - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                       - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                    type: string
+                required:
+                - type
+                type: object
+              supplementalGroups:
+                description: A list of groups applied to the first process run in
+                  each container, in addition to the container's primary GID.  If
+                  unspecified, no groups will be added to any container. Note that
+                  this field cannot be set when spec.os.name is windows.
+                items:
+                  format: int64
+                  type: integer
+                type: array
+              sysctls:
+                description: Sysctls hold a list of namespaced sysctls used for the
+                  pod. Pods with unsupported sysctls (by the container runtime) might
+                  fail to launch. Note that this field cannot be set when spec.os.name
+                  is windows.
+                items:
+                  description: Sysctl defines a kernel parameter to be set
+                  properties:
+                    name:
+                      description: Name of a property to set
+                      type: string
+                    value:
+                      description: Value of a property to set
+                      type: string
+                  required:
+                  - name
+                  - value
+                  type: object
+                type: array
+              windowsOptions:
+                description: The Windows specific settings applied to all containers.
+                  If unspecified, the options within a container's SecurityContext
+                  will be used. If set in both SecurityContext and PodSecurityContext,
+                  the value specified in SecurityContext takes precedence. Note that
+                  this field cannot be set when spec.os.name is linux.
+                properties:
+                  gmsaCredentialSpec:
+                    description: GMSACredentialSpec is where the GMSA admission webhook
+                      (https://github.com/kubernetes-sigs/windows-gmsa) inlines the
+                      contents of the GMSA credential spec named by the GMSACredentialSpecName
+                      field.
+                    type: string
+                  gmsaCredentialSpecName:
+                    description: GMSACredentialSpecName is the name of the GMSA credential
+                      spec to use.
+                    type: string
+                  hostProcess:
+                    description: HostProcess determines if a container should be run
+                      as a 'Host Process' container. This field is alpha-level and
+                      will only be honored by components that enable the WindowsHostProcessContainers
+                      feature flag. Setting this field without the feature flag will
+                      result in errors when validating the Pod. All of a Pod's containers
+                      must have the same effective HostProcess value (it is not allowed
+                      to have a mix of HostProcess containers and non-HostProcess
+                      containers).  In addition, if HostProcess is true then HostNetwork
+                      must also be set to true.
+                    type: boolean
+                  runAsUserName:
+                    description: The UserName in Windows to run the entrypoint of
+                      the container process. Defaults to the user specified in image
+                      metadata if unspecified. May also be set in PodSecurityContext.
+                      If set in both SecurityContext and PodSecurityContext, the value
+                      specified in SecurityContext takes precedence.
+                    type: string
+                type: object
+            type: object
+          serviceAccount:
+            description: 'DeprecatedServiceAccount is a depreciated alias for ServiceAccountName.
+              Deprecated: Use serviceAccountName instead.'
+            type: string
+          serviceAccountName:
+            description: 'ServiceAccountName is the name of the ServiceAccount to
+              use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+            type: string
+          setHostnameAsFQDN:
+            description: If true the pod's hostname will be configured as the pod's
+              FQDN, rather than the leaf name (the default). In Linux containers,
+              this means setting the FQDN in the hostname field of the kernel (the
+              nodename field of struct utsname). In Windows containers, this means
+              setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters
+              to FQDN. If a pod does not have FQDN, this has no effect. Default to
+              false.
+            type: boolean
+          shareProcessNamespace:
+            description: 'Share a single process namespace between all of the containers
+              in a pod. When this is set containers will be able to view and signal
+              processes from other containers in the same pod, and the first process
+              in each container will not be assigned PID 1. HostPID and ShareProcessNamespace
+              cannot both be set. Optional: Default to false.'
+            type: boolean
+          subdomain:
+            description: If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod
+              namespace>.svc.<cluster domain>". If not specified, the pod will not
+              have a domainname at all.
+            type: string
+          terminationGracePeriodSeconds:
+            description: Optional duration in seconds the pod needs to terminate gracefully.
+              May be decreased in delete request. Value must be non-negative integer.
+              The value zero indicates stop immediately via the kill signal (no opportunity
+              to shut down). If this value is nil, the default grace period will be
+              used instead. The grace period is the duration in seconds after the
+              processes running in the pod are sent a termination signal and the time
+              when the processes are forcibly halted with a kill signal. Set this
+              value longer than the expected cleanup time for your process. Defaults
+              to 30 seconds.
+            format: int64
+            type: integer
+          tolerations:
+            description: If specified, the pod's tolerations.
+            items:
+              description: The pod this Toleration is attached to tolerates any taint
+                that matches the triple <key,value,effect> using the matching operator
+                <operator>.
+              properties:
+                effect:
+                  description: |-
+                    Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+                    Possible enum values:
+                     - `"NoExecute"` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+                     - `"NoSchedule"` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+                     - `"PreferNoSchedule"` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
+                  type: string
+                key:
+                  description: Key is the taint key that the toleration applies to.
+                    Empty means match all taint keys. If the key is empty, operator
+                    must be Exists; this combination means to match all values and
+                    all keys.
+                  type: string
+                operator:
+                  description: |-
+                    Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+
+                    Possible enum values:
+                     - `"Equal"`
+                     - `"Exists"`
+                  type: string
+                tolerationSeconds:
+                  description: TolerationSeconds represents the period of time the
+                    toleration (which must be of effect NoExecute, otherwise this
+                    field is ignored) tolerates the taint. By default, it is not set,
+                    which means tolerate the taint forever (do not evict). Zero and
+                    negative values will be treated as 0 (evict immediately) by the
+                    system.
+                  format: int64
+                  type: integer
+                value:
+                  description: Value is the taint value the toleration matches to.
+                    If the operator is Exists, the value should be empty, otherwise
+                    just a regular string.
+                  type: string
+              type: object
+            type: array
+          topologySpreadConstraints:
+            description: TopologySpreadConstraints describes how a group of pods ought
+              to spread across topology domains. Scheduler will schedule pods in a
+              way which abides by the constraints. All topologySpreadConstraints are
+              ANDed.
+            items:
+              description: TopologySpreadConstraint specifies how to spread matching
+                pods among the given topology.
+              properties:
+                labelSelector:
+                  description: LabelSelector is used to find matching pods. Pods that
+                    match this label selector are counted to determine the number
+                    of pods in their corresponding topology domain.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                matchLabelKeys:
+                  description: MatchLabelKeys is a set of pod label keys to select
+                    the pods over which spreading will be calculated. The keys are
+                    used to lookup values from the incoming pod labels, those key-value
+                    labels are ANDed with labelSelector to select the group of existing
+                    pods over which spreading will be calculated for the incoming
+                    pod. Keys that don't exist in the incoming pod labels will be
+                    ignored. A null or empty list means only match against labelSelector.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: atomic
+                maxSkew:
+                  description: 'MaxSkew describes the degree to which pods may be
+                    unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                    it is the maximum permitted difference between the number of matching
+                    pods in the target topology and the global minimum. The global
+                    minimum is the minimum number of matching pods in an eligible
+                    domain or zero if the number of eligible domains is less than
+                    MinDomains. For example, in a 3-zone cluster, MaxSkew is set to
+                    1, and pods with the same labelSelector spread as 2/2/1: In this
+                    case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P
+                    P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only
+                    be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2)
+                    would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1).
+                    - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                    When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher
+                    precedence to topologies that satisfy it. It''s a required field.
+                    Default value is 1 and 0 is not allowed.'
+                  format: int32
+                  type: integer
+                minDomains:
+                  description: |-
+                    MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                    For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew.
+
+                    This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
+                  format: int32
+                  type: integer
+                nodeAffinityPolicy:
+                  description: |-
+                    NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                    If this value is nil, the behavior is equivalent to the Honor policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                  type: string
+                nodeTaintsPolicy:
+                  description: |-
+                    NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included.
+
+                    If this value is nil, the behavior is equivalent to the Ignore policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                  type: string
+                topologyKey:
+                  description: TopologyKey is the key of node labels. Nodes that have
+                    a label with this key and identical values are considered to be
+                    in the same topology. We consider each <key, value> as a "bucket",
+                    and try to put balanced number of pods into each bucket. We define
+                    a domain as a particular instance of a topology. Also, we define
+                    an eligible domain as a domain whose nodes meet the requirements
+                    of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey
+                    is "kubernetes.io/hostname", each Node is a domain of that topology.
+                    And, if TopologyKey is "topology.kubernetes.io/zone", each zone
+                    is a domain of that topology. It's a required field.
+                  type: string
+                whenUnsatisfiable:
+                  description: |-
+                    WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                      but giving higher precedence to topologies that would help reduce the
+                      skew.
+                    A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
+
+                    Possible enum values:
+                     - `"DoNotSchedule"` instructs the scheduler not to schedule the pod when constraints are not satisfied.
+                     - `"ScheduleAnyway"` instructs the scheduler to schedule the pod even if constraints are not satisfied.
+                  type: string
+              required:
+              - maxSkew
+              - topologyKey
+              - whenUnsatisfiable
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - topologyKey
+            - whenUnsatisfiable
+            x-kubernetes-list-type: map
+          volumes:
+            description: 'List of volumes that can be mounted by containers belonging
+              to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+            items:
+              description: Volume represents a named volume in a pod that may be accessed
+                by any container in the pod.
+              properties:
+                awsElasticBlockStore:
+                  description: 'awsElasticBlockStore represents an AWS Disk resource
+                    that is attached to a kubelet''s host machine and then exposed
+                    to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                  properties:
+                    fsType:
+                      description: 'fsType is the filesystem type of the volume that
+                        you want to mount. Tip: Ensure that the filesystem type is
+                        supported by the host operating system. Examples: "ext4",
+                        "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                      type: string
+                    partition:
+                      description: 'partition is the partition in the volume that
+                        you want to mount. If omitted, the default is to mount by
+                        volume name. Examples: For volume /dev/sda1, you specify the
+                        partition as "1". Similarly, the volume partition for /dev/sda
+                        is "0" (or you can leave the property empty).'
+                      format: int32
+                      type: integer
+                    readOnly:
+                      description: 'readOnly value true will force the readOnly setting
+                        in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                      type: boolean
+                    volumeID:
+                      description: 'volumeID is unique ID of the persistent disk resource
+                        in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                      type: string
+                  required:
+                  - volumeID
+                  type: object
+                azureDisk:
+                  description: azureDisk represents an Azure Data Disk mount on the
+                    host and bind mount to the pod.
+                  properties:
+                    cachingMode:
+                      description: 'cachingMode is the Host Caching mode: None, Read
+                        Only, Read Write.'
+                      type: string
+                    diskName:
+                      description: diskName is the Name of the data disk in the blob
+                        storage
+                      type: string
+                    diskURI:
+                      description: diskURI is the URI of data disk in the blob storage
+                      type: string
+                    fsType:
+                      description: fsType is Filesystem type to mount. Must be a filesystem
+                        type supported by the host operating system. Ex. "ext4", "xfs",
+                        "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                      type: string
+                    kind:
+                      description: 'kind expected values are Shared: multiple blob
+                        disks per storage account  Dedicated: single blob disk per
+                        storage account  Managed: azure managed data disk (only in
+                        managed availability set). defaults to shared'
+                      type: string
+                    readOnly:
+                      description: readOnly Defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts.
+                      type: boolean
+                  required:
+                  - diskName
+                  - diskURI
+                  type: object
+                azureFile:
+                  description: azureFile represents an Azure File Service mount on
+                    the host and bind mount to the pod.
+                  properties:
+                    readOnly:
+                      description: readOnly defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts.
+                      type: boolean
+                    secretName:
+                      description: secretName is the  name of secret that contains
+                        Azure Storage Account Name and Key
+                      type: string
+                    shareName:
+                      description: shareName is the azure share Name
+                      type: string
+                  required:
+                  - secretName
+                  - shareName
+                  type: object
+                cephfs:
+                  description: cephFS represents a Ceph FS mount on the host that
+                    shares a pod's lifetime
+                  properties:
+                    monitors:
+                      description: 'monitors is Required: Monitors is a collection
+                        of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                      items:
+                        type: string
+                      type: array
+                    path:
+                      description: 'path is Optional: Used as the mounted root, rather
+                        than the full Ceph tree, default is /'
+                      type: string
+                    readOnly:
+                      description: 'readOnly is Optional: Defaults to false (read/write).
+                        ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                      type: boolean
+                    secretFile:
+                      description: 'secretFile is Optional: SecretFile is the path
+                        to key ring for User, default is /etc/ceph/user.secret More
+                        info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                      type: string
+                    secretRef:
+                      description: 'secretRef is Optional: SecretRef is reference
+                        to the authentication secret for User, default is empty. More
+                        info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    user:
+                      description: 'user is optional: User is the rados user name,
+                        default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                      type: string
+                  required:
+                  - monitors
+                  type: object
+                cinder:
+                  description: 'cinder represents a cinder volume attached and mounted
+                    on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                  properties:
+                    fsType:
+                      description: 'fsType is the filesystem type to mount. Must be
+                        a filesystem type supported by the host operating system.
+                        Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be
+                        "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                      type: string
+                    readOnly:
+                      description: 'readOnly defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts. More
+                        info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                      type: boolean
+                    secretRef:
+                      description: 'secretRef is optional: points to a secret object
+                        containing parameters used to connect to OpenStack.'
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    volumeID:
+                      description: 'volumeID used to identify the volume in cinder.
+                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                      type: string
+                  required:
+                  - volumeID
+                  type: object
+                configMap:
+                  description: configMap represents a configMap that should populate
+                    this volume
+                  properties:
+                    defaultMode:
+                      description: 'defaultMode is optional: mode bits used to set
+                        permissions on created files by default. Must be an octal
+                        value between 0000 and 0777 or a decimal value between 0 and
+                        511. YAML accepts both octal and decimal values, JSON requires
+                        decimal values for mode bits. Defaults to 0644. Directories
+                        within the path are not affected by this setting. This might
+                        be in conflict with other options that affect the file mode,
+                        like fsGroup, and the result can be other mode bits set.'
+                      format: int32
+                      type: integer
+                    items:
+                      description: items if unspecified, each key-value pair in the
+                        Data field of the referenced ConfigMap will be projected into
+                        the volume as a file whose name is the key and content is
+                        the value. If specified, the listed keys will be projected
+                        into the specified paths, and unlisted keys will not be present.
+                        If a key is specified which is not present in the ConfigMap,
+                        the volume setup will error unless it is marked optional.
+                        Paths must be relative and may not contain the '..' path or
+                        start with '..'.
+                      items:
+                        description: Maps a string key to a path within a volume.
+                        properties:
+                          key:
+                            description: key is the key to project.
+                            type: string
+                          mode:
+                            description: 'mode is Optional: mode bits used to set
+                              permissions on this file. Must be an octal value between
+                              0000 and 0777 or a decimal value between 0 and 511.
+                              YAML accepts both octal and decimal values, JSON requires
+                              decimal values for mode bits. If not specified, the
+                              volume defaultMode will be used. This might be in conflict
+                              with other options that affect the file mode, like fsGroup,
+                              and the result can be other mode bits set.'
+                            format: int32
+                            type: integer
+                          path:
+                            description: path is the relative path of the file to
+                              map the key to. May not be an absolute path. May not
+                              contain the path element '..'. May not start with the
+                              string '..'.
+                            type: string
+                        required:
+                        - key
+                        - path
+                        type: object
+                      type: array
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    optional:
+                      description: optional specify whether the ConfigMap or its keys
+                        must be defined
+                      type: boolean
+                  type: object
+                csi:
+                  description: csi (Container Storage Interface) represents ephemeral
+                    storage that is handled by certain external CSI drivers (Beta
+                    feature).
+                  properties:
+                    driver:
+                      description: driver is the name of the CSI driver that handles
+                        this volume. Consult with your admin for the correct name
+                        as registered in the cluster.
+                      type: string
+                    fsType:
+                      description: fsType to mount. Ex. "ext4", "xfs", "ntfs". If
+                        not provided, the empty value is passed to the associated
+                        CSI driver which will determine the default filesystem to
+                        apply.
+                      type: string
+                    nodePublishSecretRef:
+                      description: nodePublishSecretRef is a reference to the secret
+                        object containing sensitive information to pass to the CSI
+                        driver to complete the CSI NodePublishVolume and NodeUnpublishVolume
+                        calls. This field is optional, and  may be empty if no secret
+                        is required. If the secret object contains more than one secret,
+                        all secret references are passed.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    readOnly:
+                      description: readOnly specifies a read-only configuration for
+                        the volume. Defaults to false (read/write).
+                      type: boolean
+                    volumeAttributes:
+                      additionalProperties:
+                        type: string
+                      description: volumeAttributes stores driver-specific properties
+                        that are passed to the CSI driver. Consult your driver's documentation
+                        for supported values.
+                      type: object
+                  required:
+                  - driver
+                  type: object
+                downwardAPI:
+                  description: downwardAPI represents downward API about the pod that
+                    should populate this volume
+                  properties:
+                    defaultMode:
+                      description: 'Optional: mode bits to use on created files by
+                        default. Must be a Optional: mode bits used to set permissions
+                        on created files by default. Must be an octal value between
+                        0000 and 0777 or a decimal value between 0 and 511. YAML accepts
+                        both octal and decimal values, JSON requires decimal values
+                        for mode bits. Defaults to 0644. Directories within the path
+                        are not affected by this setting. This might be in conflict
+                        with other options that affect the file mode, like fsGroup,
+                        and the result can be other mode bits set.'
+                      format: int32
+                      type: integer
+                    items:
+                      description: Items is a list of downward API volume file
+                      items:
+                        description: DownwardAPIVolumeFile represents information
+                          to create the file containing the pod field
+                        properties:
+                          fieldRef:
+                            description: 'Required: Selects a field of the pod: only
+                              annotations, labels, name and namespace are supported.'
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                            - fieldPath
+                            type: object
+                          mode:
+                            description: 'Optional: mode bits used to set permissions
+                              on this file, must be an octal value between 0000 and
+                              0777 or a decimal value between 0 and 511. YAML accepts
+                              both octal and decimal values, JSON requires decimal
+                              values for mode bits. If not specified, the volume defaultMode
+                              will be used. This might be in conflict with other options
+                              that affect the file mode, like fsGroup, and the result
+                              can be other mode bits set.'
+                            format: int32
+                            type: integer
+                          path:
+                            description: 'Required: Path is  the relative path name
+                              of the file to be created. Must not be absolute or contain
+                              the ''..'' path. Must be utf-8 encoded. The first item
+                              of the relative path must not start with ''..'''
+                            type: string
+                          resourceFieldRef:
+                            description: 'Selects a resource of the container: only
+                              resources limits and requests (limits.cpu, limits.memory,
+                              requests.cpu and requests.memory) are currently supported.'
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Specifies the output format of the exposed
+                                  resources, defaults to "1"
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                            - resource
+                            type: object
+                        required:
+                        - path
+                        type: object
+                      type: array
+                  type: object
+                emptyDir:
+                  description: 'emptyDir represents a temporary directory that shares
+                    a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                  properties:
+                    medium:
+                      description: 'medium represents what type of storage medium
+                        should back this directory. The default is "" which means
+                        to use the node''s default medium. Must be an empty string
+                        (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                      type: string
+                    sizeLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: 'sizeLimit is the total amount of local storage
+                        required for this EmptyDir volume. The size limit is also
+                        applicable for memory medium. The maximum usage on memory
+                        medium EmptyDir would be the minimum value between the SizeLimit
+                        specified here and the sum of memory limits of all containers
+                        in a pod. The default is nil which means that the limit is
+                        undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  type: object
+                ephemeral:
+                  description: |-
+                    ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+
+                    Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+                       tracking are needed,
+                    c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+                       a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                       information on the connection between this volume type
+                       and PersistentVolumeClaim).
+
+                    Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+
+                    Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+
+                    A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+                  properties:
+                    volumeClaimTemplate:
+                      description: |-
+                        Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+
+                        An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+
+                        This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+
+                        Required, must not be nil.
+                      properties:
+                        metadata:
+                          description: May contain labels and annotations that will
+                            be copied into the PVC when creating it. No other fields
+                            are allowed and will be rejected during validation.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        spec:
+                          description: The specification for the PersistentVolumeClaim.
+                            The entire content is copied unchanged into the PVC that
+                            gets created from this template. The same fields as in
+                            a PersistentVolumeClaim are also valid here.
+                          properties:
+                            accessModes:
+                              description: 'accessModes contains the desired access
+                                modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                              items:
+                                type: string
+                              type: array
+                            dataSource:
+                              description: 'dataSource field can be used to specify
+                                either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                * An existing PVC (PersistentVolumeClaim) If the provisioner
+                                or an external controller can support the specified
+                                data source, it will create a new volume based on
+                                the contents of the specified data source. If the
+                                AnyVolumeDataSource feature gate is enabled, this
+                                field will always have the same contents as the DataSourceRef
+                                field.'
+                              properties:
+                                apiGroup:
+                                  description: APIGroup is the group for the resource
+                                    being referenced. If APIGroup is not specified,
+                                    the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being
+                                    referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being
+                                    referenced
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            dataSourceRef:
+                              description: |-
+                                dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef
+                                  allows any non-core object, as well as PersistentVolumeClaim objects.
+                                * While DataSource ignores disallowed values (dropping them), DataSourceRef
+                                  preserves all values, and generates an error if a disallowed value is
+                                  specified.
+                                (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                              properties:
+                                apiGroup:
+                                  description: APIGroup is the group for the resource
+                                    being referenced. If APIGroup is not specified,
+                                    the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being
+                                    referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being
+                                    referenced
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            resources:
+                              description: 'resources represents the minimum resources
+                                the volume should have. If RecoverVolumeExpansionFailure
+                                feature is enabled users are allowed to specify resource
+                                requirements that are lower than previous value but
+                                must still be higher than capacity recorded in the
+                                status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                              type: object
+                            selector:
+                              description: selector is a label query over volumes
+                                to consider for binding.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            storageClassName:
+                              description: 'storageClassName is the name of the StorageClass
+                                required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                              type: string
+                            volumeMode:
+                              description: volumeMode defines what type of volume
+                                is required by the claim. Value of Filesystem is implied
+                                when not included in claim spec.
+                              type: string
+                            volumeName:
+                              description: volumeName is the binding reference to
+                                the PersistentVolume backing this claim.
+                              type: string
+                          type: object
+                      required:
+                      - spec
+                      type: object
+                  type: object
+                fc:
+                  description: fc represents a Fibre Channel resource that is attached
+                    to a kubelet's host machine and then exposed to the pod.
+                  properties:
+                    fsType:
+                      description: fsType is the filesystem type to mount. Must be
+                        a filesystem type supported by the host operating system.
+                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                        if unspecified.
+                      type: string
+                    lun:
+                      description: 'lun is Optional: FC target lun number'
+                      format: int32
+                      type: integer
+                    readOnly:
+                      description: 'readOnly is Optional: Defaults to false (read/write).
+                        ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                      type: boolean
+                    targetWWNs:
+                      description: 'targetWWNs is Optional: FC target worldwide names
+                        (WWNs)'
+                      items:
+                        type: string
+                      type: array
+                    wwids:
+                      description: 'wwids Optional: FC volume world wide identifiers
+                        (wwids) Either wwids or combination of targetWWNs and lun
+                        must be set, but not both simultaneously.'
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                flexVolume:
+                  description: flexVolume represents a generic volume resource that
+                    is provisioned/attached using an exec based plugin.
+                  properties:
+                    driver:
+                      description: driver is the name of the driver to use for this
+                        volume.
+                      type: string
+                    fsType:
+                      description: fsType is the filesystem type to mount. Must be
+                        a filesystem type supported by the host operating system.
+                        Ex. "ext4", "xfs", "ntfs". The default filesystem depends
+                        on FlexVolume script.
+                      type: string
+                    options:
+                      additionalProperties:
+                        type: string
+                      description: 'options is Optional: this field holds extra command
+                        options if any.'
+                      type: object
+                    readOnly:
+                      description: 'readOnly is Optional: defaults to false (read/write).
+                        ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                      type: boolean
+                    secretRef:
+                      description: 'secretRef is Optional: secretRef is reference
+                        to the secret object containing sensitive information to pass
+                        to the plugin scripts. This may be empty if no secret object
+                        is specified. If the secret object contains more than one
+                        secret, all secrets are passed to the plugin scripts.'
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                  required:
+                  - driver
+                  type: object
+                flocker:
+                  description: flocker represents a Flocker volume attached to a kubelet's
+                    host machine. This depends on the Flocker control service being
+                    running
+                  properties:
+                    datasetName:
+                      description: datasetName is Name of the dataset stored as metadata
+                        -> name on the dataset for Flocker should be considered as
+                        deprecated
+                      type: string
+                    datasetUUID:
+                      description: datasetUUID is the UUID of the dataset. This is
+                        unique identifier of a Flocker dataset
+                      type: string
+                  type: object
+                gcePersistentDisk:
+                  description: 'gcePersistentDisk represents a GCE Disk resource that
+                    is attached to a kubelet''s host machine and then exposed to the
+                    pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                  properties:
+                    fsType:
+                      description: 'fsType is filesystem type of the volume that you
+                        want to mount. Tip: Ensure that the filesystem type is supported
+                        by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                        Implicitly inferred to be "ext4" if unspecified. More info:
+                        https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                      type: string
+                    partition:
+                      description: 'partition is the partition in the volume that
+                        you want to mount. If omitted, the default is to mount by
+                        volume name. Examples: For volume /dev/sda1, you specify the
+                        partition as "1". Similarly, the volume partition for /dev/sda
+                        is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                      format: int32
+                      type: integer
+                    pdName:
+                      description: 'pdName is unique name of the PD resource in GCE.
+                        Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                      type: string
+                    readOnly:
+                      description: 'readOnly here will force the ReadOnly setting
+                        in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                      type: boolean
+                  required:
+                  - pdName
+                  type: object
+                gitRepo:
+                  description: 'gitRepo represents a git repository at a particular
+                    revision. DEPRECATED: GitRepo is deprecated. To provision a container
+                    with a git repo, mount an EmptyDir into an InitContainer that
+                    clones the repo using git, then mount the EmptyDir into the Pod''s
+                    container.'
+                  properties:
+                    directory:
+                      description: directory is the target directory name. Must not
+                        contain or start with '..'.  If '.' is supplied, the volume
+                        directory will be the git repository.  Otherwise, if specified,
+                        the volume will contain the git repository in the subdirectory
+                        with the given name.
+                      type: string
+                    repository:
+                      description: repository is the URL
+                      type: string
+                    revision:
+                      description: revision is the commit hash for the specified revision.
+                      type: string
+                  required:
+                  - repository
+                  type: object
+                glusterfs:
+                  description: 'glusterfs represents a Glusterfs mount on the host
+                    that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                  properties:
+                    endpoints:
+                      description: 'endpoints is the endpoint name that details Glusterfs
+                        topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                      type: string
+                    path:
+                      description: 'path is the Glusterfs volume path. More info:
+                        https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                      type: string
+                    readOnly:
+                      description: 'readOnly here will force the Glusterfs volume
+                        to be mounted with read-only permissions. Defaults to false.
+                        More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                      type: boolean
+                  required:
+                  - endpoints
+                  - path
+                  type: object
+                hostPath:
+                  description: 'hostPath represents a pre-existing file or directory
+                    on the host machine that is directly exposed to the container.
+                    This is generally used for system agents or other privileged things
+                    that are allowed to see the host machine. Most containers will
+                    NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                  properties:
+                    path:
+                      description: 'path of the directory on the host. If the path
+                        is a symlink, it will follow the link to the real path. More
+                        info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                      type: string
+                    type:
+                      description: 'type for HostPath Volume Defaults to "" More info:
+                        https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                      type: string
+                  required:
+                  - path
+                  type: object
+                iscsi:
+                  description: 'iscsi represents an ISCSI Disk resource that is attached
+                    to a kubelet''s host machine and then exposed to the pod. More
+                    info: https://examples.k8s.io/volumes/iscsi/README.md'
+                  properties:
+                    chapAuthDiscovery:
+                      description: chapAuthDiscovery defines whether support iSCSI
+                        Discovery CHAP authentication
+                      type: boolean
+                    chapAuthSession:
+                      description: chapAuthSession defines whether support iSCSI Session
+                        CHAP authentication
+                      type: boolean
+                    fsType:
+                      description: 'fsType is the filesystem type of the volume that
+                        you want to mount. Tip: Ensure that the filesystem type is
+                        supported by the host operating system. Examples: "ext4",
+                        "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                      type: string
+                    initiatorName:
+                      description: initiatorName is the custom iSCSI Initiator Name.
+                        If initiatorName is specified with iscsiInterface simultaneously,
+                        new iSCSI interface <target portal>:<volume name> will be
+                        created for the connection.
+                      type: string
+                    iqn:
+                      description: iqn is the target iSCSI Qualified Name.
+                      type: string
+                    iscsiInterface:
+                      description: iscsiInterface is the interface Name that uses
+                        an iSCSI transport. Defaults to 'default' (tcp).
+                      type: string
+                    lun:
+                      description: lun represents iSCSI Target Lun number.
+                      format: int32
+                      type: integer
+                    portals:
+                      description: portals is the iSCSI Target Portal List. The portal
+                        is either an IP or ip_addr:port if the port is other than
+                        default (typically TCP ports 860 and 3260).
+                      items:
+                        type: string
+                      type: array
+                    readOnly:
+                      description: readOnly here will force the ReadOnly setting in
+                        VolumeMounts. Defaults to false.
+                      type: boolean
+                    secretRef:
+                      description: secretRef is the CHAP Secret for iSCSI target and
+                        initiator authentication
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    targetPortal:
+                      description: targetPortal is iSCSI Target Portal. The Portal
+                        is either an IP or ip_addr:port if the port is other than
+                        default (typically TCP ports 860 and 3260).
+                      type: string
+                  required:
+                  - targetPortal
+                  - iqn
+                  - lun
+                  type: object
+                name:
+                  description: 'name of the volume. Must be a DNS_LABEL and unique
+                    within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                nfs:
+                  description: 'nfs represents an NFS mount on the host that shares
+                    a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                  properties:
+                    path:
+                      description: 'path that is exported by the NFS server. More
+                        info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                      type: string
+                    readOnly:
+                      description: 'readOnly here will force the NFS export to be
+                        mounted with read-only permissions. Defaults to false. More
+                        info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                      type: boolean
+                    server:
+                      description: 'server is the hostname or IP address of the NFS
+                        server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                      type: string
+                  required:
+                  - server
+                  - path
+                  type: object
+                persistentVolumeClaim:
+                  description: 'persistentVolumeClaimVolumeSource represents a reference
+                    to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                  properties:
+                    claimName:
+                      description: 'claimName is the name of a PersistentVolumeClaim
+                        in the same namespace as the pod using this volume. More info:
+                        https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                      type: string
+                    readOnly:
+                      description: readOnly Will force the ReadOnly setting in VolumeMounts.
+                        Default false.
+                      type: boolean
+                  required:
+                  - claimName
+                  type: object
+                photonPersistentDisk:
+                  description: photonPersistentDisk represents a PhotonController
+                    persistent disk attached and mounted on kubelets host machine
+                  properties:
+                    fsType:
+                      description: fsType is the filesystem type to mount. Must be
+                        a filesystem type supported by the host operating system.
+                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                        if unspecified.
+                      type: string
+                    pdID:
+                      description: pdID is the ID that identifies Photon Controller
+                        persistent disk
+                      type: string
+                  required:
+                  - pdID
+                  type: object
+                portworxVolume:
+                  description: portworxVolume represents a portworx volume attached
+                    and mounted on kubelets host machine
+                  properties:
+                    fsType:
+                      description: fSType represents the filesystem type to mount
+                        Must be a filesystem type supported by the host operating
+                        system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
+                        if unspecified.
+                      type: string
+                    readOnly:
+                      description: readOnly defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts.
+                      type: boolean
+                    volumeID:
+                      description: volumeID uniquely identifies a Portworx volume
+                      type: string
+                  required:
+                  - volumeID
+                  type: object
+                projected:
+                  description: projected items for all in one resources secrets, configmaps,
+                    and downward API
+                  properties:
+                    defaultMode:
+                      description: defaultMode are the mode bits used to set permissions
+                        on created files by default. Must be an octal value between
+                        0000 and 0777 or a decimal value between 0 and 511. YAML accepts
+                        both octal and decimal values, JSON requires decimal values
+                        for mode bits. Directories within the path are not affected
+                        by this setting. This might be in conflict with other options
+                        that affect the file mode, like fsGroup, and the result can
+                        be other mode bits set.
+                      format: int32
+                      type: integer
+                    sources:
+                      description: sources is the list of volume projections
+                      items:
+                        description: Projection that may be projected along with other
+                          supported volume types
+                        properties:
+                          configMap:
+                            description: configMap information about the configMap
+                              data to project
+                            properties:
+                              items:
+                                description: items if unspecified, each key-value
+                                  pair in the Data field of the referenced ConfigMap
+                                  will be projected into the volume as a file whose
+                                  name is the key and content is the value. If specified,
+                                  the listed keys will be projected into the specified
+                                  paths, and unlisted keys will not be present. If
+                                  a key is specified which is not present in the ConfigMap,
+                                  the volume setup will error unless it is marked
+                                  optional. Paths must be relative and may not contain
+                                  the '..' path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: 'mode is Optional: mode bits used
+                                        to set permissions on this file. Must be an
+                                        octal value between 0000 and 0777 or a decimal
+                                        value between 0 and 511. YAML accepts both
+                                        octal and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: path is the relative path of the
+                                        file to map the key to. May not be an absolute
+                                        path. May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: optional specify whether the ConfigMap
+                                  or its keys must be defined
+                                type: boolean
+                            type: object
+                          downwardAPI:
+                            description: downwardAPI information about the downwardAPI
+                              data to project
+                            properties:
+                              items:
+                                description: Items is a list of DownwardAPIVolume
+                                  file
+                                items:
+                                  description: DownwardAPIVolumeFile represents information
+                                    to create the file containing the pod field
+                                  properties:
+                                    fieldRef:
+                                      description: 'Required: Selects a field of the
+                                        pod: only annotations, labels, name and namespace
+                                        are supported.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    mode:
+                                      description: 'Optional: mode bits used to set
+                                        permissions on this file, must be an octal
+                                        value between 0000 and 0777 or a decimal value
+                                        between 0 and 511. YAML accepts both octal
+                                        and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: 'Required: Path is  the relative
+                                        path name of the file to be created. Must
+                                        not be absolute or contain the ''..'' path.
+                                        Must be utf-8 encoded. The first item of the
+                                        relative path must not start with ''..'''
+                                      type: string
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, requests.cpu and requests.memory)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                  required:
+                                  - path
+                                  type: object
+                                type: array
+                            type: object
+                          secret:
+                            description: secret information about the secret data
+                              to project
+                            properties:
+                              items:
+                                description: items if unspecified, each key-value
+                                  pair in the Data field of the referenced Secret
+                                  will be projected into the volume as a file whose
+                                  name is the key and content is the value. If specified,
+                                  the listed keys will be projected into the specified
+                                  paths, and unlisted keys will not be present. If
+                                  a key is specified which is not present in the Secret,
+                                  the volume setup will error unless it is marked
+                                  optional. Paths must be relative and may not contain
+                                  the '..' path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: 'mode is Optional: mode bits used
+                                        to set permissions on this file. Must be an
+                                        octal value between 0000 and 0777 or a decimal
+                                        value between 0 and 511. YAML accepts both
+                                        octal and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: path is the relative path of the
+                                        file to map the key to. May not be an absolute
+                                        path. May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: optional field specify whether the Secret
+                                  or its key must be defined
+                                type: boolean
+                            type: object
+                          serviceAccountToken:
+                            description: serviceAccountToken is information about
+                              the serviceAccountToken data to project
+                            properties:
+                              audience:
+                                description: audience is the intended audience of
+                                  the token. A recipient of a token must identify
+                                  itself with an identifier specified in the audience
+                                  of the token, and otherwise should reject the token.
+                                  The audience defaults to the identifier of the apiserver.
+                                type: string
+                              expirationSeconds:
+                                description: expirationSeconds is the requested duration
+                                  of validity of the service account token. As the
+                                  token approaches expiration, the kubelet volume
+                                  plugin will proactively rotate the service account
+                                  token. The kubelet will start trying to rotate the
+                                  token if the token is older than 80 percent of its
+                                  time to live or if the token is older than 24 hours.Defaults
+                                  to 1 hour and must be at least 10 minutes.
+                                format: int64
+                                type: integer
+                              path:
+                                description: path is the path relative to the mount
+                                  point of the file to project the token into.
+                                type: string
+                            required:
+                            - path
+                            type: object
+                        type: object
+                      type: array
+                  type: object
+                quobyte:
+                  description: quobyte represents a Quobyte mount on the host that
+                    shares a pod's lifetime
+                  properties:
+                    group:
+                      description: group to map volume access to Default is no group
+                      type: string
+                    readOnly:
+                      description: readOnly here will force the Quobyte volume to
+                        be mounted with read-only permissions. Defaults to false.
+                      type: boolean
+                    registry:
+                      description: registry represents a single or multiple Quobyte
+                        Registry services specified as a string as host:port pair
+                        (multiple entries are separated with commas) which acts as
+                        the central registry for volumes
+                      type: string
+                    tenant:
+                      description: tenant owning the given Quobyte volume in the Backend
+                        Used with dynamically provisioned Quobyte volumes, value is
+                        set by the plugin
+                      type: string
+                    user:
+                      description: user to map volume access to Defaults to serivceaccount
+                        user
+                      type: string
+                    volume:
+                      description: volume is a string that references an already created
+                        Quobyte volume by name.
+                      type: string
+                  required:
+                  - registry
+                  - volume
+                  type: object
+                rbd:
+                  description: 'rbd represents a Rados Block Device mount on the host
+                    that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                  properties:
+                    fsType:
+                      description: 'fsType is the filesystem type of the volume that
+                        you want to mount. Tip: Ensure that the filesystem type is
+                        supported by the host operating system. Examples: "ext4",
+                        "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                      type: string
+                    image:
+                      description: 'image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      type: string
+                    keyring:
+                      description: 'keyring is the path to key ring for RBDUser. Default
+                        is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      type: string
+                    monitors:
+                      description: 'monitors is a collection of Ceph monitors. More
+                        info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      items:
+                        type: string
+                      type: array
+                    pool:
+                      description: 'pool is the rados pool name. Default is rbd. More
+                        info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      type: string
+                    readOnly:
+                      description: 'readOnly here will force the ReadOnly setting
+                        in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      type: boolean
+                    secretRef:
+                      description: 'secretRef is name of the authentication secret
+                        for RBDUser. If provided overrides keyring. Default is nil.
+                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    user:
+                      description: 'user is the rados user name. Default is admin.
+                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      type: string
+                  required:
+                  - monitors
+                  - image
+                  type: object
+                scaleIO:
+                  description: scaleIO represents a ScaleIO persistent volume attached
+                    and mounted on Kubernetes nodes.
+                  properties:
+                    fsType:
+                      description: fsType is the filesystem type to mount. Must be
+                        a filesystem type supported by the host operating system.
+                        Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                      type: string
+                    gateway:
+                      description: gateway is the host address of the ScaleIO API
+                        Gateway.
+                      type: string
+                    protectionDomain:
+                      description: protectionDomain is the name of the ScaleIO Protection
+                        Domain for the configured storage.
+                      type: string
+                    readOnly:
+                      description: readOnly Defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts.
+                      type: boolean
+                    secretRef:
+                      description: secretRef references to the secret for ScaleIO
+                        user and other sensitive information. If this is not provided,
+                        Login operation will fail.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    sslEnabled:
+                      description: sslEnabled Flag enable/disable SSL communication
+                        with Gateway, default false
+                      type: boolean
+                    storageMode:
+                      description: storageMode indicates whether the storage for a
+                        volume should be ThickProvisioned or ThinProvisioned. Default
+                        is ThinProvisioned.
+                      type: string
+                    storagePool:
+                      description: storagePool is the ScaleIO Storage Pool associated
+                        with the protection domain.
+                      type: string
+                    system:
+                      description: system is the name of the storage system as configured
+                        in ScaleIO.
+                      type: string
+                    volumeName:
+                      description: volumeName is the name of a volume already created
+                        in the ScaleIO system that is associated with this volume
+                        source.
+                      type: string
+                  required:
+                  - gateway
+                  - system
+                  - secretRef
+                  type: object
+                secret:
+                  description: 'secret represents a secret that should populate this
+                    volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                  properties:
+                    defaultMode:
+                      description: 'defaultMode is Optional: mode bits used to set
+                        permissions on created files by default. Must be an octal
+                        value between 0000 and 0777 or a decimal value between 0 and
+                        511. YAML accepts both octal and decimal values, JSON requires
+                        decimal values for mode bits. Defaults to 0644. Directories
+                        within the path are not affected by this setting. This might
+                        be in conflict with other options that affect the file mode,
+                        like fsGroup, and the result can be other mode bits set.'
+                      format: int32
+                      type: integer
+                    items:
+                      description: items If unspecified, each key-value pair in the
+                        Data field of the referenced Secret will be projected into
+                        the volume as a file whose name is the key and content is
+                        the value. If specified, the listed keys will be projected
+                        into the specified paths, and unlisted keys will not be present.
+                        If a key is specified which is not present in the Secret,
+                        the volume setup will error unless it is marked optional.
+                        Paths must be relative and may not contain the '..' path or
+                        start with '..'.
+                      items:
+                        description: Maps a string key to a path within a volume.
+                        properties:
+                          key:
+                            description: key is the key to project.
+                            type: string
+                          mode:
+                            description: 'mode is Optional: mode bits used to set
+                              permissions on this file. Must be an octal value between
+                              0000 and 0777 or a decimal value between 0 and 511.
+                              YAML accepts both octal and decimal values, JSON requires
+                              decimal values for mode bits. If not specified, the
+                              volume defaultMode will be used. This might be in conflict
+                              with other options that affect the file mode, like fsGroup,
+                              and the result can be other mode bits set.'
+                            format: int32
+                            type: integer
+                          path:
+                            description: path is the relative path of the file to
+                              map the key to. May not be an absolute path. May not
+                              contain the path element '..'. May not start with the
+                              string '..'.
+                            type: string
+                        required:
+                        - key
+                        - path
+                        type: object
+                      type: array
+                    optional:
+                      description: optional field specify whether the Secret or its
+                        keys must be defined
+                      type: boolean
+                    secretName:
+                      description: 'secretName is the name of the secret in the pod''s
+                        namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                      type: string
+                  type: object
+                storageos:
+                  description: storageOS represents a StorageOS volume attached and
+                    mounted on Kubernetes nodes.
+                  properties:
+                    fsType:
+                      description: fsType is the filesystem type to mount. Must be
+                        a filesystem type supported by the host operating system.
+                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                        if unspecified.
+                      type: string
+                    readOnly:
+                      description: readOnly defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts.
+                      type: boolean
+                    secretRef:
+                      description: secretRef specifies the secret to use for obtaining
+                        the StorageOS API credentials.  If not specified, default
+                        values will be attempted.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    volumeName:
+                      description: volumeName is the human-readable name of the StorageOS
+                        volume.  Volume names are only unique within a namespace.
+                      type: string
+                    volumeNamespace:
+                      description: volumeNamespace specifies the scope of the volume
+                        within StorageOS.  If no namespace is specified then the Pod's
+                        namespace will be used.  This allows the Kubernetes name scoping
+                        to be mirrored within StorageOS for tighter integration. Set
+                        VolumeName to any name to override the default behaviour.
+                        Set to "default" if you are not using namespaces within StorageOS.
+                        Namespaces that do not pre-exist within StorageOS will be
+                        created.
+                      type: string
+                  type: object
+                vsphereVolume:
+                  description: vsphereVolume represents a vSphere volume attached
+                    and mounted on kubelets host machine
+                  properties:
+                    fsType:
+                      description: fsType is filesystem type to mount. Must be a filesystem
+                        type supported by the host operating system. Ex. "ext4", "xfs",
+                        "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                      type: string
+                    storagePolicyID:
+                      description: storagePolicyID is the storage Policy Based Management
+                        (SPBM) profile ID associated with the StoragePolicyName.
+                      type: string
+                    storagePolicyName:
+                      description: storagePolicyName is the storage Policy Based Management
+                        (SPBM) profile name.
+                      type: string
+                    volumePath:
+                      description: volumePath is the path that identifies vSphere
+                        volume vmdk
+                      type: string
+                  required:
+                  - volumePath
+                  type: object
+              required:
+              - name
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - name
+            x-kubernetes-list-type: map
+        required:
+        - containers
+        type: object
+      status:
+        description: 'Most recently observed status of the pod. This data may not
+          be up to date. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+        properties:
+          conditions:
+            description: 'Current service state of pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions'
+            items:
+              description: PodCondition contains details for the current condition
+                of this pod.
+              properties:
+                lastProbeTime:
+                  description: Last time we probed the condition.
+                  format: date-time
+                  type: string
+                lastTransitionTime:
+                  description: Last time the condition transitioned from one status
+                    to another.
+                  format: date-time
+                  type: string
+                message:
+                  description: Human-readable message indicating details about last
+                    transition.
+                  type: string
+                reason:
+                  description: Unique, one-word, CamelCase reason for the condition's
+                    last transition.
+                  type: string
+                status:
+                  description: 'Status is the status of the condition. Can be True,
+                    False, Unknown. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions'
+                  type: string
+                type:
+                  description: 'Type is the type of the condition. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions'
+                  type: string
+              required:
+              - status
+              - type
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - type
+            x-kubernetes-list-type: map
+          containerStatuses:
+            description: 'The list has one entry per container in the manifest. More
+              info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status'
+            items:
+              description: ContainerStatus contains details for the current status
+                of this container.
+              properties:
+                containerID:
+                  description: Container's ID in the format '<type>://<container_id>'.
+                  type: string
+                image:
+                  description: 'The image the container is running. More info: https://kubernetes.io/docs/concepts/containers/images.'
+                  type: string
+                imageID:
+                  description: ImageID of the container's image.
+                  type: string
+                lastState:
+                  description: Details about the container's last termination condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format '<type>://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+                name:
+                  description: This must be a DNS_LABEL. Each container in a pod must
+                    have a unique name. Cannot be updated.
+                  type: string
+                ready:
+                  description: Specifies whether the container has passed its readiness
+                    probe.
+                  type: boolean
+                restartCount:
+                  description: The number of times the container has been restarted.
+                  format: int32
+                  type: integer
+                started:
+                  description: Specifies whether the container has passed its startup
+                    probe. Initialized as false, becomes true after startupProbe is
+                    considered successful. Resets to false when the container is restarted,
+                    or if kubelet loses state temporarily. Is always true when no
+                    startupProbe is defined.
+                  type: boolean
+                state:
+                  description: Details about the container's current condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format '<type>://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+              required:
+              - name
+              - ready
+              - restartCount
+              - image
+              - imageID
+              type: object
+            type: array
+          ephemeralContainerStatuses:
+            description: Status for any ephemeral containers that have run in this
+              pod.
+            items:
+              description: ContainerStatus contains details for the current status
+                of this container.
+              properties:
+                containerID:
+                  description: Container's ID in the format '<type>://<container_id>'.
+                  type: string
+                image:
+                  description: 'The image the container is running. More info: https://kubernetes.io/docs/concepts/containers/images.'
+                  type: string
+                imageID:
+                  description: ImageID of the container's image.
+                  type: string
+                lastState:
+                  description: Details about the container's last termination condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format '<type>://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+                name:
+                  description: This must be a DNS_LABEL. Each container in a pod must
+                    have a unique name. Cannot be updated.
+                  type: string
+                ready:
+                  description: Specifies whether the container has passed its readiness
+                    probe.
+                  type: boolean
+                restartCount:
+                  description: The number of times the container has been restarted.
+                  format: int32
+                  type: integer
+                started:
+                  description: Specifies whether the container has passed its startup
+                    probe. Initialized as false, becomes true after startupProbe is
+                    considered successful. Resets to false when the container is restarted,
+                    or if kubelet loses state temporarily. Is always true when no
+                    startupProbe is defined.
+                  type: boolean
+                state:
+                  description: Details about the container's current condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format '<type>://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+              required:
+              - name
+              - ready
+              - restartCount
+              - image
+              - imageID
+              type: object
+            type: array
+          hostIP:
+            description: IP address of the host to which the pod is assigned. Empty
+              if not yet scheduled.
+            type: string
+          initContainerStatuses:
+            description: 'The list has one entry per init container in the manifest.
+              The most recent successful init container will have ready = true, the
+              most recently started container will have startTime set. More info:
+              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status'
+            items:
+              description: ContainerStatus contains details for the current status
+                of this container.
+              properties:
+                containerID:
+                  description: Container's ID in the format '<type>://<container_id>'.
+                  type: string
+                image:
+                  description: 'The image the container is running. More info: https://kubernetes.io/docs/concepts/containers/images.'
+                  type: string
+                imageID:
+                  description: ImageID of the container's image.
+                  type: string
+                lastState:
+                  description: Details about the container's last termination condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format '<type>://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+                name:
+                  description: This must be a DNS_LABEL. Each container in a pod must
+                    have a unique name. Cannot be updated.
+                  type: string
+                ready:
+                  description: Specifies whether the container has passed its readiness
+                    probe.
+                  type: boolean
+                restartCount:
+                  description: The number of times the container has been restarted.
+                  format: int32
+                  type: integer
+                started:
+                  description: Specifies whether the container has passed its startup
+                    probe. Initialized as false, becomes true after startupProbe is
+                    considered successful. Resets to false when the container is restarted,
+                    or if kubelet loses state temporarily. Is always true when no
+                    startupProbe is defined.
+                  type: boolean
+                state:
+                  description: Details about the container's current condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format '<type>://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+              required:
+              - name
+              - ready
+              - restartCount
+              - image
+              - imageID
+              type: object
+            type: array
+          message:
+            description: A human readable message indicating details about why the
+              pod is in this condition.
+            type: string
+          nominatedNodeName:
+            description: nominatedNodeName is set only when this pod preempts other
+              pods on the node, but it cannot be scheduled right away as preemption
+              victims receive their graceful termination periods. This field does
+              not guarantee that the pod will be scheduled on this node. Scheduler
+              may decide to place the pod elsewhere if other nodes become available
+              sooner. Scheduler may also decide to give the resources on this node
+              to a higher priority pod that is created after preemption. As a result,
+              this field may be different than PodSpec.nodeName when the pod is scheduled.
+            type: string
+          phase:
+            description: |-
+              The phase of a Pod is a simple, high-level summary of where the Pod is in its lifecycle. The conditions array, the reason and message fields, and the individual container status arrays contain more detail about the pod's status. There are five possible phase values:
+
+              Pending: The pod has been accepted by the Kubernetes system, but one or more of the container images has not been created. This includes time before being scheduled as well as time spent downloading images over the network, which could take a while. Running: The pod has been bound to a node, and all of the containers have been created. At least one container is still running, or is in the process of starting or restarting. Succeeded: All containers in the pod have terminated in success, and will not be restarted. Failed: All containers in the pod have terminated, and at least one container has terminated in failure. The container either exited with non-zero status or was terminated by the system. Unknown: For some reason the state of the pod could not be obtained, typically due to an error in communicating with the host of the pod.
+
+              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-phase
+
+              Possible enum values:
+               - `"Failed"` means that all containers in the pod have terminated, and at least one container has terminated in a failure (exited with a non-zero exit code or was stopped by the system).
+               - `"Pending"` means the pod has been accepted by the system, but one or more of the containers has not been started. This includes time before being bound to a node, as well as time spent pulling images onto the host.
+               - `"Running"` means the pod has been bound to a node and all of the containers have been started. At least one container is still running or is in the process of being restarted.
+               - `"Succeeded"` means that all containers in the pod have voluntarily terminated with a container exit code of 0, and the system is not going to restart any of these containers.
+               - `"Unknown"` means that for some reason the state of the pod could not be obtained, typically due to an error in communicating with the host of the pod. Deprecated: It isn't being set since 2015 (74da3b14b0c0f658b3bb8d2def5094686d0e9095)
+            type: string
+          podIP:
+            description: IP address allocated to the pod. Routable at least within
+              the cluster. Empty if not yet allocated.
+            type: string
+          podIPs:
+            description: podIPs holds the IP addresses allocated to the pod. If this
+              field is specified, the 0th entry must match the podIP field. Pods may
+              be allocated at most 1 value for each of IPv4 and IPv6. This list is
+              empty if no IPs have been allocated yet.
+            items:
+              description: "IP address information for entries in the (plural) PodIPs
+                field. Each entry includes:\n\n\tIP: An IP address allocated to the
+                pod. Routable at least within the cluster."
+              properties:
+                ip:
+                  description: ip is an IP address (IPv4 or IPv6) assigned to the
+                    pod
+                  type: string
+              required:
+              - ip
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - ip
+            x-kubernetes-list-type: map
+          qosClass:
+            description: |-
+              The Quality of Service (QOS) classification assigned to the pod based on resource requirements See PodQOSClass type for available QOS classes More info: https://git.k8s.io/community/contributors/design-proposals/node/resource-qos.md
+
+              Possible enum values:
+               - `"BestEffort"` is the BestEffort qos class.
+               - `"Burstable"` is the Burstable qos class.
+               - `"Guaranteed"` is the Guaranteed qos class.
+            type: string
+          reason:
+            description: A brief CamelCase message indicating details about why the
+              pod is in this state. e.g. 'Evicted'
+            type: string
+          startTime:
+            description: RFC 3339 date and time at which the object was acknowledged
+              by the Kubelet. This is before the Kubelet pulled the container image(s)
+              for the pod.
+            format: date-time
+            type: string
+        type: object
+    type: object
+  plural: pods
+  scope: Namespaced
+  shortNames:
+  - po
+  singular: pod
+  subResources:
+  - name: status

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/3-NegotiatedAPIResource-services.v1.core.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/3-NegotiatedAPIResource-services.v1.core.yaml
@@ -1,0 +1,416 @@
+apiVersion: apiresource.kcp.io/v1alpha1
+kind: NegotiatedAPIResource
+metadata:
+  annotations:
+    apiresource.kcp.io/apiVersion: v1
+    kcp.io/cluster: br3qimk2t1o3jb70
+  creationTimestamp: "2023-03-21T17:10:09Z"
+  generation: 1
+  name: services.v1.core
+  resourceVersion: "9142"
+  uid: 00122015-6a42-4004-a98b-b226b4f9c290
+spec:
+  categories:
+  - all
+  groupVersion:
+    version: v1
+  kind: Service
+  listKind: ServiceList
+  openAPIV3Schema:
+    description: Service is a named abstraction of software service (for example,
+      mysql) consisting of local port (for example 3306) that the proxy listens on,
+      and the selector that determines which pods will answer requests sent through
+      the proxy.
+    properties:
+      apiVersion:
+        description: 'APIVersion defines the versioned schema of this representation
+          of an object. Servers should convert recognized schemas to the latest internal
+          value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+        type: string
+      kind:
+        description: 'Kind is a string value representing the REST resource this object
+          represents. Servers may infer this from the endpoint the client submits
+          requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+        type: string
+      metadata:
+        type: object
+      spec:
+        description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        properties:
+          allocateLoadBalancerNodePorts:
+            description: allocateLoadBalancerNodePorts defines if NodePorts will be
+              automatically allocated for services with type LoadBalancer.  Default
+              is "true". It may be set to "false" if the cluster load-balancer does
+              not rely on NodePorts.  If the caller requests specific NodePorts (by
+              specifying a value), those requests will be respected, regardless of
+              this field. This field may only be set for services with type LoadBalancer
+              and will be cleared if the type is changed to any other type.
+            type: boolean
+          clusterIP:
+            description: 'clusterIP is the IP address of the service and is usually
+              assigned randomly. If an address is specified manually, is in-range
+              (as per system configuration), and is not in use, it will be allocated
+              to the service; otherwise creation of the service will fail. This field
+              may not be changed through updates unless the type field is also being
+              changed to ExternalName (which requires this field to be blank) or the
+              type field is being changed from ExternalName (in which case this field
+              may optionally be specified, as describe above).  Valid values are "None",
+              empty string (""), or a valid IP address. Setting this to "None" makes
+              a "headless service" (no virtual IP), which is useful when direct endpoint
+              connections are preferred and proxying is not required.  Only applies
+              to types ClusterIP, NodePort, and LoadBalancer. If this field is specified
+              when creating a Service of type ExternalName, creation will fail. This
+              field will be wiped when updating a Service to type ExternalName. More
+              info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+            type: string
+          clusterIPs:
+            description: |-
+              ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address.  Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value.
+
+              This field may hold a maximum of two entries (dual-stack IPs, in either order). These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+            items:
+              type: string
+            type: array
+            x-kubernetes-list-type: atomic
+          externalIPs:
+            description: externalIPs is a list of IP addresses for which nodes in
+              the cluster will also accept traffic for this service.  These IPs are
+              not managed by Kubernetes.  The user is responsible for ensuring that
+              traffic arrives at a node with this IP.  A common example is external
+              load-balancers that are not part of the Kubernetes system.
+            items:
+              type: string
+            type: array
+          externalName:
+            description: externalName is the external reference that discovery mechanisms
+              will return as an alias for this service (e.g. a DNS CNAME record).
+              No proxying will be involved.  Must be a lowercase RFC-1123 hostname
+              (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
+            type: string
+          externalTrafficPolicy:
+            description: |-
+              externalTrafficPolicy describes how nodes distribute service traffic they receive on one of the Service's "externally-facing" addresses (NodePorts, ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure the service in a way that assumes that external load balancers will take care of balancing the service traffic between nodes, and so each node will deliver traffic only to the node-local endpoints of the service, without masquerading the client source IP. (Traffic mistakenly sent to a node with no endpoints will be dropped.) The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features). Note that traffic sent to an External IP or LoadBalancer IP from within the cluster will always get "Cluster" semantics, but clients sending to a NodePort from within the cluster may need to take traffic policy into account when picking a node.
+
+              Possible enum values:
+               - `"Cluster"` routes traffic to all endpoints.
+               - `"Local"` preserves the source IP of the traffic by routing only to endpoints on the same node as the traffic was received on (dropping the traffic if there are no local endpoints).
+            type: string
+          healthCheckNodePort:
+            description: healthCheckNodePort specifies the healthcheck nodePort for
+              the service. This only applies when type is set to LoadBalancer and
+              externalTrafficPolicy is set to Local. If a value is specified, is in-range,
+              and is not in use, it will be used.  If not specified, a value will
+              be automatically allocated.  External systems (e.g. load-balancers)
+              can use this port to determine if a given node holds endpoints for this
+              service or not.  If this field is specified when creating a Service
+              which does not need it, creation will fail. This field will be wiped
+              when updating a Service to no longer need it (e.g. changing type). This
+              field cannot be updated once set.
+            format: int32
+            type: integer
+          internalTrafficPolicy:
+            description: InternalTrafficPolicy describes how nodes distribute service
+              traffic they receive on the ClusterIP. If set to "Local", the proxy
+              will assume that pods only want to talk to endpoints of the service
+              on the same node as the pod, dropping the traffic if there are no local
+              endpoints. The default value, "Cluster", uses the standard behavior
+              of routing to all endpoints evenly (possibly modified by topology and
+              other features).
+            type: string
+          ipFamilies:
+            description: |-
+              IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service. This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail. This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service. Valid values are "IPv4" and "IPv6".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to "headless" services. This field will be wiped when updating a Service to type ExternalName.
+
+              This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field.
+            items:
+              type: string
+            type: array
+            x-kubernetes-list-type: atomic
+          ipFamilyPolicy:
+            description: IPFamilyPolicy represents the dual-stack-ness requested or
+              required by this Service. If there is no value provided, then this field
+              will be set to SingleStack. Services can be "SingleStack" (a single
+              IP family), "PreferDualStack" (two IP families on dual-stack configured
+              clusters or a single IP family on single-stack clusters), or "RequireDualStack"
+              (two IP families on dual-stack configured clusters, otherwise fail).
+              The ipFamilies and clusterIPs fields depend on the value of this field.
+              This field will be wiped when updating a service to type ExternalName.
+            type: string
+          loadBalancerClass:
+            description: loadBalancerClass is the class of the load balancer implementation
+              this Service belongs to. If specified, the value of this field must
+              be a label-style identifier, with an optional prefix, e.g. "internal-vip"
+              or "example.com/internal-vip". Unprefixed names are reserved for end-users.
+              This field can only be set when the Service type is 'LoadBalancer'.
+              If not set, the default load balancer implementation is used, today
+              this is typically done through the cloud provider integration, but should
+              apply for any default implementation. If set, it is assumed that a load
+              balancer implementation is watching for Services with a matching class.
+              Any default load balancer implementation (e.g. cloud providers) should
+              ignore Services that set this field. This field can only be set when
+              creating or updating a Service to type 'LoadBalancer'. Once set, it
+              can not be changed. This field will be wiped when a service is updated
+              to a non 'LoadBalancer' type.
+            type: string
+          loadBalancerIP:
+            description: 'Only applies to Service Type: LoadBalancer. This feature
+              depends on whether the underlying cloud-provider supports specifying
+              the loadBalancerIP when a load balancer is created. This field will
+              be ignored if the cloud-provider does not support the feature. Deprecated:
+              This field was under-specified and its meaning varies across implementations,
+              and it cannot support dual-stack. As of Kubernetes v1.24, users are
+              encouraged to use implementation-specific annotations when available.
+              This field may be removed in a future API version.'
+            type: string
+          loadBalancerSourceRanges:
+            description: 'If specified and supported by the platform, this will restrict
+              traffic through the cloud-provider load-balancer will be restricted
+              to the specified client IPs. This field will be ignored if the cloud-provider
+              does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/'
+            items:
+              type: string
+            type: array
+          ports:
+            description: 'The list of ports that are exposed by this service. More
+              info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+            items:
+              description: ServicePort contains information on service's port.
+              properties:
+                appProtocol:
+                  description: The application protocol for this port. This field
+                    follows standard Kubernetes label syntax. Un-prefixed names are
+                    reserved for IANA standard service names (as per RFC-6335 and
+                    https://www.iana.org/assignments/service-names). Non-standard
+                    protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+                  type: string
+                name:
+                  description: The name of this port within the service. This must
+                    be a DNS_LABEL. All ports within a ServiceSpec must have unique
+                    names. When considering the endpoints for a Service, this must
+                    match the 'name' field in the EndpointPort. Optional if only one
+                    ServicePort is defined on this service.
+                  type: string
+                nodePort:
+                  description: 'The port on each node on which this service is exposed
+                    when type is NodePort or LoadBalancer.  Usually assigned by the
+                    system. If a value is specified, in-range, and not in use it will
+                    be used, otherwise the operation will fail.  If not specified,
+                    a port will be allocated if this Service requires one.  If this
+                    field is specified when creating a Service which does not need
+                    it, creation will fail. This field will be wiped when updating
+                    a Service to no longer need it (e.g. changing type from NodePort
+                    to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                  format: int32
+                  type: integer
+                port:
+                  description: The port that will be exposed by this service.
+                  format: int32
+                  type: integer
+                protocol:
+                  default: TCP
+                  description: |-
+                    The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+
+                    Possible enum values:
+                     - `"SCTP"` is the SCTP protocol.
+                     - `"TCP"` is the TCP protocol.
+                     - `"UDP"` is the UDP protocol.
+                  type: string
+                targetPort:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: 'Number or name of the port to access on the pods targeted
+                    by the service. Number must be in the range 1 to 65535. Name must
+                    be an IANA_SVC_NAME. If this is a string, it will be looked up
+                    as a named port in the target Pod''s container ports. If this
+                    is not specified, the value of the ''port'' field is used (an
+                    identity map). This field is ignored for services with clusterIP=None,
+                    and should be omitted or set equal to the ''port'' field. More
+                    info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                  x-kubernetes-int-or-string: true
+              required:
+              - port
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - port
+            - protocol
+            x-kubernetes-list-type: map
+          publishNotReadyAddresses:
+            description: publishNotReadyAddresses indicates that any agent which deals
+              with endpoints for this Service should disregard any indications of
+              ready/not-ready. The primary use case for setting this field is for
+              a StatefulSet's Headless Service to propagate SRV DNS records for its
+              Pods for the purpose of peer discovery. The Kubernetes controllers that
+              generate Endpoints and EndpointSlice resources for Services interpret
+              this to mean that all endpoints are considered "ready" even if the Pods
+              themselves are not. Agents which consume only Kubernetes generated endpoints
+              through the Endpoints or EndpointSlice resources can safely assume this
+              behavior.
+            type: boolean
+          selector:
+            additionalProperties:
+              type: string
+            description: 'Route service traffic to pods with label keys and values
+              matching this selector. If empty or not present, the service is assumed
+              to have an external process managing its endpoints, which Kubernetes
+              will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer.
+              Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+            type: object
+          sessionAffinity:
+            description: |-
+              Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+
+              Possible enum values:
+               - `"ClientIP"` is the Client IP based.
+               - `"None"` - no session affinity.
+            type: string
+          sessionAffinityConfig:
+            description: sessionAffinityConfig contains the configurations of session
+              affinity.
+            properties:
+              clientIP:
+                description: clientIP contains the configurations of Client IP based
+                  session affinity.
+                properties:
+                  timeoutSeconds:
+                    description: timeoutSeconds specifies the seconds of ClientIP
+                      type session sticky time. The value must be >0 && <=86400(for
+                      1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for
+                      3 hours).
+                    format: int32
+                    type: integer
+                type: object
+            type: object
+          type:
+            description: |-
+              type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+
+              Possible enum values:
+               - `"ClusterIP"` means a service will only be accessible inside the cluster, via the cluster IP.
+               - `"ExternalName"` means a service consists of only a reference to an external name that kubedns or equivalent will return as a CNAME record, with no exposing or proxying of any pods involved.
+               - `"LoadBalancer"` means a service will be exposed via an external load balancer (if the cloud provider supports it), in addition to 'NodePort' type.
+               - `"NodePort"` means a service will be exposed on one port of every node, in addition to 'ClusterIP' type.
+            type: string
+        type: object
+      status:
+        description: 'Most recently observed status of the service. Populated by the
+          system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+        properties:
+          conditions:
+            description: Current service state
+            items:
+              description: Condition contains details for one aspect of the current
+                state of this API Resource.
+              properties:
+                lastTransitionTime:
+                  description: lastTransitionTime is the last time the condition transitioned
+                    from one status to another. This should be when the underlying
+                    condition changed.  If that is not known, then using the time
+                    when the API field changed is acceptable.
+                  format: date-time
+                  type: string
+                message:
+                  description: message is a human readable message indicating details
+                    about the transition. This may be an empty string.
+                  type: string
+                observedGeneration:
+                  description: observedGeneration represents the .metadata.generation
+                    that the condition was set based upon. For instance, if .metadata.generation
+                    is currently 12, but the .status.conditions[x].observedGeneration
+                    is 9, the condition is out of date with respect to the current
+                    state of the instance.
+                  format: int64
+                  type: integer
+                reason:
+                  description: reason contains a programmatic identifier indicating
+                    the reason for the condition's last transition. Producers of specific
+                    condition types may define expected values and meanings for this
+                    field, and whether the values are considered a guaranteed API.
+                    The value should be a CamelCase string. This field may not be
+                    empty.
+                  type: string
+                status:
+                  description: status of the condition, one of True, False, Unknown.
+                  type: string
+                type:
+                  description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                  type: string
+              required:
+              - lastTransitionTime
+              - message
+              - reason
+              - status
+              - type
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - type
+            x-kubernetes-list-type: map
+          loadBalancer:
+            description: LoadBalancer contains the current status of the load-balancer,
+              if one is present.
+            properties:
+              ingress:
+                description: Ingress is a list containing ingress points for the load-balancer.
+                  Traffic intended for the service should be sent to these ingress
+                  points.
+                items:
+                  description: 'LoadBalancerIngress represents the status of a load-balancer
+                    ingress point: traffic intended for the service should be sent
+                    to an ingress point.'
+                  properties:
+                    hostname:
+                      description: Hostname is set for load-balancer ingress points
+                        that are DNS based (typically AWS load-balancers)
+                      type: string
+                    ip:
+                      description: IP is set for load-balancer ingress points that
+                        are IP based (typically GCE or OpenStack load-balancers)
+                      type: string
+                    ports:
+                      description: Ports is a list of records of service ports If
+                        used, every port defined in the service should have an entry
+                        in it
+                      items:
+                        properties:
+                          error:
+                            description: |-
+                              Error is to record the problem with the service port The format of the error shall comply with the following rules: - built-in error values shall be specified in this file and those shall use
+                                CamelCase names
+                              - cloud provider specific error values must have names that comply with the
+                                format foo.example.com/CamelCase.
+                            type: string
+                          port:
+                            description: Port is the port number of the service port
+                              of which status is recorded here
+                            format: int32
+                            type: integer
+                          protocol:
+                            description: |-
+                              Protocol is the protocol of the service port of which status is recorded here The supported values are: "TCP", "UDP", "SCTP"
+
+                              Possible enum values:
+                               - `"SCTP"` is the SCTP protocol.
+                               - `"TCP"` is the TCP protocol.
+                               - `"UDP"` is the UDP protocol.
+                            type: string
+                        required:
+                        - port
+                        - protocol
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  type: object
+                type: array
+            type: object
+        type: object
+    type: object
+  plural: services
+  scope: Namespaced
+  shortNames:
+  - svc
+  singular: service
+  subResources:
+  - name: status

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/3-apibinding-kubernetes.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/3-apibinding-kubernetes.yaml
@@ -1,0 +1,42 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIBinding
+metadata:
+  annotations:
+    extra.apis.kcp.io/compute.workload.kcp.io: "true"
+    kcp.io/cluster: br3qimk2t1o3jb70
+  creationTimestamp: "2023-03-21T17:05:37Z"
+  finalizers:
+  - apis.kcp.io/apibinding-finalizer
+  generation: 1
+  labels:
+    claimed.internal.apis.kcp.io/2rwzR3UC0Z0lSFUGD5EuXbE1OSTXPKljY8O67v: LstvmbbzVDDOn90ZbhzSQO5U3DMCf88h1pZ
+    internal.apis.kcp.io/export: 2rwzR3UC0Z0lSFUGD5EuXbE1OSTXPKljY8O67v
+  name: kubernetes
+  resourceVersion: "9101"
+  uid: ba26edd8-fb9c-4b85-a5e1-e662e882a8ca
+spec:
+  reference:
+    export:
+      name: kubernetes
+status:
+  apiExportClusterName: br3qimk2t1o3jb70
+  conditions:
+  - lastTransitionTime: "2023-03-21T17:05:37Z"
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2023-03-21T17:05:37Z"
+    status: "True"
+    type: APIExportValid
+  - lastTransitionTime: "2023-03-21T17:05:37Z"
+    status: "True"
+    type: BindingUpToDate
+  - lastTransitionTime: "2023-03-21T17:05:37Z"
+    status: "True"
+    type: InitialBindingCompleted
+  - lastTransitionTime: "2023-03-21T17:05:37Z"
+    status: "True"
+    type: PermissionClaimsApplied
+  - lastTransitionTime: "2023-03-21T17:05:37Z"
+    status: "True"
+    type: PermissionClaimsValid
+  phase: Bound

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/3-apiexport-kubernetes.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/3-apiexport-kubernetes.yaml
@@ -1,0 +1,29 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIExport
+metadata:
+  annotations:
+    extra.apis.kcp.io/compute.workload.kcp.io: "true"
+    kcp.io/cluster: br3qimk2t1o3jb70
+    kcp.io/path: root:kind
+    workload.kcp.io/skip-default-object-creation: "true"
+  creationTimestamp: "2023-03-21T17:05:37Z"
+  generation: 2
+  name: kubernetes
+  resourceVersion: "9098"
+  uid: 92c4a3e0-c366-466b-8474-b905d81f8fc2
+spec:
+  identity:
+    secretRef:
+      name: kubernetes
+      namespace: kcp-system
+status:
+  conditions:
+  - lastTransitionTime: "2023-03-21T17:05:37Z"
+    status: "True"
+    type: IdentityValid
+  - lastTransitionTime: "2023-03-21T17:05:37Z"
+    status: "True"
+    type: VirtualWorkspaceURLsReady
+  identityHash: 2650446b7496d5eb53a84d078251342a607b3e638c0e1477b3999b02b8fe307d
+  virtualWorkspaces:
+  - url: https://<kcp-url>:6443/services/apiexport/br3qimk2t1o3jb70/kubernetes

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/3-location-default.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/3-location-default.yaml
@@ -1,0 +1,20 @@
+apiVersion: scheduling.kcp.io/v1alpha1
+kind: Location
+metadata:
+  annotations:
+    kcp.io/cluster: br3qimk2t1o3jb70
+    kcp.io/path: root:kind
+  creationTimestamp: "2023-03-21T17:05:37Z"
+  generation: 1
+  name: default
+  resourceVersion: "9136"
+  uid: d5ecd13e-d413-4d87-a62b-c154f9156e73
+spec:
+  instanceSelector: {}
+  resource:
+    group: workload.kcp.io
+    resource: synctargets
+    version: v1alpha1
+status:
+  availableInstances: 1
+  instances: 1

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/3-synctarget-kind.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/3-synctarget-kind.yaml
@@ -1,0 +1,55 @@
+apiVersion: workload.kcp.io/v1alpha1
+kind: SyncTarget
+metadata:
+  annotations:
+    kcp.io/cluster: br3qimk2t1o3jb70
+  creationTimestamp: "2023-03-21T17:05:37Z"
+  generation: 1
+  labels:
+    internal.workload.kcp.io/key: alIviEyJiysDMorx9fWmI2ygTHSTrvxXGyVwSJ
+  name: kind
+  resourceVersion: "9266"
+  uid: 8df305e7-f4f8-439f-9115-51054d519361
+spec:
+  supportedAPIExports:
+  - export: kubernetes
+    path: root:compute
+  unschedulable: false
+status:
+  conditions:
+  - lastTransitionTime: "2023-03-21T17:10:07Z"
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2023-03-21T17:10:07Z"
+    status: "True"
+    type: HeartbeatHealthy
+  - lastTransitionTime: "2023-03-21T17:10:07Z"
+    status: "True"
+    type: SyncerAuthorized
+  lastSyncerHeartbeatTime: "2023-03-21T17:19:07Z"
+  syncedResources:
+  - identityHash: <id-hash>
+    resource: services
+    state: Accepted
+    versions:
+    - v1
+  - identityHash: <id-hash>
+    resource: pods
+    state: Accepted
+    versions:
+    - v1
+  - group: networking.k8s.io
+    identityHash: <id-hash>
+    resource: ingresses
+    state: Accepted
+    versions:
+    - v1
+  - group: apps
+    identityHash: <id-hash>
+    resource: deployments
+    state: Accepted
+    versions:
+    - v1
+  virtualWorkspaces:
+  - syncerURL: https://<kcp-url>:6443/services/syncer/br3qimk2t1o3jb70/kind/8df305e7-f4f8-439f-9115-51054d519361
+    upsyncerURL: https://<kcp-url>:6443/services/upsyncer/br3qimk2t1o3jb70/kind/8df305e7-f4f8-439f-9115-51054d519361

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/3-synctarget-kind.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/3-synctarget-kind.yaml
@@ -28,24 +28,24 @@ status:
     type: SyncerAuthorized
   lastSyncerHeartbeatTime: "2023-03-21T17:19:07Z"
   syncedResources:
-  - identityHash: <id-hash>
+  - identityHash: 1215a6f9c5bad3a00c7af77b1bd715f81357d9238b1f4d2968b0a23cb3412217
     resource: services
     state: Accepted
     versions:
     - v1
-  - identityHash: <id-hash>
+  - identityHash: 1215a6f9c5bad3a00c7af77b1bd715f81357d9238b1f4d2968b0a23cb3412217
     resource: pods
     state: Accepted
     versions:
     - v1
   - group: networking.k8s.io
-    identityHash: <id-hash>
+    identityHash: 1215a6f9c5bad3a00c7af77b1bd715f81357d9238b1f4d2968b0a23cb3412217
     resource: ingresses
     state: Accepted
     versions:
     - v1
   - group: apps
-    identityHash: <id-hash>
+    identityHash: 1215a6f9c5bad3a00c7af77b1bd715f81357d9238b1f4d2968b0a23cb3412217
     resource: deployments
     state: Accepted
     versions:

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/4-APIResourceImport-deployments.kind.v1.apps.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/4-APIResourceImport-deployments.kind.v1.apps.yaml
@@ -1,0 +1,7132 @@
+apiVersion: apiresource.kcp.io/v1alpha1
+kind: APIResourceImport
+metadata:
+  annotations:
+    apiresource.kcp.io/apiVersion: apps/v1
+    kcp.io/cluster: br3qimk2t1o3jb70
+  creationTimestamp: "2023-03-21T17:10:10Z"
+  generation: 1
+  name: deployments.kind.v1.apps
+  ownerReferences:
+  - apiVersion: workload.kcp.io/v1alpha1
+    controller: true
+    kind: SyncTarget
+    name: kind
+    uid: 8df305e7-f4f8-439f-9115-51054d519361
+  resourceVersion: "9155"
+  uid: 7ccaf56d-a031-477a-92f3-1ab9c5c8acfb
+spec:
+  categories:
+  - all
+  groupVersion:
+    group: apps
+    version: v1
+  kind: Deployment
+  listKind: DeploymentList
+  location: kind
+  openAPIV3Schema:
+    description: Deployment enables declarative updates for Pods and ReplicaSets.
+    properties:
+      apiVersion:
+        description: 'APIVersion defines the versioned schema of this representation
+          of an object. Servers should convert recognized schemas to the latest internal
+          value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+        type: string
+      kind:
+        description: 'Kind is a string value representing the REST resource this object
+          represents. Servers may infer this from the endpoint the client submits
+          requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+        type: string
+      metadata:
+        type: object
+      spec:
+        description: Specification of the desired behavior of the Deployment.
+        properties:
+          minReadySeconds:
+            description: Minimum number of seconds for which a newly created pod should
+              be ready without any of its container crashing, for it to be considered
+              available. Defaults to 0 (pod will be considered available as soon as
+              it is ready)
+            format: int32
+            type: integer
+          paused:
+            description: Indicates that the deployment is paused.
+            type: boolean
+          progressDeadlineSeconds:
+            description: The maximum time in seconds for a deployment to make progress
+              before it is considered to be failed. The deployment controller will
+              continue to process failed deployments and a condition with a ProgressDeadlineExceeded
+              reason will be surfaced in the deployment status. Note that progress
+              will not be estimated during the time a deployment is paused. Defaults
+              to 600s.
+            format: int32
+            type: integer
+          replicas:
+            description: Number of desired pods. This is a pointer to distinguish
+              between explicit zero and not specified. Defaults to 1.
+            format: int32
+            type: integer
+          revisionHistoryLimit:
+            description: The number of old ReplicaSets to retain to allow rollback.
+              This is a pointer to distinguish between explicit zero and not specified.
+              Defaults to 10.
+            format: int32
+            type: integer
+          selector:
+            description: Label selector for pods. Existing ReplicaSets whose pods
+              are selected by this will be the ones affected by this deployment. It
+              must match the pod template's labels.
+            properties:
+              matchExpressions:
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
+                items:
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
+                  properties:
+                    key:
+                      description: key is the label key that the selector applies
+                        to.
+                      type: string
+                    operator:
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      type: string
+                    values:
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - key
+                  - operator
+                  type: object
+                type: array
+              matchLabels:
+                additionalProperties:
+                  type: string
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
+                type: object
+            type: object
+          strategy:
+            description: The deployment strategy to use to replace existing pods with
+              new ones.
+            properties:
+              rollingUpdate:
+                description: Rolling update config params. Present only if DeploymentStrategyType
+                  = RollingUpdate.
+                properties:
+                  maxSurge:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'The maximum number of pods that can be scheduled
+                      above the desired number of pods. Value can be an absolute number
+                      (ex: 5) or a percentage of desired pods (ex: 10%). This can
+                      not be 0 if MaxUnavailable is 0. Absolute number is calculated
+                      from percentage by rounding up. Defaults to 25%. Example: when
+                      this is set to 30%, the new ReplicaSet can be scaled up immediately
+                      when the rolling update starts, such that the total number of
+                      old and new pods do not exceed 130% of desired pods. Once old
+                      pods have been killed, new ReplicaSet can be scaled up further,
+                      ensuring that total number of pods running at any time during
+                      the update is at most 130% of desired pods.'
+                    x-kubernetes-int-or-string: true
+                  maxUnavailable:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'The maximum number of pods that can be unavailable
+                      during the update. Value can be an absolute number (ex: 5) or
+                      a percentage of desired pods (ex: 10%). Absolute number is calculated
+                      from percentage by rounding down. This can not be 0 if MaxSurge
+                      is 0. Defaults to 25%. Example: when this is set to 30%, the
+                      old ReplicaSet can be scaled down to 70% of desired pods immediately
+                      when the rolling update starts. Once new pods are ready, old
+                      ReplicaSet can be scaled down further, followed by scaling up
+                      the new ReplicaSet, ensuring that the total number of pods available
+                      at all times during the update is at least 70% of desired pods.'
+                    x-kubernetes-int-or-string: true
+                type: object
+              type:
+                description: |-
+                  Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+
+                  Possible enum values:
+                   - `"Recreate"` Kill all existing pods before creating new ones.
+                   - `"RollingUpdate"` Replace the old ReplicaSets by new one using rolling update i.e gradually scale down the old ReplicaSets and scale up the new one.
+                type: string
+            type: object
+          template:
+            description: Template describes the pods that will be created.
+            properties:
+              metadata:
+                description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              spec:
+                description: 'Specification of the desired behavior of the pod. More
+                  info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                properties:
+                  activeDeadlineSeconds:
+                    description: Optional duration in seconds the pod may be active
+                      on the node relative to StartTime before the system will actively
+                      try to mark it failed and kill associated containers. Value
+                      must be a positive integer.
+                    format: int64
+                    type: integer
+                  affinity:
+                    description: If specified, the pod's scheduling constraints
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for
+                          the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node matches the corresponding matchExpressions;
+                              the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches
+                                all objects with implicit weight 0 (i.e. it's a no-op).
+                                A null preferred scheduling term matches no objects
+                                (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                              Possible enum values:
+                                               - `"DoesNotExist"`
+                                               - `"Exists"`
+                                               - `"Gt"`
+                                               - `"In"`
+                                               - `"Lt"`
+                                               - `"NotIn"`
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                              Possible enum values:
+                                               - `"DoesNotExist"`
+                                               - `"Exists"`
+                                               - `"Gt"`
+                                               - `"In"`
+                                               - `"Lt"`
+                                               - `"NotIn"`
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the
+                                    corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - weight
+                              - preference
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by
+                              this field are not met at scheduling time, the pod will
+                              not be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from
+                              its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term
+                                    matches no objects. The requirements of them are
+                                    ANDed. The TopologySelectorTerm type implements
+                                    a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                              Possible enum values:
+                                               - `"DoesNotExist"`
+                                               - `"Exists"`
+                                               - `"Gt"`
+                                               - `"In"`
+                                               - `"Lt"`
+                                               - `"NotIn"`
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                              Possible enum values:
+                                               - `"DoesNotExist"`
+                                               - `"Exists"`
+                                               - `"Gt"`
+                                               - `"In"`
+                                               - `"Lt"`
+                                               - `"NotIn"`
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g.
+                          co-locate this pod in the same node, zone, etc. as some
+                          other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node has pods which matches the corresponding
+                              podAffinityTerm; the node(s) with the highest sum are
+                              the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the
+                                    corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - weight
+                              - podAffinityTerm
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by
+                              this field are not met at scheduling time, the pod will
+                              not be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to a pod label update),
+                              the system may or may not try to eventually evict the
+                              pod from its node. When there are multiple elements,
+                              the lists of nodes corresponding to each podAffinityTerm
+                              are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located
+                                is defined as running on a node whose value of the
+                                label with key <topologyKey> matches that of any node
+                                on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules
+                          (e.g. avoid putting this pod in the same node, zone, etc.
+                          as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the anti-affinity expressions
+                              specified by this field, but it may choose a node that
+                              violates one or more of the expressions. The node that
+                              is most preferred is the one with the greatest sum of
+                              weights, i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              anti-affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node has pods which matches the corresponding
+                              podAffinityTerm; the node(s) with the highest sum are
+                              the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the
+                                    corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - weight
+                              - podAffinityTerm
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified
+                              by this field are not met at scheduling time, the pod
+                              will not be scheduled onto the node. If the anti-affinity
+                              requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod
+                              label update), the system may or may not try to eventually
+                              evict the pod from its node. When there are multiple
+                              elements, the lists of nodes corresponding to each podAffinityTerm
+                              are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located
+                                is defined as running on a node whose value of the
+                                label with key <topologyKey> matches that of any node
+                                on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  automountServiceAccountToken:
+                    description: AutomountServiceAccountToken indicates whether a
+                      service account token should be automatically mounted.
+                    type: boolean
+                  containers:
+                    description: List of containers belonging to the pod. Containers
+                      cannot currently be added or removed. There must be at least
+                      one container in a Pod. Cannot be updated.
+                    items:
+                      description: A single application container that you want to
+                        run within a pod.
+                      properties:
+                        args:
+                          description: 'Arguments to the entrypoint. The container
+                            image''s CMD is used if this is not provided. Variable
+                            references $(VAR_NAME) are expanded using the container''s
+                            environment. If a variable cannot be resolved, the reference
+                            in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME)
+                            syntax: i.e. "$$(VAR_NAME)" will produce the string literal
+                            "$(VAR_NAME)". Escaped references will never be expanded,
+                            regardless of whether the variable exists or not. Cannot
+                            be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: 'Entrypoint array. Not executed within a shell.
+                            The container image''s ENTRYPOINT is used if this is not
+                            provided. Variable references $(VAR_NAME) are expanded
+                            using the container''s environment. If a variable cannot
+                            be resolved, the reference in the input string will be
+                            unchanged. Double $$ are reduced to a single $, which
+                            allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                            will produce the string literal "$(VAR_NAME)". Escaped
+                            references will never be expanded, regardless of whether
+                            the variable exists or not. Cannot be updated. More info:
+                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the
+                            container. Cannot be updated.
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previously defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  Double $$ are reduced to a single $, which allows
+                                  for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                  will produce the string literal "$(VAR_NAME)". Escaped
+                                  references will never be expanded, regardless of
+                                  whether the variable exists or not. Defaults to
+                                  "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's
+                                  value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container. The keys defined within a source must
+                            be a C_IDENTIFIER. All invalid keys will be reported as
+                            an event when the container is starting. When a key exists
+                            in multiple sources, the value associated with the last
+                            source will take precedence. Values defined by an Env
+                            with a duplicate key will take precedence. Cannot be updated.
+                          items:
+                            description: EnvFromSource represents the source of a
+                              set of ConfigMaps
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must
+                                      be defined
+                                    type: boolean
+                                type: object
+                              prefix:
+                                description: An optional identifier to prepend to
+                                  each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be
+                                      defined
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                            This field is optional to allow higher level config management
+                            to default or override container images in workload controllers
+                            like Deployments and StatefulSets.'
+                          type: string
+                        imagePullPolicy:
+                          description: |-
+                            Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                            Possible enum values:
+                             - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                             - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                             - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                          type: string
+                        lifecycle:
+                          description: Actions that the management system should take
+                            in response to container lifecycle events. Cannot be updated.
+                          properties:
+                            postStart:
+                              description: 'PostStart is called immediately after
+                                a container is created. If the handler fails, the
+                                container is terminated and restarted according to
+                                its restart policy. Other management of the container
+                                blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            preStop:
+                              description: 'PreStop is called immediately before a
+                                container is terminated due to an API request or management
+                                event such as liveness/startup probe failure, preemption,
+                                resource contention, etc. The handler is not called
+                                if the container crashes or exits. The Pod''s termination
+                                grace period countdown begins before the PreStop hook
+                                is executed. Regardless of the outcome of the handler,
+                                the container will eventually terminate within the
+                                Pod''s termination grace period (unless delayed by
+                                finalizers). Other management of the container blocks
+                                until the hook completes or until the termination
+                                grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                          type: object
+                        livenessProbe:
+                          description: 'Periodic probe of container liveness. Container
+                            will be restarted if the probe fails. Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: Name of the container specified as a DNS_LABEL.
+                            Each container in a pod must have a unique name (DNS_LABEL).
+                            Cannot be updated.
+                          type: string
+                        ports:
+                          description: List of ports to expose from the container.
+                            Not specifying a port here DOES NOT prevent that port
+                            from being exposed. Any port which is listening on the
+                            default "0.0.0.0" address inside a container will be accessible
+                            from the network. Modifying this array with strategic
+                            merge patch may corrupt the data. For more information
+                            See https://github.com/kubernetes/kubernetes/issues/108255.
+                            Cannot be updated.
+                          items:
+                            description: ContainerPort represents a network port in
+                              a single container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's
+                                  IP address. This must be a valid port number, 0
+                                  < x < 65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port
+                                  to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host.
+                                  If specified, this must be a valid port number,
+                                  0 < x < 65536. If HostNetwork is specified, this
+                                  must match ContainerPort. Most containers do not
+                                  need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a
+                                  pod must have a unique name. Name for the port that
+                                  can be referred to by services.
+                                type: string
+                              protocol:
+                                default: TCP
+                                description: |-
+                                  Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                  Possible enum values:
+                                   - `"SCTP"` is the SCTP protocol.
+                                   - `"TCP"` is the TCP protocol.
+                                   - `"UDP"` is the UDP protocol.
+                                type: string
+                            required:
+                            - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - containerPort
+                          - protocol
+                          x-kubernetes-list-type: map
+                        readinessProbe:
+                          description: 'Periodic probe of container service readiness.
+                            Container will be removed from service endpoints if the
+                            probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          description: 'Compute Resources required by this container.
+                            Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        securityContext:
+                          description: 'SecurityContext defines the security options
+                            the container should be run with. If set, the fields of
+                            SecurityContext override the equivalent fields of PodSecurityContext.
+                            More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                          properties:
+                            allowPrivilegeEscalation:
+                              description: 'AllowPrivilegeEscalation controls whether
+                                a process can gain more privileges than its parent
+                                process. This bool directly controls if the no_new_privs
+                                flag will be set on the container process. AllowPrivilegeEscalation
+                                is true always when the container is: 1) run as Privileged
+                                2) has CAP_SYS_ADMIN Note that this field cannot be
+                                set when spec.os.name is windows.'
+                              type: boolean
+                            capabilities:
+                              description: The capabilities to add/drop when running
+                                containers. Defaults to the default set of capabilities
+                                granted by the container runtime. Note that this field
+                                cannot be set when spec.os.name is windows.
+                              properties:
+                                add:
+                                  description: Added capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                                drop:
+                                  description: Removed capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            privileged:
+                              description: Run container in privileged mode. Processes
+                                in privileged containers are essentially equivalent
+                                to root on the host. Defaults to false. Note that
+                                this field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            procMount:
+                              description: procMount denotes the type of proc mount
+                                to use for the containers. The default is DefaultProcMount
+                                which uses the container runtime defaults for readonly
+                                paths and masked paths. This requires the ProcMountType
+                                feature flag to be enabled. Note that this field cannot
+                                be set when spec.os.name is windows.
+                              type: string
+                            readOnlyRootFilesystem:
+                              description: Whether this container has a read-only
+                                root filesystem. Default is false. Note that this
+                                field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            runAsGroup:
+                              description: The GID to run the entrypoint of the container
+                                process. Uses runtime default if unset. May also be
+                                set in PodSecurityContext.  If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is windows.
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              description: Indicates that the container must run as
+                                a non-root user. If true, the Kubelet will validate
+                                the image at runtime to ensure that it does not run
+                                as UID 0 (root) and fail to start the container if
+                                it does. If unset or false, no such validation will
+                                be performed. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                              type: boolean
+                            runAsUser:
+                              description: The UID to run the entrypoint of the container
+                                process. Defaults to user specified in image metadata
+                                if unspecified. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name
+                                is windows.
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              description: The SELinux context to be applied to the
+                                container. If unspecified, the container runtime will
+                                allocate a random SELinux context for each container.  May
+                                also be set in PodSecurityContext.  If set in both
+                                SecurityContext and PodSecurityContext, the value
+                                specified in SecurityContext takes precedence. Note
+                                that this field cannot be set when spec.os.name is
+                                windows.
+                              properties:
+                                level:
+                                  description: Level is SELinux level label that applies
+                                    to the container.
+                                  type: string
+                                role:
+                                  description: Role is a SELinux role label that applies
+                                    to the container.
+                                  type: string
+                                type:
+                                  description: Type is a SELinux type label that applies
+                                    to the container.
+                                  type: string
+                                user:
+                                  description: User is a SELinux user label that applies
+                                    to the container.
+                                  type: string
+                              type: object
+                            seccompProfile:
+                              description: The seccomp options to use by this container.
+                                If seccomp options are provided at both the pod &
+                                container level, the container options override the
+                                pod options. Note that this field cannot be set when
+                                spec.os.name is windows.
+                              properties:
+                                localhostProfile:
+                                  description: localhostProfile indicates a profile
+                                    defined in a file on the node should be used.
+                                    The profile must be preconfigured on the node
+                                    to work. Must be a descending path, relative to
+                                    the kubelet's configured seccomp profile location.
+                                    Must only be set if type is "Localhost".
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                    Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                    Possible enum values:
+                                     - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                     - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                     - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            windowsOptions:
+                              description: The Windows specific settings applied to
+                                all containers. If unspecified, the options from the
+                                PodSecurityContext will be used. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is linux.
+                              properties:
+                                gmsaCredentialSpec:
+                                  description: GMSACredentialSpec is where the GMSA
+                                    admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                    inlines the contents of the GMSA credential spec
+                                    named by the GMSACredentialSpecName field.
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  description: GMSACredentialSpecName is the name
+                                    of the GMSA credential spec to use.
+                                  type: string
+                                hostProcess:
+                                  description: HostProcess determines if a container
+                                    should be run as a 'Host Process' container. This
+                                    field is alpha-level and will only be honored
+                                    by components that enable the WindowsHostProcessContainers
+                                    feature flag. Setting this field without the feature
+                                    flag will result in errors when validating the
+                                    Pod. All of a Pod's containers must have the same
+                                    effective HostProcess value (it is not allowed
+                                    to have a mix of HostProcess containers and non-HostProcess
+                                    containers).  In addition, if HostProcess is true
+                                    then HostNetwork must also be set to true.
+                                  type: boolean
+                                runAsUserName:
+                                  description: The UserName in Windows to run the
+                                    entrypoint of the container process. Defaults
+                                    to the user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  type: string
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: 'StartupProbe indicates that the Pod has successfully
+                            initialized. If specified, no other probes are executed
+                            until this completes successfully. If this probe fails,
+                            the Pod will be restarted, just as if the livenessProbe
+                            failed. This can be used to provide different probe parameters
+                            at the beginning of a Pod''s lifecycle, when it might
+                            take a long time to load data or warm a cache, than during
+                            steady-state operation. This cannot be updated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        stdin:
+                          description: Whether this container should allocate a buffer
+                            for stdin in the container runtime. If this is not set,
+                            reads from stdin in the container will always result in
+                            EOF. Default is false.
+                          type: boolean
+                        stdinOnce:
+                          description: Whether the container runtime should close
+                            the stdin channel after it has been opened by a single
+                            attach. When stdin is true the stdin stream will remain
+                            open across multiple attach sessions. If stdinOnce is
+                            set to true, stdin is opened on container start, is empty
+                            until the first client attaches to stdin, and then remains
+                            open and accepts data until the client disconnects, at
+                            which time stdin is closed and remains closed until the
+                            container is restarted. If this flag is false, a container
+                            processes that reads from stdin will never receive an
+                            EOF. Default is false
+                          type: boolean
+                        terminationMessagePath:
+                          description: 'Optional: Path at which the file to which
+                            the container''s termination message will be written is
+                            mounted into the container''s filesystem. Message written
+                            is intended to be brief final status, such as an assertion
+                            failure message. Will be truncated by the node if greater
+                            than 4096 bytes. The total message length across all containers
+                            will be limited to 12kb. Defaults to /dev/termination-log.
+                            Cannot be updated.'
+                          type: string
+                        terminationMessagePolicy:
+                          description: |-
+                            Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                            Possible enum values:
+                             - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                             - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                          type: string
+                        tty:
+                          description: Whether this container should allocate a TTY
+                            for itself, also requires 'stdin' to be true. Default
+                            is false.
+                          type: boolean
+                        volumeDevices:
+                          description: volumeDevices is the list of block devices
+                            to be used by the container.
+                          items:
+                            description: volumeDevice describes a mapping of a raw
+                              block device within a container.
+                            properties:
+                              devicePath:
+                                description: devicePath is the path inside of the
+                                  container that the device will be mapped to.
+                                type: string
+                              name:
+                                description: name must match the name of a persistentVolumeClaim
+                                  in the pod
+                                type: string
+                            required:
+                            - devicePath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - devicePath
+                          x-kubernetes-list-type: map
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                            Cannot be updated.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write
+                                  otherwise (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the
+                                  container's volume should be mounted. Defaults to
+                                  "" (volume's root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from
+                                  which the container's volume should be mounted.
+                                  Behaves similarly to SubPath but environment variable
+                                  references $(VAR_NAME) are expanded using the container's
+                                  environment. Defaults to "" (volume's root). SubPathExpr
+                                  and SubPath are mutually exclusive.
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - mountPath
+                          x-kubernetes-list-type: map
+                        workingDir:
+                          description: Container's working directory. If not specified,
+                            the container runtime's default will be used, which might
+                            be configured in the container image. Cannot be updated.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  dnsConfig:
+                    description: Specifies the DNS parameters of a pod. Parameters
+                      specified here will be merged to the generated DNS configuration
+                      based on DNSPolicy.
+                    properties:
+                      nameservers:
+                        description: A list of DNS name server IP addresses. This
+                          will be appended to the base nameservers generated from
+                          DNSPolicy. Duplicated nameservers will be removed.
+                        items:
+                          type: string
+                        type: array
+                      options:
+                        description: A list of DNS resolver options. This will be
+                          merged with the base options generated from DNSPolicy. Duplicated
+                          entries will be removed. Resolution options given in Options
+                          will override those that appear in the base DNSPolicy.
+                        items:
+                          description: PodDNSConfigOption defines DNS resolver options
+                            of a pod.
+                          properties:
+                            name:
+                              description: Required.
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                      searches:
+                        description: A list of DNS search domains for host-name lookup.
+                          This will be appended to the base search paths generated
+                          from DNSPolicy. Duplicated search paths will be removed.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  dnsPolicy:
+                    description: |-
+                      Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+
+                      Possible enum values:
+                       - `"ClusterFirst"` indicates that the pod should use cluster DNS first unless hostNetwork is true, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                       - `"ClusterFirstWithHostNet"` indicates that the pod should use cluster DNS first, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                       - `"Default"` indicates that the pod should use the default (as determined by kubelet) DNS settings.
+                       - `"None"` indicates that the pod should use empty DNS settings. DNS parameters such as nameservers and search paths should be defined via DNSConfig.
+                    type: string
+                  enableServiceLinks:
+                    description: 'EnableServiceLinks indicates whether information
+                      about services should be injected into pod''s environment variables,
+                      matching the syntax of Docker links. Optional: Defaults to true.'
+                    type: boolean
+                  ephemeralContainers:
+                    description: List of ephemeral containers run in this pod. Ephemeral
+                      containers may be run in an existing pod to perform user-initiated
+                      actions such as debugging. This list cannot be specified when
+                      creating a pod, and it cannot be modified by updating the pod
+                      spec. In order to add an ephemeral container to an existing
+                      pod, use the pod's ephemeralcontainers subresource.
+                    items:
+                      description: |-
+                        An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation.
+
+                        To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.
+                      properties:
+                        args:
+                          description: 'Arguments to the entrypoint. The image''s
+                            CMD is used if this is not provided. Variable references
+                            $(VAR_NAME) are expanded using the container''s environment.
+                            If a variable cannot be resolved, the reference in the
+                            input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME)
+                            syntax: i.e. "$$(VAR_NAME)" will produce the string literal
+                            "$(VAR_NAME)". Escaped references will never be expanded,
+                            regardless of whether the variable exists or not. Cannot
+                            be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: 'Entrypoint array. Not executed within a shell.
+                            The image''s ENTRYPOINT is used if this is not provided.
+                            Variable references $(VAR_NAME) are expanded using the
+                            container''s environment. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double
+                            $$ are reduced to a single $, which allows for escaping
+                            the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                            the string literal "$(VAR_NAME)". Escaped references will
+                            never be expanded, regardless of whether the variable
+                            exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the
+                            container. Cannot be updated.
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previously defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  Double $$ are reduced to a single $, which allows
+                                  for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                  will produce the string literal "$(VAR_NAME)". Escaped
+                                  references will never be expanded, regardless of
+                                  whether the variable exists or not. Defaults to
+                                  "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's
+                                  value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container. The keys defined within a source must
+                            be a C_IDENTIFIER. All invalid keys will be reported as
+                            an event when the container is starting. When a key exists
+                            in multiple sources, the value associated with the last
+                            source will take precedence. Values defined by an Env
+                            with a duplicate key will take precedence. Cannot be updated.
+                          items:
+                            description: EnvFromSource represents the source of a
+                              set of ConfigMaps
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must
+                                      be defined
+                                    type: boolean
+                                type: object
+                              prefix:
+                                description: An optional identifier to prepend to
+                                  each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be
+                                      defined
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                          type: string
+                        imagePullPolicy:
+                          description: |-
+                            Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                            Possible enum values:
+                             - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                             - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                             - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                          type: string
+                        lifecycle:
+                          description: Lifecycle is not allowed for ephemeral containers.
+                          properties:
+                            postStart:
+                              description: 'PostStart is called immediately after
+                                a container is created. If the handler fails, the
+                                container is terminated and restarted according to
+                                its restart policy. Other management of the container
+                                blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            preStop:
+                              description: 'PreStop is called immediately before a
+                                container is terminated due to an API request or management
+                                event such as liveness/startup probe failure, preemption,
+                                resource contention, etc. The handler is not called
+                                if the container crashes or exits. The Pod''s termination
+                                grace period countdown begins before the PreStop hook
+                                is executed. Regardless of the outcome of the handler,
+                                the container will eventually terminate within the
+                                Pod''s termination grace period (unless delayed by
+                                finalizers). Other management of the container blocks
+                                until the hook completes or until the termination
+                                grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                          type: object
+                        livenessProbe:
+                          description: Probes are not allowed for ephemeral containers.
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: Name of the ephemeral container specified as
+                            a DNS_LABEL. This name must be unique among all containers,
+                            init containers and ephemeral containers.
+                          type: string
+                        ports:
+                          description: Ports are not allowed for ephemeral containers.
+                          items:
+                            description: ContainerPort represents a network port in
+                              a single container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's
+                                  IP address. This must be a valid port number, 0
+                                  < x < 65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port
+                                  to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host.
+                                  If specified, this must be a valid port number,
+                                  0 < x < 65536. If HostNetwork is specified, this
+                                  must match ContainerPort. Most containers do not
+                                  need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a
+                                  pod must have a unique name. Name for the port that
+                                  can be referred to by services.
+                                type: string
+                              protocol:
+                                default: TCP
+                                description: |-
+                                  Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                  Possible enum values:
+                                   - `"SCTP"` is the SCTP protocol.
+                                   - `"TCP"` is the TCP protocol.
+                                   - `"UDP"` is the UDP protocol.
+                                type: string
+                            required:
+                            - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - containerPort
+                          - protocol
+                          x-kubernetes-list-type: map
+                        readinessProbe:
+                          description: Probes are not allowed for ephemeral containers.
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          description: Resources are not allowed for ephemeral containers.
+                            Ephemeral containers use spare resources already allocated
+                            to the pod.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        securityContext:
+                          description: 'Optional: SecurityContext defines the security
+                            options the ephemeral container should be run with. If
+                            set, the fields of SecurityContext override the equivalent
+                            fields of PodSecurityContext.'
+                          properties:
+                            allowPrivilegeEscalation:
+                              description: 'AllowPrivilegeEscalation controls whether
+                                a process can gain more privileges than its parent
+                                process. This bool directly controls if the no_new_privs
+                                flag will be set on the container process. AllowPrivilegeEscalation
+                                is true always when the container is: 1) run as Privileged
+                                2) has CAP_SYS_ADMIN Note that this field cannot be
+                                set when spec.os.name is windows.'
+                              type: boolean
+                            capabilities:
+                              description: The capabilities to add/drop when running
+                                containers. Defaults to the default set of capabilities
+                                granted by the container runtime. Note that this field
+                                cannot be set when spec.os.name is windows.
+                              properties:
+                                add:
+                                  description: Added capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                                drop:
+                                  description: Removed capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            privileged:
+                              description: Run container in privileged mode. Processes
+                                in privileged containers are essentially equivalent
+                                to root on the host. Defaults to false. Note that
+                                this field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            procMount:
+                              description: procMount denotes the type of proc mount
+                                to use for the containers. The default is DefaultProcMount
+                                which uses the container runtime defaults for readonly
+                                paths and masked paths. This requires the ProcMountType
+                                feature flag to be enabled. Note that this field cannot
+                                be set when spec.os.name is windows.
+                              type: string
+                            readOnlyRootFilesystem:
+                              description: Whether this container has a read-only
+                                root filesystem. Default is false. Note that this
+                                field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            runAsGroup:
+                              description: The GID to run the entrypoint of the container
+                                process. Uses runtime default if unset. May also be
+                                set in PodSecurityContext.  If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is windows.
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              description: Indicates that the container must run as
+                                a non-root user. If true, the Kubelet will validate
+                                the image at runtime to ensure that it does not run
+                                as UID 0 (root) and fail to start the container if
+                                it does. If unset or false, no such validation will
+                                be performed. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                              type: boolean
+                            runAsUser:
+                              description: The UID to run the entrypoint of the container
+                                process. Defaults to user specified in image metadata
+                                if unspecified. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name
+                                is windows.
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              description: The SELinux context to be applied to the
+                                container. If unspecified, the container runtime will
+                                allocate a random SELinux context for each container.  May
+                                also be set in PodSecurityContext.  If set in both
+                                SecurityContext and PodSecurityContext, the value
+                                specified in SecurityContext takes precedence. Note
+                                that this field cannot be set when spec.os.name is
+                                windows.
+                              properties:
+                                level:
+                                  description: Level is SELinux level label that applies
+                                    to the container.
+                                  type: string
+                                role:
+                                  description: Role is a SELinux role label that applies
+                                    to the container.
+                                  type: string
+                                type:
+                                  description: Type is a SELinux type label that applies
+                                    to the container.
+                                  type: string
+                                user:
+                                  description: User is a SELinux user label that applies
+                                    to the container.
+                                  type: string
+                              type: object
+                            seccompProfile:
+                              description: The seccomp options to use by this container.
+                                If seccomp options are provided at both the pod &
+                                container level, the container options override the
+                                pod options. Note that this field cannot be set when
+                                spec.os.name is windows.
+                              properties:
+                                localhostProfile:
+                                  description: localhostProfile indicates a profile
+                                    defined in a file on the node should be used.
+                                    The profile must be preconfigured on the node
+                                    to work. Must be a descending path, relative to
+                                    the kubelet's configured seccomp profile location.
+                                    Must only be set if type is "Localhost".
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                    Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                    Possible enum values:
+                                     - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                     - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                     - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            windowsOptions:
+                              description: The Windows specific settings applied to
+                                all containers. If unspecified, the options from the
+                                PodSecurityContext will be used. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is linux.
+                              properties:
+                                gmsaCredentialSpec:
+                                  description: GMSACredentialSpec is where the GMSA
+                                    admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                    inlines the contents of the GMSA credential spec
+                                    named by the GMSACredentialSpecName field.
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  description: GMSACredentialSpecName is the name
+                                    of the GMSA credential spec to use.
+                                  type: string
+                                hostProcess:
+                                  description: HostProcess determines if a container
+                                    should be run as a 'Host Process' container. This
+                                    field is alpha-level and will only be honored
+                                    by components that enable the WindowsHostProcessContainers
+                                    feature flag. Setting this field without the feature
+                                    flag will result in errors when validating the
+                                    Pod. All of a Pod's containers must have the same
+                                    effective HostProcess value (it is not allowed
+                                    to have a mix of HostProcess containers and non-HostProcess
+                                    containers).  In addition, if HostProcess is true
+                                    then HostNetwork must also be set to true.
+                                  type: boolean
+                                runAsUserName:
+                                  description: The UserName in Windows to run the
+                                    entrypoint of the container process. Defaults
+                                    to the user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  type: string
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: Probes are not allowed for ephemeral containers.
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        stdin:
+                          description: Whether this container should allocate a buffer
+                            for stdin in the container runtime. If this is not set,
+                            reads from stdin in the container will always result in
+                            EOF. Default is false.
+                          type: boolean
+                        stdinOnce:
+                          description: Whether the container runtime should close
+                            the stdin channel after it has been opened by a single
+                            attach. When stdin is true the stdin stream will remain
+                            open across multiple attach sessions. If stdinOnce is
+                            set to true, stdin is opened on container start, is empty
+                            until the first client attaches to stdin, and then remains
+                            open and accepts data until the client disconnects, at
+                            which time stdin is closed and remains closed until the
+                            container is restarted. If this flag is false, a container
+                            processes that reads from stdin will never receive an
+                            EOF. Default is false
+                          type: boolean
+                        targetContainerName:
+                          description: |-
+                            If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+                            The container runtime must implement support for this feature. If the runtime does not support namespace targeting then the result of setting this field is undefined.
+                          type: string
+                        terminationMessagePath:
+                          description: 'Optional: Path at which the file to which
+                            the container''s termination message will be written is
+                            mounted into the container''s filesystem. Message written
+                            is intended to be brief final status, such as an assertion
+                            failure message. Will be truncated by the node if greater
+                            than 4096 bytes. The total message length across all containers
+                            will be limited to 12kb. Defaults to /dev/termination-log.
+                            Cannot be updated.'
+                          type: string
+                        terminationMessagePolicy:
+                          description: |-
+                            Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                            Possible enum values:
+                             - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                             - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                          type: string
+                        tty:
+                          description: Whether this container should allocate a TTY
+                            for itself, also requires 'stdin' to be true. Default
+                            is false.
+                          type: boolean
+                        volumeDevices:
+                          description: volumeDevices is the list of block devices
+                            to be used by the container.
+                          items:
+                            description: volumeDevice describes a mapping of a raw
+                              block device within a container.
+                            properties:
+                              devicePath:
+                                description: devicePath is the path inside of the
+                                  container that the device will be mapped to.
+                                type: string
+                              name:
+                                description: name must match the name of a persistentVolumeClaim
+                                  in the pod
+                                type: string
+                            required:
+                            - devicePath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - devicePath
+                          x-kubernetes-list-type: map
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                            Subpath mounts are not allowed for ephemeral containers.
+                            Cannot be updated.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write
+                                  otherwise (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the
+                                  container's volume should be mounted. Defaults to
+                                  "" (volume's root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from
+                                  which the container's volume should be mounted.
+                                  Behaves similarly to SubPath but environment variable
+                                  references $(VAR_NAME) are expanded using the container's
+                                  environment. Defaults to "" (volume's root). SubPathExpr
+                                  and SubPath are mutually exclusive.
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - mountPath
+                          x-kubernetes-list-type: map
+                        workingDir:
+                          description: Container's working directory. If not specified,
+                            the container runtime's default will be used, which might
+                            be configured in the container image. Cannot be updated.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  hostAliases:
+                    description: HostAliases is an optional list of hosts and IPs
+                      that will be injected into the pod's hosts file if specified.
+                      This is only valid for non-hostNetwork pods.
+                    items:
+                      description: HostAlias holds the mapping between IP and hostnames
+                        that will be injected as an entry in the pod's hosts file.
+                      properties:
+                        hostnames:
+                          description: Hostnames for the above IP address.
+                          items:
+                            type: string
+                          type: array
+                        ip:
+                          description: IP address of the host file entry.
+                          type: string
+                      required:
+                      - ip
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - ip
+                    x-kubernetes-list-type: map
+                  hostIPC:
+                    description: 'Use the host''s ipc namespace. Optional: Default
+                      to false.'
+                    type: boolean
+                  hostNetwork:
+                    description: Host networking requested for this pod. Use the host's
+                      network namespace. If this option is set, the ports that will
+                      be used must be specified. Default to false.
+                    type: boolean
+                  hostPID:
+                    description: 'Use the host''s pid namespace. Optional: Default
+                      to false.'
+                    type: boolean
+                  hostUsers:
+                    description: 'Use the host''s user namespace. Optional: Default
+                      to true. If set to true or not present, the pod will be run
+                      in the host user namespace, useful for when the pod needs a
+                      feature only available to the host user namespace, such as loading
+                      a kernel module with CAP_SYS_MODULE. When set to false, a new
+                      userns is created for the pod. Setting false is useful for mitigating
+                      container breakout vulnerabilities even allowing users to run
+                      their containers as root without actually having root privileges
+                      on the host. This field is alpha-level and is only honored by
+                      servers that enable the UserNamespacesSupport feature.'
+                    type: boolean
+                  hostname:
+                    description: Specifies the hostname of the Pod If not specified,
+                      the pod's hostname will be set to a system-defined value.
+                    type: string
+                  imagePullSecrets:
+                    description: 'ImagePullSecrets is an optional list of references
+                      to secrets in the same namespace to use for pulling any of the
+                      images used by this PodSpec. If specified, these secrets will
+                      be passed to individual puller implementations for them to use.
+                      More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                    items:
+                      description: LocalObjectReference contains enough information
+                        to let you locate the referenced object inside the same namespace.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  initContainers:
+                    description: 'List of initialization containers belonging to the
+                      pod. Init containers are executed in order prior to containers
+                      being started. If any init container fails, the pod is considered
+                      to have failed and is handled according to its restartPolicy.
+                      The name for an init container or normal container must be unique
+                      among all containers. Init containers may not have Lifecycle
+                      actions, Readiness probes, Liveness probes, or Startup probes.
+                      The resourceRequirements of an init container are taken into
+                      account during scheduling by finding the highest request/limit
+                      for each resource type, and then using the max of of that value
+                      or the sum of the normal containers. Limits are applied to init
+                      containers in a similar fashion. Init containers cannot currently
+                      be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                    items:
+                      description: A single application container that you want to
+                        run within a pod.
+                      properties:
+                        args:
+                          description: 'Arguments to the entrypoint. The container
+                            image''s CMD is used if this is not provided. Variable
+                            references $(VAR_NAME) are expanded using the container''s
+                            environment. If a variable cannot be resolved, the reference
+                            in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME)
+                            syntax: i.e. "$$(VAR_NAME)" will produce the string literal
+                            "$(VAR_NAME)". Escaped references will never be expanded,
+                            regardless of whether the variable exists or not. Cannot
+                            be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: 'Entrypoint array. Not executed within a shell.
+                            The container image''s ENTRYPOINT is used if this is not
+                            provided. Variable references $(VAR_NAME) are expanded
+                            using the container''s environment. If a variable cannot
+                            be resolved, the reference in the input string will be
+                            unchanged. Double $$ are reduced to a single $, which
+                            allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                            will produce the string literal "$(VAR_NAME)". Escaped
+                            references will never be expanded, regardless of whether
+                            the variable exists or not. Cannot be updated. More info:
+                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the
+                            container. Cannot be updated.
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previously defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  Double $$ are reduced to a single $, which allows
+                                  for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                  will produce the string literal "$(VAR_NAME)". Escaped
+                                  references will never be expanded, regardless of
+                                  whether the variable exists or not. Defaults to
+                                  "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's
+                                  value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container. The keys defined within a source must
+                            be a C_IDENTIFIER. All invalid keys will be reported as
+                            an event when the container is starting. When a key exists
+                            in multiple sources, the value associated with the last
+                            source will take precedence. Values defined by an Env
+                            with a duplicate key will take precedence. Cannot be updated.
+                          items:
+                            description: EnvFromSource represents the source of a
+                              set of ConfigMaps
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must
+                                      be defined
+                                    type: boolean
+                                type: object
+                              prefix:
+                                description: An optional identifier to prepend to
+                                  each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be
+                                      defined
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                            This field is optional to allow higher level config management
+                            to default or override container images in workload controllers
+                            like Deployments and StatefulSets.'
+                          type: string
+                        imagePullPolicy:
+                          description: |-
+                            Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                            Possible enum values:
+                             - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                             - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                             - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                          type: string
+                        lifecycle:
+                          description: Actions that the management system should take
+                            in response to container lifecycle events. Cannot be updated.
+                          properties:
+                            postStart:
+                              description: 'PostStart is called immediately after
+                                a container is created. If the handler fails, the
+                                container is terminated and restarted according to
+                                its restart policy. Other management of the container
+                                blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            preStop:
+                              description: 'PreStop is called immediately before a
+                                container is terminated due to an API request or management
+                                event such as liveness/startup probe failure, preemption,
+                                resource contention, etc. The handler is not called
+                                if the container crashes or exits. The Pod''s termination
+                                grace period countdown begins before the PreStop hook
+                                is executed. Regardless of the outcome of the handler,
+                                the container will eventually terminate within the
+                                Pod''s termination grace period (unless delayed by
+                                finalizers). Other management of the container blocks
+                                until the hook completes or until the termination
+                                grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                          type: object
+                        livenessProbe:
+                          description: 'Periodic probe of container liveness. Container
+                            will be restarted if the probe fails. Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: Name of the container specified as a DNS_LABEL.
+                            Each container in a pod must have a unique name (DNS_LABEL).
+                            Cannot be updated.
+                          type: string
+                        ports:
+                          description: List of ports to expose from the container.
+                            Not specifying a port here DOES NOT prevent that port
+                            from being exposed. Any port which is listening on the
+                            default "0.0.0.0" address inside a container will be accessible
+                            from the network. Modifying this array with strategic
+                            merge patch may corrupt the data. For more information
+                            See https://github.com/kubernetes/kubernetes/issues/108255.
+                            Cannot be updated.
+                          items:
+                            description: ContainerPort represents a network port in
+                              a single container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's
+                                  IP address. This must be a valid port number, 0
+                                  < x < 65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port
+                                  to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host.
+                                  If specified, this must be a valid port number,
+                                  0 < x < 65536. If HostNetwork is specified, this
+                                  must match ContainerPort. Most containers do not
+                                  need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a
+                                  pod must have a unique name. Name for the port that
+                                  can be referred to by services.
+                                type: string
+                              protocol:
+                                default: TCP
+                                description: |-
+                                  Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                  Possible enum values:
+                                   - `"SCTP"` is the SCTP protocol.
+                                   - `"TCP"` is the TCP protocol.
+                                   - `"UDP"` is the UDP protocol.
+                                type: string
+                            required:
+                            - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - containerPort
+                          - protocol
+                          x-kubernetes-list-type: map
+                        readinessProbe:
+                          description: 'Periodic probe of container service readiness.
+                            Container will be removed from service endpoints if the
+                            probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          description: 'Compute Resources required by this container.
+                            Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        securityContext:
+                          description: 'SecurityContext defines the security options
+                            the container should be run with. If set, the fields of
+                            SecurityContext override the equivalent fields of PodSecurityContext.
+                            More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                          properties:
+                            allowPrivilegeEscalation:
+                              description: 'AllowPrivilegeEscalation controls whether
+                                a process can gain more privileges than its parent
+                                process. This bool directly controls if the no_new_privs
+                                flag will be set on the container process. AllowPrivilegeEscalation
+                                is true always when the container is: 1) run as Privileged
+                                2) has CAP_SYS_ADMIN Note that this field cannot be
+                                set when spec.os.name is windows.'
+                              type: boolean
+                            capabilities:
+                              description: The capabilities to add/drop when running
+                                containers. Defaults to the default set of capabilities
+                                granted by the container runtime. Note that this field
+                                cannot be set when spec.os.name is windows.
+                              properties:
+                                add:
+                                  description: Added capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                                drop:
+                                  description: Removed capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            privileged:
+                              description: Run container in privileged mode. Processes
+                                in privileged containers are essentially equivalent
+                                to root on the host. Defaults to false. Note that
+                                this field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            procMount:
+                              description: procMount denotes the type of proc mount
+                                to use for the containers. The default is DefaultProcMount
+                                which uses the container runtime defaults for readonly
+                                paths and masked paths. This requires the ProcMountType
+                                feature flag to be enabled. Note that this field cannot
+                                be set when spec.os.name is windows.
+                              type: string
+                            readOnlyRootFilesystem:
+                              description: Whether this container has a read-only
+                                root filesystem. Default is false. Note that this
+                                field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            runAsGroup:
+                              description: The GID to run the entrypoint of the container
+                                process. Uses runtime default if unset. May also be
+                                set in PodSecurityContext.  If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is windows.
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              description: Indicates that the container must run as
+                                a non-root user. If true, the Kubelet will validate
+                                the image at runtime to ensure that it does not run
+                                as UID 0 (root) and fail to start the container if
+                                it does. If unset or false, no such validation will
+                                be performed. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                              type: boolean
+                            runAsUser:
+                              description: The UID to run the entrypoint of the container
+                                process. Defaults to user specified in image metadata
+                                if unspecified. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name
+                                is windows.
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              description: The SELinux context to be applied to the
+                                container. If unspecified, the container runtime will
+                                allocate a random SELinux context for each container.  May
+                                also be set in PodSecurityContext.  If set in both
+                                SecurityContext and PodSecurityContext, the value
+                                specified in SecurityContext takes precedence. Note
+                                that this field cannot be set when spec.os.name is
+                                windows.
+                              properties:
+                                level:
+                                  description: Level is SELinux level label that applies
+                                    to the container.
+                                  type: string
+                                role:
+                                  description: Role is a SELinux role label that applies
+                                    to the container.
+                                  type: string
+                                type:
+                                  description: Type is a SELinux type label that applies
+                                    to the container.
+                                  type: string
+                                user:
+                                  description: User is a SELinux user label that applies
+                                    to the container.
+                                  type: string
+                              type: object
+                            seccompProfile:
+                              description: The seccomp options to use by this container.
+                                If seccomp options are provided at both the pod &
+                                container level, the container options override the
+                                pod options. Note that this field cannot be set when
+                                spec.os.name is windows.
+                              properties:
+                                localhostProfile:
+                                  description: localhostProfile indicates a profile
+                                    defined in a file on the node should be used.
+                                    The profile must be preconfigured on the node
+                                    to work. Must be a descending path, relative to
+                                    the kubelet's configured seccomp profile location.
+                                    Must only be set if type is "Localhost".
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                    Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                    Possible enum values:
+                                     - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                     - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                     - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            windowsOptions:
+                              description: The Windows specific settings applied to
+                                all containers. If unspecified, the options from the
+                                PodSecurityContext will be used. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is linux.
+                              properties:
+                                gmsaCredentialSpec:
+                                  description: GMSACredentialSpec is where the GMSA
+                                    admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                    inlines the contents of the GMSA credential spec
+                                    named by the GMSACredentialSpecName field.
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  description: GMSACredentialSpecName is the name
+                                    of the GMSA credential spec to use.
+                                  type: string
+                                hostProcess:
+                                  description: HostProcess determines if a container
+                                    should be run as a 'Host Process' container. This
+                                    field is alpha-level and will only be honored
+                                    by components that enable the WindowsHostProcessContainers
+                                    feature flag. Setting this field without the feature
+                                    flag will result in errors when validating the
+                                    Pod. All of a Pod's containers must have the same
+                                    effective HostProcess value (it is not allowed
+                                    to have a mix of HostProcess containers and non-HostProcess
+                                    containers).  In addition, if HostProcess is true
+                                    then HostNetwork must also be set to true.
+                                  type: boolean
+                                runAsUserName:
+                                  description: The UserName in Windows to run the
+                                    entrypoint of the container process. Defaults
+                                    to the user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  type: string
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: 'StartupProbe indicates that the Pod has successfully
+                            initialized. If specified, no other probes are executed
+                            until this completes successfully. If this probe fails,
+                            the Pod will be restarted, just as if the livenessProbe
+                            failed. This can be used to provide different probe parameters
+                            at the beginning of a Pod''s lifecycle, when it might
+                            take a long time to load data or warm a cache, than during
+                            steady-state operation. This cannot be updated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        stdin:
+                          description: Whether this container should allocate a buffer
+                            for stdin in the container runtime. If this is not set,
+                            reads from stdin in the container will always result in
+                            EOF. Default is false.
+                          type: boolean
+                        stdinOnce:
+                          description: Whether the container runtime should close
+                            the stdin channel after it has been opened by a single
+                            attach. When stdin is true the stdin stream will remain
+                            open across multiple attach sessions. If stdinOnce is
+                            set to true, stdin is opened on container start, is empty
+                            until the first client attaches to stdin, and then remains
+                            open and accepts data until the client disconnects, at
+                            which time stdin is closed and remains closed until the
+                            container is restarted. If this flag is false, a container
+                            processes that reads from stdin will never receive an
+                            EOF. Default is false
+                          type: boolean
+                        terminationMessagePath:
+                          description: 'Optional: Path at which the file to which
+                            the container''s termination message will be written is
+                            mounted into the container''s filesystem. Message written
+                            is intended to be brief final status, such as an assertion
+                            failure message. Will be truncated by the node if greater
+                            than 4096 bytes. The total message length across all containers
+                            will be limited to 12kb. Defaults to /dev/termination-log.
+                            Cannot be updated.'
+                          type: string
+                        terminationMessagePolicy:
+                          description: |-
+                            Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                            Possible enum values:
+                             - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                             - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                          type: string
+                        tty:
+                          description: Whether this container should allocate a TTY
+                            for itself, also requires 'stdin' to be true. Default
+                            is false.
+                          type: boolean
+                        volumeDevices:
+                          description: volumeDevices is the list of block devices
+                            to be used by the container.
+                          items:
+                            description: volumeDevice describes a mapping of a raw
+                              block device within a container.
+                            properties:
+                              devicePath:
+                                description: devicePath is the path inside of the
+                                  container that the device will be mapped to.
+                                type: string
+                              name:
+                                description: name must match the name of a persistentVolumeClaim
+                                  in the pod
+                                type: string
+                            required:
+                            - devicePath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - devicePath
+                          x-kubernetes-list-type: map
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                            Cannot be updated.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write
+                                  otherwise (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the
+                                  container's volume should be mounted. Defaults to
+                                  "" (volume's root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from
+                                  which the container's volume should be mounted.
+                                  Behaves similarly to SubPath but environment variable
+                                  references $(VAR_NAME) are expanded using the container's
+                                  environment. Defaults to "" (volume's root). SubPathExpr
+                                  and SubPath are mutually exclusive.
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - mountPath
+                          x-kubernetes-list-type: map
+                        workingDir:
+                          description: Container's working directory. If not specified,
+                            the container runtime's default will be used, which might
+                            be configured in the container image. Cannot be updated.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  nodeName:
+                    description: NodeName is a request to schedule this pod onto a
+                      specific node. If it is non-empty, the scheduler simply schedules
+                      this pod onto that node, assuming that it fits resource requirements.
+                    type: string
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'NodeSelector is a selector which must be true for
+                      the pod to fit on a node. Selector which must match a node''s
+                      labels for the pod to be scheduled on that node. More info:
+                      https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                    type: object
+                  os:
+                    description: |-
+                      Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set.
+
+                      If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions
+
+                      If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup
+                    properties:
+                      name:
+                        description: 'Name is the name of the operating system. The
+                          currently supported values are linux and windows. Additional
+                          value may be defined in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                          Clients should expect to handle additional values and treat
+                          unrecognized values in this field as os: null'
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  overhead:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Overhead represents the resource overhead associated
+                      with running a pod for a given RuntimeClass. This field will
+                      be autopopulated at admission time by the RuntimeClass admission
+                      controller. If the RuntimeClass admission controller is enabled,
+                      overhead must not be set in Pod create requests. The RuntimeClass
+                      admission controller will reject Pod create requests which have
+                      the overhead already set. If RuntimeClass is configured and
+                      selected in the PodSpec, Overhead will be set to the value defined
+                      in the corresponding RuntimeClass, otherwise it will remain
+                      unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
+                    type: object
+                  preemptionPolicy:
+                    description: PreemptionPolicy is the Policy for preempting pods
+                      with lower priority. One of Never, PreemptLowerPriority. Defaults
+                      to PreemptLowerPriority if unset.
+                    type: string
+                  priority:
+                    description: The priority value. Various system components use
+                      this field to find the priority of the pod. When Priority Admission
+                      Controller is enabled, it prevents users from setting this field.
+                      The admission controller populates this field from PriorityClassName.
+                      The higher the value, the higher the priority.
+                    format: int32
+                    type: integer
+                  priorityClassName:
+                    description: If specified, indicates the pod's priority. "system-node-critical"
+                      and "system-cluster-critical" are two special keywords which
+                      indicate the highest priorities with the former being the highest
+                      priority. Any other name must be defined by creating a PriorityClass
+                      object with that name. If not specified, the pod priority will
+                      be default or zero if there is no default.
+                    type: string
+                  readinessGates:
+                    description: 'If specified, all readiness gates will be evaluated
+                      for pod readiness. A pod is ready when all its containers are
+                      ready AND all conditions specified in the readiness gates have
+                      status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
+                    items:
+                      description: PodReadinessGate contains the reference to a pod
+                        condition
+                      properties:
+                        conditionType:
+                          description: ConditionType refers to a condition in the
+                            pod's condition list with matching type.
+                          type: string
+                      required:
+                      - conditionType
+                      type: object
+                    type: array
+                  restartPolicy:
+                    description: |-
+                      Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+
+                      Possible enum values:
+                       - `"Always"`
+                       - `"Never"`
+                       - `"OnFailure"`
+                    type: string
+                  runtimeClassName:
+                    description: 'RuntimeClassName refers to a RuntimeClass object
+                      in the node.k8s.io group, which should be used to run this pod.  If
+                      no RuntimeClass resource matches the named class, the pod will
+                      not be run. If unset or empty, the "legacy" RuntimeClass will
+                      be used, which is an implicit class with an empty definition
+                      that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
+                    type: string
+                  schedulerName:
+                    description: If specified, the pod will be dispatched by specified
+                      scheduler. If not specified, the pod will be dispatched by default
+                      scheduler.
+                    type: string
+                  securityContext:
+                    description: 'SecurityContext holds pod-level security attributes
+                      and common container settings. Optional: Defaults to empty.  See
+                      type description for default values of each field.'
+                    properties:
+                      fsGroup:
+                        description: |-
+                          A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
+                          1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
+                          If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      fsGroupChangePolicy:
+                        description: 'fsGroupChangePolicy defines behavior of changing
+                          ownership and permission of the volume before being exposed
+                          inside Pod. This field will only apply to volume types which
+                          support fsGroup based ownership(and permissions). It will
+                          have no effect on ephemeral volume types such as: secret,
+                          configmaps and emptydir. Valid values are "OnRootMismatch"
+                          and "Always". If not specified, "Always" is used. Note that
+                          this field cannot be set when spec.os.name is windows.'
+                        type: string
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence for that container. Note that this field
+                          cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in SecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in SecurityContext.  If set
+                          in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence for that container.
+                          Note that this field cannot be set when spec.os.name is
+                          windows.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to all containers.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          SecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence
+                          for that container. Note that this field cannot be set when
+                          spec.os.name is windows.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: The seccomp options to use by the containers
+                          in this pod. Note that this field cannot be set when spec.os.name
+                          is windows.
+                        properties:
+                          localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used. The profile must
+                              be preconfigured on the node to work. Must be a descending
+                              path, relative to the kubelet's configured seccomp profile
+                              location. Must only be set if type is "Localhost".
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                              Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                              Possible enum values:
+                               - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                               - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                               - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      supplementalGroups:
+                        description: A list of groups applied to the first process
+                          run in each container, in addition to the container's primary
+                          GID.  If unspecified, no groups will be added to any container.
+                          Note that this field cannot be set when spec.os.name is
+                          windows.
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      sysctls:
+                        description: Sysctls hold a list of namespaced sysctls used
+                          for the pod. Pods with unsupported sysctls (by the container
+                          runtime) might fail to launch. Note that this field cannot
+                          be set when spec.os.name is windows.
+                        items:
+                          description: Sysctl defines a kernel parameter to be set
+                          properties:
+                            name:
+                              description: Name of a property to set
+                              type: string
+                            value:
+                              description: Value of a property to set
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options within a container's
+                          SecurityContext will be used. If set in both SecurityContext
+                          and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence. Note that this field cannot be set when
+                          spec.os.name is linux.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: HostProcess determines if a container should
+                              be run as a 'Host Process' container. This field is
+                              alpha-level and will only be honored by components that
+                              enable the WindowsHostProcessContainers feature flag.
+                              Setting this field without the feature flag will result
+                              in errors when validating the Pod. All of a Pod's containers
+                              must have the same effective HostProcess value (it is
+                              not allowed to have a mix of HostProcess containers
+                              and non-HostProcess containers).  In addition, if HostProcess
+                              is true then HostNetwork must also be set to true.
+                            type: boolean
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  serviceAccount:
+                    description: 'DeprecatedServiceAccount is a depreciated alias
+                      for ServiceAccountName. Deprecated: Use serviceAccountName instead.'
+                    type: string
+                  serviceAccountName:
+                    description: 'ServiceAccountName is the name of the ServiceAccount
+                      to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                    type: string
+                  setHostnameAsFQDN:
+                    description: If true the pod's hostname will be configured as
+                      the pod's FQDN, rather than the leaf name (the default). In
+                      Linux containers, this means setting the FQDN in the hostname
+                      field of the kernel (the nodename field of struct utsname).
+                      In Windows containers, this means setting the registry value
+                      of hostname for the registry key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters
+                      to FQDN. If a pod does not have FQDN, this has no effect. Default
+                      to false.
+                    type: boolean
+                  shareProcessNamespace:
+                    description: 'Share a single process namespace between all of
+                      the containers in a pod. When this is set containers will be
+                      able to view and signal processes from other containers in the
+                      same pod, and the first process in each container will not be
+                      assigned PID 1. HostPID and ShareProcessNamespace cannot both
+                      be set. Optional: Default to false.'
+                    type: boolean
+                  subdomain:
+                    description: If specified, the fully qualified Pod hostname will
+                      be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+                      If not specified, the pod will not have a domainname at all.
+                    type: string
+                  terminationGracePeriodSeconds:
+                    description: Optional duration in seconds the pod needs to terminate
+                      gracefully. May be decreased in delete request. Value must be
+                      non-negative integer. The value zero indicates stop immediately
+                      via the kill signal (no opportunity to shut down). If this value
+                      is nil, the default grace period will be used instead. The grace
+                      period is the duration in seconds after the processes running
+                      in the pod are sent a termination signal and the time when the
+                      processes are forcibly halted with a kill signal. Set this value
+                      longer than the expected cleanup time for your process. Defaults
+                      to 30 seconds.
+                    format: int64
+                    type: integer
+                  tolerations:
+                    description: If specified, the pod's tolerations.
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using
+                        the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+                            Possible enum values:
+                             - `"NoExecute"` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+                             - `"NoSchedule"` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+                             - `"PreferNoSchedule"` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+
+                            Possible enum values:
+                             - `"Equal"`
+                             - `"Exists"`
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of
+                            time the toleration (which must be of effect NoExecute,
+                            otherwise this field is ignored) tolerates the taint.
+                            By default, it is not set, which means tolerate the taint
+                            forever (do not evict). Zero and negative values will
+                            be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  topologySpreadConstraints:
+                    description: TopologySpreadConstraints describes how a group of
+                      pods ought to spread across topology domains. Scheduler will
+                      schedule pods in a way which abides by the constraints. All
+                      topologySpreadConstraints are ANDed.
+                    items:
+                      description: TopologySpreadConstraint specifies how to spread
+                        matching pods among the given topology.
+                      properties:
+                        labelSelector:
+                          description: LabelSelector is used to find matching pods.
+                            Pods that match this label selector are counted to determine
+                            the number of pods in their corresponding topology domain.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        matchLabelKeys:
+                          description: MatchLabelKeys is a set of pod label keys to
+                            select the pods over which spreading will be calculated.
+                            The keys are used to lookup values from the incoming pod
+                            labels, those key-value labels are ANDed with labelSelector
+                            to select the group of existing pods over which spreading
+                            will be calculated for the incoming pod. Keys that don't
+                            exist in the incoming pod labels will be ignored. A null
+                            or empty list means only match against labelSelector.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        maxSkew:
+                          description: 'MaxSkew describes the degree to which pods
+                            may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                            it is the maximum permitted difference between the number
+                            of matching pods in the target topology and the global
+                            minimum. The global minimum is the minimum number of matching
+                            pods in an eligible domain or zero if the number of eligible
+                            domains is less than MinDomains. For example, in a 3-zone
+                            cluster, MaxSkew is set to 1, and pods with the same labelSelector
+                            spread as 2/2/1: In this case, the global minimum is 1.
+                            | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | -
+                            if MaxSkew is 1, incoming pod can only be scheduled to
+                            zone3 to become 2/2/2; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(3-1) on zone1(zone2) violate
+                            MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
+                            onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                            it is used to give higher precedence to topologies that
+                            satisfy it. It''s a required field. Default value is 1
+                            and 0 is not allowed.'
+                          format: int32
+                          type: integer
+                        minDomains:
+                          description: |-
+                            MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                            For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew.
+
+                            This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
+                          format: int32
+                          type: integer
+                        nodeAffinityPolicy:
+                          description: |-
+                            NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                            If this value is nil, the behavior is equivalent to the Honor policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                          type: string
+                        nodeTaintsPolicy:
+                          description: |-
+                            NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included.
+
+                            If this value is nil, the behavior is equivalent to the Ignore policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                          type: string
+                        topologyKey:
+                          description: TopologyKey is the key of node labels. Nodes
+                            that have a label with this key and identical values are
+                            considered to be in the same topology. We consider each
+                            <key, value> as a "bucket", and try to put balanced number
+                            of pods into each bucket. We define a domain as a particular
+                            instance of a topology. Also, we define an eligible domain
+                            as a domain whose nodes meet the requirements of nodeAffinityPolicy
+                            and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
+                            each Node is a domain of that topology. And, if TopologyKey
+                            is "topology.kubernetes.io/zone", each zone is a domain
+                            of that topology. It's a required field.
+                          type: string
+                        whenUnsatisfiable:
+                          description: |-
+                            WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                              but giving higher precedence to topologies that would help reduce the
+                              skew.
+                            A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
+
+                            Possible enum values:
+                             - `"DoNotSchedule"` instructs the scheduler not to schedule the pod when constraints are not satisfied.
+                             - `"ScheduleAnyway"` instructs the scheduler to schedule the pod even if constraints are not satisfied.
+                          type: string
+                      required:
+                      - maxSkew
+                      - topologyKey
+                      - whenUnsatisfiable
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - topologyKey
+                    - whenUnsatisfiable
+                    x-kubernetes-list-type: map
+                  volumes:
+                    description: 'List of volumes that can be mounted by containers
+                      belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                    items:
+                      description: Volume represents a named volume in a pod that
+                        may be accessed by any container in the pod.
+                      properties:
+                        awsElasticBlockStore:
+                          description: 'awsElasticBlockStore represents an AWS Disk
+                            resource that is attached to a kubelet''s host machine
+                            and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                          properties:
+                            fsType:
+                              description: 'fsType is the filesystem type of the volume
+                                that you want to mount. Tip: Ensure that the filesystem
+                                type is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              type: string
+                            partition:
+                              description: 'partition is the partition in the volume
+                                that you want to mount. If omitted, the default is
+                                to mount by volume name. Examples: For volume /dev/sda1,
+                                you specify the partition as "1". Similarly, the volume
+                                partition for /dev/sda is "0" (or you can leave the
+                                property empty).'
+                              format: int32
+                              type: integer
+                            readOnly:
+                              description: 'readOnly value true will force the readOnly
+                                setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              type: boolean
+                            volumeID:
+                              description: 'volumeID is unique ID of the persistent
+                                disk resource in AWS (Amazon EBS volume). More info:
+                                https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        azureDisk:
+                          description: azureDisk represents an Azure Data Disk mount
+                            on the host and bind mount to the pod.
+                          properties:
+                            cachingMode:
+                              description: 'cachingMode is the Host Caching mode:
+                                None, Read Only, Read Write.'
+                              type: string
+                            diskName:
+                              description: diskName is the Name of the data disk in
+                                the blob storage
+                              type: string
+                            diskURI:
+                              description: diskURI is the URI of data disk in the
+                                blob storage
+                              type: string
+                            fsType:
+                              description: fsType is Filesystem type to mount. Must
+                                be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified.
+                              type: string
+                            kind:
+                              description: 'kind expected values are Shared: multiple
+                                blob disks per storage account  Dedicated: single
+                                blob disk per storage account  Managed: azure managed
+                                data disk (only in managed availability set). defaults
+                                to shared'
+                              type: string
+                            readOnly:
+                              description: readOnly Defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                          required:
+                          - diskName
+                          - diskURI
+                          type: object
+                        azureFile:
+                          description: azureFile represents an Azure File Service
+                            mount on the host and bind mount to the pod.
+                          properties:
+                            readOnly:
+                              description: readOnly defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretName:
+                              description: secretName is the  name of secret that
+                                contains Azure Storage Account Name and Key
+                              type: string
+                            shareName:
+                              description: shareName is the azure share Name
+                              type: string
+                          required:
+                          - secretName
+                          - shareName
+                          type: object
+                        cephfs:
+                          description: cephFS represents a Ceph FS mount on the host
+                            that shares a pod's lifetime
+                          properties:
+                            monitors:
+                              description: 'monitors is Required: Monitors is a collection
+                                of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              items:
+                                type: string
+                              type: array
+                            path:
+                              description: 'path is Optional: Used as the mounted
+                                root, rather than the full Ceph tree, default is /'
+                              type: string
+                            readOnly:
+                              description: 'readOnly is Optional: Defaults to false
+                                (read/write). ReadOnly here will force the ReadOnly
+                                setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              type: boolean
+                            secretFile:
+                              description: 'secretFile is Optional: SecretFile is
+                                the path to key ring for User, default is /etc/ceph/user.secret
+                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              type: string
+                            secretRef:
+                              description: 'secretRef is Optional: SecretRef is reference
+                                to the authentication secret for User, default is
+                                empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            user:
+                              description: 'user is optional: User is the rados user
+                                name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              type: string
+                          required:
+                          - monitors
+                          type: object
+                        cinder:
+                          description: 'cinder represents a cinder volume attached
+                            and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                          properties:
+                            fsType:
+                              description: 'fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              type: string
+                            readOnly:
+                              description: 'readOnly defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              type: boolean
+                            secretRef:
+                              description: 'secretRef is optional: points to a secret
+                                object containing parameters used to connect to OpenStack.'
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            volumeID:
+                              description: 'volumeID used to identify the volume in
+                                cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        configMap:
+                          description: configMap represents a configMap that should
+                            populate this volume
+                          properties:
+                            defaultMode:
+                              description: 'defaultMode is optional: mode bits used
+                                to set permissions on created files by default. Must
+                                be an octal value between 0000 and 0777 or a decimal
+                                value between 0 and 511. YAML accepts both octal and
+                                decimal values, JSON requires decimal values for mode
+                                bits. Defaults to 0644. Directories within the path
+                                are not affected by this setting. This might be in
+                                conflict with other options that affect the file mode,
+                                like fsGroup, and the result can be other mode bits
+                                set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: items if unspecified, each key-value pair
+                                in the Data field of the referenced ConfigMap will
+                                be projected into the volume as a file whose name
+                                is the key and content is the value. If specified,
+                                the listed keys will be projected into the specified
+                                paths, and unlisted keys will not be present. If a
+                                key is specified which is not present in the ConfigMap,
+                                the volume setup will error unless it is marked optional.
+                                Paths must be relative and may not contain the '..'
+                                path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a
+                                  volume.
+                                properties:
+                                  key:
+                                    description: key is the key to project.
+                                    type: string
+                                  mode:
+                                    description: 'mode is Optional: mode bits used
+                                      to set permissions on this file. Must be an
+                                      octal value between 0000 and 0777 or a decimal
+                                      value between 0 and 511. YAML accepts both octal
+                                      and decimal values, JSON requires decimal values
+                                      for mode bits. If not specified, the volume
+                                      defaultMode will be used. This might be in conflict
+                                      with other options that affect the file mode,
+                                      like fsGroup, and the result can be other mode
+                                      bits set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: path is the relative path of the
+                                      file to map the key to. May not be an absolute
+                                      path. May not contain the path element '..'.
+                                      May not start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            optional:
+                              description: optional specify whether the ConfigMap
+                                or its keys must be defined
+                              type: boolean
+                          type: object
+                        csi:
+                          description: csi (Container Storage Interface) represents
+                            ephemeral storage that is handled by certain external
+                            CSI drivers (Beta feature).
+                          properties:
+                            driver:
+                              description: driver is the name of the CSI driver that
+                                handles this volume. Consult with your admin for the
+                                correct name as registered in the cluster.
+                              type: string
+                            fsType:
+                              description: fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                If not provided, the empty value is passed to the
+                                associated CSI driver which will determine the default
+                                filesystem to apply.
+                              type: string
+                            nodePublishSecretRef:
+                              description: nodePublishSecretRef is a reference to
+                                the secret object containing sensitive information
+                                to pass to the CSI driver to complete the CSI NodePublishVolume
+                                and NodeUnpublishVolume calls. This field is optional,
+                                and  may be empty if no secret is required. If the
+                                secret object contains more than one secret, all secret
+                                references are passed.
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            readOnly:
+                              description: readOnly specifies a read-only configuration
+                                for the volume. Defaults to false (read/write).
+                              type: boolean
+                            volumeAttributes:
+                              additionalProperties:
+                                type: string
+                              description: volumeAttributes stores driver-specific
+                                properties that are passed to the CSI driver. Consult
+                                your driver's documentation for supported values.
+                              type: object
+                          required:
+                          - driver
+                          type: object
+                        downwardAPI:
+                          description: downwardAPI represents downward API about the
+                            pod that should populate this volume
+                          properties:
+                            defaultMode:
+                              description: 'Optional: mode bits to use on created
+                                files by default. Must be a Optional: mode bits used
+                                to set permissions on created files by default. Must
+                                be an octal value between 0000 and 0777 or a decimal
+                                value between 0 and 511. YAML accepts both octal and
+                                decimal values, JSON requires decimal values for mode
+                                bits. Defaults to 0644. Directories within the path
+                                are not affected by this setting. This might be in
+                                conflict with other options that affect the file mode,
+                                like fsGroup, and the result can be other mode bits
+                                set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: Items is a list of downward API volume
+                                file
+                              items:
+                                description: DownwardAPIVolumeFile represents information
+                                  to create the file containing the pod field
+                                properties:
+                                  fieldRef:
+                                    description: 'Required: Selects a field of the
+                                      pod: only annotations, labels, name and namespace
+                                      are supported.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  mode:
+                                    description: 'Optional: mode bits used to set
+                                      permissions on this file, must be an octal value
+                                      between 0000 and 0777 or a decimal value between
+                                      0 and 511. YAML accepts both octal and decimal
+                                      values, JSON requires decimal values for mode
+                                      bits. If not specified, the volume defaultMode
+                                      will be used. This might be in conflict with
+                                      other options that affect the file mode, like
+                                      fsGroup, and the result can be other mode bits
+                                      set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: 'Required: Path is  the relative
+                                      path name of the file to be created. Must not
+                                      be absolute or contain the ''..'' path. Must
+                                      be utf-8 encoded. The first item of the relative
+                                      path must not start with ''..'''
+                                    type: string
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, requests.cpu and requests.memory)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                required:
+                                - path
+                                type: object
+                              type: array
+                          type: object
+                        emptyDir:
+                          description: 'emptyDir represents a temporary directory
+                            that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                          properties:
+                            medium:
+                              description: 'medium represents what type of storage
+                                medium should back this directory. The default is
+                                "" which means to use the node''s default medium.
+                                Must be an empty string (default) or Memory. More
+                                info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              type: string
+                            sizeLimit:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: 'sizeLimit is the total amount of local
+                                storage required for this EmptyDir volume. The size
+                                limit is also applicable for memory medium. The maximum
+                                usage on memory medium EmptyDir would be the minimum
+                                value between the SizeLimit specified here and the
+                                sum of memory limits of all containers in a pod. The
+                                default is nil which means that the limit is undefined.
+                                More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          type: object
+                        ephemeral:
+                          description: |-
+                            ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+
+                            Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+                               tracking are needed,
+                            c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+                               a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                               information on the connection between this volume type
+                               and PersistentVolumeClaim).
+
+                            Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+
+                            Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+
+                            A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+                          properties:
+                            volumeClaimTemplate:
+                              description: |-
+                                Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+
+                                An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+
+                                This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+
+                                Required, must not be nil.
+                              properties:
+                                metadata:
+                                  description: May contain labels and annotations
+                                    that will be copied into the PVC when creating
+                                    it. No other fields are allowed and will be rejected
+                                    during validation.
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                spec:
+                                  description: The specification for the PersistentVolumeClaim.
+                                    The entire content is copied unchanged into the
+                                    PVC that gets created from this template. The
+                                    same fields as in a PersistentVolumeClaim are
+                                    also valid here.
+                                  properties:
+                                    accessModes:
+                                      description: 'accessModes contains the desired
+                                        access modes the volume should have. More
+                                        info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                      items:
+                                        type: string
+                                      type: array
+                                    dataSource:
+                                      description: 'dataSource field can be used to
+                                        specify either: * An existing VolumeSnapshot
+                                        object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                        * An existing PVC (PersistentVolumeClaim)
+                                        If the provisioner or an external controller
+                                        can support the specified data source, it
+                                        will create a new volume based on the contents
+                                        of the specified data source. If the AnyVolumeDataSource
+                                        feature gate is enabled, this field will always
+                                        have the same contents as the DataSourceRef
+                                        field.'
+                                      properties:
+                                        apiGroup:
+                                          description: APIGroup is the group for the
+                                            resource being referenced. If APIGroup
+                                            is not specified, the specified Kind must
+                                            be in the core API group. For any other
+                                            third-party types, APIGroup is required.
+                                          type: string
+                                        kind:
+                                          description: Kind is the type of resource
+                                            being referenced
+                                          type: string
+                                        name:
+                                          description: Name is the name of resource
+                                            being referenced
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                    dataSourceRef:
+                                      description: |-
+                                        dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef
+                                          allows any non-core object, as well as PersistentVolumeClaim objects.
+                                        * While DataSource ignores disallowed values (dropping them), DataSourceRef
+                                          preserves all values, and generates an error if a disallowed value is
+                                          specified.
+                                        (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                      properties:
+                                        apiGroup:
+                                          description: APIGroup is the group for the
+                                            resource being referenced. If APIGroup
+                                            is not specified, the specified Kind must
+                                            be in the core API group. For any other
+                                            third-party types, APIGroup is required.
+                                          type: string
+                                        kind:
+                                          description: Kind is the type of resource
+                                            being referenced
+                                          type: string
+                                        name:
+                                          description: Name is the name of resource
+                                            being referenced
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                    resources:
+                                      description: 'resources represents the minimum
+                                        resources the volume should have. If RecoverVolumeExpansionFailure
+                                        feature is enabled users are allowed to specify
+                                        resource requirements that are lower than
+                                        previous value but must still be higher than
+                                        capacity recorded in the status field of the
+                                        claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Limits describes the maximum
+                                            amount of compute resources allowed. More
+                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Requests describes the minimum
+                                            amount of compute resources required.
+                                            If Requests is omitted for a container,
+                                            it defaults to Limits if that is explicitly
+                                            specified, otherwise to an implementation-defined
+                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                      type: object
+                                    selector:
+                                      description: selector is a label query over
+                                        volumes to consider for binding.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    storageClassName:
+                                      description: 'storageClassName is the name of
+                                        the StorageClass required by the claim. More
+                                        info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                      type: string
+                                    volumeMode:
+                                      description: volumeMode defines what type of
+                                        volume is required by the claim. Value of
+                                        Filesystem is implied when not included in
+                                        claim spec.
+                                      type: string
+                                    volumeName:
+                                      description: volumeName is the binding reference
+                                        to the PersistentVolume backing this claim.
+                                      type: string
+                                  type: object
+                              required:
+                              - spec
+                              type: object
+                          type: object
+                        fc:
+                          description: fc represents a Fibre Channel resource that
+                            is attached to a kubelet's host machine and then exposed
+                            to the pod.
+                          properties:
+                            fsType:
+                              description: fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified.
+                              type: string
+                            lun:
+                              description: 'lun is Optional: FC target lun number'
+                              format: int32
+                              type: integer
+                            readOnly:
+                              description: 'readOnly is Optional: Defaults to false
+                                (read/write). ReadOnly here will force the ReadOnly
+                                setting in VolumeMounts.'
+                              type: boolean
+                            targetWWNs:
+                              description: 'targetWWNs is Optional: FC target worldwide
+                                names (WWNs)'
+                              items:
+                                type: string
+                              type: array
+                            wwids:
+                              description: 'wwids Optional: FC volume world wide identifiers
+                                (wwids) Either wwids or combination of targetWWNs
+                                and lun must be set, but not both simultaneously.'
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        flexVolume:
+                          description: flexVolume represents a generic volume resource
+                            that is provisioned/attached using an exec based plugin.
+                          properties:
+                            driver:
+                              description: driver is the name of the driver to use
+                                for this volume.
+                              type: string
+                            fsType:
+                              description: fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". The default filesystem
+                                depends on FlexVolume script.
+                              type: string
+                            options:
+                              additionalProperties:
+                                type: string
+                              description: 'options is Optional: this field holds
+                                extra command options if any.'
+                              type: object
+                            readOnly:
+                              description: 'readOnly is Optional: defaults to false
+                                (read/write). ReadOnly here will force the ReadOnly
+                                setting in VolumeMounts.'
+                              type: boolean
+                            secretRef:
+                              description: 'secretRef is Optional: secretRef is reference
+                                to the secret object containing sensitive information
+                                to pass to the plugin scripts. This may be empty if
+                                no secret object is specified. If the secret object
+                                contains more than one secret, all secrets are passed
+                                to the plugin scripts.'
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                          required:
+                          - driver
+                          type: object
+                        flocker:
+                          description: flocker represents a Flocker volume attached
+                            to a kubelet's host machine. This depends on the Flocker
+                            control service being running
+                          properties:
+                            datasetName:
+                              description: datasetName is Name of the dataset stored
+                                as metadata -> name on the dataset for Flocker should
+                                be considered as deprecated
+                              type: string
+                            datasetUUID:
+                              description: datasetUUID is the UUID of the dataset.
+                                This is unique identifier of a Flocker dataset
+                              type: string
+                          type: object
+                        gcePersistentDisk:
+                          description: 'gcePersistentDisk represents a GCE Disk resource
+                            that is attached to a kubelet''s host machine and then
+                            exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                          properties:
+                            fsType:
+                              description: 'fsType is filesystem type of the volume
+                                that you want to mount. Tip: Ensure that the filesystem
+                                type is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              type: string
+                            partition:
+                              description: 'partition is the partition in the volume
+                                that you want to mount. If omitted, the default is
+                                to mount by volume name. Examples: For volume /dev/sda1,
+                                you specify the partition as "1". Similarly, the volume
+                                partition for /dev/sda is "0" (or you can leave the
+                                property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              format: int32
+                              type: integer
+                            pdName:
+                              description: 'pdName is unique name of the PD resource
+                                in GCE. Used to identify the disk in GCE. More info:
+                                https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              type: string
+                            readOnly:
+                              description: 'readOnly here will force the ReadOnly
+                                setting in VolumeMounts. Defaults to false. More info:
+                                https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              type: boolean
+                          required:
+                          - pdName
+                          type: object
+                        gitRepo:
+                          description: 'gitRepo represents a git repository at a particular
+                            revision. DEPRECATED: GitRepo is deprecated. To provision
+                            a container with a git repo, mount an EmptyDir into an
+                            InitContainer that clones the repo using git, then mount
+                            the EmptyDir into the Pod''s container.'
+                          properties:
+                            directory:
+                              description: directory is the target directory name.
+                                Must not contain or start with '..'.  If '.' is supplied,
+                                the volume directory will be the git repository.  Otherwise,
+                                if specified, the volume will contain the git repository
+                                in the subdirectory with the given name.
+                              type: string
+                            repository:
+                              description: repository is the URL
+                              type: string
+                            revision:
+                              description: revision is the commit hash for the specified
+                                revision.
+                              type: string
+                          required:
+                          - repository
+                          type: object
+                        glusterfs:
+                          description: 'glusterfs represents a Glusterfs mount on
+                            the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                          properties:
+                            endpoints:
+                              description: 'endpoints is the endpoint name that details
+                                Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                              type: string
+                            path:
+                              description: 'path is the Glusterfs volume path. More
+                                info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                              type: string
+                            readOnly:
+                              description: 'readOnly here will force the Glusterfs
+                                volume to be mounted with read-only permissions. Defaults
+                                to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                              type: boolean
+                          required:
+                          - endpoints
+                          - path
+                          type: object
+                        hostPath:
+                          description: 'hostPath represents a pre-existing file or
+                            directory on the host machine that is directly exposed
+                            to the container. This is generally used for system agents
+                            or other privileged things that are allowed to see the
+                            host machine. Most containers will NOT need this. More
+                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                          properties:
+                            path:
+                              description: 'path of the directory on the host. If
+                                the path is a symlink, it will follow the link to
+                                the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                              type: string
+                            type:
+                              description: 'type for HostPath Volume Defaults to ""
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        iscsi:
+                          description: 'iscsi represents an ISCSI Disk resource that
+                            is attached to a kubelet''s host machine and then exposed
+                            to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                          properties:
+                            chapAuthDiscovery:
+                              description: chapAuthDiscovery defines whether support
+                                iSCSI Discovery CHAP authentication
+                              type: boolean
+                            chapAuthSession:
+                              description: chapAuthSession defines whether support
+                                iSCSI Session CHAP authentication
+                              type: boolean
+                            fsType:
+                              description: 'fsType is the filesystem type of the volume
+                                that you want to mount. Tip: Ensure that the filesystem
+                                type is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                              type: string
+                            initiatorName:
+                              description: initiatorName is the custom iSCSI Initiator
+                                Name. If initiatorName is specified with iscsiInterface
+                                simultaneously, new iSCSI interface <target portal>:<volume
+                                name> will be created for the connection.
+                              type: string
+                            iqn:
+                              description: iqn is the target iSCSI Qualified Name.
+                              type: string
+                            iscsiInterface:
+                              description: iscsiInterface is the interface Name that
+                                uses an iSCSI transport. Defaults to 'default' (tcp).
+                              type: string
+                            lun:
+                              description: lun represents iSCSI Target Lun number.
+                              format: int32
+                              type: integer
+                            portals:
+                              description: portals is the iSCSI Target Portal List.
+                                The portal is either an IP or ip_addr:port if the
+                                port is other than default (typically TCP ports 860
+                                and 3260).
+                              items:
+                                type: string
+                              type: array
+                            readOnly:
+                              description: readOnly here will force the ReadOnly setting
+                                in VolumeMounts. Defaults to false.
+                              type: boolean
+                            secretRef:
+                              description: secretRef is the CHAP Secret for iSCSI
+                                target and initiator authentication
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            targetPortal:
+                              description: targetPortal is iSCSI Target Portal. The
+                                Portal is either an IP or ip_addr:port if the port
+                                is other than default (typically TCP ports 860 and
+                                3260).
+                              type: string
+                          required:
+                          - targetPortal
+                          - iqn
+                          - lun
+                          type: object
+                        name:
+                          description: 'name of the volume. Must be a DNS_LABEL and
+                            unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        nfs:
+                          description: 'nfs represents an NFS mount on the host that
+                            shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                          properties:
+                            path:
+                              description: 'path that is exported by the NFS server.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              type: string
+                            readOnly:
+                              description: 'readOnly here will force the NFS export
+                                to be mounted with read-only permissions. Defaults
+                                to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              type: boolean
+                            server:
+                              description: 'server is the hostname or IP address of
+                                the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              type: string
+                          required:
+                          - server
+                          - path
+                          type: object
+                        persistentVolumeClaim:
+                          description: 'persistentVolumeClaimVolumeSource represents
+                            a reference to a PersistentVolumeClaim in the same namespace.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          properties:
+                            claimName:
+                              description: 'claimName is the name of a PersistentVolumeClaim
+                                in the same namespace as the pod using this volume.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              type: string
+                            readOnly:
+                              description: readOnly Will force the ReadOnly setting
+                                in VolumeMounts. Default false.
+                              type: boolean
+                          required:
+                          - claimName
+                          type: object
+                        photonPersistentDisk:
+                          description: photonPersistentDisk represents a PhotonController
+                            persistent disk attached and mounted on kubelets host
+                            machine
+                          properties:
+                            fsType:
+                              description: fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified.
+                              type: string
+                            pdID:
+                              description: pdID is the ID that identifies Photon Controller
+                                persistent disk
+                              type: string
+                          required:
+                          - pdID
+                          type: object
+                        portworxVolume:
+                          description: portworxVolume represents a portworx volume
+                            attached and mounted on kubelets host machine
+                          properties:
+                            fsType:
+                              description: fSType represents the filesystem type to
+                                mount Must be a filesystem type supported by the host
+                                operating system. Ex. "ext4", "xfs". Implicitly inferred
+                                to be "ext4" if unspecified.
+                              type: string
+                            readOnly:
+                              description: readOnly defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            volumeID:
+                              description: volumeID uniquely identifies a Portworx
+                                volume
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        projected:
+                          description: projected items for all in one resources secrets,
+                            configmaps, and downward API
+                          properties:
+                            defaultMode:
+                              description: defaultMode are the mode bits used to set
+                                permissions on created files by default. Must be an
+                                octal value between 0000 and 0777 or a decimal value
+                                between 0 and 511. YAML accepts both octal and decimal
+                                values, JSON requires decimal values for mode bits.
+                                Directories within the path are not affected by this
+                                setting. This might be in conflict with other options
+                                that affect the file mode, like fsGroup, and the result
+                                can be other mode bits set.
+                              format: int32
+                              type: integer
+                            sources:
+                              description: sources is the list of volume projections
+                              items:
+                                description: Projection that may be projected along
+                                  with other supported volume types
+                                properties:
+                                  configMap:
+                                    description: configMap information about the configMap
+                                      data to project
+                                    properties:
+                                      items:
+                                        description: items if unspecified, each key-value
+                                          pair in the Data field of the referenced
+                                          ConfigMap will be projected into the volume
+                                          as a file whose name is the key and content
+                                          is the value. If specified, the listed keys
+                                          will be projected into the specified paths,
+                                          and unlisted keys will not be present. If
+                                          a key is specified which is not present
+                                          in the ConfigMap, the volume setup will
+                                          error unless it is marked optional. Paths
+                                          must be relative and may not contain the
+                                          '..' path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: key is the key to project.
+                                              type: string
+                                            mode:
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: path is the relative path
+                                                of the file to map the key to. May
+                                                not be an absolute path. May not contain
+                                                the path element '..'. May not start
+                                                with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: optional specify whether the
+                                          ConfigMap or its keys must be defined
+                                        type: boolean
+                                    type: object
+                                  downwardAPI:
+                                    description: downwardAPI information about the
+                                      downwardAPI data to project
+                                    properties:
+                                      items:
+                                        description: Items is a list of DownwardAPIVolume
+                                          file
+                                        items:
+                                          description: DownwardAPIVolumeFile represents
+                                            information to create the file containing
+                                            the pod field
+                                          properties:
+                                            fieldRef:
+                                              description: 'Required: Selects a field
+                                                of the pod: only annotations, labels,
+                                                name and namespace are supported.'
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                            mode:
+                                              description: 'Optional: mode bits used
+                                                to set permissions on this file, must
+                                                be an octal value between 0000 and
+                                                0777 or a decimal value between 0
+                                                and 511. YAML accepts both octal and
+                                                decimal values, JSON requires decimal
+                                                values for mode bits. If not specified,
+                                                the volume defaultMode will be used.
+                                                This might be in conflict with other
+                                                options that affect the file mode,
+                                                like fsGroup, and the result can be
+                                                other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: 'Required: Path is  the
+                                                relative path name of the file to
+                                                be created. Must not be absolute or
+                                                contain the ''..'' path. Must be utf-8
+                                                encoded. The first item of the relative
+                                                path must not start with ''..'''
+                                              type: string
+                                            resourceFieldRef:
+                                              description: 'Selects a resource of
+                                                the container: only resources limits
+                                                and requests (limits.cpu, limits.memory,
+                                                requests.cpu and requests.memory)
+                                                are currently supported.'
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                          required:
+                                          - path
+                                          type: object
+                                        type: array
+                                    type: object
+                                  secret:
+                                    description: secret information about the secret
+                                      data to project
+                                    properties:
+                                      items:
+                                        description: items if unspecified, each key-value
+                                          pair in the Data field of the referenced
+                                          Secret will be projected into the volume
+                                          as a file whose name is the key and content
+                                          is the value. If specified, the listed keys
+                                          will be projected into the specified paths,
+                                          and unlisted keys will not be present. If
+                                          a key is specified which is not present
+                                          in the Secret, the volume setup will error
+                                          unless it is marked optional. Paths must
+                                          be relative and may not contain the '..'
+                                          path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: key is the key to project.
+                                              type: string
+                                            mode:
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: path is the relative path
+                                                of the file to map the key to. May
+                                                not be an absolute path. May not contain
+                                                the path element '..'. May not start
+                                                with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: optional field specify whether
+                                          the Secret or its key must be defined
+                                        type: boolean
+                                    type: object
+                                  serviceAccountToken:
+                                    description: serviceAccountToken is information
+                                      about the serviceAccountToken data to project
+                                    properties:
+                                      audience:
+                                        description: audience is the intended audience
+                                          of the token. A recipient of a token must
+                                          identify itself with an identifier specified
+                                          in the audience of the token, and otherwise
+                                          should reject the token. The audience defaults
+                                          to the identifier of the apiserver.
+                                        type: string
+                                      expirationSeconds:
+                                        description: expirationSeconds is the requested
+                                          duration of validity of the service account
+                                          token. As the token approaches expiration,
+                                          the kubelet volume plugin will proactively
+                                          rotate the service account token. The kubelet
+                                          will start trying to rotate the token if
+                                          the token is older than 80 percent of its
+                                          time to live or if the token is older than
+                                          24 hours.Defaults to 1 hour and must be
+                                          at least 10 minutes.
+                                        format: int64
+                                        type: integer
+                                      path:
+                                        description: path is the path relative to
+                                          the mount point of the file to project the
+                                          token into.
+                                        type: string
+                                    required:
+                                    - path
+                                    type: object
+                                type: object
+                              type: array
+                          type: object
+                        quobyte:
+                          description: quobyte represents a Quobyte mount on the host
+                            that shares a pod's lifetime
+                          properties:
+                            group:
+                              description: group to map volume access to Default is
+                                no group
+                              type: string
+                            readOnly:
+                              description: readOnly here will force the Quobyte volume
+                                to be mounted with read-only permissions. Defaults
+                                to false.
+                              type: boolean
+                            registry:
+                              description: registry represents a single or multiple
+                                Quobyte Registry services specified as a string as
+                                host:port pair (multiple entries are separated with
+                                commas) which acts as the central registry for volumes
+                              type: string
+                            tenant:
+                              description: tenant owning the given Quobyte volume
+                                in the Backend Used with dynamically provisioned Quobyte
+                                volumes, value is set by the plugin
+                              type: string
+                            user:
+                              description: user to map volume access to Defaults to
+                                serivceaccount user
+                              type: string
+                            volume:
+                              description: volume is a string that references an already
+                                created Quobyte volume by name.
+                              type: string
+                          required:
+                          - registry
+                          - volume
+                          type: object
+                        rbd:
+                          description: 'rbd represents a Rados Block Device mount
+                            on the host that shares a pod''s lifetime. More info:
+                            https://examples.k8s.io/volumes/rbd/README.md'
+                          properties:
+                            fsType:
+                              description: 'fsType is the filesystem type of the volume
+                                that you want to mount. Tip: Ensure that the filesystem
+                                type is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                              type: string
+                            image:
+                              description: 'image is the rados image name. More info:
+                                https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: string
+                            keyring:
+                              description: 'keyring is the path to key ring for RBDUser.
+                                Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: string
+                            monitors:
+                              description: 'monitors is a collection of Ceph monitors.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              items:
+                                type: string
+                              type: array
+                            pool:
+                              description: 'pool is the rados pool name. Default is
+                                rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: string
+                            readOnly:
+                              description: 'readOnly here will force the ReadOnly
+                                setting in VolumeMounts. Defaults to false. More info:
+                                https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: boolean
+                            secretRef:
+                              description: 'secretRef is name of the authentication
+                                secret for RBDUser. If provided overrides keyring.
+                                Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            user:
+                              description: 'user is the rados user name. Default is
+                                admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: string
+                          required:
+                          - monitors
+                          - image
+                          type: object
+                        scaleIO:
+                          description: scaleIO represents a ScaleIO persistent volume
+                            attached and mounted on Kubernetes nodes.
+                          properties:
+                            fsType:
+                              description: fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                              type: string
+                            gateway:
+                              description: gateway is the host address of the ScaleIO
+                                API Gateway.
+                              type: string
+                            protectionDomain:
+                              description: protectionDomain is the name of the ScaleIO
+                                Protection Domain for the configured storage.
+                              type: string
+                            readOnly:
+                              description: readOnly Defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretRef:
+                              description: secretRef references to the secret for
+                                ScaleIO user and other sensitive information. If this
+                                is not provided, Login operation will fail.
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            sslEnabled:
+                              description: sslEnabled Flag enable/disable SSL communication
+                                with Gateway, default false
+                              type: boolean
+                            storageMode:
+                              description: storageMode indicates whether the storage
+                                for a volume should be ThickProvisioned or ThinProvisioned.
+                                Default is ThinProvisioned.
+                              type: string
+                            storagePool:
+                              description: storagePool is the ScaleIO Storage Pool
+                                associated with the protection domain.
+                              type: string
+                            system:
+                              description: system is the name of the storage system
+                                as configured in ScaleIO.
+                              type: string
+                            volumeName:
+                              description: volumeName is the name of a volume already
+                                created in the ScaleIO system that is associated with
+                                this volume source.
+                              type: string
+                          required:
+                          - gateway
+                          - system
+                          - secretRef
+                          type: object
+                        secret:
+                          description: 'secret represents a secret that should populate
+                            this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                          properties:
+                            defaultMode:
+                              description: 'defaultMode is Optional: mode bits used
+                                to set permissions on created files by default. Must
+                                be an octal value between 0000 and 0777 or a decimal
+                                value between 0 and 511. YAML accepts both octal and
+                                decimal values, JSON requires decimal values for mode
+                                bits. Defaults to 0644. Directories within the path
+                                are not affected by this setting. This might be in
+                                conflict with other options that affect the file mode,
+                                like fsGroup, and the result can be other mode bits
+                                set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: items If unspecified, each key-value pair
+                                in the Data field of the referenced Secret will be
+                                projected into the volume as a file whose name is
+                                the key and content is the value. If specified, the
+                                listed keys will be projected into the specified paths,
+                                and unlisted keys will not be present. If a key is
+                                specified which is not present in the Secret, the
+                                volume setup will error unless it is marked optional.
+                                Paths must be relative and may not contain the '..'
+                                path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a
+                                  volume.
+                                properties:
+                                  key:
+                                    description: key is the key to project.
+                                    type: string
+                                  mode:
+                                    description: 'mode is Optional: mode bits used
+                                      to set permissions on this file. Must be an
+                                      octal value between 0000 and 0777 or a decimal
+                                      value between 0 and 511. YAML accepts both octal
+                                      and decimal values, JSON requires decimal values
+                                      for mode bits. If not specified, the volume
+                                      defaultMode will be used. This might be in conflict
+                                      with other options that affect the file mode,
+                                      like fsGroup, and the result can be other mode
+                                      bits set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: path is the relative path of the
+                                      file to map the key to. May not be an absolute
+                                      path. May not contain the path element '..'.
+                                      May not start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                            optional:
+                              description: optional field specify whether the Secret
+                                or its keys must be defined
+                              type: boolean
+                            secretName:
+                              description: 'secretName is the name of the secret in
+                                the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              type: string
+                          type: object
+                        storageos:
+                          description: storageOS represents a StorageOS volume attached
+                            and mounted on Kubernetes nodes.
+                          properties:
+                            fsType:
+                              description: fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified.
+                              type: string
+                            readOnly:
+                              description: readOnly defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretRef:
+                              description: secretRef specifies the secret to use for
+                                obtaining the StorageOS API credentials.  If not specified,
+                                default values will be attempted.
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            volumeName:
+                              description: volumeName is the human-readable name of
+                                the StorageOS volume.  Volume names are only unique
+                                within a namespace.
+                              type: string
+                            volumeNamespace:
+                              description: volumeNamespace specifies the scope of
+                                the volume within StorageOS.  If no namespace is specified
+                                then the Pod's namespace will be used.  This allows
+                                the Kubernetes name scoping to be mirrored within
+                                StorageOS for tighter integration. Set VolumeName
+                                to any name to override the default behaviour. Set
+                                to "default" if you are not using namespaces within
+                                StorageOS. Namespaces that do not pre-exist within
+                                StorageOS will be created.
+                              type: string
+                          type: object
+                        vsphereVolume:
+                          description: vsphereVolume represents a vSphere volume attached
+                            and mounted on kubelets host machine
+                          properties:
+                            fsType:
+                              description: fsType is filesystem type to mount. Must
+                                be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified.
+                              type: string
+                            storagePolicyID:
+                              description: storagePolicyID is the storage Policy Based
+                                Management (SPBM) profile ID associated with the StoragePolicyName.
+                              type: string
+                            storagePolicyName:
+                              description: storagePolicyName is the storage Policy
+                                Based Management (SPBM) profile name.
+                              type: string
+                            volumePath:
+                              description: volumePath is the path that identifies
+                                vSphere volume vmdk
+                              type: string
+                          required:
+                          - volumePath
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                required:
+                - containers
+                type: object
+            type: object
+        required:
+        - selector
+        - template
+        type: object
+      status:
+        description: Most recently observed status of the Deployment.
+        properties:
+          availableReplicas:
+            description: Total number of available pods (ready for at least minReadySeconds)
+              targeted by this deployment.
+            format: int32
+            type: integer
+          collisionCount:
+            description: Count of hash collisions for the Deployment. The Deployment
+              controller uses this field as a collision avoidance mechanism when it
+              needs to create the name for the newest ReplicaSet.
+            format: int32
+            type: integer
+          conditions:
+            description: Represents the latest available observations of a deployment's
+              current state.
+            items:
+              description: DeploymentCondition describes the state of a deployment
+                at a certain point.
+              properties:
+                lastTransitionTime:
+                  description: Last time the condition transitioned from one status
+                    to another.
+                  format: date-time
+                  type: string
+                lastUpdateTime:
+                  description: The last time this condition was updated.
+                  format: date-time
+                  type: string
+                message:
+                  description: A human readable message indicating details about the
+                    transition.
+                  type: string
+                reason:
+                  description: The reason for the condition's last transition.
+                  type: string
+                status:
+                  description: Status of the condition, one of True, False, Unknown.
+                  type: string
+                type:
+                  description: Type of deployment condition.
+                  type: string
+              required:
+              - status
+              - type
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - type
+            x-kubernetes-list-type: map
+          observedGeneration:
+            description: The generation observed by the deployment controller.
+            format: int64
+            type: integer
+          readyReplicas:
+            description: readyReplicas is the number of pods targeted by this Deployment
+              with a Ready Condition.
+            format: int32
+            type: integer
+          replicas:
+            description: Total number of non-terminated pods targeted by this deployment
+              (their labels match the selector).
+            format: int32
+            type: integer
+          unavailableReplicas:
+            description: Total number of unavailable pods targeted by this deployment.
+              This is the total number of pods that are still required for the deployment
+              to have 100% available capacity. They may either be pods that are running
+              but not yet available or pods that still have not been created.
+            format: int32
+            type: integer
+          updatedReplicas:
+            description: Total number of non-terminated pods targeted by this deployment
+              that have the desired template spec.
+            format: int32
+            type: integer
+        type: object
+    type: object
+  plural: deployments
+  schemaUpdateStrategy: UpdateUnpublished
+  scope: Namespaced
+  shortNames:
+  - deploy
+  singular: deployment
+  subResources:
+  - name: scale
+  - name: status
+status:
+  conditions:
+  - lastTransitionTime: "2023-03-21T17:10:10Z"
+    status: "True"
+    type: Compatible

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/4-APIResourceImport-ingresses.kind.v1.networking.k8s.io.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/4-APIResourceImport-ingresses.kind.v1.networking.k8s.io.yaml
@@ -1,0 +1,356 @@
+apiVersion: apiresource.kcp.io/v1alpha1
+kind: APIResourceImport
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kcp-dev/kubernetes/pull/4
+    apiresource.kcp.io/apiVersion: networking.k8s.io/v1
+    kcp.io/cluster: br3qimk2t1o3jb70
+  creationTimestamp: "2023-03-21T17:10:10Z"
+  generation: 1
+  name: ingresses.kind.v1.networking.k8s.io
+  ownerReferences:
+  - apiVersion: workload.kcp.io/v1alpha1
+    controller: true
+    kind: SyncTarget
+    name: kind
+    uid: 8df305e7-f4f8-439f-9115-51054d519361
+  resourceVersion: "9154"
+  uid: 64009668-946b-4101-82a1-199cac106e65
+spec:
+  groupVersion:
+    group: networking.k8s.io
+    version: v1
+  kind: Ingress
+  listKind: IngressList
+  location: kind
+  openAPIV3Schema:
+    description: Ingress is a collection of rules that allow inbound connections to
+      reach the endpoints defined by a backend. An Ingress can be configured to give
+      services externally-reachable urls, load balance traffic, terminate SSL, offer
+      name based virtual hosting etc.
+    properties:
+      apiVersion:
+        description: 'APIVersion defines the versioned schema of this representation
+          of an object. Servers should convert recognized schemas to the latest internal
+          value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+        type: string
+      kind:
+        description: 'Kind is a string value representing the REST resource this object
+          represents. Servers may infer this from the endpoint the client submits
+          requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+        type: string
+      metadata:
+        type: object
+      spec:
+        description: 'Spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+        properties:
+          defaultBackend:
+            description: DefaultBackend is the backend that should handle requests
+              that don't match any rule. If Rules are not specified, DefaultBackend
+              must be specified. If DefaultBackend is not set, the handling of requests
+              that do not match any of the rules will be up to the Ingress controller.
+            properties:
+              resource:
+                description: Resource is an ObjectRef to another Kubernetes resource
+                  in the namespace of the Ingress object. If resource is specified,
+                  a service.Name and service.Port must not be specified. This is a
+                  mutually exclusive setting with "Service".
+                properties:
+                  apiGroup:
+                    description: APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in
+                      the core API group. For any other third-party types, APIGroup
+                      is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              service:
+                description: Service references a Service as a Backend. This is a
+                  mutually exclusive setting with "Resource".
+                properties:
+                  name:
+                    description: Name is the referenced service. The service must
+                      exist in the same namespace as the Ingress object.
+                    type: string
+                  port:
+                    description: Port of the referenced service. A port name or port
+                      number is required for a IngressServiceBackend.
+                    properties:
+                      name:
+                        description: Name is the name of the port on the Service.
+                          This is a mutually exclusive setting with "Number".
+                        type: string
+                      number:
+                        description: Number is the numerical port number (e.g. 80)
+                          on the Service. This is a mutually exclusive setting with
+                          "Name".
+                        format: int32
+                        type: integer
+                    type: object
+                required:
+                - name
+                type: object
+            type: object
+          ingressClassName:
+            description: IngressClassName is the name of an IngressClass cluster resource.
+              Ingress controller implementations use this field to know whether they
+              should be serving this Ingress resource, by a transitive connection
+              (controller -> IngressClass -> Ingress resource). Although the `kubernetes.io/ingress.class`
+              annotation (simple constant name) was never formally defined, it was
+              widely supported by Ingress controllers to create a direct binding between
+              Ingress controller and Ingress resources. Newly created Ingress resources
+              should prefer using the field. However, even though the annotation is
+              officially deprecated, for backwards compatibility reasons, ingress
+              controllers should still honor that annotation if present.
+            type: string
+          rules:
+            description: A list of host rules used to configure the Ingress. If unspecified,
+              or no rule matches, all traffic is sent to the default backend.
+            items:
+              description: IngressRule represents the rules mapping the paths under
+                a specified host to the related backend services. Incoming requests
+                are first evaluated for a host match, then routed to the backend associated
+                with the matching IngressRuleValue.
+              properties:
+                host:
+                  description: "Host is the fully qualified domain name of a network
+                    host, as defined by RFC 3986. Note the following deviations from
+                    the \"host\" part of the URI as defined in RFC 3986: 1. IPs are
+                    not allowed. Currently an IngressRuleValue can only apply to\n
+                    \  the IP in the Spec of the parent Ingress.\n2. The `:` delimiter
+                    is not respected because ports are not allowed.\n\t  Currently
+                    the port of an Ingress is implicitly :80 for http and\n\t  :443
+                    for https.\nBoth these may change in the future. Incoming requests
+                    are matched against the host before the IngressRuleValue. If the
+                    host is unspecified, the Ingress routes all traffic based on the
+                    specified IngressRuleValue.\n\nHost can be \"precise\" which is
+                    a domain name without the terminating dot of a network host (e.g.
+                    \"foo.bar.com\") or \"wildcard\", which is a domain name prefixed
+                    with a single wildcard label (e.g. \"*.foo.com\"). The wildcard
+                    character '*' must appear by itself as the first DNS label and
+                    matches only a single label. You cannot have a wildcard label
+                    by itself (e.g. Host == \"*\"). Requests will be matched against
+                    the Host field in the following way: 1. If Host is precise, the
+                    request matches this rule if the http host header is equal to
+                    Host. 2. If Host is a wildcard, then the request matches this
+                    rule if the http host header is to equal to the suffix (removing
+                    the first label) of the wildcard rule."
+                  type: string
+                http:
+                  description: 'HTTPIngressRuleValue is a list of http selectors pointing
+                    to backends. In the example: http://<host>/<path>?<searchpart>
+                    -> backend where where parts of the url correspond to RFC 3986,
+                    this resource will be used to match against everything after the
+                    last ''/'' and before the first ''?'' or ''#''.'
+                  properties:
+                    paths:
+                      description: A collection of paths that map requests to backends.
+                      items:
+                        description: HTTPIngressPath associates a path with a backend.
+                          Incoming urls matching the path are forwarded to the backend.
+                        properties:
+                          backend:
+                            description: Backend defines the referenced service endpoint
+                              to which the traffic will be forwarded to.
+                            properties:
+                              resource:
+                                description: Resource is an ObjectRef to another Kubernetes
+                                  resource in the namespace of the Ingress object.
+                                  If resource is specified, a service.Name and service.Port
+                                  must not be specified. This is a mutually exclusive
+                                  setting with "Service".
+                                properties:
+                                  apiGroup:
+                                    description: APIGroup is the group for the resource
+                                      being referenced. If APIGroup is not specified,
+                                      the specified Kind must be in the core API group.
+                                      For any other third-party types, APIGroup is
+                                      required.
+                                    type: string
+                                  kind:
+                                    description: Kind is the type of resource being
+                                      referenced
+                                    type: string
+                                  name:
+                                    description: Name is the name of resource being
+                                      referenced
+                                    type: string
+                                required:
+                                - kind
+                                - name
+                                type: object
+                              service:
+                                description: Service references a Service as a Backend.
+                                  This is a mutually exclusive setting with "Resource".
+                                properties:
+                                  name:
+                                    description: Name is the referenced service. The
+                                      service must exist in the same namespace as
+                                      the Ingress object.
+                                    type: string
+                                  port:
+                                    description: Port of the referenced service. A
+                                      port name or port number is required for a IngressServiceBackend.
+                                    properties:
+                                      name:
+                                        description: Name is the name of the port
+                                          on the Service. This is a mutually exclusive
+                                          setting with "Number".
+                                        type: string
+                                      number:
+                                        description: Number is the numerical port
+                                          number (e.g. 80) on the Service. This is
+                                          a mutually exclusive setting with "Name".
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                            type: object
+                          path:
+                            description: Path is matched against the path of an incoming
+                              request. Currently it can contain characters disallowed
+                              from the conventional "path" part of a URL as defined
+                              by RFC 3986. Paths must begin with a '/' and must be
+                              present when using PathType with value "Exact" or "Prefix".
+                            type: string
+                          pathType:
+                            description: |-
+                              PathType determines the interpretation of the Path matching. PathType can be one of the following values: * Exact: Matches the URL path exactly. * Prefix: Matches based on a URL path prefix split by '/'. Matching is
+                                done on a path element by element basis. A path element refers is the
+                                list of labels in the path split by the '/' separator. A request is a
+                                match for path p if every p is an element-wise prefix of p of the
+                                request path. Note that if the last element of the path is a substring
+                                of the last element in request path, it is not a match (e.g. /foo/bar
+                                matches /foo/bar/baz, but does not match /foo/barbaz).
+                              * ImplementationSpecific: Interpretation of the Path matching is up to
+                                the IngressClass. Implementations can treat this as a separate PathType
+                                or treat it identically to Prefix or Exact path types.
+                              Implementations are required to support all path types.
+                            type: string
+                        required:
+                        - pathType
+                        - backend
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  required:
+                  - paths
+                  type: object
+              type: object
+            type: array
+            x-kubernetes-list-type: atomic
+          tls:
+            description: TLS configuration. Currently the Ingress only supports a
+              single TLS port, 443. If multiple members of this list specify different
+              hosts, they will be multiplexed on the same port according to the hostname
+              specified through the SNI TLS extension, if the ingress controller fulfilling
+              the ingress supports SNI.
+            items:
+              description: IngressTLS describes the transport layer security associated
+                with an Ingress.
+              properties:
+                hosts:
+                  description: Hosts are a list of hosts included in the TLS certificate.
+                    The values in this list must match the name/s used in the tlsSecret.
+                    Defaults to the wildcard host setting for the loadbalancer controller
+                    fulfilling this Ingress, if left unspecified.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: atomic
+                secretName:
+                  description: SecretName is the name of the secret used to terminate
+                    TLS traffic on port 443. Field is left optional to allow TLS routing
+                    based on SNI hostname alone. If the SNI host in a listener conflicts
+                    with the "Host" header field used by an IngressRule, the SNI host
+                    is used for termination and value of the Host header is used for
+                    routing.
+                  type: string
+              type: object
+            type: array
+            x-kubernetes-list-type: atomic
+        type: object
+      status:
+        description: 'Status is the current state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+        properties:
+          loadBalancer:
+            description: LoadBalancer contains the current status of the load-balancer.
+            properties:
+              ingress:
+                description: Ingress is a list containing ingress points for the load-balancer.
+                  Traffic intended for the service should be sent to these ingress
+                  points.
+                items:
+                  description: 'LoadBalancerIngress represents the status of a load-balancer
+                    ingress point: traffic intended for the service should be sent
+                    to an ingress point.'
+                  properties:
+                    hostname:
+                      description: Hostname is set for load-balancer ingress points
+                        that are DNS based (typically AWS load-balancers)
+                      type: string
+                    ip:
+                      description: IP is set for load-balancer ingress points that
+                        are IP based (typically GCE or OpenStack load-balancers)
+                      type: string
+                    ports:
+                      description: Ports is a list of records of service ports If
+                        used, every port defined in the service should have an entry
+                        in it
+                      items:
+                        properties:
+                          error:
+                            description: |-
+                              Error is to record the problem with the service port The format of the error shall comply with the following rules: - built-in error values shall be specified in this file and those shall use
+                                CamelCase names
+                              - cloud provider specific error values must have names that comply with the
+                                format foo.example.com/CamelCase.
+                            type: string
+                          port:
+                            description: Port is the port number of the service port
+                              of which status is recorded here
+                            format: int32
+                            type: integer
+                          protocol:
+                            description: |-
+                              Protocol is the protocol of the service port of which status is recorded here The supported values are: "TCP", "UDP", "SCTP"
+
+                              Possible enum values:
+                               - `"SCTP"` is the SCTP protocol.
+                               - `"TCP"` is the TCP protocol.
+                               - `"UDP"` is the UDP protocol.
+                            type: string
+                        required:
+                        - port
+                        - protocol
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  type: object
+                type: array
+            type: object
+        type: object
+    type: object
+  plural: ingresses
+  schemaUpdateStrategy: UpdateUnpublished
+  scope: Namespaced
+  shortNames:
+  - ing
+  singular: ingress
+  subResources:
+  - name: status
+status:
+  conditions:
+  - lastTransitionTime: "2023-03-21T17:10:10Z"
+    status: "True"
+    type: Compatible

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/4-APIResourceImport-pods.kind.v1.core.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/4-APIResourceImport-pods.kind.v1.core.yaml
@@ -1,0 +1,7105 @@
+apiVersion: apiresource.kcp.io/v1alpha1
+kind: APIResourceImport
+metadata:
+  annotations:
+    apiresource.kcp.io/apiVersion: v1
+    kcp.io/cluster: br3qimk2t1o3jb70
+  creationTimestamp: "2023-03-21T17:10:09Z"
+  generation: 1
+  name: pods.kind.v1.core
+  ownerReferences:
+  - apiVersion: workload.kcp.io/v1alpha1
+    controller: true
+    kind: SyncTarget
+    name: kind
+    uid: 8df305e7-f4f8-439f-9115-51054d519361
+  resourceVersion: "9156"
+  uid: ae3bc872-30e7-4abf-9501-93142a390803
+spec:
+  categories:
+  - all
+  groupVersion:
+    version: v1
+  kind: Pod
+  listKind: PodList
+  location: kind
+  openAPIV3Schema:
+    description: Pod is a collection of containers that can run on a host. This resource
+      is created by clients and scheduled onto hosts.
+    properties:
+      apiVersion:
+        description: 'APIVersion defines the versioned schema of this representation
+          of an object. Servers should convert recognized schemas to the latest internal
+          value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+        type: string
+      kind:
+        description: 'Kind is a string value representing the REST resource this object
+          represents. Servers may infer this from the endpoint the client submits
+          requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+        type: string
+      metadata:
+        type: object
+      spec:
+        description: 'Specification of the desired behavior of the pod. More info:
+          https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+        properties:
+          activeDeadlineSeconds:
+            description: Optional duration in seconds the pod may be active on the
+              node relative to StartTime before the system will actively try to mark
+              it failed and kill associated containers. Value must be a positive integer.
+            format: int64
+            type: integer
+          affinity:
+            description: If specified, the pod's scheduling constraints
+            properties:
+              nodeAffinity:
+                description: Describes node affinity scheduling rules for the pod.
+                properties:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    description: The scheduler will prefer to schedule pods to nodes
+                      that satisfy the affinity expressions specified by this field,
+                      but it may choose a node that violates one or more of the expressions.
+                      The node that is most preferred is the one with the greatest
+                      sum of weights, i.e. for each node that meets all of the scheduling
+                      requirements (resource request, requiredDuringScheduling affinity
+                      expressions, etc.), compute a sum by iterating through the elements
+                      of this field and adding "weight" to the sum if the node matches
+                      the corresponding matchExpressions; the node(s) with the highest
+                      sum are the most preferred.
+                    items:
+                      description: An empty preferred scheduling term matches all
+                        objects with implicit weight 0 (i.e. it's a no-op). A null
+                        preferred scheduling term matches no objects (i.e. is also
+                        a no-op).
+                      properties:
+                        preference:
+                          description: A node selector term, associated with the corresponding
+                            weight.
+                          properties:
+                            matchExpressions:
+                              description: A list of node selector requirements by
+                                node's labels.
+                              items:
+                                description: A node selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: The label key that the selector applies
+                                      to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                      Possible enum values:
+                                       - `"DoesNotExist"`
+                                       - `"Exists"`
+                                       - `"Gt"`
+                                       - `"In"`
+                                       - `"Lt"`
+                                       - `"NotIn"`
+                                    type: string
+                                  values:
+                                    description: An array of string values. If the
+                                      operator is In or NotIn, the values array must
+                                      be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator
+                                      is Gt or Lt, the values array must have a single
+                                      element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchFields:
+                              description: A list of node selector requirements by
+                                node's fields.
+                              items:
+                                description: A node selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: The label key that the selector applies
+                                      to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                      Possible enum values:
+                                       - `"DoesNotExist"`
+                                       - `"Exists"`
+                                       - `"Gt"`
+                                       - `"In"`
+                                       - `"Lt"`
+                                       - `"NotIn"`
+                                    type: string
+                                  values:
+                                    description: An array of string values. If the
+                                      operator is In or NotIn, the values array must
+                                      be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator
+                                      is Gt or Lt, the values array must have a single
+                                      element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                          type: object
+                        weight:
+                          description: Weight associated with matching the corresponding
+                            nodeSelectorTerm, in the range 1-100.
+                          format: int32
+                          type: integer
+                      required:
+                      - weight
+                      - preference
+                      type: object
+                    type: array
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    description: If the affinity requirements specified by this field
+                      are not met at scheduling time, the pod will not be scheduled
+                      onto the node. If the affinity requirements specified by this
+                      field cease to be met at some point during pod execution (e.g.
+                      due to an update), the system may or may not try to eventually
+                      evict the pod from its node.
+                    properties:
+                      nodeSelectorTerms:
+                        description: Required. A list of node selector terms. The
+                          terms are ORed.
+                        items:
+                          description: A null or empty node selector term matches
+                            no objects. The requirements of them are ANDed. The TopologySelectorTerm
+                            type implements a subset of the NodeSelectorTerm.
+                          properties:
+                            matchExpressions:
+                              description: A list of node selector requirements by
+                                node's labels.
+                              items:
+                                description: A node selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: The label key that the selector applies
+                                      to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                      Possible enum values:
+                                       - `"DoesNotExist"`
+                                       - `"Exists"`
+                                       - `"Gt"`
+                                       - `"In"`
+                                       - `"Lt"`
+                                       - `"NotIn"`
+                                    type: string
+                                  values:
+                                    description: An array of string values. If the
+                                      operator is In or NotIn, the values array must
+                                      be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator
+                                      is Gt or Lt, the values array must have a single
+                                      element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchFields:
+                              description: A list of node selector requirements by
+                                node's fields.
+                              items:
+                                description: A node selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: The label key that the selector applies
+                                      to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                      Possible enum values:
+                                       - `"DoesNotExist"`
+                                       - `"Exists"`
+                                       - `"Gt"`
+                                       - `"In"`
+                                       - `"Lt"`
+                                       - `"NotIn"`
+                                    type: string
+                                  values:
+                                    description: An array of string values. If the
+                                      operator is In or NotIn, the values array must
+                                      be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator
+                                      is Gt or Lt, the values array must have a single
+                                      element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                          type: object
+                        type: array
+                    required:
+                    - nodeSelectorTerms
+                    type: object
+                type: object
+              podAffinity:
+                description: Describes pod affinity scheduling rules (e.g. co-locate
+                  this pod in the same node, zone, etc. as some other pod(s)).
+                properties:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    description: The scheduler will prefer to schedule pods to nodes
+                      that satisfy the affinity expressions specified by this field,
+                      but it may choose a node that violates one or more of the expressions.
+                      The node that is most preferred is the one with the greatest
+                      sum of weights, i.e. for each node that meets all of the scheduling
+                      requirements (resource request, requiredDuringScheduling affinity
+                      expressions, etc.), compute a sum by iterating through the elements
+                      of this field and adding "weight" to the sum if the node has
+                      pods which matches the corresponding podAffinityTerm; the node(s)
+                      with the highest sum are the most preferred.
+                    items:
+                      description: The weights of all of the matched WeightedPodAffinityTerm
+                        fields are added per-node to find the most preferred node(s)
+                      properties:
+                        podAffinityTerm:
+                          description: Required. A pod affinity term, associated with
+                            the corresponding weight.
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field. null selector
+                                and null or empty namespaces list means "this pod's
+                                namespace". An empty selector ({}) matches all namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector. null or
+                                empty namespaces list and null namespaceSelector means
+                                "this pod's namespace".
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        weight:
+                          description: weight associated with matching the corresponding
+                            podAffinityTerm, in the range 1-100.
+                          format: int32
+                          type: integer
+                      required:
+                      - weight
+                      - podAffinityTerm
+                      type: object
+                    type: array
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    description: If the affinity requirements specified by this field
+                      are not met at scheduling time, the pod will not be scheduled
+                      onto the node. If the affinity requirements specified by this
+                      field cease to be met at some point during pod execution (e.g.
+                      due to a pod label update), the system may or may not try to
+                      eventually evict the pod from its node. When there are multiple
+                      elements, the lists of nodes corresponding to each podAffinityTerm
+                      are intersected, i.e. all terms must be satisfied.
+                    items:
+                      description: Defines a set of pods (namely those matching the
+                        labelSelector relative to the given namespace(s)) that this
+                        pod should be co-located (affinity) or not co-located (anti-affinity)
+                        with, where co-located is defined as running on a node whose
+                        value of the label with key <topologyKey> matches that of
+                        any node on which a pod of the set of pods is running
+                      properties:
+                        labelSelector:
+                          description: A label query over a set of resources, in this
+                            case pods.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        namespaceSelector:
+                          description: A label query over the set of namespaces that
+                            the term applies to. The term is applied to the union
+                            of the namespaces selected by this field and the ones
+                            listed in the namespaces field. null selector and null
+                            or empty namespaces list means "this pod's namespace".
+                            An empty selector ({}) matches all namespaces.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        namespaces:
+                          description: namespaces specifies a static list of namespace
+                            names that the term applies to. The term is applied to
+                            the union of the namespaces listed in this field and the
+                            ones selected by namespaceSelector. null or empty namespaces
+                            list and null namespaceSelector means "this pod's namespace".
+                          items:
+                            type: string
+                          type: array
+                        topologyKey:
+                          description: This pod should be co-located (affinity) or
+                            not co-located (anti-affinity) with the pods matching
+                            the labelSelector in the specified namespaces, where co-located
+                            is defined as running on a node whose value of the label
+                            with key topologyKey matches that of any node on which
+                            any of the selected pods is running. Empty topologyKey
+                            is not allowed.
+                          type: string
+                      required:
+                      - topologyKey
+                      type: object
+                    type: array
+                type: object
+              podAntiAffinity:
+                description: Describes pod anti-affinity scheduling rules (e.g. avoid
+                  putting this pod in the same node, zone, etc. as some other pod(s)).
+                properties:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    description: The scheduler will prefer to schedule pods to nodes
+                      that satisfy the anti-affinity expressions specified by this
+                      field, but it may choose a node that violates one or more of
+                      the expressions. The node that is most preferred is the one
+                      with the greatest sum of weights, i.e. for each node that meets
+                      all of the scheduling requirements (resource request, requiredDuringScheduling
+                      anti-affinity expressions, etc.), compute a sum by iterating
+                      through the elements of this field and adding "weight" to the
+                      sum if the node has pods which matches the corresponding podAffinityTerm;
+                      the node(s) with the highest sum are the most preferred.
+                    items:
+                      description: The weights of all of the matched WeightedPodAffinityTerm
+                        fields are added per-node to find the most preferred node(s)
+                      properties:
+                        podAffinityTerm:
+                          description: Required. A pod affinity term, associated with
+                            the corresponding weight.
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field. null selector
+                                and null or empty namespaces list means "this pod's
+                                namespace". An empty selector ({}) matches all namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector. null or
+                                empty namespaces list and null namespaceSelector means
+                                "this pod's namespace".
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        weight:
+                          description: weight associated with matching the corresponding
+                            podAffinityTerm, in the range 1-100.
+                          format: int32
+                          type: integer
+                      required:
+                      - weight
+                      - podAffinityTerm
+                      type: object
+                    type: array
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    description: If the anti-affinity requirements specified by this
+                      field are not met at scheduling time, the pod will not be scheduled
+                      onto the node. If the anti-affinity requirements specified by
+                      this field cease to be met at some point during pod execution
+                      (e.g. due to a pod label update), the system may or may not
+                      try to eventually evict the pod from its node. When there are
+                      multiple elements, the lists of nodes corresponding to each
+                      podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                    items:
+                      description: Defines a set of pods (namely those matching the
+                        labelSelector relative to the given namespace(s)) that this
+                        pod should be co-located (affinity) or not co-located (anti-affinity)
+                        with, where co-located is defined as running on a node whose
+                        value of the label with key <topologyKey> matches that of
+                        any node on which a pod of the set of pods is running
+                      properties:
+                        labelSelector:
+                          description: A label query over a set of resources, in this
+                            case pods.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        namespaceSelector:
+                          description: A label query over the set of namespaces that
+                            the term applies to. The term is applied to the union
+                            of the namespaces selected by this field and the ones
+                            listed in the namespaces field. null selector and null
+                            or empty namespaces list means "this pod's namespace".
+                            An empty selector ({}) matches all namespaces.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        namespaces:
+                          description: namespaces specifies a static list of namespace
+                            names that the term applies to. The term is applied to
+                            the union of the namespaces listed in this field and the
+                            ones selected by namespaceSelector. null or empty namespaces
+                            list and null namespaceSelector means "this pod's namespace".
+                          items:
+                            type: string
+                          type: array
+                        topologyKey:
+                          description: This pod should be co-located (affinity) or
+                            not co-located (anti-affinity) with the pods matching
+                            the labelSelector in the specified namespaces, where co-located
+                            is defined as running on a node whose value of the label
+                            with key topologyKey matches that of any node on which
+                            any of the selected pods is running. Empty topologyKey
+                            is not allowed.
+                          type: string
+                      required:
+                      - topologyKey
+                      type: object
+                    type: array
+                type: object
+            type: object
+          automountServiceAccountToken:
+            description: AutomountServiceAccountToken indicates whether a service
+              account token should be automatically mounted.
+            type: boolean
+          containers:
+            description: List of containers belonging to the pod. Containers cannot
+              currently be added or removed. There must be at least one container
+              in a Pod. Cannot be updated.
+            items:
+              description: A single application container that you want to run within
+                a pod.
+              properties:
+                args:
+                  description: 'Arguments to the entrypoint. The container image''s
+                    CMD is used if this is not provided. Variable references $(VAR_NAME)
+                    are expanded using the container''s environment. If a variable
+                    cannot be resolved, the reference in the input string will be
+                    unchanged. Double $$ are reduced to a single $, which allows for
+                    escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                    the string literal "$(VAR_NAME)". Escaped references will never
+                    be expanded, regardless of whether the variable exists or not.
+                    Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                command:
+                  description: 'Entrypoint array. Not executed within a shell. The
+                    container image''s ENTRYPOINT is used if this is not provided.
+                    Variable references $(VAR_NAME) are expanded using the container''s
+                    environment. If a variable cannot be resolved, the reference in
+                    the input string will be unchanged. Double $$ are reduced to a
+                    single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                    Escaped references will never be expanded, regardless of whether
+                    the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                env:
+                  description: List of environment variables to set in the container.
+                    Cannot be updated.
+                  items:
+                    description: EnvVar represents an environment variable present
+                      in a Container.
+                    properties:
+                      name:
+                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        type: string
+                      value:
+                        description: 'Variable references $(VAR_NAME) are expanded
+                          using the previously defined environment variables in the
+                          container and any service environment variables. If a variable
+                          cannot be resolved, the reference in the input string will
+                          be unchanged. Double $$ are reduced to a single $, which
+                          allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                          will produce the string literal "$(VAR_NAME)". Escaped references
+                          will never be expanded, regardless of whether the variable
+                          exists or not. Defaults to "".'
+                        type: string
+                      valueFrom:
+                        description: Source for the environment variable's value.
+                          Cannot be used if value is not empty.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          fieldRef:
+                            description: 'Selects a field of the pod: supports metadata.name,
+                              metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                              spec.nodeName, spec.serviceAccountName, status.hostIP,
+                              status.podIP, status.podIPs.'
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                            - fieldPath
+                            type: object
+                          resourceFieldRef:
+                            description: 'Selects a resource of the container: only
+                              resources limits and requests (limits.cpu, limits.memory,
+                              limits.ephemeral-storage, requests.cpu, requests.memory
+                              and requests.ephemeral-storage) are currently supported.'
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Specifies the output format of the exposed
+                                  resources, defaults to "1"
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                            - resource
+                            type: object
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - name
+                  x-kubernetes-list-type: map
+                envFrom:
+                  description: List of sources to populate environment variables in
+                    the container. The keys defined within a source must be a C_IDENTIFIER.
+                    All invalid keys will be reported as an event when the container
+                    is starting. When a key exists in multiple sources, the value
+                    associated with the last source will take precedence. Values defined
+                    by an Env with a duplicate key will take precedence. Cannot be
+                    updated.
+                  items:
+                    description: EnvFromSource represents the source of a set of ConfigMaps
+                    properties:
+                      configMapRef:
+                        description: The ConfigMap to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the ConfigMap must be defined
+                            type: boolean
+                        type: object
+                      prefix:
+                        description: An optional identifier to prepend to each key
+                          in the ConfigMap. Must be a C_IDENTIFIER.
+                        type: string
+                      secretRef:
+                        description: The Secret to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret must be defined
+                            type: boolean
+                        type: object
+                    type: object
+                  type: array
+                image:
+                  description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                    This field is optional to allow higher level config management
+                    to default or override container images in workload controllers
+                    like Deployments and StatefulSets.'
+                  type: string
+                imagePullPolicy:
+                  description: |-
+                    Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                    Possible enum values:
+                     - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                     - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                     - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                  type: string
+                lifecycle:
+                  description: Actions that the management system should take in response
+                    to container lifecycle events. Cannot be updated.
+                  properties:
+                    postStart:
+                      description: 'PostStart is called immediately after a container
+                        is created. If the handler fails, the container is terminated
+                        and restarted according to its restart policy. Other management
+                        of the container blocks until the hook completes. More info:
+                        https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: |-
+                                Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                Possible enum values:
+                                 - `"HTTP"` means that the scheme used will be http://
+                                 - `"HTTPS"` means that the scheme used will be https://
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: Deprecated. TCPSocket is NOT supported as a
+                            LifecycleHandler and kept for the backward compatibility.
+                            There are no validation of this field and lifecycle hooks
+                            will fail in runtime when tcp handler is specified.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                    preStop:
+                      description: 'PreStop is called immediately before a container
+                        is terminated due to an API request or management event such
+                        as liveness/startup probe failure, preemption, resource contention,
+                        etc. The handler is not called if the container crashes or
+                        exits. The Pod''s termination grace period countdown begins
+                        before the PreStop hook is executed. Regardless of the outcome
+                        of the handler, the container will eventually terminate within
+                        the Pod''s termination grace period (unless delayed by finalizers).
+                        Other management of the container blocks until the hook completes
+                        or until the termination grace period is reached. More info:
+                        https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: |-
+                                Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                Possible enum values:
+                                 - `"HTTP"` means that the scheme used will be http://
+                                 - `"HTTPS"` means that the scheme used will be https://
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: Deprecated. TCPSocket is NOT supported as a
+                            LifecycleHandler and kept for the backward compatibility.
+                            There are no validation of this field and lifecycle hooks
+                            will fail in runtime when tcp handler is specified.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                  type: object
+                livenessProbe:
+                  description: 'Periodic probe of container liveness. Container will
+                    be restarted if the probe fails. Cannot be updated. More info:
+                    https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                name:
+                  description: Name of the container specified as a DNS_LABEL. Each
+                    container in a pod must have a unique name (DNS_LABEL). Cannot
+                    be updated.
+                  type: string
+                ports:
+                  description: List of ports to expose from the container. Not specifying
+                    a port here DOES NOT prevent that port from being exposed. Any
+                    port which is listening on the default "0.0.0.0" address inside
+                    a container will be accessible from the network. Modifying this
+                    array with strategic merge patch may corrupt the data. For more
+                    information See https://github.com/kubernetes/kubernetes/issues/108255.
+                    Cannot be updated.
+                  items:
+                    description: ContainerPort represents a network port in a single
+                      container.
+                    properties:
+                      containerPort:
+                        description: Number of port to expose on the pod's IP address.
+                          This must be a valid port number, 0 < x < 65536.
+                        format: int32
+                        type: integer
+                      hostIP:
+                        description: What host IP to bind the external port to.
+                        type: string
+                      hostPort:
+                        description: Number of port to expose on the host. If specified,
+                          this must be a valid port number, 0 < x < 65536. If HostNetwork
+                          is specified, this must match ContainerPort. Most containers
+                          do not need this.
+                        format: int32
+                        type: integer
+                      name:
+                        description: If specified, this must be an IANA_SVC_NAME and
+                          unique within the pod. Each named port in a pod must have
+                          a unique name. Name for the port that can be referred to
+                          by services.
+                        type: string
+                      protocol:
+                        default: TCP
+                        description: |-
+                          Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                          Possible enum values:
+                           - `"SCTP"` is the SCTP protocol.
+                           - `"TCP"` is the TCP protocol.
+                           - `"UDP"` is the UDP protocol.
+                        type: string
+                    required:
+                    - containerPort
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - containerPort
+                  - protocol
+                  x-kubernetes-list-type: map
+                readinessProbe:
+                  description: 'Periodic probe of container service readiness. Container
+                    will be removed from service endpoints if the probe fails. Cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                resources:
+                  description: 'Compute Resources required by this container. Cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                  type: object
+                securityContext:
+                  description: 'SecurityContext defines the security options the container
+                    should be run with. If set, the fields of SecurityContext override
+                    the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                  properties:
+                    allowPrivilegeEscalation:
+                      description: 'AllowPrivilegeEscalation controls whether a process
+                        can gain more privileges than its parent process. This bool
+                        directly controls if the no_new_privs flag will be set on
+                        the container process. AllowPrivilegeEscalation is true always
+                        when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
+                        Note that this field cannot be set when spec.os.name is windows.'
+                      type: boolean
+                    capabilities:
+                      description: The capabilities to add/drop when running containers.
+                        Defaults to the default set of capabilities granted by the
+                        container runtime. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      properties:
+                        add:
+                          description: Added capabilities
+                          items:
+                            type: string
+                          type: array
+                        drop:
+                          description: Removed capabilities
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    privileged:
+                      description: Run container in privileged mode. Processes in
+                        privileged containers are essentially equivalent to root on
+                        the host. Defaults to false. Note that this field cannot be
+                        set when spec.os.name is windows.
+                      type: boolean
+                    procMount:
+                      description: procMount denotes the type of proc mount to use
+                        for the containers. The default is DefaultProcMount which
+                        uses the container runtime defaults for readonly paths and
+                        masked paths. This requires the ProcMountType feature flag
+                        to be enabled. Note that this field cannot be set when spec.os.name
+                        is windows.
+                      type: string
+                    readOnlyRootFilesystem:
+                      description: Whether this container has a read-only root filesystem.
+                        Default is false. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      type: boolean
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container
+                        process. Uses runtime default if unset. May also be set in
+                        PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence. Note
+                        that this field cannot be set when spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to
+                        start the container if it does. If unset or false, no such
+                        validation will be performed. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container
+                        process. Defaults to user specified in image metadata if unspecified.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: The SELinux context to be applied to the container.
+                        If unspecified, the container runtime will allocate a random
+                        SELinux context for each container.  May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence. Note that this
+                        field cannot be set when spec.os.name is windows.
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
+                      type: object
+                    seccompProfile:
+                      description: The seccomp options to use by this container. If
+                        seccomp options are provided at both the pod & container level,
+                        the container options override the pod options. Note that
+                        this field cannot be set when spec.os.name is windows.
+                      properties:
+                        localhostProfile:
+                          description: localhostProfile indicates a profile defined
+                            in a file on the node should be used. The profile must
+                            be preconfigured on the node to work. Must be a descending
+                            path, relative to the kubelet's configured seccomp profile
+                            location. Must only be set if type is "Localhost".
+                          type: string
+                        type:
+                          description: |-
+                            type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                            Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                            Possible enum values:
+                             - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                             - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                             - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    windowsOptions:
+                      description: The Windows specific settings applied to all containers.
+                        If unspecified, the options from the PodSecurityContext will
+                        be used. If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence. Note
+                        that this field cannot be set when spec.os.name is linux.
+                      properties:
+                        gmsaCredentialSpec:
+                          description: GMSACredentialSpec is where the GMSA admission
+                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                            inlines the contents of the GMSA credential spec named
+                            by the GMSACredentialSpecName field.
+                          type: string
+                        gmsaCredentialSpecName:
+                          description: GMSACredentialSpecName is the name of the GMSA
+                            credential spec to use.
+                          type: string
+                        hostProcess:
+                          description: HostProcess determines if a container should
+                            be run as a 'Host Process' container. This field is alpha-level
+                            and will only be honored by components that enable the
+                            WindowsHostProcessContainers feature flag. Setting this
+                            field without the feature flag will result in errors when
+                            validating the Pod. All of a Pod's containers must have
+                            the same effective HostProcess value (it is not allowed
+                            to have a mix of HostProcess containers and non-HostProcess
+                            containers).  In addition, if HostProcess is true then
+                            HostNetwork must also be set to true.
+                          type: boolean
+                        runAsUserName:
+                          description: The UserName in Windows to run the entrypoint
+                            of the container process. Defaults to the user specified
+                            in image metadata if unspecified. May also be set in PodSecurityContext.
+                            If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence.
+                          type: string
+                      type: object
+                  type: object
+                startupProbe:
+                  description: 'StartupProbe indicates that the Pod has successfully
+                    initialized. If specified, no other probes are executed until
+                    this completes successfully. If this probe fails, the Pod will
+                    be restarted, just as if the livenessProbe failed. This can be
+                    used to provide different probe parameters at the beginning of
+                    a Pod''s lifecycle, when it might take a long time to load data
+                    or warm a cache, than during steady-state operation. This cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                stdin:
+                  description: Whether this container should allocate a buffer for
+                    stdin in the container runtime. If this is not set, reads from
+                    stdin in the container will always result in EOF. Default is false.
+                  type: boolean
+                stdinOnce:
+                  description: Whether the container runtime should close the stdin
+                    channel after it has been opened by a single attach. When stdin
+                    is true the stdin stream will remain open across multiple attach
+                    sessions. If stdinOnce is set to true, stdin is opened on container
+                    start, is empty until the first client attaches to stdin, and
+                    then remains open and accepts data until the client disconnects,
+                    at which time stdin is closed and remains closed until the container
+                    is restarted. If this flag is false, a container processes that
+                    reads from stdin will never receive an EOF. Default is false
+                  type: boolean
+                terminationMessagePath:
+                  description: 'Optional: Path at which the file to which the container''s
+                    termination message will be written is mounted into the container''s
+                    filesystem. Message written is intended to be brief final status,
+                    such as an assertion failure message. Will be truncated by the
+                    node if greater than 4096 bytes. The total message length across
+                    all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                    Cannot be updated.'
+                  type: string
+                terminationMessagePolicy:
+                  description: |-
+                    Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                    Possible enum values:
+                     - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                     - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                  type: string
+                tty:
+                  description: Whether this container should allocate a TTY for itself,
+                    also requires 'stdin' to be true. Default is false.
+                  type: boolean
+                volumeDevices:
+                  description: volumeDevices is the list of block devices to be used
+                    by the container.
+                  items:
+                    description: volumeDevice describes a mapping of a raw block device
+                      within a container.
+                    properties:
+                      devicePath:
+                        description: devicePath is the path inside of the container
+                          that the device will be mapped to.
+                        type: string
+                      name:
+                        description: name must match the name of a persistentVolumeClaim
+                          in the pod
+                        type: string
+                    required:
+                    - devicePath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - devicePath
+                  x-kubernetes-list-type: map
+                volumeMounts:
+                  description: Pod volumes to mount into the container's filesystem.
+                    Cannot be updated.
+                  items:
+                    description: VolumeMount describes a mounting of a Volume within
+                      a container.
+                    properties:
+                      mountPath:
+                        description: Path within the container at which the volume
+                          should be mounted.  Must not contain ':'.
+                        type: string
+                      mountPropagation:
+                        description: mountPropagation determines how mounts are propagated
+                          from the host to container and the other way around. When
+                          not set, MountPropagationNone is used. This field is beta
+                          in 1.10.
+                        type: string
+                      name:
+                        description: This must match the Name of a Volume.
+                        type: string
+                      readOnly:
+                        description: Mounted read-only if true, read-write otherwise
+                          (false or unspecified). Defaults to false.
+                        type: boolean
+                      subPath:
+                        description: Path within the volume from which the container's
+                          volume should be mounted. Defaults to "" (volume's root).
+                        type: string
+                      subPathExpr:
+                        description: Expanded path within the volume from which the
+                          container's volume should be mounted. Behaves similarly
+                          to SubPath but environment variable references $(VAR_NAME)
+                          are expanded using the container's environment. Defaults
+                          to "" (volume's root). SubPathExpr and SubPath are mutually
+                          exclusive.
+                        type: string
+                    required:
+                    - mountPath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - mountPath
+                  x-kubernetes-list-type: map
+                workingDir:
+                  description: Container's working directory. If not specified, the
+                    container runtime's default will be used, which might be configured
+                    in the container image. Cannot be updated.
+                  type: string
+              required:
+              - name
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - name
+            x-kubernetes-list-type: map
+          dnsConfig:
+            description: Specifies the DNS parameters of a pod. Parameters specified
+              here will be merged to the generated DNS configuration based on DNSPolicy.
+            properties:
+              nameservers:
+                description: A list of DNS name server IP addresses. This will be
+                  appended to the base nameservers generated from DNSPolicy. Duplicated
+                  nameservers will be removed.
+                items:
+                  type: string
+                type: array
+              options:
+                description: A list of DNS resolver options. This will be merged with
+                  the base options generated from DNSPolicy. Duplicated entries will
+                  be removed. Resolution options given in Options will override those
+                  that appear in the base DNSPolicy.
+                items:
+                  description: PodDNSConfigOption defines DNS resolver options of
+                    a pod.
+                  properties:
+                    name:
+                      description: Required.
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
+              searches:
+                description: A list of DNS search domains for host-name lookup. This
+                  will be appended to the base search paths generated from DNSPolicy.
+                  Duplicated search paths will be removed.
+                items:
+                  type: string
+                type: array
+            type: object
+          dnsPolicy:
+            description: |-
+              Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+
+              Possible enum values:
+               - `"ClusterFirst"` indicates that the pod should use cluster DNS first unless hostNetwork is true, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+               - `"ClusterFirstWithHostNet"` indicates that the pod should use cluster DNS first, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+               - `"Default"` indicates that the pod should use the default (as determined by kubelet) DNS settings.
+               - `"None"` indicates that the pod should use empty DNS settings. DNS parameters such as nameservers and search paths should be defined via DNSConfig.
+            type: string
+          enableServiceLinks:
+            description: 'EnableServiceLinks indicates whether information about services
+              should be injected into pod''s environment variables, matching the syntax
+              of Docker links. Optional: Defaults to true.'
+            type: boolean
+          ephemeralContainers:
+            description: List of ephemeral containers run in this pod. Ephemeral containers
+              may be run in an existing pod to perform user-initiated actions such
+              as debugging. This list cannot be specified when creating a pod, and
+              it cannot be modified by updating the pod spec. In order to add an ephemeral
+              container to an existing pod, use the pod's ephemeralcontainers subresource.
+            items:
+              description: |-
+                An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation.
+
+                To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.
+              properties:
+                args:
+                  description: 'Arguments to the entrypoint. The image''s CMD is used
+                    if this is not provided. Variable references $(VAR_NAME) are expanded
+                    using the container''s environment. If a variable cannot be resolved,
+                    the reference in the input string will be unchanged. Double $$
+                    are reduced to a single $, which allows for escaping the $(VAR_NAME)
+                    syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                    Escaped references will never be expanded, regardless of whether
+                    the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                command:
+                  description: 'Entrypoint array. Not executed within a shell. The
+                    image''s ENTRYPOINT is used if this is not provided. Variable
+                    references $(VAR_NAME) are expanded using the container''s environment.
+                    If a variable cannot be resolved, the reference in the input string
+                    will be unchanged. Double $$ are reduced to a single $, which
+                    allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                    will produce the string literal "$(VAR_NAME)". Escaped references
+                    will never be expanded, regardless of whether the variable exists
+                    or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                env:
+                  description: List of environment variables to set in the container.
+                    Cannot be updated.
+                  items:
+                    description: EnvVar represents an environment variable present
+                      in a Container.
+                    properties:
+                      name:
+                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        type: string
+                      value:
+                        description: 'Variable references $(VAR_NAME) are expanded
+                          using the previously defined environment variables in the
+                          container and any service environment variables. If a variable
+                          cannot be resolved, the reference in the input string will
+                          be unchanged. Double $$ are reduced to a single $, which
+                          allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                          will produce the string literal "$(VAR_NAME)". Escaped references
+                          will never be expanded, regardless of whether the variable
+                          exists or not. Defaults to "".'
+                        type: string
+                      valueFrom:
+                        description: Source for the environment variable's value.
+                          Cannot be used if value is not empty.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          fieldRef:
+                            description: 'Selects a field of the pod: supports metadata.name,
+                              metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                              spec.nodeName, spec.serviceAccountName, status.hostIP,
+                              status.podIP, status.podIPs.'
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                            - fieldPath
+                            type: object
+                          resourceFieldRef:
+                            description: 'Selects a resource of the container: only
+                              resources limits and requests (limits.cpu, limits.memory,
+                              limits.ephemeral-storage, requests.cpu, requests.memory
+                              and requests.ephemeral-storage) are currently supported.'
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Specifies the output format of the exposed
+                                  resources, defaults to "1"
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                            - resource
+                            type: object
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - name
+                  x-kubernetes-list-type: map
+                envFrom:
+                  description: List of sources to populate environment variables in
+                    the container. The keys defined within a source must be a C_IDENTIFIER.
+                    All invalid keys will be reported as an event when the container
+                    is starting. When a key exists in multiple sources, the value
+                    associated with the last source will take precedence. Values defined
+                    by an Env with a duplicate key will take precedence. Cannot be
+                    updated.
+                  items:
+                    description: EnvFromSource represents the source of a set of ConfigMaps
+                    properties:
+                      configMapRef:
+                        description: The ConfigMap to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the ConfigMap must be defined
+                            type: boolean
+                        type: object
+                      prefix:
+                        description: An optional identifier to prepend to each key
+                          in the ConfigMap. Must be a C_IDENTIFIER.
+                        type: string
+                      secretRef:
+                        description: The Secret to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret must be defined
+                            type: boolean
+                        type: object
+                    type: object
+                  type: array
+                image:
+                  description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                  type: string
+                imagePullPolicy:
+                  description: |-
+                    Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                    Possible enum values:
+                     - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                     - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                     - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                  type: string
+                lifecycle:
+                  description: Lifecycle is not allowed for ephemeral containers.
+                  properties:
+                    postStart:
+                      description: 'PostStart is called immediately after a container
+                        is created. If the handler fails, the container is terminated
+                        and restarted according to its restart policy. Other management
+                        of the container blocks until the hook completes. More info:
+                        https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: |-
+                                Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                Possible enum values:
+                                 - `"HTTP"` means that the scheme used will be http://
+                                 - `"HTTPS"` means that the scheme used will be https://
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: Deprecated. TCPSocket is NOT supported as a
+                            LifecycleHandler and kept for the backward compatibility.
+                            There are no validation of this field and lifecycle hooks
+                            will fail in runtime when tcp handler is specified.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                    preStop:
+                      description: 'PreStop is called immediately before a container
+                        is terminated due to an API request or management event such
+                        as liveness/startup probe failure, preemption, resource contention,
+                        etc. The handler is not called if the container crashes or
+                        exits. The Pod''s termination grace period countdown begins
+                        before the PreStop hook is executed. Regardless of the outcome
+                        of the handler, the container will eventually terminate within
+                        the Pod''s termination grace period (unless delayed by finalizers).
+                        Other management of the container blocks until the hook completes
+                        or until the termination grace period is reached. More info:
+                        https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: |-
+                                Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                Possible enum values:
+                                 - `"HTTP"` means that the scheme used will be http://
+                                 - `"HTTPS"` means that the scheme used will be https://
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: Deprecated. TCPSocket is NOT supported as a
+                            LifecycleHandler and kept for the backward compatibility.
+                            There are no validation of this field and lifecycle hooks
+                            will fail in runtime when tcp handler is specified.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                  type: object
+                livenessProbe:
+                  description: Probes are not allowed for ephemeral containers.
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                name:
+                  description: Name of the ephemeral container specified as a DNS_LABEL.
+                    This name must be unique among all containers, init containers
+                    and ephemeral containers.
+                  type: string
+                ports:
+                  description: Ports are not allowed for ephemeral containers.
+                  items:
+                    description: ContainerPort represents a network port in a single
+                      container.
+                    properties:
+                      containerPort:
+                        description: Number of port to expose on the pod's IP address.
+                          This must be a valid port number, 0 < x < 65536.
+                        format: int32
+                        type: integer
+                      hostIP:
+                        description: What host IP to bind the external port to.
+                        type: string
+                      hostPort:
+                        description: Number of port to expose on the host. If specified,
+                          this must be a valid port number, 0 < x < 65536. If HostNetwork
+                          is specified, this must match ContainerPort. Most containers
+                          do not need this.
+                        format: int32
+                        type: integer
+                      name:
+                        description: If specified, this must be an IANA_SVC_NAME and
+                          unique within the pod. Each named port in a pod must have
+                          a unique name. Name for the port that can be referred to
+                          by services.
+                        type: string
+                      protocol:
+                        default: TCP
+                        description: |-
+                          Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                          Possible enum values:
+                           - `"SCTP"` is the SCTP protocol.
+                           - `"TCP"` is the TCP protocol.
+                           - `"UDP"` is the UDP protocol.
+                        type: string
+                    required:
+                    - containerPort
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - containerPort
+                  - protocol
+                  x-kubernetes-list-type: map
+                readinessProbe:
+                  description: Probes are not allowed for ephemeral containers.
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                resources:
+                  description: Resources are not allowed for ephemeral containers.
+                    Ephemeral containers use spare resources already allocated to
+                    the pod.
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                  type: object
+                securityContext:
+                  description: 'Optional: SecurityContext defines the security options
+                    the ephemeral container should be run with. If set, the fields
+                    of SecurityContext override the equivalent fields of PodSecurityContext.'
+                  properties:
+                    allowPrivilegeEscalation:
+                      description: 'AllowPrivilegeEscalation controls whether a process
+                        can gain more privileges than its parent process. This bool
+                        directly controls if the no_new_privs flag will be set on
+                        the container process. AllowPrivilegeEscalation is true always
+                        when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
+                        Note that this field cannot be set when spec.os.name is windows.'
+                      type: boolean
+                    capabilities:
+                      description: The capabilities to add/drop when running containers.
+                        Defaults to the default set of capabilities granted by the
+                        container runtime. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      properties:
+                        add:
+                          description: Added capabilities
+                          items:
+                            type: string
+                          type: array
+                        drop:
+                          description: Removed capabilities
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    privileged:
+                      description: Run container in privileged mode. Processes in
+                        privileged containers are essentially equivalent to root on
+                        the host. Defaults to false. Note that this field cannot be
+                        set when spec.os.name is windows.
+                      type: boolean
+                    procMount:
+                      description: procMount denotes the type of proc mount to use
+                        for the containers. The default is DefaultProcMount which
+                        uses the container runtime defaults for readonly paths and
+                        masked paths. This requires the ProcMountType feature flag
+                        to be enabled. Note that this field cannot be set when spec.os.name
+                        is windows.
+                      type: string
+                    readOnlyRootFilesystem:
+                      description: Whether this container has a read-only root filesystem.
+                        Default is false. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      type: boolean
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container
+                        process. Uses runtime default if unset. May also be set in
+                        PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence. Note
+                        that this field cannot be set when spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to
+                        start the container if it does. If unset or false, no such
+                        validation will be performed. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container
+                        process. Defaults to user specified in image metadata if unspecified.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: The SELinux context to be applied to the container.
+                        If unspecified, the container runtime will allocate a random
+                        SELinux context for each container.  May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence. Note that this
+                        field cannot be set when spec.os.name is windows.
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
+                      type: object
+                    seccompProfile:
+                      description: The seccomp options to use by this container. If
+                        seccomp options are provided at both the pod & container level,
+                        the container options override the pod options. Note that
+                        this field cannot be set when spec.os.name is windows.
+                      properties:
+                        localhostProfile:
+                          description: localhostProfile indicates a profile defined
+                            in a file on the node should be used. The profile must
+                            be preconfigured on the node to work. Must be a descending
+                            path, relative to the kubelet's configured seccomp profile
+                            location. Must only be set if type is "Localhost".
+                          type: string
+                        type:
+                          description: |-
+                            type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                            Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                            Possible enum values:
+                             - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                             - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                             - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    windowsOptions:
+                      description: The Windows specific settings applied to all containers.
+                        If unspecified, the options from the PodSecurityContext will
+                        be used. If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence. Note
+                        that this field cannot be set when spec.os.name is linux.
+                      properties:
+                        gmsaCredentialSpec:
+                          description: GMSACredentialSpec is where the GMSA admission
+                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                            inlines the contents of the GMSA credential spec named
+                            by the GMSACredentialSpecName field.
+                          type: string
+                        gmsaCredentialSpecName:
+                          description: GMSACredentialSpecName is the name of the GMSA
+                            credential spec to use.
+                          type: string
+                        hostProcess:
+                          description: HostProcess determines if a container should
+                            be run as a 'Host Process' container. This field is alpha-level
+                            and will only be honored by components that enable the
+                            WindowsHostProcessContainers feature flag. Setting this
+                            field without the feature flag will result in errors when
+                            validating the Pod. All of a Pod's containers must have
+                            the same effective HostProcess value (it is not allowed
+                            to have a mix of HostProcess containers and non-HostProcess
+                            containers).  In addition, if HostProcess is true then
+                            HostNetwork must also be set to true.
+                          type: boolean
+                        runAsUserName:
+                          description: The UserName in Windows to run the entrypoint
+                            of the container process. Defaults to the user specified
+                            in image metadata if unspecified. May also be set in PodSecurityContext.
+                            If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence.
+                          type: string
+                      type: object
+                  type: object
+                startupProbe:
+                  description: Probes are not allowed for ephemeral containers.
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                stdin:
+                  description: Whether this container should allocate a buffer for
+                    stdin in the container runtime. If this is not set, reads from
+                    stdin in the container will always result in EOF. Default is false.
+                  type: boolean
+                stdinOnce:
+                  description: Whether the container runtime should close the stdin
+                    channel after it has been opened by a single attach. When stdin
+                    is true the stdin stream will remain open across multiple attach
+                    sessions. If stdinOnce is set to true, stdin is opened on container
+                    start, is empty until the first client attaches to stdin, and
+                    then remains open and accepts data until the client disconnects,
+                    at which time stdin is closed and remains closed until the container
+                    is restarted. If this flag is false, a container processes that
+                    reads from stdin will never receive an EOF. Default is false
+                  type: boolean
+                targetContainerName:
+                  description: |-
+                    If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+                    The container runtime must implement support for this feature. If the runtime does not support namespace targeting then the result of setting this field is undefined.
+                  type: string
+                terminationMessagePath:
+                  description: 'Optional: Path at which the file to which the container''s
+                    termination message will be written is mounted into the container''s
+                    filesystem. Message written is intended to be brief final status,
+                    such as an assertion failure message. Will be truncated by the
+                    node if greater than 4096 bytes. The total message length across
+                    all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                    Cannot be updated.'
+                  type: string
+                terminationMessagePolicy:
+                  description: |-
+                    Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                    Possible enum values:
+                     - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                     - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                  type: string
+                tty:
+                  description: Whether this container should allocate a TTY for itself,
+                    also requires 'stdin' to be true. Default is false.
+                  type: boolean
+                volumeDevices:
+                  description: volumeDevices is the list of block devices to be used
+                    by the container.
+                  items:
+                    description: volumeDevice describes a mapping of a raw block device
+                      within a container.
+                    properties:
+                      devicePath:
+                        description: devicePath is the path inside of the container
+                          that the device will be mapped to.
+                        type: string
+                      name:
+                        description: name must match the name of a persistentVolumeClaim
+                          in the pod
+                        type: string
+                    required:
+                    - devicePath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - devicePath
+                  x-kubernetes-list-type: map
+                volumeMounts:
+                  description: Pod volumes to mount into the container's filesystem.
+                    Subpath mounts are not allowed for ephemeral containers. Cannot
+                    be updated.
+                  items:
+                    description: VolumeMount describes a mounting of a Volume within
+                      a container.
+                    properties:
+                      mountPath:
+                        description: Path within the container at which the volume
+                          should be mounted.  Must not contain ':'.
+                        type: string
+                      mountPropagation:
+                        description: mountPropagation determines how mounts are propagated
+                          from the host to container and the other way around. When
+                          not set, MountPropagationNone is used. This field is beta
+                          in 1.10.
+                        type: string
+                      name:
+                        description: This must match the Name of a Volume.
+                        type: string
+                      readOnly:
+                        description: Mounted read-only if true, read-write otherwise
+                          (false or unspecified). Defaults to false.
+                        type: boolean
+                      subPath:
+                        description: Path within the volume from which the container's
+                          volume should be mounted. Defaults to "" (volume's root).
+                        type: string
+                      subPathExpr:
+                        description: Expanded path within the volume from which the
+                          container's volume should be mounted. Behaves similarly
+                          to SubPath but environment variable references $(VAR_NAME)
+                          are expanded using the container's environment. Defaults
+                          to "" (volume's root). SubPathExpr and SubPath are mutually
+                          exclusive.
+                        type: string
+                    required:
+                    - mountPath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - mountPath
+                  x-kubernetes-list-type: map
+                workingDir:
+                  description: Container's working directory. If not specified, the
+                    container runtime's default will be used, which might be configured
+                    in the container image. Cannot be updated.
+                  type: string
+              required:
+              - name
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - name
+            x-kubernetes-list-type: map
+          hostAliases:
+            description: HostAliases is an optional list of hosts and IPs that will
+              be injected into the pod's hosts file if specified. This is only valid
+              for non-hostNetwork pods.
+            items:
+              description: HostAlias holds the mapping between IP and hostnames that
+                will be injected as an entry in the pod's hosts file.
+              properties:
+                hostnames:
+                  description: Hostnames for the above IP address.
+                  items:
+                    type: string
+                  type: array
+                ip:
+                  description: IP address of the host file entry.
+                  type: string
+              required:
+              - ip
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - ip
+            x-kubernetes-list-type: map
+          hostIPC:
+            description: 'Use the host''s ipc namespace. Optional: Default to false.'
+            type: boolean
+          hostNetwork:
+            description: Host networking requested for this pod. Use the host's network
+              namespace. If this option is set, the ports that will be used must be
+              specified. Default to false.
+            type: boolean
+          hostPID:
+            description: 'Use the host''s pid namespace. Optional: Default to false.'
+            type: boolean
+          hostUsers:
+            description: 'Use the host''s user namespace. Optional: Default to true.
+              If set to true or not present, the pod will be run in the host user
+              namespace, useful for when the pod needs a feature only available to
+              the host user namespace, such as loading a kernel module with CAP_SYS_MODULE.
+              When set to false, a new userns is created for the pod. Setting false
+              is useful for mitigating container breakout vulnerabilities even allowing
+              users to run their containers as root without actually having root privileges
+              on the host. This field is alpha-level and is only honored by servers
+              that enable the UserNamespacesSupport feature.'
+            type: boolean
+          hostname:
+            description: Specifies the hostname of the Pod If not specified, the pod's
+              hostname will be set to a system-defined value.
+            type: string
+          imagePullSecrets:
+            description: 'ImagePullSecrets is an optional list of references to secrets
+              in the same namespace to use for pulling any of the images used by this
+              PodSpec. If specified, these secrets will be passed to individual puller
+              implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+            items:
+              description: LocalObjectReference contains enough information to let
+                you locate the referenced object inside the same namespace.
+              properties:
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+              required:
+              - name
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - name
+            x-kubernetes-list-type: map
+          initContainers:
+            description: 'List of initialization containers belonging to the pod.
+              Init containers are executed in order prior to containers being started.
+              If any init container fails, the pod is considered to have failed and
+              is handled according to its restartPolicy. The name for an init container
+              or normal container must be unique among all containers. Init containers
+              may not have Lifecycle actions, Readiness probes, Liveness probes, or
+              Startup probes. The resourceRequirements of an init container are taken
+              into account during scheduling by finding the highest request/limit
+              for each resource type, and then using the max of of that value or the
+              sum of the normal containers. Limits are applied to init containers
+              in a similar fashion. Init containers cannot currently be added or removed.
+              Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+            items:
+              description: A single application container that you want to run within
+                a pod.
+              properties:
+                args:
+                  description: 'Arguments to the entrypoint. The container image''s
+                    CMD is used if this is not provided. Variable references $(VAR_NAME)
+                    are expanded using the container''s environment. If a variable
+                    cannot be resolved, the reference in the input string will be
+                    unchanged. Double $$ are reduced to a single $, which allows for
+                    escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                    the string literal "$(VAR_NAME)". Escaped references will never
+                    be expanded, regardless of whether the variable exists or not.
+                    Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                command:
+                  description: 'Entrypoint array. Not executed within a shell. The
+                    container image''s ENTRYPOINT is used if this is not provided.
+                    Variable references $(VAR_NAME) are expanded using the container''s
+                    environment. If a variable cannot be resolved, the reference in
+                    the input string will be unchanged. Double $$ are reduced to a
+                    single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                    Escaped references will never be expanded, regardless of whether
+                    the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                env:
+                  description: List of environment variables to set in the container.
+                    Cannot be updated.
+                  items:
+                    description: EnvVar represents an environment variable present
+                      in a Container.
+                    properties:
+                      name:
+                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        type: string
+                      value:
+                        description: 'Variable references $(VAR_NAME) are expanded
+                          using the previously defined environment variables in the
+                          container and any service environment variables. If a variable
+                          cannot be resolved, the reference in the input string will
+                          be unchanged. Double $$ are reduced to a single $, which
+                          allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                          will produce the string literal "$(VAR_NAME)". Escaped references
+                          will never be expanded, regardless of whether the variable
+                          exists or not. Defaults to "".'
+                        type: string
+                      valueFrom:
+                        description: Source for the environment variable's value.
+                          Cannot be used if value is not empty.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          fieldRef:
+                            description: 'Selects a field of the pod: supports metadata.name,
+                              metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                              spec.nodeName, spec.serviceAccountName, status.hostIP,
+                              status.podIP, status.podIPs.'
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                            - fieldPath
+                            type: object
+                          resourceFieldRef:
+                            description: 'Selects a resource of the container: only
+                              resources limits and requests (limits.cpu, limits.memory,
+                              limits.ephemeral-storage, requests.cpu, requests.memory
+                              and requests.ephemeral-storage) are currently supported.'
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Specifies the output format of the exposed
+                                  resources, defaults to "1"
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                            - resource
+                            type: object
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - name
+                  x-kubernetes-list-type: map
+                envFrom:
+                  description: List of sources to populate environment variables in
+                    the container. The keys defined within a source must be a C_IDENTIFIER.
+                    All invalid keys will be reported as an event when the container
+                    is starting. When a key exists in multiple sources, the value
+                    associated with the last source will take precedence. Values defined
+                    by an Env with a duplicate key will take precedence. Cannot be
+                    updated.
+                  items:
+                    description: EnvFromSource represents the source of a set of ConfigMaps
+                    properties:
+                      configMapRef:
+                        description: The ConfigMap to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the ConfigMap must be defined
+                            type: boolean
+                        type: object
+                      prefix:
+                        description: An optional identifier to prepend to each key
+                          in the ConfigMap. Must be a C_IDENTIFIER.
+                        type: string
+                      secretRef:
+                        description: The Secret to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret must be defined
+                            type: boolean
+                        type: object
+                    type: object
+                  type: array
+                image:
+                  description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                    This field is optional to allow higher level config management
+                    to default or override container images in workload controllers
+                    like Deployments and StatefulSets.'
+                  type: string
+                imagePullPolicy:
+                  description: |-
+                    Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                    Possible enum values:
+                     - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                     - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                     - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                  type: string
+                lifecycle:
+                  description: Actions that the management system should take in response
+                    to container lifecycle events. Cannot be updated.
+                  properties:
+                    postStart:
+                      description: 'PostStart is called immediately after a container
+                        is created. If the handler fails, the container is terminated
+                        and restarted according to its restart policy. Other management
+                        of the container blocks until the hook completes. More info:
+                        https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: |-
+                                Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                Possible enum values:
+                                 - `"HTTP"` means that the scheme used will be http://
+                                 - `"HTTPS"` means that the scheme used will be https://
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: Deprecated. TCPSocket is NOT supported as a
+                            LifecycleHandler and kept for the backward compatibility.
+                            There are no validation of this field and lifecycle hooks
+                            will fail in runtime when tcp handler is specified.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                    preStop:
+                      description: 'PreStop is called immediately before a container
+                        is terminated due to an API request or management event such
+                        as liveness/startup probe failure, preemption, resource contention,
+                        etc. The handler is not called if the container crashes or
+                        exits. The Pod''s termination grace period countdown begins
+                        before the PreStop hook is executed. Regardless of the outcome
+                        of the handler, the container will eventually terminate within
+                        the Pod''s termination grace period (unless delayed by finalizers).
+                        Other management of the container blocks until the hook completes
+                        or until the termination grace period is reached. More info:
+                        https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: |-
+                                Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                Possible enum values:
+                                 - `"HTTP"` means that the scheme used will be http://
+                                 - `"HTTPS"` means that the scheme used will be https://
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: Deprecated. TCPSocket is NOT supported as a
+                            LifecycleHandler and kept for the backward compatibility.
+                            There are no validation of this field and lifecycle hooks
+                            will fail in runtime when tcp handler is specified.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                  type: object
+                livenessProbe:
+                  description: 'Periodic probe of container liveness. Container will
+                    be restarted if the probe fails. Cannot be updated. More info:
+                    https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                name:
+                  description: Name of the container specified as a DNS_LABEL. Each
+                    container in a pod must have a unique name (DNS_LABEL). Cannot
+                    be updated.
+                  type: string
+                ports:
+                  description: List of ports to expose from the container. Not specifying
+                    a port here DOES NOT prevent that port from being exposed. Any
+                    port which is listening on the default "0.0.0.0" address inside
+                    a container will be accessible from the network. Modifying this
+                    array with strategic merge patch may corrupt the data. For more
+                    information See https://github.com/kubernetes/kubernetes/issues/108255.
+                    Cannot be updated.
+                  items:
+                    description: ContainerPort represents a network port in a single
+                      container.
+                    properties:
+                      containerPort:
+                        description: Number of port to expose on the pod's IP address.
+                          This must be a valid port number, 0 < x < 65536.
+                        format: int32
+                        type: integer
+                      hostIP:
+                        description: What host IP to bind the external port to.
+                        type: string
+                      hostPort:
+                        description: Number of port to expose on the host. If specified,
+                          this must be a valid port number, 0 < x < 65536. If HostNetwork
+                          is specified, this must match ContainerPort. Most containers
+                          do not need this.
+                        format: int32
+                        type: integer
+                      name:
+                        description: If specified, this must be an IANA_SVC_NAME and
+                          unique within the pod. Each named port in a pod must have
+                          a unique name. Name for the port that can be referred to
+                          by services.
+                        type: string
+                      protocol:
+                        default: TCP
+                        description: |-
+                          Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                          Possible enum values:
+                           - `"SCTP"` is the SCTP protocol.
+                           - `"TCP"` is the TCP protocol.
+                           - `"UDP"` is the UDP protocol.
+                        type: string
+                    required:
+                    - containerPort
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - containerPort
+                  - protocol
+                  x-kubernetes-list-type: map
+                readinessProbe:
+                  description: 'Periodic probe of container service readiness. Container
+                    will be removed from service endpoints if the probe fails. Cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                resources:
+                  description: 'Compute Resources required by this container. Cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                  type: object
+                securityContext:
+                  description: 'SecurityContext defines the security options the container
+                    should be run with. If set, the fields of SecurityContext override
+                    the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                  properties:
+                    allowPrivilegeEscalation:
+                      description: 'AllowPrivilegeEscalation controls whether a process
+                        can gain more privileges than its parent process. This bool
+                        directly controls if the no_new_privs flag will be set on
+                        the container process. AllowPrivilegeEscalation is true always
+                        when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
+                        Note that this field cannot be set when spec.os.name is windows.'
+                      type: boolean
+                    capabilities:
+                      description: The capabilities to add/drop when running containers.
+                        Defaults to the default set of capabilities granted by the
+                        container runtime. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      properties:
+                        add:
+                          description: Added capabilities
+                          items:
+                            type: string
+                          type: array
+                        drop:
+                          description: Removed capabilities
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    privileged:
+                      description: Run container in privileged mode. Processes in
+                        privileged containers are essentially equivalent to root on
+                        the host. Defaults to false. Note that this field cannot be
+                        set when spec.os.name is windows.
+                      type: boolean
+                    procMount:
+                      description: procMount denotes the type of proc mount to use
+                        for the containers. The default is DefaultProcMount which
+                        uses the container runtime defaults for readonly paths and
+                        masked paths. This requires the ProcMountType feature flag
+                        to be enabled. Note that this field cannot be set when spec.os.name
+                        is windows.
+                      type: string
+                    readOnlyRootFilesystem:
+                      description: Whether this container has a read-only root filesystem.
+                        Default is false. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      type: boolean
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container
+                        process. Uses runtime default if unset. May also be set in
+                        PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence. Note
+                        that this field cannot be set when spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to
+                        start the container if it does. If unset or false, no such
+                        validation will be performed. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container
+                        process. Defaults to user specified in image metadata if unspecified.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: The SELinux context to be applied to the container.
+                        If unspecified, the container runtime will allocate a random
+                        SELinux context for each container.  May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence. Note that this
+                        field cannot be set when spec.os.name is windows.
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
+                      type: object
+                    seccompProfile:
+                      description: The seccomp options to use by this container. If
+                        seccomp options are provided at both the pod & container level,
+                        the container options override the pod options. Note that
+                        this field cannot be set when spec.os.name is windows.
+                      properties:
+                        localhostProfile:
+                          description: localhostProfile indicates a profile defined
+                            in a file on the node should be used. The profile must
+                            be preconfigured on the node to work. Must be a descending
+                            path, relative to the kubelet's configured seccomp profile
+                            location. Must only be set if type is "Localhost".
+                          type: string
+                        type:
+                          description: |-
+                            type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                            Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                            Possible enum values:
+                             - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                             - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                             - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    windowsOptions:
+                      description: The Windows specific settings applied to all containers.
+                        If unspecified, the options from the PodSecurityContext will
+                        be used. If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence. Note
+                        that this field cannot be set when spec.os.name is linux.
+                      properties:
+                        gmsaCredentialSpec:
+                          description: GMSACredentialSpec is where the GMSA admission
+                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                            inlines the contents of the GMSA credential spec named
+                            by the GMSACredentialSpecName field.
+                          type: string
+                        gmsaCredentialSpecName:
+                          description: GMSACredentialSpecName is the name of the GMSA
+                            credential spec to use.
+                          type: string
+                        hostProcess:
+                          description: HostProcess determines if a container should
+                            be run as a 'Host Process' container. This field is alpha-level
+                            and will only be honored by components that enable the
+                            WindowsHostProcessContainers feature flag. Setting this
+                            field without the feature flag will result in errors when
+                            validating the Pod. All of a Pod's containers must have
+                            the same effective HostProcess value (it is not allowed
+                            to have a mix of HostProcess containers and non-HostProcess
+                            containers).  In addition, if HostProcess is true then
+                            HostNetwork must also be set to true.
+                          type: boolean
+                        runAsUserName:
+                          description: The UserName in Windows to run the entrypoint
+                            of the container process. Defaults to the user specified
+                            in image metadata if unspecified. May also be set in PodSecurityContext.
+                            If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence.
+                          type: string
+                      type: object
+                  type: object
+                startupProbe:
+                  description: 'StartupProbe indicates that the Pod has successfully
+                    initialized. If specified, no other probes are executed until
+                    this completes successfully. If this probe fails, the Pod will
+                    be restarted, just as if the livenessProbe failed. This can be
+                    used to provide different probe parameters at the beginning of
+                    a Pod''s lifecycle, when it might take a long time to load data
+                    or warm a cache, than during steady-state operation. This cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                stdin:
+                  description: Whether this container should allocate a buffer for
+                    stdin in the container runtime. If this is not set, reads from
+                    stdin in the container will always result in EOF. Default is false.
+                  type: boolean
+                stdinOnce:
+                  description: Whether the container runtime should close the stdin
+                    channel after it has been opened by a single attach. When stdin
+                    is true the stdin stream will remain open across multiple attach
+                    sessions. If stdinOnce is set to true, stdin is opened on container
+                    start, is empty until the first client attaches to stdin, and
+                    then remains open and accepts data until the client disconnects,
+                    at which time stdin is closed and remains closed until the container
+                    is restarted. If this flag is false, a container processes that
+                    reads from stdin will never receive an EOF. Default is false
+                  type: boolean
+                terminationMessagePath:
+                  description: 'Optional: Path at which the file to which the container''s
+                    termination message will be written is mounted into the container''s
+                    filesystem. Message written is intended to be brief final status,
+                    such as an assertion failure message. Will be truncated by the
+                    node if greater than 4096 bytes. The total message length across
+                    all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                    Cannot be updated.'
+                  type: string
+                terminationMessagePolicy:
+                  description: |-
+                    Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                    Possible enum values:
+                     - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                     - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                  type: string
+                tty:
+                  description: Whether this container should allocate a TTY for itself,
+                    also requires 'stdin' to be true. Default is false.
+                  type: boolean
+                volumeDevices:
+                  description: volumeDevices is the list of block devices to be used
+                    by the container.
+                  items:
+                    description: volumeDevice describes a mapping of a raw block device
+                      within a container.
+                    properties:
+                      devicePath:
+                        description: devicePath is the path inside of the container
+                          that the device will be mapped to.
+                        type: string
+                      name:
+                        description: name must match the name of a persistentVolumeClaim
+                          in the pod
+                        type: string
+                    required:
+                    - devicePath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - devicePath
+                  x-kubernetes-list-type: map
+                volumeMounts:
+                  description: Pod volumes to mount into the container's filesystem.
+                    Cannot be updated.
+                  items:
+                    description: VolumeMount describes a mounting of a Volume within
+                      a container.
+                    properties:
+                      mountPath:
+                        description: Path within the container at which the volume
+                          should be mounted.  Must not contain ':'.
+                        type: string
+                      mountPropagation:
+                        description: mountPropagation determines how mounts are propagated
+                          from the host to container and the other way around. When
+                          not set, MountPropagationNone is used. This field is beta
+                          in 1.10.
+                        type: string
+                      name:
+                        description: This must match the Name of a Volume.
+                        type: string
+                      readOnly:
+                        description: Mounted read-only if true, read-write otherwise
+                          (false or unspecified). Defaults to false.
+                        type: boolean
+                      subPath:
+                        description: Path within the volume from which the container's
+                          volume should be mounted. Defaults to "" (volume's root).
+                        type: string
+                      subPathExpr:
+                        description: Expanded path within the volume from which the
+                          container's volume should be mounted. Behaves similarly
+                          to SubPath but environment variable references $(VAR_NAME)
+                          are expanded using the container's environment. Defaults
+                          to "" (volume's root). SubPathExpr and SubPath are mutually
+                          exclusive.
+                        type: string
+                    required:
+                    - mountPath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - mountPath
+                  x-kubernetes-list-type: map
+                workingDir:
+                  description: Container's working directory. If not specified, the
+                    container runtime's default will be used, which might be configured
+                    in the container image. Cannot be updated.
+                  type: string
+              required:
+              - name
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - name
+            x-kubernetes-list-type: map
+          nodeName:
+            description: NodeName is a request to schedule this pod onto a specific
+              node. If it is non-empty, the scheduler simply schedules this pod onto
+              that node, assuming that it fits resource requirements.
+            type: string
+          nodeSelector:
+            additionalProperties:
+              type: string
+            description: 'NodeSelector is a selector which must be true for the pod
+              to fit on a node. Selector which must match a node''s labels for the
+              pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+            type: object
+          os:
+            description: |-
+              Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set.
+
+              If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions
+
+              If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup
+            properties:
+              name:
+                description: 'Name is the name of the operating system. The currently
+                  supported values are linux and windows. Additional value may be
+                  defined in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                  Clients should expect to handle additional values and treat unrecognized
+                  values in this field as os: null'
+                type: string
+            required:
+            - name
+            type: object
+          overhead:
+            additionalProperties:
+              anyOf:
+              - type: integer
+              - type: string
+              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+              x-kubernetes-int-or-string: true
+            description: 'Overhead represents the resource overhead associated with
+              running a pod for a given RuntimeClass. This field will be autopopulated
+              at admission time by the RuntimeClass admission controller. If the RuntimeClass
+              admission controller is enabled, overhead must not be set in Pod create
+              requests. The RuntimeClass admission controller will reject Pod create
+              requests which have the overhead already set. If RuntimeClass is configured
+              and selected in the PodSpec, Overhead will be set to the value defined
+              in the corresponding RuntimeClass, otherwise it will remain unset and
+              treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
+            type: object
+          preemptionPolicy:
+            description: PreemptionPolicy is the Policy for preempting pods with lower
+              priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority
+              if unset.
+            type: string
+          priority:
+            description: The priority value. Various system components use this field
+              to find the priority of the pod. When Priority Admission Controller
+              is enabled, it prevents users from setting this field. The admission
+              controller populates this field from PriorityClassName. The higher the
+              value, the higher the priority.
+            format: int32
+            type: integer
+          priorityClassName:
+            description: If specified, indicates the pod's priority. "system-node-critical"
+              and "system-cluster-critical" are two special keywords which indicate
+              the highest priorities with the former being the highest priority. Any
+              other name must be defined by creating a PriorityClass object with that
+              name. If not specified, the pod priority will be default or zero if
+              there is no default.
+            type: string
+          readinessGates:
+            description: 'If specified, all readiness gates will be evaluated for
+              pod readiness. A pod is ready when all its containers are ready AND
+              all conditions specified in the readiness gates have status equal to
+              "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
+            items:
+              description: PodReadinessGate contains the reference to a pod condition
+              properties:
+                conditionType:
+                  description: ConditionType refers to a condition in the pod's condition
+                    list with matching type.
+                  type: string
+              required:
+              - conditionType
+              type: object
+            type: array
+          restartPolicy:
+            description: |-
+              Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+
+              Possible enum values:
+               - `"Always"`
+               - `"Never"`
+               - `"OnFailure"`
+            type: string
+          runtimeClassName:
+            description: 'RuntimeClassName refers to a RuntimeClass object in the
+              node.k8s.io group, which should be used to run this pod.  If no RuntimeClass
+              resource matches the named class, the pod will not be run. If unset
+              or empty, the "legacy" RuntimeClass will be used, which is an implicit
+              class with an empty definition that uses the default runtime handler.
+              More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
+            type: string
+          schedulerName:
+            description: If specified, the pod will be dispatched by specified scheduler.
+              If not specified, the pod will be dispatched by default scheduler.
+            type: string
+          securityContext:
+            description: 'SecurityContext holds pod-level security attributes and
+              common container settings. Optional: Defaults to empty.  See type description
+              for default values of each field.'
+            properties:
+              fsGroup:
+                description: |-
+                  A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
+                  1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
+                  If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.
+                format: int64
+                type: integer
+              fsGroupChangePolicy:
+                description: 'fsGroupChangePolicy defines behavior of changing ownership
+                  and permission of the volume before being exposed inside Pod. This
+                  field will only apply to volume types which support fsGroup based
+                  ownership(and permissions). It will have no effect on ephemeral
+                  volume types such as: secret, configmaps and emptydir. Valid values
+                  are "OnRootMismatch" and "Always". If not specified, "Always" is
+                  used. Note that this field cannot be set when spec.os.name is windows.'
+                type: string
+              runAsGroup:
+                description: The GID to run the entrypoint of the container process.
+                  Uses runtime default if unset. May also be set in SecurityContext.  If
+                  set in both SecurityContext and PodSecurityContext, the value specified
+                  in SecurityContext takes precedence for that container. Note that
+                  this field cannot be set when spec.os.name is windows.
+                format: int64
+                type: integer
+              runAsNonRoot:
+                description: Indicates that the container must run as a non-root user.
+                  If true, the Kubelet will validate the image at runtime to ensure
+                  that it does not run as UID 0 (root) and fail to start the container
+                  if it does. If unset or false, no such validation will be performed.
+                  May also be set in SecurityContext.  If set in both SecurityContext
+                  and PodSecurityContext, the value specified in SecurityContext takes
+                  precedence.
+                type: boolean
+              runAsUser:
+                description: The UID to run the entrypoint of the container process.
+                  Defaults to user specified in image metadata if unspecified. May
+                  also be set in SecurityContext.  If set in both SecurityContext
+                  and PodSecurityContext, the value specified in SecurityContext takes
+                  precedence for that container. Note that this field cannot be set
+                  when spec.os.name is windows.
+                format: int64
+                type: integer
+              seLinuxOptions:
+                description: The SELinux context to be applied to all containers.
+                  If unspecified, the container runtime will allocate a random SELinux
+                  context for each container.  May also be set in SecurityContext.  If
+                  set in both SecurityContext and PodSecurityContext, the value specified
+                  in SecurityContext takes precedence for that container. Note that
+                  this field cannot be set when spec.os.name is windows.
+                properties:
+                  level:
+                    description: Level is SELinux level label that applies to the
+                      container.
+                    type: string
+                  role:
+                    description: Role is a SELinux role label that applies to the
+                      container.
+                    type: string
+                  type:
+                    description: Type is a SELinux type label that applies to the
+                      container.
+                    type: string
+                  user:
+                    description: User is a SELinux user label that applies to the
+                      container.
+                    type: string
+                type: object
+              seccompProfile:
+                description: The seccomp options to use by the containers in this
+                  pod. Note that this field cannot be set when spec.os.name is windows.
+                properties:
+                  localhostProfile:
+                    description: localhostProfile indicates a profile defined in a
+                      file on the node should be used. The profile must be preconfigured
+                      on the node to work. Must be a descending path, relative to
+                      the kubelet's configured seccomp profile location. Must only
+                      be set if type is "Localhost".
+                    type: string
+                  type:
+                    description: |-
+                      type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                      Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                      Possible enum values:
+                       - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                       - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                       - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                    type: string
+                required:
+                - type
+                type: object
+              supplementalGroups:
+                description: A list of groups applied to the first process run in
+                  each container, in addition to the container's primary GID.  If
+                  unspecified, no groups will be added to any container. Note that
+                  this field cannot be set when spec.os.name is windows.
+                items:
+                  format: int64
+                  type: integer
+                type: array
+              sysctls:
+                description: Sysctls hold a list of namespaced sysctls used for the
+                  pod. Pods with unsupported sysctls (by the container runtime) might
+                  fail to launch. Note that this field cannot be set when spec.os.name
+                  is windows.
+                items:
+                  description: Sysctl defines a kernel parameter to be set
+                  properties:
+                    name:
+                      description: Name of a property to set
+                      type: string
+                    value:
+                      description: Value of a property to set
+                      type: string
+                  required:
+                  - name
+                  - value
+                  type: object
+                type: array
+              windowsOptions:
+                description: The Windows specific settings applied to all containers.
+                  If unspecified, the options within a container's SecurityContext
+                  will be used. If set in both SecurityContext and PodSecurityContext,
+                  the value specified in SecurityContext takes precedence. Note that
+                  this field cannot be set when spec.os.name is linux.
+                properties:
+                  gmsaCredentialSpec:
+                    description: GMSACredentialSpec is where the GMSA admission webhook
+                      (https://github.com/kubernetes-sigs/windows-gmsa) inlines the
+                      contents of the GMSA credential spec named by the GMSACredentialSpecName
+                      field.
+                    type: string
+                  gmsaCredentialSpecName:
+                    description: GMSACredentialSpecName is the name of the GMSA credential
+                      spec to use.
+                    type: string
+                  hostProcess:
+                    description: HostProcess determines if a container should be run
+                      as a 'Host Process' container. This field is alpha-level and
+                      will only be honored by components that enable the WindowsHostProcessContainers
+                      feature flag. Setting this field without the feature flag will
+                      result in errors when validating the Pod. All of a Pod's containers
+                      must have the same effective HostProcess value (it is not allowed
+                      to have a mix of HostProcess containers and non-HostProcess
+                      containers).  In addition, if HostProcess is true then HostNetwork
+                      must also be set to true.
+                    type: boolean
+                  runAsUserName:
+                    description: The UserName in Windows to run the entrypoint of
+                      the container process. Defaults to the user specified in image
+                      metadata if unspecified. May also be set in PodSecurityContext.
+                      If set in both SecurityContext and PodSecurityContext, the value
+                      specified in SecurityContext takes precedence.
+                    type: string
+                type: object
+            type: object
+          serviceAccount:
+            description: 'DeprecatedServiceAccount is a depreciated alias for ServiceAccountName.
+              Deprecated: Use serviceAccountName instead.'
+            type: string
+          serviceAccountName:
+            description: 'ServiceAccountName is the name of the ServiceAccount to
+              use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+            type: string
+          setHostnameAsFQDN:
+            description: If true the pod's hostname will be configured as the pod's
+              FQDN, rather than the leaf name (the default). In Linux containers,
+              this means setting the FQDN in the hostname field of the kernel (the
+              nodename field of struct utsname). In Windows containers, this means
+              setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters
+              to FQDN. If a pod does not have FQDN, this has no effect. Default to
+              false.
+            type: boolean
+          shareProcessNamespace:
+            description: 'Share a single process namespace between all of the containers
+              in a pod. When this is set containers will be able to view and signal
+              processes from other containers in the same pod, and the first process
+              in each container will not be assigned PID 1. HostPID and ShareProcessNamespace
+              cannot both be set. Optional: Default to false.'
+            type: boolean
+          subdomain:
+            description: If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod
+              namespace>.svc.<cluster domain>". If not specified, the pod will not
+              have a domainname at all.
+            type: string
+          terminationGracePeriodSeconds:
+            description: Optional duration in seconds the pod needs to terminate gracefully.
+              May be decreased in delete request. Value must be non-negative integer.
+              The value zero indicates stop immediately via the kill signal (no opportunity
+              to shut down). If this value is nil, the default grace period will be
+              used instead. The grace period is the duration in seconds after the
+              processes running in the pod are sent a termination signal and the time
+              when the processes are forcibly halted with a kill signal. Set this
+              value longer than the expected cleanup time for your process. Defaults
+              to 30 seconds.
+            format: int64
+            type: integer
+          tolerations:
+            description: If specified, the pod's tolerations.
+            items:
+              description: The pod this Toleration is attached to tolerates any taint
+                that matches the triple <key,value,effect> using the matching operator
+                <operator>.
+              properties:
+                effect:
+                  description: |-
+                    Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+                    Possible enum values:
+                     - `"NoExecute"` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+                     - `"NoSchedule"` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+                     - `"PreferNoSchedule"` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
+                  type: string
+                key:
+                  description: Key is the taint key that the toleration applies to.
+                    Empty means match all taint keys. If the key is empty, operator
+                    must be Exists; this combination means to match all values and
+                    all keys.
+                  type: string
+                operator:
+                  description: |-
+                    Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+
+                    Possible enum values:
+                     - `"Equal"`
+                     - `"Exists"`
+                  type: string
+                tolerationSeconds:
+                  description: TolerationSeconds represents the period of time the
+                    toleration (which must be of effect NoExecute, otherwise this
+                    field is ignored) tolerates the taint. By default, it is not set,
+                    which means tolerate the taint forever (do not evict). Zero and
+                    negative values will be treated as 0 (evict immediately) by the
+                    system.
+                  format: int64
+                  type: integer
+                value:
+                  description: Value is the taint value the toleration matches to.
+                    If the operator is Exists, the value should be empty, otherwise
+                    just a regular string.
+                  type: string
+              type: object
+            type: array
+          topologySpreadConstraints:
+            description: TopologySpreadConstraints describes how a group of pods ought
+              to spread across topology domains. Scheduler will schedule pods in a
+              way which abides by the constraints. All topologySpreadConstraints are
+              ANDed.
+            items:
+              description: TopologySpreadConstraint specifies how to spread matching
+                pods among the given topology.
+              properties:
+                labelSelector:
+                  description: LabelSelector is used to find matching pods. Pods that
+                    match this label selector are counted to determine the number
+                    of pods in their corresponding topology domain.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                matchLabelKeys:
+                  description: MatchLabelKeys is a set of pod label keys to select
+                    the pods over which spreading will be calculated. The keys are
+                    used to lookup values from the incoming pod labels, those key-value
+                    labels are ANDed with labelSelector to select the group of existing
+                    pods over which spreading will be calculated for the incoming
+                    pod. Keys that don't exist in the incoming pod labels will be
+                    ignored. A null or empty list means only match against labelSelector.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: atomic
+                maxSkew:
+                  description: 'MaxSkew describes the degree to which pods may be
+                    unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                    it is the maximum permitted difference between the number of matching
+                    pods in the target topology and the global minimum. The global
+                    minimum is the minimum number of matching pods in an eligible
+                    domain or zero if the number of eligible domains is less than
+                    MinDomains. For example, in a 3-zone cluster, MaxSkew is set to
+                    1, and pods with the same labelSelector spread as 2/2/1: In this
+                    case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P
+                    P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only
+                    be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2)
+                    would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1).
+                    - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                    When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher
+                    precedence to topologies that satisfy it. It''s a required field.
+                    Default value is 1 and 0 is not allowed.'
+                  format: int32
+                  type: integer
+                minDomains:
+                  description: |-
+                    MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                    For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew.
+
+                    This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
+                  format: int32
+                  type: integer
+                nodeAffinityPolicy:
+                  description: |-
+                    NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                    If this value is nil, the behavior is equivalent to the Honor policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                  type: string
+                nodeTaintsPolicy:
+                  description: |-
+                    NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included.
+
+                    If this value is nil, the behavior is equivalent to the Ignore policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                  type: string
+                topologyKey:
+                  description: TopologyKey is the key of node labels. Nodes that have
+                    a label with this key and identical values are considered to be
+                    in the same topology. We consider each <key, value> as a "bucket",
+                    and try to put balanced number of pods into each bucket. We define
+                    a domain as a particular instance of a topology. Also, we define
+                    an eligible domain as a domain whose nodes meet the requirements
+                    of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey
+                    is "kubernetes.io/hostname", each Node is a domain of that topology.
+                    And, if TopologyKey is "topology.kubernetes.io/zone", each zone
+                    is a domain of that topology. It's a required field.
+                  type: string
+                whenUnsatisfiable:
+                  description: |-
+                    WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                      but giving higher precedence to topologies that would help reduce the
+                      skew.
+                    A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
+
+                    Possible enum values:
+                     - `"DoNotSchedule"` instructs the scheduler not to schedule the pod when constraints are not satisfied.
+                     - `"ScheduleAnyway"` instructs the scheduler to schedule the pod even if constraints are not satisfied.
+                  type: string
+              required:
+              - maxSkew
+              - topologyKey
+              - whenUnsatisfiable
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - topologyKey
+            - whenUnsatisfiable
+            x-kubernetes-list-type: map
+          volumes:
+            description: 'List of volumes that can be mounted by containers belonging
+              to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+            items:
+              description: Volume represents a named volume in a pod that may be accessed
+                by any container in the pod.
+              properties:
+                awsElasticBlockStore:
+                  description: 'awsElasticBlockStore represents an AWS Disk resource
+                    that is attached to a kubelet''s host machine and then exposed
+                    to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                  properties:
+                    fsType:
+                      description: 'fsType is the filesystem type of the volume that
+                        you want to mount. Tip: Ensure that the filesystem type is
+                        supported by the host operating system. Examples: "ext4",
+                        "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                      type: string
+                    partition:
+                      description: 'partition is the partition in the volume that
+                        you want to mount. If omitted, the default is to mount by
+                        volume name. Examples: For volume /dev/sda1, you specify the
+                        partition as "1". Similarly, the volume partition for /dev/sda
+                        is "0" (or you can leave the property empty).'
+                      format: int32
+                      type: integer
+                    readOnly:
+                      description: 'readOnly value true will force the readOnly setting
+                        in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                      type: boolean
+                    volumeID:
+                      description: 'volumeID is unique ID of the persistent disk resource
+                        in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                      type: string
+                  required:
+                  - volumeID
+                  type: object
+                azureDisk:
+                  description: azureDisk represents an Azure Data Disk mount on the
+                    host and bind mount to the pod.
+                  properties:
+                    cachingMode:
+                      description: 'cachingMode is the Host Caching mode: None, Read
+                        Only, Read Write.'
+                      type: string
+                    diskName:
+                      description: diskName is the Name of the data disk in the blob
+                        storage
+                      type: string
+                    diskURI:
+                      description: diskURI is the URI of data disk in the blob storage
+                      type: string
+                    fsType:
+                      description: fsType is Filesystem type to mount. Must be a filesystem
+                        type supported by the host operating system. Ex. "ext4", "xfs",
+                        "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                      type: string
+                    kind:
+                      description: 'kind expected values are Shared: multiple blob
+                        disks per storage account  Dedicated: single blob disk per
+                        storage account  Managed: azure managed data disk (only in
+                        managed availability set). defaults to shared'
+                      type: string
+                    readOnly:
+                      description: readOnly Defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts.
+                      type: boolean
+                  required:
+                  - diskName
+                  - diskURI
+                  type: object
+                azureFile:
+                  description: azureFile represents an Azure File Service mount on
+                    the host and bind mount to the pod.
+                  properties:
+                    readOnly:
+                      description: readOnly defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts.
+                      type: boolean
+                    secretName:
+                      description: secretName is the  name of secret that contains
+                        Azure Storage Account Name and Key
+                      type: string
+                    shareName:
+                      description: shareName is the azure share Name
+                      type: string
+                  required:
+                  - secretName
+                  - shareName
+                  type: object
+                cephfs:
+                  description: cephFS represents a Ceph FS mount on the host that
+                    shares a pod's lifetime
+                  properties:
+                    monitors:
+                      description: 'monitors is Required: Monitors is a collection
+                        of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                      items:
+                        type: string
+                      type: array
+                    path:
+                      description: 'path is Optional: Used as the mounted root, rather
+                        than the full Ceph tree, default is /'
+                      type: string
+                    readOnly:
+                      description: 'readOnly is Optional: Defaults to false (read/write).
+                        ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                      type: boolean
+                    secretFile:
+                      description: 'secretFile is Optional: SecretFile is the path
+                        to key ring for User, default is /etc/ceph/user.secret More
+                        info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                      type: string
+                    secretRef:
+                      description: 'secretRef is Optional: SecretRef is reference
+                        to the authentication secret for User, default is empty. More
+                        info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    user:
+                      description: 'user is optional: User is the rados user name,
+                        default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                      type: string
+                  required:
+                  - monitors
+                  type: object
+                cinder:
+                  description: 'cinder represents a cinder volume attached and mounted
+                    on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                  properties:
+                    fsType:
+                      description: 'fsType is the filesystem type to mount. Must be
+                        a filesystem type supported by the host operating system.
+                        Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be
+                        "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                      type: string
+                    readOnly:
+                      description: 'readOnly defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts. More
+                        info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                      type: boolean
+                    secretRef:
+                      description: 'secretRef is optional: points to a secret object
+                        containing parameters used to connect to OpenStack.'
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    volumeID:
+                      description: 'volumeID used to identify the volume in cinder.
+                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                      type: string
+                  required:
+                  - volumeID
+                  type: object
+                configMap:
+                  description: configMap represents a configMap that should populate
+                    this volume
+                  properties:
+                    defaultMode:
+                      description: 'defaultMode is optional: mode bits used to set
+                        permissions on created files by default. Must be an octal
+                        value between 0000 and 0777 or a decimal value between 0 and
+                        511. YAML accepts both octal and decimal values, JSON requires
+                        decimal values for mode bits. Defaults to 0644. Directories
+                        within the path are not affected by this setting. This might
+                        be in conflict with other options that affect the file mode,
+                        like fsGroup, and the result can be other mode bits set.'
+                      format: int32
+                      type: integer
+                    items:
+                      description: items if unspecified, each key-value pair in the
+                        Data field of the referenced ConfigMap will be projected into
+                        the volume as a file whose name is the key and content is
+                        the value. If specified, the listed keys will be projected
+                        into the specified paths, and unlisted keys will not be present.
+                        If a key is specified which is not present in the ConfigMap,
+                        the volume setup will error unless it is marked optional.
+                        Paths must be relative and may not contain the '..' path or
+                        start with '..'.
+                      items:
+                        description: Maps a string key to a path within a volume.
+                        properties:
+                          key:
+                            description: key is the key to project.
+                            type: string
+                          mode:
+                            description: 'mode is Optional: mode bits used to set
+                              permissions on this file. Must be an octal value between
+                              0000 and 0777 or a decimal value between 0 and 511.
+                              YAML accepts both octal and decimal values, JSON requires
+                              decimal values for mode bits. If not specified, the
+                              volume defaultMode will be used. This might be in conflict
+                              with other options that affect the file mode, like fsGroup,
+                              and the result can be other mode bits set.'
+                            format: int32
+                            type: integer
+                          path:
+                            description: path is the relative path of the file to
+                              map the key to. May not be an absolute path. May not
+                              contain the path element '..'. May not start with the
+                              string '..'.
+                            type: string
+                        required:
+                        - key
+                        - path
+                        type: object
+                      type: array
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    optional:
+                      description: optional specify whether the ConfigMap or its keys
+                        must be defined
+                      type: boolean
+                  type: object
+                csi:
+                  description: csi (Container Storage Interface) represents ephemeral
+                    storage that is handled by certain external CSI drivers (Beta
+                    feature).
+                  properties:
+                    driver:
+                      description: driver is the name of the CSI driver that handles
+                        this volume. Consult with your admin for the correct name
+                        as registered in the cluster.
+                      type: string
+                    fsType:
+                      description: fsType to mount. Ex. "ext4", "xfs", "ntfs". If
+                        not provided, the empty value is passed to the associated
+                        CSI driver which will determine the default filesystem to
+                        apply.
+                      type: string
+                    nodePublishSecretRef:
+                      description: nodePublishSecretRef is a reference to the secret
+                        object containing sensitive information to pass to the CSI
+                        driver to complete the CSI NodePublishVolume and NodeUnpublishVolume
+                        calls. This field is optional, and  may be empty if no secret
+                        is required. If the secret object contains more than one secret,
+                        all secret references are passed.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    readOnly:
+                      description: readOnly specifies a read-only configuration for
+                        the volume. Defaults to false (read/write).
+                      type: boolean
+                    volumeAttributes:
+                      additionalProperties:
+                        type: string
+                      description: volumeAttributes stores driver-specific properties
+                        that are passed to the CSI driver. Consult your driver's documentation
+                        for supported values.
+                      type: object
+                  required:
+                  - driver
+                  type: object
+                downwardAPI:
+                  description: downwardAPI represents downward API about the pod that
+                    should populate this volume
+                  properties:
+                    defaultMode:
+                      description: 'Optional: mode bits to use on created files by
+                        default. Must be a Optional: mode bits used to set permissions
+                        on created files by default. Must be an octal value between
+                        0000 and 0777 or a decimal value between 0 and 511. YAML accepts
+                        both octal and decimal values, JSON requires decimal values
+                        for mode bits. Defaults to 0644. Directories within the path
+                        are not affected by this setting. This might be in conflict
+                        with other options that affect the file mode, like fsGroup,
+                        and the result can be other mode bits set.'
+                      format: int32
+                      type: integer
+                    items:
+                      description: Items is a list of downward API volume file
+                      items:
+                        description: DownwardAPIVolumeFile represents information
+                          to create the file containing the pod field
+                        properties:
+                          fieldRef:
+                            description: 'Required: Selects a field of the pod: only
+                              annotations, labels, name and namespace are supported.'
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                            - fieldPath
+                            type: object
+                          mode:
+                            description: 'Optional: mode bits used to set permissions
+                              on this file, must be an octal value between 0000 and
+                              0777 or a decimal value between 0 and 511. YAML accepts
+                              both octal and decimal values, JSON requires decimal
+                              values for mode bits. If not specified, the volume defaultMode
+                              will be used. This might be in conflict with other options
+                              that affect the file mode, like fsGroup, and the result
+                              can be other mode bits set.'
+                            format: int32
+                            type: integer
+                          path:
+                            description: 'Required: Path is  the relative path name
+                              of the file to be created. Must not be absolute or contain
+                              the ''..'' path. Must be utf-8 encoded. The first item
+                              of the relative path must not start with ''..'''
+                            type: string
+                          resourceFieldRef:
+                            description: 'Selects a resource of the container: only
+                              resources limits and requests (limits.cpu, limits.memory,
+                              requests.cpu and requests.memory) are currently supported.'
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Specifies the output format of the exposed
+                                  resources, defaults to "1"
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                            - resource
+                            type: object
+                        required:
+                        - path
+                        type: object
+                      type: array
+                  type: object
+                emptyDir:
+                  description: 'emptyDir represents a temporary directory that shares
+                    a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                  properties:
+                    medium:
+                      description: 'medium represents what type of storage medium
+                        should back this directory. The default is "" which means
+                        to use the node''s default medium. Must be an empty string
+                        (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                      type: string
+                    sizeLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: 'sizeLimit is the total amount of local storage
+                        required for this EmptyDir volume. The size limit is also
+                        applicable for memory medium. The maximum usage on memory
+                        medium EmptyDir would be the minimum value between the SizeLimit
+                        specified here and the sum of memory limits of all containers
+                        in a pod. The default is nil which means that the limit is
+                        undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  type: object
+                ephemeral:
+                  description: |-
+                    ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+
+                    Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+                       tracking are needed,
+                    c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+                       a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                       information on the connection between this volume type
+                       and PersistentVolumeClaim).
+
+                    Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+
+                    Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+
+                    A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+                  properties:
+                    volumeClaimTemplate:
+                      description: |-
+                        Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+
+                        An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+
+                        This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+
+                        Required, must not be nil.
+                      properties:
+                        metadata:
+                          description: May contain labels and annotations that will
+                            be copied into the PVC when creating it. No other fields
+                            are allowed and will be rejected during validation.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        spec:
+                          description: The specification for the PersistentVolumeClaim.
+                            The entire content is copied unchanged into the PVC that
+                            gets created from this template. The same fields as in
+                            a PersistentVolumeClaim are also valid here.
+                          properties:
+                            accessModes:
+                              description: 'accessModes contains the desired access
+                                modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                              items:
+                                type: string
+                              type: array
+                            dataSource:
+                              description: 'dataSource field can be used to specify
+                                either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                * An existing PVC (PersistentVolumeClaim) If the provisioner
+                                or an external controller can support the specified
+                                data source, it will create a new volume based on
+                                the contents of the specified data source. If the
+                                AnyVolumeDataSource feature gate is enabled, this
+                                field will always have the same contents as the DataSourceRef
+                                field.'
+                              properties:
+                                apiGroup:
+                                  description: APIGroup is the group for the resource
+                                    being referenced. If APIGroup is not specified,
+                                    the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being
+                                    referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being
+                                    referenced
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            dataSourceRef:
+                              description: |-
+                                dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef
+                                  allows any non-core object, as well as PersistentVolumeClaim objects.
+                                * While DataSource ignores disallowed values (dropping them), DataSourceRef
+                                  preserves all values, and generates an error if a disallowed value is
+                                  specified.
+                                (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                              properties:
+                                apiGroup:
+                                  description: APIGroup is the group for the resource
+                                    being referenced. If APIGroup is not specified,
+                                    the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being
+                                    referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being
+                                    referenced
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            resources:
+                              description: 'resources represents the minimum resources
+                                the volume should have. If RecoverVolumeExpansionFailure
+                                feature is enabled users are allowed to specify resource
+                                requirements that are lower than previous value but
+                                must still be higher than capacity recorded in the
+                                status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                              type: object
+                            selector:
+                              description: selector is a label query over volumes
+                                to consider for binding.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            storageClassName:
+                              description: 'storageClassName is the name of the StorageClass
+                                required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                              type: string
+                            volumeMode:
+                              description: volumeMode defines what type of volume
+                                is required by the claim. Value of Filesystem is implied
+                                when not included in claim spec.
+                              type: string
+                            volumeName:
+                              description: volumeName is the binding reference to
+                                the PersistentVolume backing this claim.
+                              type: string
+                          type: object
+                      required:
+                      - spec
+                      type: object
+                  type: object
+                fc:
+                  description: fc represents a Fibre Channel resource that is attached
+                    to a kubelet's host machine and then exposed to the pod.
+                  properties:
+                    fsType:
+                      description: fsType is the filesystem type to mount. Must be
+                        a filesystem type supported by the host operating system.
+                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                        if unspecified.
+                      type: string
+                    lun:
+                      description: 'lun is Optional: FC target lun number'
+                      format: int32
+                      type: integer
+                    readOnly:
+                      description: 'readOnly is Optional: Defaults to false (read/write).
+                        ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                      type: boolean
+                    targetWWNs:
+                      description: 'targetWWNs is Optional: FC target worldwide names
+                        (WWNs)'
+                      items:
+                        type: string
+                      type: array
+                    wwids:
+                      description: 'wwids Optional: FC volume world wide identifiers
+                        (wwids) Either wwids or combination of targetWWNs and lun
+                        must be set, but not both simultaneously.'
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                flexVolume:
+                  description: flexVolume represents a generic volume resource that
+                    is provisioned/attached using an exec based plugin.
+                  properties:
+                    driver:
+                      description: driver is the name of the driver to use for this
+                        volume.
+                      type: string
+                    fsType:
+                      description: fsType is the filesystem type to mount. Must be
+                        a filesystem type supported by the host operating system.
+                        Ex. "ext4", "xfs", "ntfs". The default filesystem depends
+                        on FlexVolume script.
+                      type: string
+                    options:
+                      additionalProperties:
+                        type: string
+                      description: 'options is Optional: this field holds extra command
+                        options if any.'
+                      type: object
+                    readOnly:
+                      description: 'readOnly is Optional: defaults to false (read/write).
+                        ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                      type: boolean
+                    secretRef:
+                      description: 'secretRef is Optional: secretRef is reference
+                        to the secret object containing sensitive information to pass
+                        to the plugin scripts. This may be empty if no secret object
+                        is specified. If the secret object contains more than one
+                        secret, all secrets are passed to the plugin scripts.'
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                  required:
+                  - driver
+                  type: object
+                flocker:
+                  description: flocker represents a Flocker volume attached to a kubelet's
+                    host machine. This depends on the Flocker control service being
+                    running
+                  properties:
+                    datasetName:
+                      description: datasetName is Name of the dataset stored as metadata
+                        -> name on the dataset for Flocker should be considered as
+                        deprecated
+                      type: string
+                    datasetUUID:
+                      description: datasetUUID is the UUID of the dataset. This is
+                        unique identifier of a Flocker dataset
+                      type: string
+                  type: object
+                gcePersistentDisk:
+                  description: 'gcePersistentDisk represents a GCE Disk resource that
+                    is attached to a kubelet''s host machine and then exposed to the
+                    pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                  properties:
+                    fsType:
+                      description: 'fsType is filesystem type of the volume that you
+                        want to mount. Tip: Ensure that the filesystem type is supported
+                        by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                        Implicitly inferred to be "ext4" if unspecified. More info:
+                        https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                      type: string
+                    partition:
+                      description: 'partition is the partition in the volume that
+                        you want to mount. If omitted, the default is to mount by
+                        volume name. Examples: For volume /dev/sda1, you specify the
+                        partition as "1". Similarly, the volume partition for /dev/sda
+                        is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                      format: int32
+                      type: integer
+                    pdName:
+                      description: 'pdName is unique name of the PD resource in GCE.
+                        Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                      type: string
+                    readOnly:
+                      description: 'readOnly here will force the ReadOnly setting
+                        in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                      type: boolean
+                  required:
+                  - pdName
+                  type: object
+                gitRepo:
+                  description: 'gitRepo represents a git repository at a particular
+                    revision. DEPRECATED: GitRepo is deprecated. To provision a container
+                    with a git repo, mount an EmptyDir into an InitContainer that
+                    clones the repo using git, then mount the EmptyDir into the Pod''s
+                    container.'
+                  properties:
+                    directory:
+                      description: directory is the target directory name. Must not
+                        contain or start with '..'.  If '.' is supplied, the volume
+                        directory will be the git repository.  Otherwise, if specified,
+                        the volume will contain the git repository in the subdirectory
+                        with the given name.
+                      type: string
+                    repository:
+                      description: repository is the URL
+                      type: string
+                    revision:
+                      description: revision is the commit hash for the specified revision.
+                      type: string
+                  required:
+                  - repository
+                  type: object
+                glusterfs:
+                  description: 'glusterfs represents a Glusterfs mount on the host
+                    that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                  properties:
+                    endpoints:
+                      description: 'endpoints is the endpoint name that details Glusterfs
+                        topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                      type: string
+                    path:
+                      description: 'path is the Glusterfs volume path. More info:
+                        https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                      type: string
+                    readOnly:
+                      description: 'readOnly here will force the Glusterfs volume
+                        to be mounted with read-only permissions. Defaults to false.
+                        More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                      type: boolean
+                  required:
+                  - endpoints
+                  - path
+                  type: object
+                hostPath:
+                  description: 'hostPath represents a pre-existing file or directory
+                    on the host machine that is directly exposed to the container.
+                    This is generally used for system agents or other privileged things
+                    that are allowed to see the host machine. Most containers will
+                    NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                  properties:
+                    path:
+                      description: 'path of the directory on the host. If the path
+                        is a symlink, it will follow the link to the real path. More
+                        info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                      type: string
+                    type:
+                      description: 'type for HostPath Volume Defaults to "" More info:
+                        https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                      type: string
+                  required:
+                  - path
+                  type: object
+                iscsi:
+                  description: 'iscsi represents an ISCSI Disk resource that is attached
+                    to a kubelet''s host machine and then exposed to the pod. More
+                    info: https://examples.k8s.io/volumes/iscsi/README.md'
+                  properties:
+                    chapAuthDiscovery:
+                      description: chapAuthDiscovery defines whether support iSCSI
+                        Discovery CHAP authentication
+                      type: boolean
+                    chapAuthSession:
+                      description: chapAuthSession defines whether support iSCSI Session
+                        CHAP authentication
+                      type: boolean
+                    fsType:
+                      description: 'fsType is the filesystem type of the volume that
+                        you want to mount. Tip: Ensure that the filesystem type is
+                        supported by the host operating system. Examples: "ext4",
+                        "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                      type: string
+                    initiatorName:
+                      description: initiatorName is the custom iSCSI Initiator Name.
+                        If initiatorName is specified with iscsiInterface simultaneously,
+                        new iSCSI interface <target portal>:<volume name> will be
+                        created for the connection.
+                      type: string
+                    iqn:
+                      description: iqn is the target iSCSI Qualified Name.
+                      type: string
+                    iscsiInterface:
+                      description: iscsiInterface is the interface Name that uses
+                        an iSCSI transport. Defaults to 'default' (tcp).
+                      type: string
+                    lun:
+                      description: lun represents iSCSI Target Lun number.
+                      format: int32
+                      type: integer
+                    portals:
+                      description: portals is the iSCSI Target Portal List. The portal
+                        is either an IP or ip_addr:port if the port is other than
+                        default (typically TCP ports 860 and 3260).
+                      items:
+                        type: string
+                      type: array
+                    readOnly:
+                      description: readOnly here will force the ReadOnly setting in
+                        VolumeMounts. Defaults to false.
+                      type: boolean
+                    secretRef:
+                      description: secretRef is the CHAP Secret for iSCSI target and
+                        initiator authentication
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    targetPortal:
+                      description: targetPortal is iSCSI Target Portal. The Portal
+                        is either an IP or ip_addr:port if the port is other than
+                        default (typically TCP ports 860 and 3260).
+                      type: string
+                  required:
+                  - targetPortal
+                  - iqn
+                  - lun
+                  type: object
+                name:
+                  description: 'name of the volume. Must be a DNS_LABEL and unique
+                    within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                nfs:
+                  description: 'nfs represents an NFS mount on the host that shares
+                    a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                  properties:
+                    path:
+                      description: 'path that is exported by the NFS server. More
+                        info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                      type: string
+                    readOnly:
+                      description: 'readOnly here will force the NFS export to be
+                        mounted with read-only permissions. Defaults to false. More
+                        info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                      type: boolean
+                    server:
+                      description: 'server is the hostname or IP address of the NFS
+                        server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                      type: string
+                  required:
+                  - server
+                  - path
+                  type: object
+                persistentVolumeClaim:
+                  description: 'persistentVolumeClaimVolumeSource represents a reference
+                    to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                  properties:
+                    claimName:
+                      description: 'claimName is the name of a PersistentVolumeClaim
+                        in the same namespace as the pod using this volume. More info:
+                        https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                      type: string
+                    readOnly:
+                      description: readOnly Will force the ReadOnly setting in VolumeMounts.
+                        Default false.
+                      type: boolean
+                  required:
+                  - claimName
+                  type: object
+                photonPersistentDisk:
+                  description: photonPersistentDisk represents a PhotonController
+                    persistent disk attached and mounted on kubelets host machine
+                  properties:
+                    fsType:
+                      description: fsType is the filesystem type to mount. Must be
+                        a filesystem type supported by the host operating system.
+                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                        if unspecified.
+                      type: string
+                    pdID:
+                      description: pdID is the ID that identifies Photon Controller
+                        persistent disk
+                      type: string
+                  required:
+                  - pdID
+                  type: object
+                portworxVolume:
+                  description: portworxVolume represents a portworx volume attached
+                    and mounted on kubelets host machine
+                  properties:
+                    fsType:
+                      description: fSType represents the filesystem type to mount
+                        Must be a filesystem type supported by the host operating
+                        system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
+                        if unspecified.
+                      type: string
+                    readOnly:
+                      description: readOnly defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts.
+                      type: boolean
+                    volumeID:
+                      description: volumeID uniquely identifies a Portworx volume
+                      type: string
+                  required:
+                  - volumeID
+                  type: object
+                projected:
+                  description: projected items for all in one resources secrets, configmaps,
+                    and downward API
+                  properties:
+                    defaultMode:
+                      description: defaultMode are the mode bits used to set permissions
+                        on created files by default. Must be an octal value between
+                        0000 and 0777 or a decimal value between 0 and 511. YAML accepts
+                        both octal and decimal values, JSON requires decimal values
+                        for mode bits. Directories within the path are not affected
+                        by this setting. This might be in conflict with other options
+                        that affect the file mode, like fsGroup, and the result can
+                        be other mode bits set.
+                      format: int32
+                      type: integer
+                    sources:
+                      description: sources is the list of volume projections
+                      items:
+                        description: Projection that may be projected along with other
+                          supported volume types
+                        properties:
+                          configMap:
+                            description: configMap information about the configMap
+                              data to project
+                            properties:
+                              items:
+                                description: items if unspecified, each key-value
+                                  pair in the Data field of the referenced ConfigMap
+                                  will be projected into the volume as a file whose
+                                  name is the key and content is the value. If specified,
+                                  the listed keys will be projected into the specified
+                                  paths, and unlisted keys will not be present. If
+                                  a key is specified which is not present in the ConfigMap,
+                                  the volume setup will error unless it is marked
+                                  optional. Paths must be relative and may not contain
+                                  the '..' path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: 'mode is Optional: mode bits used
+                                        to set permissions on this file. Must be an
+                                        octal value between 0000 and 0777 or a decimal
+                                        value between 0 and 511. YAML accepts both
+                                        octal and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: path is the relative path of the
+                                        file to map the key to. May not be an absolute
+                                        path. May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: optional specify whether the ConfigMap
+                                  or its keys must be defined
+                                type: boolean
+                            type: object
+                          downwardAPI:
+                            description: downwardAPI information about the downwardAPI
+                              data to project
+                            properties:
+                              items:
+                                description: Items is a list of DownwardAPIVolume
+                                  file
+                                items:
+                                  description: DownwardAPIVolumeFile represents information
+                                    to create the file containing the pod field
+                                  properties:
+                                    fieldRef:
+                                      description: 'Required: Selects a field of the
+                                        pod: only annotations, labels, name and namespace
+                                        are supported.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    mode:
+                                      description: 'Optional: mode bits used to set
+                                        permissions on this file, must be an octal
+                                        value between 0000 and 0777 or a decimal value
+                                        between 0 and 511. YAML accepts both octal
+                                        and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: 'Required: Path is  the relative
+                                        path name of the file to be created. Must
+                                        not be absolute or contain the ''..'' path.
+                                        Must be utf-8 encoded. The first item of the
+                                        relative path must not start with ''..'''
+                                      type: string
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, requests.cpu and requests.memory)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                  required:
+                                  - path
+                                  type: object
+                                type: array
+                            type: object
+                          secret:
+                            description: secret information about the secret data
+                              to project
+                            properties:
+                              items:
+                                description: items if unspecified, each key-value
+                                  pair in the Data field of the referenced Secret
+                                  will be projected into the volume as a file whose
+                                  name is the key and content is the value. If specified,
+                                  the listed keys will be projected into the specified
+                                  paths, and unlisted keys will not be present. If
+                                  a key is specified which is not present in the Secret,
+                                  the volume setup will error unless it is marked
+                                  optional. Paths must be relative and may not contain
+                                  the '..' path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: 'mode is Optional: mode bits used
+                                        to set permissions on this file. Must be an
+                                        octal value between 0000 and 0777 or a decimal
+                                        value between 0 and 511. YAML accepts both
+                                        octal and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: path is the relative path of the
+                                        file to map the key to. May not be an absolute
+                                        path. May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: optional field specify whether the Secret
+                                  or its key must be defined
+                                type: boolean
+                            type: object
+                          serviceAccountToken:
+                            description: serviceAccountToken is information about
+                              the serviceAccountToken data to project
+                            properties:
+                              audience:
+                                description: audience is the intended audience of
+                                  the token. A recipient of a token must identify
+                                  itself with an identifier specified in the audience
+                                  of the token, and otherwise should reject the token.
+                                  The audience defaults to the identifier of the apiserver.
+                                type: string
+                              expirationSeconds:
+                                description: expirationSeconds is the requested duration
+                                  of validity of the service account token. As the
+                                  token approaches expiration, the kubelet volume
+                                  plugin will proactively rotate the service account
+                                  token. The kubelet will start trying to rotate the
+                                  token if the token is older than 80 percent of its
+                                  time to live or if the token is older than 24 hours.Defaults
+                                  to 1 hour and must be at least 10 minutes.
+                                format: int64
+                                type: integer
+                              path:
+                                description: path is the path relative to the mount
+                                  point of the file to project the token into.
+                                type: string
+                            required:
+                            - path
+                            type: object
+                        type: object
+                      type: array
+                  type: object
+                quobyte:
+                  description: quobyte represents a Quobyte mount on the host that
+                    shares a pod's lifetime
+                  properties:
+                    group:
+                      description: group to map volume access to Default is no group
+                      type: string
+                    readOnly:
+                      description: readOnly here will force the Quobyte volume to
+                        be mounted with read-only permissions. Defaults to false.
+                      type: boolean
+                    registry:
+                      description: registry represents a single or multiple Quobyte
+                        Registry services specified as a string as host:port pair
+                        (multiple entries are separated with commas) which acts as
+                        the central registry for volumes
+                      type: string
+                    tenant:
+                      description: tenant owning the given Quobyte volume in the Backend
+                        Used with dynamically provisioned Quobyte volumes, value is
+                        set by the plugin
+                      type: string
+                    user:
+                      description: user to map volume access to Defaults to serivceaccount
+                        user
+                      type: string
+                    volume:
+                      description: volume is a string that references an already created
+                        Quobyte volume by name.
+                      type: string
+                  required:
+                  - registry
+                  - volume
+                  type: object
+                rbd:
+                  description: 'rbd represents a Rados Block Device mount on the host
+                    that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                  properties:
+                    fsType:
+                      description: 'fsType is the filesystem type of the volume that
+                        you want to mount. Tip: Ensure that the filesystem type is
+                        supported by the host operating system. Examples: "ext4",
+                        "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                      type: string
+                    image:
+                      description: 'image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      type: string
+                    keyring:
+                      description: 'keyring is the path to key ring for RBDUser. Default
+                        is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      type: string
+                    monitors:
+                      description: 'monitors is a collection of Ceph monitors. More
+                        info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      items:
+                        type: string
+                      type: array
+                    pool:
+                      description: 'pool is the rados pool name. Default is rbd. More
+                        info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      type: string
+                    readOnly:
+                      description: 'readOnly here will force the ReadOnly setting
+                        in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      type: boolean
+                    secretRef:
+                      description: 'secretRef is name of the authentication secret
+                        for RBDUser. If provided overrides keyring. Default is nil.
+                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    user:
+                      description: 'user is the rados user name. Default is admin.
+                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      type: string
+                  required:
+                  - monitors
+                  - image
+                  type: object
+                scaleIO:
+                  description: scaleIO represents a ScaleIO persistent volume attached
+                    and mounted on Kubernetes nodes.
+                  properties:
+                    fsType:
+                      description: fsType is the filesystem type to mount. Must be
+                        a filesystem type supported by the host operating system.
+                        Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                      type: string
+                    gateway:
+                      description: gateway is the host address of the ScaleIO API
+                        Gateway.
+                      type: string
+                    protectionDomain:
+                      description: protectionDomain is the name of the ScaleIO Protection
+                        Domain for the configured storage.
+                      type: string
+                    readOnly:
+                      description: readOnly Defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts.
+                      type: boolean
+                    secretRef:
+                      description: secretRef references to the secret for ScaleIO
+                        user and other sensitive information. If this is not provided,
+                        Login operation will fail.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    sslEnabled:
+                      description: sslEnabled Flag enable/disable SSL communication
+                        with Gateway, default false
+                      type: boolean
+                    storageMode:
+                      description: storageMode indicates whether the storage for a
+                        volume should be ThickProvisioned or ThinProvisioned. Default
+                        is ThinProvisioned.
+                      type: string
+                    storagePool:
+                      description: storagePool is the ScaleIO Storage Pool associated
+                        with the protection domain.
+                      type: string
+                    system:
+                      description: system is the name of the storage system as configured
+                        in ScaleIO.
+                      type: string
+                    volumeName:
+                      description: volumeName is the name of a volume already created
+                        in the ScaleIO system that is associated with this volume
+                        source.
+                      type: string
+                  required:
+                  - gateway
+                  - system
+                  - secretRef
+                  type: object
+                secret:
+                  description: 'secret represents a secret that should populate this
+                    volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                  properties:
+                    defaultMode:
+                      description: 'defaultMode is Optional: mode bits used to set
+                        permissions on created files by default. Must be an octal
+                        value between 0000 and 0777 or a decimal value between 0 and
+                        511. YAML accepts both octal and decimal values, JSON requires
+                        decimal values for mode bits. Defaults to 0644. Directories
+                        within the path are not affected by this setting. This might
+                        be in conflict with other options that affect the file mode,
+                        like fsGroup, and the result can be other mode bits set.'
+                      format: int32
+                      type: integer
+                    items:
+                      description: items If unspecified, each key-value pair in the
+                        Data field of the referenced Secret will be projected into
+                        the volume as a file whose name is the key and content is
+                        the value. If specified, the listed keys will be projected
+                        into the specified paths, and unlisted keys will not be present.
+                        If a key is specified which is not present in the Secret,
+                        the volume setup will error unless it is marked optional.
+                        Paths must be relative and may not contain the '..' path or
+                        start with '..'.
+                      items:
+                        description: Maps a string key to a path within a volume.
+                        properties:
+                          key:
+                            description: key is the key to project.
+                            type: string
+                          mode:
+                            description: 'mode is Optional: mode bits used to set
+                              permissions on this file. Must be an octal value between
+                              0000 and 0777 or a decimal value between 0 and 511.
+                              YAML accepts both octal and decimal values, JSON requires
+                              decimal values for mode bits. If not specified, the
+                              volume defaultMode will be used. This might be in conflict
+                              with other options that affect the file mode, like fsGroup,
+                              and the result can be other mode bits set.'
+                            format: int32
+                            type: integer
+                          path:
+                            description: path is the relative path of the file to
+                              map the key to. May not be an absolute path. May not
+                              contain the path element '..'. May not start with the
+                              string '..'.
+                            type: string
+                        required:
+                        - key
+                        - path
+                        type: object
+                      type: array
+                    optional:
+                      description: optional field specify whether the Secret or its
+                        keys must be defined
+                      type: boolean
+                    secretName:
+                      description: 'secretName is the name of the secret in the pod''s
+                        namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                      type: string
+                  type: object
+                storageos:
+                  description: storageOS represents a StorageOS volume attached and
+                    mounted on Kubernetes nodes.
+                  properties:
+                    fsType:
+                      description: fsType is the filesystem type to mount. Must be
+                        a filesystem type supported by the host operating system.
+                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                        if unspecified.
+                      type: string
+                    readOnly:
+                      description: readOnly defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts.
+                      type: boolean
+                    secretRef:
+                      description: secretRef specifies the secret to use for obtaining
+                        the StorageOS API credentials.  If not specified, default
+                        values will be attempted.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    volumeName:
+                      description: volumeName is the human-readable name of the StorageOS
+                        volume.  Volume names are only unique within a namespace.
+                      type: string
+                    volumeNamespace:
+                      description: volumeNamespace specifies the scope of the volume
+                        within StorageOS.  If no namespace is specified then the Pod's
+                        namespace will be used.  This allows the Kubernetes name scoping
+                        to be mirrored within StorageOS for tighter integration. Set
+                        VolumeName to any name to override the default behaviour.
+                        Set to "default" if you are not using namespaces within StorageOS.
+                        Namespaces that do not pre-exist within StorageOS will be
+                        created.
+                      type: string
+                  type: object
+                vsphereVolume:
+                  description: vsphereVolume represents a vSphere volume attached
+                    and mounted on kubelets host machine
+                  properties:
+                    fsType:
+                      description: fsType is filesystem type to mount. Must be a filesystem
+                        type supported by the host operating system. Ex. "ext4", "xfs",
+                        "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                      type: string
+                    storagePolicyID:
+                      description: storagePolicyID is the storage Policy Based Management
+                        (SPBM) profile ID associated with the StoragePolicyName.
+                      type: string
+                    storagePolicyName:
+                      description: storagePolicyName is the storage Policy Based Management
+                        (SPBM) profile name.
+                      type: string
+                    volumePath:
+                      description: volumePath is the path that identifies vSphere
+                        volume vmdk
+                      type: string
+                  required:
+                  - volumePath
+                  type: object
+              required:
+              - name
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - name
+            x-kubernetes-list-type: map
+        required:
+        - containers
+        type: object
+      status:
+        description: 'Most recently observed status of the pod. This data may not
+          be up to date. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+        properties:
+          conditions:
+            description: 'Current service state of pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions'
+            items:
+              description: PodCondition contains details for the current condition
+                of this pod.
+              properties:
+                lastProbeTime:
+                  description: Last time we probed the condition.
+                  format: date-time
+                  type: string
+                lastTransitionTime:
+                  description: Last time the condition transitioned from one status
+                    to another.
+                  format: date-time
+                  type: string
+                message:
+                  description: Human-readable message indicating details about last
+                    transition.
+                  type: string
+                reason:
+                  description: Unique, one-word, CamelCase reason for the condition's
+                    last transition.
+                  type: string
+                status:
+                  description: 'Status is the status of the condition. Can be True,
+                    False, Unknown. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions'
+                  type: string
+                type:
+                  description: 'Type is the type of the condition. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions'
+                  type: string
+              required:
+              - status
+              - type
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - type
+            x-kubernetes-list-type: map
+          containerStatuses:
+            description: 'The list has one entry per container in the manifest. More
+              info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status'
+            items:
+              description: ContainerStatus contains details for the current status
+                of this container.
+              properties:
+                containerID:
+                  description: Container's ID in the format '<type>://<container_id>'.
+                  type: string
+                image:
+                  description: 'The image the container is running. More info: https://kubernetes.io/docs/concepts/containers/images.'
+                  type: string
+                imageID:
+                  description: ImageID of the container's image.
+                  type: string
+                lastState:
+                  description: Details about the container's last termination condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format '<type>://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+                name:
+                  description: This must be a DNS_LABEL. Each container in a pod must
+                    have a unique name. Cannot be updated.
+                  type: string
+                ready:
+                  description: Specifies whether the container has passed its readiness
+                    probe.
+                  type: boolean
+                restartCount:
+                  description: The number of times the container has been restarted.
+                  format: int32
+                  type: integer
+                started:
+                  description: Specifies whether the container has passed its startup
+                    probe. Initialized as false, becomes true after startupProbe is
+                    considered successful. Resets to false when the container is restarted,
+                    or if kubelet loses state temporarily. Is always true when no
+                    startupProbe is defined.
+                  type: boolean
+                state:
+                  description: Details about the container's current condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format '<type>://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+              required:
+              - name
+              - ready
+              - restartCount
+              - image
+              - imageID
+              type: object
+            type: array
+          ephemeralContainerStatuses:
+            description: Status for any ephemeral containers that have run in this
+              pod.
+            items:
+              description: ContainerStatus contains details for the current status
+                of this container.
+              properties:
+                containerID:
+                  description: Container's ID in the format '<type>://<container_id>'.
+                  type: string
+                image:
+                  description: 'The image the container is running. More info: https://kubernetes.io/docs/concepts/containers/images.'
+                  type: string
+                imageID:
+                  description: ImageID of the container's image.
+                  type: string
+                lastState:
+                  description: Details about the container's last termination condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format '<type>://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+                name:
+                  description: This must be a DNS_LABEL. Each container in a pod must
+                    have a unique name. Cannot be updated.
+                  type: string
+                ready:
+                  description: Specifies whether the container has passed its readiness
+                    probe.
+                  type: boolean
+                restartCount:
+                  description: The number of times the container has been restarted.
+                  format: int32
+                  type: integer
+                started:
+                  description: Specifies whether the container has passed its startup
+                    probe. Initialized as false, becomes true after startupProbe is
+                    considered successful. Resets to false when the container is restarted,
+                    or if kubelet loses state temporarily. Is always true when no
+                    startupProbe is defined.
+                  type: boolean
+                state:
+                  description: Details about the container's current condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format '<type>://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+              required:
+              - name
+              - ready
+              - restartCount
+              - image
+              - imageID
+              type: object
+            type: array
+          hostIP:
+            description: IP address of the host to which the pod is assigned. Empty
+              if not yet scheduled.
+            type: string
+          initContainerStatuses:
+            description: 'The list has one entry per init container in the manifest.
+              The most recent successful init container will have ready = true, the
+              most recently started container will have startTime set. More info:
+              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status'
+            items:
+              description: ContainerStatus contains details for the current status
+                of this container.
+              properties:
+                containerID:
+                  description: Container's ID in the format '<type>://<container_id>'.
+                  type: string
+                image:
+                  description: 'The image the container is running. More info: https://kubernetes.io/docs/concepts/containers/images.'
+                  type: string
+                imageID:
+                  description: ImageID of the container's image.
+                  type: string
+                lastState:
+                  description: Details about the container's last termination condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format '<type>://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+                name:
+                  description: This must be a DNS_LABEL. Each container in a pod must
+                    have a unique name. Cannot be updated.
+                  type: string
+                ready:
+                  description: Specifies whether the container has passed its readiness
+                    probe.
+                  type: boolean
+                restartCount:
+                  description: The number of times the container has been restarted.
+                  format: int32
+                  type: integer
+                started:
+                  description: Specifies whether the container has passed its startup
+                    probe. Initialized as false, becomes true after startupProbe is
+                    considered successful. Resets to false when the container is restarted,
+                    or if kubelet loses state temporarily. Is always true when no
+                    startupProbe is defined.
+                  type: boolean
+                state:
+                  description: Details about the container's current condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format '<type>://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+              required:
+              - name
+              - ready
+              - restartCount
+              - image
+              - imageID
+              type: object
+            type: array
+          message:
+            description: A human readable message indicating details about why the
+              pod is in this condition.
+            type: string
+          nominatedNodeName:
+            description: nominatedNodeName is set only when this pod preempts other
+              pods on the node, but it cannot be scheduled right away as preemption
+              victims receive their graceful termination periods. This field does
+              not guarantee that the pod will be scheduled on this node. Scheduler
+              may decide to place the pod elsewhere if other nodes become available
+              sooner. Scheduler may also decide to give the resources on this node
+              to a higher priority pod that is created after preemption. As a result,
+              this field may be different than PodSpec.nodeName when the pod is scheduled.
+            type: string
+          phase:
+            description: |-
+              The phase of a Pod is a simple, high-level summary of where the Pod is in its lifecycle. The conditions array, the reason and message fields, and the individual container status arrays contain more detail about the pod's status. There are five possible phase values:
+
+              Pending: The pod has been accepted by the Kubernetes system, but one or more of the container images has not been created. This includes time before being scheduled as well as time spent downloading images over the network, which could take a while. Running: The pod has been bound to a node, and all of the containers have been created. At least one container is still running, or is in the process of starting or restarting. Succeeded: All containers in the pod have terminated in success, and will not be restarted. Failed: All containers in the pod have terminated, and at least one container has terminated in failure. The container either exited with non-zero status or was terminated by the system. Unknown: For some reason the state of the pod could not be obtained, typically due to an error in communicating with the host of the pod.
+
+              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-phase
+
+              Possible enum values:
+               - `"Failed"` means that all containers in the pod have terminated, and at least one container has terminated in a failure (exited with a non-zero exit code or was stopped by the system).
+               - `"Pending"` means the pod has been accepted by the system, but one or more of the containers has not been started. This includes time before being bound to a node, as well as time spent pulling images onto the host.
+               - `"Running"` means the pod has been bound to a node and all of the containers have been started. At least one container is still running or is in the process of being restarted.
+               - `"Succeeded"` means that all containers in the pod have voluntarily terminated with a container exit code of 0, and the system is not going to restart any of these containers.
+               - `"Unknown"` means that for some reason the state of the pod could not be obtained, typically due to an error in communicating with the host of the pod. Deprecated: It isn't being set since 2015 (74da3b14b0c0f658b3bb8d2def5094686d0e9095)
+            type: string
+          podIP:
+            description: IP address allocated to the pod. Routable at least within
+              the cluster. Empty if not yet allocated.
+            type: string
+          podIPs:
+            description: podIPs holds the IP addresses allocated to the pod. If this
+              field is specified, the 0th entry must match the podIP field. Pods may
+              be allocated at most 1 value for each of IPv4 and IPv6. This list is
+              empty if no IPs have been allocated yet.
+            items:
+              description: "IP address information for entries in the (plural) PodIPs
+                field. Each entry includes:\n\n\tIP: An IP address allocated to the
+                pod. Routable at least within the cluster."
+              properties:
+                ip:
+                  description: ip is an IP address (IPv4 or IPv6) assigned to the
+                    pod
+                  type: string
+              required:
+              - ip
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - ip
+            x-kubernetes-list-type: map
+          qosClass:
+            description: |-
+              The Quality of Service (QOS) classification assigned to the pod based on resource requirements See PodQOSClass type for available QOS classes More info: https://git.k8s.io/community/contributors/design-proposals/node/resource-qos.md
+
+              Possible enum values:
+               - `"BestEffort"` is the BestEffort qos class.
+               - `"Burstable"` is the Burstable qos class.
+               - `"Guaranteed"` is the Guaranteed qos class.
+            type: string
+          reason:
+            description: A brief CamelCase message indicating details about why the
+              pod is in this state. e.g. 'Evicted'
+            type: string
+          startTime:
+            description: RFC 3339 date and time at which the object was acknowledged
+              by the Kubelet. This is before the Kubelet pulled the container image(s)
+              for the pod.
+            format: date-time
+            type: string
+        type: object
+    type: object
+  plural: pods
+  schemaUpdateStrategy: UpdateUnpublished
+  scope: Namespaced
+  shortNames:
+  - po
+  singular: pod
+  subResources:
+  - name: status
+status:
+  conditions:
+  - lastTransitionTime: "2023-03-21T17:10:10Z"
+    status: "True"
+    type: Compatible

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/4-APIResourceImport-services.kind.v1.core.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/4-APIResourceImport-services.kind.v1.core.yaml
@@ -1,0 +1,429 @@
+apiVersion: apiresource.kcp.io/v1alpha1
+kind: APIResourceImport
+metadata:
+  annotations:
+    apiresource.kcp.io/apiVersion: v1
+    kcp.io/cluster: br3qimk2t1o3jb70
+  creationTimestamp: "2023-03-21T17:10:09Z"
+  generation: 1
+  name: services.kind.v1.core
+  ownerReferences:
+  - apiVersion: workload.kcp.io/v1alpha1
+    controller: true
+    kind: SyncTarget
+    name: kind
+    uid: 8df305e7-f4f8-439f-9115-51054d519361
+  resourceVersion: "9143"
+  uid: 5f801853-c70e-47ac-9585-b497fd42e65d
+spec:
+  categories:
+  - all
+  groupVersion:
+    version: v1
+  kind: Service
+  listKind: ServiceList
+  location: kind
+  openAPIV3Schema:
+    description: Service is a named abstraction of software service (for example,
+      mysql) consisting of local port (for example 3306) that the proxy listens on,
+      and the selector that determines which pods will answer requests sent through
+      the proxy.
+    properties:
+      apiVersion:
+        description: 'APIVersion defines the versioned schema of this representation
+          of an object. Servers should convert recognized schemas to the latest internal
+          value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+        type: string
+      kind:
+        description: 'Kind is a string value representing the REST resource this object
+          represents. Servers may infer this from the endpoint the client submits
+          requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+        type: string
+      metadata:
+        type: object
+      spec:
+        description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        properties:
+          allocateLoadBalancerNodePorts:
+            description: allocateLoadBalancerNodePorts defines if NodePorts will be
+              automatically allocated for services with type LoadBalancer.  Default
+              is "true". It may be set to "false" if the cluster load-balancer does
+              not rely on NodePorts.  If the caller requests specific NodePorts (by
+              specifying a value), those requests will be respected, regardless of
+              this field. This field may only be set for services with type LoadBalancer
+              and will be cleared if the type is changed to any other type.
+            type: boolean
+          clusterIP:
+            description: 'clusterIP is the IP address of the service and is usually
+              assigned randomly. If an address is specified manually, is in-range
+              (as per system configuration), and is not in use, it will be allocated
+              to the service; otherwise creation of the service will fail. This field
+              may not be changed through updates unless the type field is also being
+              changed to ExternalName (which requires this field to be blank) or the
+              type field is being changed from ExternalName (in which case this field
+              may optionally be specified, as describe above).  Valid values are "None",
+              empty string (""), or a valid IP address. Setting this to "None" makes
+              a "headless service" (no virtual IP), which is useful when direct endpoint
+              connections are preferred and proxying is not required.  Only applies
+              to types ClusterIP, NodePort, and LoadBalancer. If this field is specified
+              when creating a Service of type ExternalName, creation will fail. This
+              field will be wiped when updating a Service to type ExternalName. More
+              info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+            type: string
+          clusterIPs:
+            description: |-
+              ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address.  Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value.
+
+              This field may hold a maximum of two entries (dual-stack IPs, in either order). These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+            items:
+              type: string
+            type: array
+            x-kubernetes-list-type: atomic
+          externalIPs:
+            description: externalIPs is a list of IP addresses for which nodes in
+              the cluster will also accept traffic for this service.  These IPs are
+              not managed by Kubernetes.  The user is responsible for ensuring that
+              traffic arrives at a node with this IP.  A common example is external
+              load-balancers that are not part of the Kubernetes system.
+            items:
+              type: string
+            type: array
+          externalName:
+            description: externalName is the external reference that discovery mechanisms
+              will return as an alias for this service (e.g. a DNS CNAME record).
+              No proxying will be involved.  Must be a lowercase RFC-1123 hostname
+              (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
+            type: string
+          externalTrafficPolicy:
+            description: |-
+              externalTrafficPolicy describes how nodes distribute service traffic they receive on one of the Service's "externally-facing" addresses (NodePorts, ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure the service in a way that assumes that external load balancers will take care of balancing the service traffic between nodes, and so each node will deliver traffic only to the node-local endpoints of the service, without masquerading the client source IP. (Traffic mistakenly sent to a node with no endpoints will be dropped.) The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features). Note that traffic sent to an External IP or LoadBalancer IP from within the cluster will always get "Cluster" semantics, but clients sending to a NodePort from within the cluster may need to take traffic policy into account when picking a node.
+
+              Possible enum values:
+               - `"Cluster"` routes traffic to all endpoints.
+               - `"Local"` preserves the source IP of the traffic by routing only to endpoints on the same node as the traffic was received on (dropping the traffic if there are no local endpoints).
+            type: string
+          healthCheckNodePort:
+            description: healthCheckNodePort specifies the healthcheck nodePort for
+              the service. This only applies when type is set to LoadBalancer and
+              externalTrafficPolicy is set to Local. If a value is specified, is in-range,
+              and is not in use, it will be used.  If not specified, a value will
+              be automatically allocated.  External systems (e.g. load-balancers)
+              can use this port to determine if a given node holds endpoints for this
+              service or not.  If this field is specified when creating a Service
+              which does not need it, creation will fail. This field will be wiped
+              when updating a Service to no longer need it (e.g. changing type). This
+              field cannot be updated once set.
+            format: int32
+            type: integer
+          internalTrafficPolicy:
+            description: InternalTrafficPolicy describes how nodes distribute service
+              traffic they receive on the ClusterIP. If set to "Local", the proxy
+              will assume that pods only want to talk to endpoints of the service
+              on the same node as the pod, dropping the traffic if there are no local
+              endpoints. The default value, "Cluster", uses the standard behavior
+              of routing to all endpoints evenly (possibly modified by topology and
+              other features).
+            type: string
+          ipFamilies:
+            description: |-
+              IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service. This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail. This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service. Valid values are "IPv4" and "IPv6".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to "headless" services. This field will be wiped when updating a Service to type ExternalName.
+
+              This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field.
+            items:
+              type: string
+            type: array
+            x-kubernetes-list-type: atomic
+          ipFamilyPolicy:
+            description: IPFamilyPolicy represents the dual-stack-ness requested or
+              required by this Service. If there is no value provided, then this field
+              will be set to SingleStack. Services can be "SingleStack" (a single
+              IP family), "PreferDualStack" (two IP families on dual-stack configured
+              clusters or a single IP family on single-stack clusters), or "RequireDualStack"
+              (two IP families on dual-stack configured clusters, otherwise fail).
+              The ipFamilies and clusterIPs fields depend on the value of this field.
+              This field will be wiped when updating a service to type ExternalName.
+            type: string
+          loadBalancerClass:
+            description: loadBalancerClass is the class of the load balancer implementation
+              this Service belongs to. If specified, the value of this field must
+              be a label-style identifier, with an optional prefix, e.g. "internal-vip"
+              or "example.com/internal-vip". Unprefixed names are reserved for end-users.
+              This field can only be set when the Service type is 'LoadBalancer'.
+              If not set, the default load balancer implementation is used, today
+              this is typically done through the cloud provider integration, but should
+              apply for any default implementation. If set, it is assumed that a load
+              balancer implementation is watching for Services with a matching class.
+              Any default load balancer implementation (e.g. cloud providers) should
+              ignore Services that set this field. This field can only be set when
+              creating or updating a Service to type 'LoadBalancer'. Once set, it
+              can not be changed. This field will be wiped when a service is updated
+              to a non 'LoadBalancer' type.
+            type: string
+          loadBalancerIP:
+            description: 'Only applies to Service Type: LoadBalancer. This feature
+              depends on whether the underlying cloud-provider supports specifying
+              the loadBalancerIP when a load balancer is created. This field will
+              be ignored if the cloud-provider does not support the feature. Deprecated:
+              This field was under-specified and its meaning varies across implementations,
+              and it cannot support dual-stack. As of Kubernetes v1.24, users are
+              encouraged to use implementation-specific annotations when available.
+              This field may be removed in a future API version.'
+            type: string
+          loadBalancerSourceRanges:
+            description: 'If specified and supported by the platform, this will restrict
+              traffic through the cloud-provider load-balancer will be restricted
+              to the specified client IPs. This field will be ignored if the cloud-provider
+              does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/'
+            items:
+              type: string
+            type: array
+          ports:
+            description: 'The list of ports that are exposed by this service. More
+              info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+            items:
+              description: ServicePort contains information on service's port.
+              properties:
+                appProtocol:
+                  description: The application protocol for this port. This field
+                    follows standard Kubernetes label syntax. Un-prefixed names are
+                    reserved for IANA standard service names (as per RFC-6335 and
+                    https://www.iana.org/assignments/service-names). Non-standard
+                    protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+                  type: string
+                name:
+                  description: The name of this port within the service. This must
+                    be a DNS_LABEL. All ports within a ServiceSpec must have unique
+                    names. When considering the endpoints for a Service, this must
+                    match the 'name' field in the EndpointPort. Optional if only one
+                    ServicePort is defined on this service.
+                  type: string
+                nodePort:
+                  description: 'The port on each node on which this service is exposed
+                    when type is NodePort or LoadBalancer.  Usually assigned by the
+                    system. If a value is specified, in-range, and not in use it will
+                    be used, otherwise the operation will fail.  If not specified,
+                    a port will be allocated if this Service requires one.  If this
+                    field is specified when creating a Service which does not need
+                    it, creation will fail. This field will be wiped when updating
+                    a Service to no longer need it (e.g. changing type from NodePort
+                    to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                  format: int32
+                  type: integer
+                port:
+                  description: The port that will be exposed by this service.
+                  format: int32
+                  type: integer
+                protocol:
+                  default: TCP
+                  description: |-
+                    The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+
+                    Possible enum values:
+                     - `"SCTP"` is the SCTP protocol.
+                     - `"TCP"` is the TCP protocol.
+                     - `"UDP"` is the UDP protocol.
+                  type: string
+                targetPort:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: 'Number or name of the port to access on the pods targeted
+                    by the service. Number must be in the range 1 to 65535. Name must
+                    be an IANA_SVC_NAME. If this is a string, it will be looked up
+                    as a named port in the target Pod''s container ports. If this
+                    is not specified, the value of the ''port'' field is used (an
+                    identity map). This field is ignored for services with clusterIP=None,
+                    and should be omitted or set equal to the ''port'' field. More
+                    info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                  x-kubernetes-int-or-string: true
+              required:
+              - port
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - port
+            - protocol
+            x-kubernetes-list-type: map
+          publishNotReadyAddresses:
+            description: publishNotReadyAddresses indicates that any agent which deals
+              with endpoints for this Service should disregard any indications of
+              ready/not-ready. The primary use case for setting this field is for
+              a StatefulSet's Headless Service to propagate SRV DNS records for its
+              Pods for the purpose of peer discovery. The Kubernetes controllers that
+              generate Endpoints and EndpointSlice resources for Services interpret
+              this to mean that all endpoints are considered "ready" even if the Pods
+              themselves are not. Agents which consume only Kubernetes generated endpoints
+              through the Endpoints or EndpointSlice resources can safely assume this
+              behavior.
+            type: boolean
+          selector:
+            additionalProperties:
+              type: string
+            description: 'Route service traffic to pods with label keys and values
+              matching this selector. If empty or not present, the service is assumed
+              to have an external process managing its endpoints, which Kubernetes
+              will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer.
+              Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+            type: object
+          sessionAffinity:
+            description: |-
+              Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+
+              Possible enum values:
+               - `"ClientIP"` is the Client IP based.
+               - `"None"` - no session affinity.
+            type: string
+          sessionAffinityConfig:
+            description: sessionAffinityConfig contains the configurations of session
+              affinity.
+            properties:
+              clientIP:
+                description: clientIP contains the configurations of Client IP based
+                  session affinity.
+                properties:
+                  timeoutSeconds:
+                    description: timeoutSeconds specifies the seconds of ClientIP
+                      type session sticky time. The value must be >0 && <=86400(for
+                      1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for
+                      3 hours).
+                    format: int32
+                    type: integer
+                type: object
+            type: object
+          type:
+            description: |-
+              type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+
+              Possible enum values:
+               - `"ClusterIP"` means a service will only be accessible inside the cluster, via the cluster IP.
+               - `"ExternalName"` means a service consists of only a reference to an external name that kubedns or equivalent will return as a CNAME record, with no exposing or proxying of any pods involved.
+               - `"LoadBalancer"` means a service will be exposed via an external load balancer (if the cloud provider supports it), in addition to 'NodePort' type.
+               - `"NodePort"` means a service will be exposed on one port of every node, in addition to 'ClusterIP' type.
+            type: string
+        type: object
+      status:
+        description: 'Most recently observed status of the service. Populated by the
+          system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+        properties:
+          conditions:
+            description: Current service state
+            items:
+              description: Condition contains details for one aspect of the current
+                state of this API Resource.
+              properties:
+                lastTransitionTime:
+                  description: lastTransitionTime is the last time the condition transitioned
+                    from one status to another. This should be when the underlying
+                    condition changed.  If that is not known, then using the time
+                    when the API field changed is acceptable.
+                  format: date-time
+                  type: string
+                message:
+                  description: message is a human readable message indicating details
+                    about the transition. This may be an empty string.
+                  type: string
+                observedGeneration:
+                  description: observedGeneration represents the .metadata.generation
+                    that the condition was set based upon. For instance, if .metadata.generation
+                    is currently 12, but the .status.conditions[x].observedGeneration
+                    is 9, the condition is out of date with respect to the current
+                    state of the instance.
+                  format: int64
+                  type: integer
+                reason:
+                  description: reason contains a programmatic identifier indicating
+                    the reason for the condition's last transition. Producers of specific
+                    condition types may define expected values and meanings for this
+                    field, and whether the values are considered a guaranteed API.
+                    The value should be a CamelCase string. This field may not be
+                    empty.
+                  type: string
+                status:
+                  description: status of the condition, one of True, False, Unknown.
+                  type: string
+                type:
+                  description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                  type: string
+              required:
+              - lastTransitionTime
+              - message
+              - reason
+              - status
+              - type
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - type
+            x-kubernetes-list-type: map
+          loadBalancer:
+            description: LoadBalancer contains the current status of the load-balancer,
+              if one is present.
+            properties:
+              ingress:
+                description: Ingress is a list containing ingress points for the load-balancer.
+                  Traffic intended for the service should be sent to these ingress
+                  points.
+                items:
+                  description: 'LoadBalancerIngress represents the status of a load-balancer
+                    ingress point: traffic intended for the service should be sent
+                    to an ingress point.'
+                  properties:
+                    hostname:
+                      description: Hostname is set for load-balancer ingress points
+                        that are DNS based (typically AWS load-balancers)
+                      type: string
+                    ip:
+                      description: IP is set for load-balancer ingress points that
+                        are IP based (typically GCE or OpenStack load-balancers)
+                      type: string
+                    ports:
+                      description: Ports is a list of records of service ports If
+                        used, every port defined in the service should have an entry
+                        in it
+                      items:
+                        properties:
+                          error:
+                            description: |-
+                              Error is to record the problem with the service port The format of the error shall comply with the following rules: - built-in error values shall be specified in this file and those shall use
+                                CamelCase names
+                              - cloud provider specific error values must have names that comply with the
+                                format foo.example.com/CamelCase.
+                            type: string
+                          port:
+                            description: Port is the port number of the service port
+                              of which status is recorded here
+                            format: int32
+                            type: integer
+                          protocol:
+                            description: |-
+                              Protocol is the protocol of the service port of which status is recorded here The supported values are: "TCP", "UDP", "SCTP"
+
+                              Possible enum values:
+                               - `"SCTP"` is the SCTP protocol.
+                               - `"TCP"` is the TCP protocol.
+                               - `"UDP"` is the UDP protocol.
+                            type: string
+                        required:
+                        - port
+                        - protocol
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  type: object
+                type: array
+            type: object
+        type: object
+    type: object
+  plural: services
+  schemaUpdateStrategy: UpdateUnpublished
+  scope: Namespaced
+  shortNames:
+  - svc
+  singular: service
+  subResources:
+  - name: status
+status:
+  conditions:
+  - lastTransitionTime: "2023-03-21T17:10:09Z"
+    status: "True"
+    type: Compatible

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/4-NegotiatedAPIResource-deployments.v1.apps.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/4-NegotiatedAPIResource-deployments.v1.apps.yaml
@@ -1,0 +1,7119 @@
+apiVersion: apiresource.kcp.io/v1alpha1
+kind: NegotiatedAPIResource
+metadata:
+  annotations:
+    apiresource.kcp.io/apiVersion: apps/v1
+    kcp.io/cluster: br3qimk2t1o3jb70
+  creationTimestamp: "2023-03-21T17:10:10Z"
+  generation: 1
+  name: deployments.v1.apps
+  resourceVersion: "9151"
+  uid: fbd66449-8b09-4438-92f6-eb9091b980c2
+spec:
+  categories:
+  - all
+  groupVersion:
+    group: apps
+    version: v1
+  kind: Deployment
+  listKind: DeploymentList
+  openAPIV3Schema:
+    description: Deployment enables declarative updates for Pods and ReplicaSets.
+    properties:
+      apiVersion:
+        description: 'APIVersion defines the versioned schema of this representation
+          of an object. Servers should convert recognized schemas to the latest internal
+          value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+        type: string
+      kind:
+        description: 'Kind is a string value representing the REST resource this object
+          represents. Servers may infer this from the endpoint the client submits
+          requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+        type: string
+      metadata:
+        type: object
+      spec:
+        description: Specification of the desired behavior of the Deployment.
+        properties:
+          minReadySeconds:
+            description: Minimum number of seconds for which a newly created pod should
+              be ready without any of its container crashing, for it to be considered
+              available. Defaults to 0 (pod will be considered available as soon as
+              it is ready)
+            format: int32
+            type: integer
+          paused:
+            description: Indicates that the deployment is paused.
+            type: boolean
+          progressDeadlineSeconds:
+            description: The maximum time in seconds for a deployment to make progress
+              before it is considered to be failed. The deployment controller will
+              continue to process failed deployments and a condition with a ProgressDeadlineExceeded
+              reason will be surfaced in the deployment status. Note that progress
+              will not be estimated during the time a deployment is paused. Defaults
+              to 600s.
+            format: int32
+            type: integer
+          replicas:
+            description: Number of desired pods. This is a pointer to distinguish
+              between explicit zero and not specified. Defaults to 1.
+            format: int32
+            type: integer
+          revisionHistoryLimit:
+            description: The number of old ReplicaSets to retain to allow rollback.
+              This is a pointer to distinguish between explicit zero and not specified.
+              Defaults to 10.
+            format: int32
+            type: integer
+          selector:
+            description: Label selector for pods. Existing ReplicaSets whose pods
+              are selected by this will be the ones affected by this deployment. It
+              must match the pod template's labels.
+            properties:
+              matchExpressions:
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
+                items:
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
+                  properties:
+                    key:
+                      description: key is the label key that the selector applies
+                        to.
+                      type: string
+                    operator:
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      type: string
+                    values:
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - key
+                  - operator
+                  type: object
+                type: array
+              matchLabels:
+                additionalProperties:
+                  type: string
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
+                type: object
+            type: object
+          strategy:
+            description: The deployment strategy to use to replace existing pods with
+              new ones.
+            properties:
+              rollingUpdate:
+                description: Rolling update config params. Present only if DeploymentStrategyType
+                  = RollingUpdate.
+                properties:
+                  maxSurge:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'The maximum number of pods that can be scheduled
+                      above the desired number of pods. Value can be an absolute number
+                      (ex: 5) or a percentage of desired pods (ex: 10%). This can
+                      not be 0 if MaxUnavailable is 0. Absolute number is calculated
+                      from percentage by rounding up. Defaults to 25%. Example: when
+                      this is set to 30%, the new ReplicaSet can be scaled up immediately
+                      when the rolling update starts, such that the total number of
+                      old and new pods do not exceed 130% of desired pods. Once old
+                      pods have been killed, new ReplicaSet can be scaled up further,
+                      ensuring that total number of pods running at any time during
+                      the update is at most 130% of desired pods.'
+                    x-kubernetes-int-or-string: true
+                  maxUnavailable:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'The maximum number of pods that can be unavailable
+                      during the update. Value can be an absolute number (ex: 5) or
+                      a percentage of desired pods (ex: 10%). Absolute number is calculated
+                      from percentage by rounding down. This can not be 0 if MaxSurge
+                      is 0. Defaults to 25%. Example: when this is set to 30%, the
+                      old ReplicaSet can be scaled down to 70% of desired pods immediately
+                      when the rolling update starts. Once new pods are ready, old
+                      ReplicaSet can be scaled down further, followed by scaling up
+                      the new ReplicaSet, ensuring that the total number of pods available
+                      at all times during the update is at least 70% of desired pods.'
+                    x-kubernetes-int-or-string: true
+                type: object
+              type:
+                description: |-
+                  Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+
+                  Possible enum values:
+                   - `"Recreate"` Kill all existing pods before creating new ones.
+                   - `"RollingUpdate"` Replace the old ReplicaSets by new one using rolling update i.e gradually scale down the old ReplicaSets and scale up the new one.
+                type: string
+            type: object
+          template:
+            description: Template describes the pods that will be created.
+            properties:
+              metadata:
+                description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              spec:
+                description: 'Specification of the desired behavior of the pod. More
+                  info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                properties:
+                  activeDeadlineSeconds:
+                    description: Optional duration in seconds the pod may be active
+                      on the node relative to StartTime before the system will actively
+                      try to mark it failed and kill associated containers. Value
+                      must be a positive integer.
+                    format: int64
+                    type: integer
+                  affinity:
+                    description: If specified, the pod's scheduling constraints
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for
+                          the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node matches the corresponding matchExpressions;
+                              the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches
+                                all objects with implicit weight 0 (i.e. it's a no-op).
+                                A null preferred scheduling term matches no objects
+                                (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                              Possible enum values:
+                                               - `"DoesNotExist"`
+                                               - `"Exists"`
+                                               - `"Gt"`
+                                               - `"In"`
+                                               - `"Lt"`
+                                               - `"NotIn"`
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                              Possible enum values:
+                                               - `"DoesNotExist"`
+                                               - `"Exists"`
+                                               - `"Gt"`
+                                               - `"In"`
+                                               - `"Lt"`
+                                               - `"NotIn"`
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the
+                                    corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - weight
+                              - preference
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by
+                              this field are not met at scheduling time, the pod will
+                              not be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from
+                              its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term
+                                    matches no objects. The requirements of them are
+                                    ANDed. The TopologySelectorTerm type implements
+                                    a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                              Possible enum values:
+                                               - `"DoesNotExist"`
+                                               - `"Exists"`
+                                               - `"Gt"`
+                                               - `"In"`
+                                               - `"Lt"`
+                                               - `"NotIn"`
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                              Possible enum values:
+                                               - `"DoesNotExist"`
+                                               - `"Exists"`
+                                               - `"Gt"`
+                                               - `"In"`
+                                               - `"Lt"`
+                                               - `"NotIn"`
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g.
+                          co-locate this pod in the same node, zone, etc. as some
+                          other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node has pods which matches the corresponding
+                              podAffinityTerm; the node(s) with the highest sum are
+                              the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the
+                                    corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - weight
+                              - podAffinityTerm
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by
+                              this field are not met at scheduling time, the pod will
+                              not be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to a pod label update),
+                              the system may or may not try to eventually evict the
+                              pod from its node. When there are multiple elements,
+                              the lists of nodes corresponding to each podAffinityTerm
+                              are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located
+                                is defined as running on a node whose value of the
+                                label with key <topologyKey> matches that of any node
+                                on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules
+                          (e.g. avoid putting this pod in the same node, zone, etc.
+                          as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the anti-affinity expressions
+                              specified by this field, but it may choose a node that
+                              violates one or more of the expressions. The node that
+                              is most preferred is the one with the greatest sum of
+                              weights, i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              anti-affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node has pods which matches the corresponding
+                              podAffinityTerm; the node(s) with the highest sum are
+                              the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the
+                                    corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - weight
+                              - podAffinityTerm
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified
+                              by this field are not met at scheduling time, the pod
+                              will not be scheduled onto the node. If the anti-affinity
+                              requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod
+                              label update), the system may or may not try to eventually
+                              evict the pod from its node. When there are multiple
+                              elements, the lists of nodes corresponding to each podAffinityTerm
+                              are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located
+                                is defined as running on a node whose value of the
+                                label with key <topologyKey> matches that of any node
+                                on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  automountServiceAccountToken:
+                    description: AutomountServiceAccountToken indicates whether a
+                      service account token should be automatically mounted.
+                    type: boolean
+                  containers:
+                    description: List of containers belonging to the pod. Containers
+                      cannot currently be added or removed. There must be at least
+                      one container in a Pod. Cannot be updated.
+                    items:
+                      description: A single application container that you want to
+                        run within a pod.
+                      properties:
+                        args:
+                          description: 'Arguments to the entrypoint. The container
+                            image''s CMD is used if this is not provided. Variable
+                            references $(VAR_NAME) are expanded using the container''s
+                            environment. If a variable cannot be resolved, the reference
+                            in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME)
+                            syntax: i.e. "$$(VAR_NAME)" will produce the string literal
+                            "$(VAR_NAME)". Escaped references will never be expanded,
+                            regardless of whether the variable exists or not. Cannot
+                            be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: 'Entrypoint array. Not executed within a shell.
+                            The container image''s ENTRYPOINT is used if this is not
+                            provided. Variable references $(VAR_NAME) are expanded
+                            using the container''s environment. If a variable cannot
+                            be resolved, the reference in the input string will be
+                            unchanged. Double $$ are reduced to a single $, which
+                            allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                            will produce the string literal "$(VAR_NAME)". Escaped
+                            references will never be expanded, regardless of whether
+                            the variable exists or not. Cannot be updated. More info:
+                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the
+                            container. Cannot be updated.
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previously defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  Double $$ are reduced to a single $, which allows
+                                  for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                  will produce the string literal "$(VAR_NAME)". Escaped
+                                  references will never be expanded, regardless of
+                                  whether the variable exists or not. Defaults to
+                                  "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's
+                                  value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container. The keys defined within a source must
+                            be a C_IDENTIFIER. All invalid keys will be reported as
+                            an event when the container is starting. When a key exists
+                            in multiple sources, the value associated with the last
+                            source will take precedence. Values defined by an Env
+                            with a duplicate key will take precedence. Cannot be updated.
+                          items:
+                            description: EnvFromSource represents the source of a
+                              set of ConfigMaps
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must
+                                      be defined
+                                    type: boolean
+                                type: object
+                              prefix:
+                                description: An optional identifier to prepend to
+                                  each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be
+                                      defined
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                            This field is optional to allow higher level config management
+                            to default or override container images in workload controllers
+                            like Deployments and StatefulSets.'
+                          type: string
+                        imagePullPolicy:
+                          description: |-
+                            Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                            Possible enum values:
+                             - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                             - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                             - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                          type: string
+                        lifecycle:
+                          description: Actions that the management system should take
+                            in response to container lifecycle events. Cannot be updated.
+                          properties:
+                            postStart:
+                              description: 'PostStart is called immediately after
+                                a container is created. If the handler fails, the
+                                container is terminated and restarted according to
+                                its restart policy. Other management of the container
+                                blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            preStop:
+                              description: 'PreStop is called immediately before a
+                                container is terminated due to an API request or management
+                                event such as liveness/startup probe failure, preemption,
+                                resource contention, etc. The handler is not called
+                                if the container crashes or exits. The Pod''s termination
+                                grace period countdown begins before the PreStop hook
+                                is executed. Regardless of the outcome of the handler,
+                                the container will eventually terminate within the
+                                Pod''s termination grace period (unless delayed by
+                                finalizers). Other management of the container blocks
+                                until the hook completes or until the termination
+                                grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                          type: object
+                        livenessProbe:
+                          description: 'Periodic probe of container liveness. Container
+                            will be restarted if the probe fails. Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: Name of the container specified as a DNS_LABEL.
+                            Each container in a pod must have a unique name (DNS_LABEL).
+                            Cannot be updated.
+                          type: string
+                        ports:
+                          description: List of ports to expose from the container.
+                            Not specifying a port here DOES NOT prevent that port
+                            from being exposed. Any port which is listening on the
+                            default "0.0.0.0" address inside a container will be accessible
+                            from the network. Modifying this array with strategic
+                            merge patch may corrupt the data. For more information
+                            See https://github.com/kubernetes/kubernetes/issues/108255.
+                            Cannot be updated.
+                          items:
+                            description: ContainerPort represents a network port in
+                              a single container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's
+                                  IP address. This must be a valid port number, 0
+                                  < x < 65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port
+                                  to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host.
+                                  If specified, this must be a valid port number,
+                                  0 < x < 65536. If HostNetwork is specified, this
+                                  must match ContainerPort. Most containers do not
+                                  need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a
+                                  pod must have a unique name. Name for the port that
+                                  can be referred to by services.
+                                type: string
+                              protocol:
+                                default: TCP
+                                description: |-
+                                  Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                  Possible enum values:
+                                   - `"SCTP"` is the SCTP protocol.
+                                   - `"TCP"` is the TCP protocol.
+                                   - `"UDP"` is the UDP protocol.
+                                type: string
+                            required:
+                            - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - containerPort
+                          - protocol
+                          x-kubernetes-list-type: map
+                        readinessProbe:
+                          description: 'Periodic probe of container service readiness.
+                            Container will be removed from service endpoints if the
+                            probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          description: 'Compute Resources required by this container.
+                            Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        securityContext:
+                          description: 'SecurityContext defines the security options
+                            the container should be run with. If set, the fields of
+                            SecurityContext override the equivalent fields of PodSecurityContext.
+                            More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                          properties:
+                            allowPrivilegeEscalation:
+                              description: 'AllowPrivilegeEscalation controls whether
+                                a process can gain more privileges than its parent
+                                process. This bool directly controls if the no_new_privs
+                                flag will be set on the container process. AllowPrivilegeEscalation
+                                is true always when the container is: 1) run as Privileged
+                                2) has CAP_SYS_ADMIN Note that this field cannot be
+                                set when spec.os.name is windows.'
+                              type: boolean
+                            capabilities:
+                              description: The capabilities to add/drop when running
+                                containers. Defaults to the default set of capabilities
+                                granted by the container runtime. Note that this field
+                                cannot be set when spec.os.name is windows.
+                              properties:
+                                add:
+                                  description: Added capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                                drop:
+                                  description: Removed capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            privileged:
+                              description: Run container in privileged mode. Processes
+                                in privileged containers are essentially equivalent
+                                to root on the host. Defaults to false. Note that
+                                this field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            procMount:
+                              description: procMount denotes the type of proc mount
+                                to use for the containers. The default is DefaultProcMount
+                                which uses the container runtime defaults for readonly
+                                paths and masked paths. This requires the ProcMountType
+                                feature flag to be enabled. Note that this field cannot
+                                be set when spec.os.name is windows.
+                              type: string
+                            readOnlyRootFilesystem:
+                              description: Whether this container has a read-only
+                                root filesystem. Default is false. Note that this
+                                field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            runAsGroup:
+                              description: The GID to run the entrypoint of the container
+                                process. Uses runtime default if unset. May also be
+                                set in PodSecurityContext.  If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is windows.
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              description: Indicates that the container must run as
+                                a non-root user. If true, the Kubelet will validate
+                                the image at runtime to ensure that it does not run
+                                as UID 0 (root) and fail to start the container if
+                                it does. If unset or false, no such validation will
+                                be performed. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                              type: boolean
+                            runAsUser:
+                              description: The UID to run the entrypoint of the container
+                                process. Defaults to user specified in image metadata
+                                if unspecified. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name
+                                is windows.
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              description: The SELinux context to be applied to the
+                                container. If unspecified, the container runtime will
+                                allocate a random SELinux context for each container.  May
+                                also be set in PodSecurityContext.  If set in both
+                                SecurityContext and PodSecurityContext, the value
+                                specified in SecurityContext takes precedence. Note
+                                that this field cannot be set when spec.os.name is
+                                windows.
+                              properties:
+                                level:
+                                  description: Level is SELinux level label that applies
+                                    to the container.
+                                  type: string
+                                role:
+                                  description: Role is a SELinux role label that applies
+                                    to the container.
+                                  type: string
+                                type:
+                                  description: Type is a SELinux type label that applies
+                                    to the container.
+                                  type: string
+                                user:
+                                  description: User is a SELinux user label that applies
+                                    to the container.
+                                  type: string
+                              type: object
+                            seccompProfile:
+                              description: The seccomp options to use by this container.
+                                If seccomp options are provided at both the pod &
+                                container level, the container options override the
+                                pod options. Note that this field cannot be set when
+                                spec.os.name is windows.
+                              properties:
+                                localhostProfile:
+                                  description: localhostProfile indicates a profile
+                                    defined in a file on the node should be used.
+                                    The profile must be preconfigured on the node
+                                    to work. Must be a descending path, relative to
+                                    the kubelet's configured seccomp profile location.
+                                    Must only be set if type is "Localhost".
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                    Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                    Possible enum values:
+                                     - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                     - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                     - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            windowsOptions:
+                              description: The Windows specific settings applied to
+                                all containers. If unspecified, the options from the
+                                PodSecurityContext will be used. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is linux.
+                              properties:
+                                gmsaCredentialSpec:
+                                  description: GMSACredentialSpec is where the GMSA
+                                    admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                    inlines the contents of the GMSA credential spec
+                                    named by the GMSACredentialSpecName field.
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  description: GMSACredentialSpecName is the name
+                                    of the GMSA credential spec to use.
+                                  type: string
+                                hostProcess:
+                                  description: HostProcess determines if a container
+                                    should be run as a 'Host Process' container. This
+                                    field is alpha-level and will only be honored
+                                    by components that enable the WindowsHostProcessContainers
+                                    feature flag. Setting this field without the feature
+                                    flag will result in errors when validating the
+                                    Pod. All of a Pod's containers must have the same
+                                    effective HostProcess value (it is not allowed
+                                    to have a mix of HostProcess containers and non-HostProcess
+                                    containers).  In addition, if HostProcess is true
+                                    then HostNetwork must also be set to true.
+                                  type: boolean
+                                runAsUserName:
+                                  description: The UserName in Windows to run the
+                                    entrypoint of the container process. Defaults
+                                    to the user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  type: string
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: 'StartupProbe indicates that the Pod has successfully
+                            initialized. If specified, no other probes are executed
+                            until this completes successfully. If this probe fails,
+                            the Pod will be restarted, just as if the livenessProbe
+                            failed. This can be used to provide different probe parameters
+                            at the beginning of a Pod''s lifecycle, when it might
+                            take a long time to load data or warm a cache, than during
+                            steady-state operation. This cannot be updated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        stdin:
+                          description: Whether this container should allocate a buffer
+                            for stdin in the container runtime. If this is not set,
+                            reads from stdin in the container will always result in
+                            EOF. Default is false.
+                          type: boolean
+                        stdinOnce:
+                          description: Whether the container runtime should close
+                            the stdin channel after it has been opened by a single
+                            attach. When stdin is true the stdin stream will remain
+                            open across multiple attach sessions. If stdinOnce is
+                            set to true, stdin is opened on container start, is empty
+                            until the first client attaches to stdin, and then remains
+                            open and accepts data until the client disconnects, at
+                            which time stdin is closed and remains closed until the
+                            container is restarted. If this flag is false, a container
+                            processes that reads from stdin will never receive an
+                            EOF. Default is false
+                          type: boolean
+                        terminationMessagePath:
+                          description: 'Optional: Path at which the file to which
+                            the container''s termination message will be written is
+                            mounted into the container''s filesystem. Message written
+                            is intended to be brief final status, such as an assertion
+                            failure message. Will be truncated by the node if greater
+                            than 4096 bytes. The total message length across all containers
+                            will be limited to 12kb. Defaults to /dev/termination-log.
+                            Cannot be updated.'
+                          type: string
+                        terminationMessagePolicy:
+                          description: |-
+                            Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                            Possible enum values:
+                             - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                             - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                          type: string
+                        tty:
+                          description: Whether this container should allocate a TTY
+                            for itself, also requires 'stdin' to be true. Default
+                            is false.
+                          type: boolean
+                        volumeDevices:
+                          description: volumeDevices is the list of block devices
+                            to be used by the container.
+                          items:
+                            description: volumeDevice describes a mapping of a raw
+                              block device within a container.
+                            properties:
+                              devicePath:
+                                description: devicePath is the path inside of the
+                                  container that the device will be mapped to.
+                                type: string
+                              name:
+                                description: name must match the name of a persistentVolumeClaim
+                                  in the pod
+                                type: string
+                            required:
+                            - devicePath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - devicePath
+                          x-kubernetes-list-type: map
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                            Cannot be updated.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write
+                                  otherwise (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the
+                                  container's volume should be mounted. Defaults to
+                                  "" (volume's root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from
+                                  which the container's volume should be mounted.
+                                  Behaves similarly to SubPath but environment variable
+                                  references $(VAR_NAME) are expanded using the container's
+                                  environment. Defaults to "" (volume's root). SubPathExpr
+                                  and SubPath are mutually exclusive.
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - mountPath
+                          x-kubernetes-list-type: map
+                        workingDir:
+                          description: Container's working directory. If not specified,
+                            the container runtime's default will be used, which might
+                            be configured in the container image. Cannot be updated.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  dnsConfig:
+                    description: Specifies the DNS parameters of a pod. Parameters
+                      specified here will be merged to the generated DNS configuration
+                      based on DNSPolicy.
+                    properties:
+                      nameservers:
+                        description: A list of DNS name server IP addresses. This
+                          will be appended to the base nameservers generated from
+                          DNSPolicy. Duplicated nameservers will be removed.
+                        items:
+                          type: string
+                        type: array
+                      options:
+                        description: A list of DNS resolver options. This will be
+                          merged with the base options generated from DNSPolicy. Duplicated
+                          entries will be removed. Resolution options given in Options
+                          will override those that appear in the base DNSPolicy.
+                        items:
+                          description: PodDNSConfigOption defines DNS resolver options
+                            of a pod.
+                          properties:
+                            name:
+                              description: Required.
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                      searches:
+                        description: A list of DNS search domains for host-name lookup.
+                          This will be appended to the base search paths generated
+                          from DNSPolicy. Duplicated search paths will be removed.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  dnsPolicy:
+                    description: |-
+                      Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+
+                      Possible enum values:
+                       - `"ClusterFirst"` indicates that the pod should use cluster DNS first unless hostNetwork is true, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                       - `"ClusterFirstWithHostNet"` indicates that the pod should use cluster DNS first, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                       - `"Default"` indicates that the pod should use the default (as determined by kubelet) DNS settings.
+                       - `"None"` indicates that the pod should use empty DNS settings. DNS parameters such as nameservers and search paths should be defined via DNSConfig.
+                    type: string
+                  enableServiceLinks:
+                    description: 'EnableServiceLinks indicates whether information
+                      about services should be injected into pod''s environment variables,
+                      matching the syntax of Docker links. Optional: Defaults to true.'
+                    type: boolean
+                  ephemeralContainers:
+                    description: List of ephemeral containers run in this pod. Ephemeral
+                      containers may be run in an existing pod to perform user-initiated
+                      actions such as debugging. This list cannot be specified when
+                      creating a pod, and it cannot be modified by updating the pod
+                      spec. In order to add an ephemeral container to an existing
+                      pod, use the pod's ephemeralcontainers subresource.
+                    items:
+                      description: |-
+                        An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation.
+
+                        To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.
+                      properties:
+                        args:
+                          description: 'Arguments to the entrypoint. The image''s
+                            CMD is used if this is not provided. Variable references
+                            $(VAR_NAME) are expanded using the container''s environment.
+                            If a variable cannot be resolved, the reference in the
+                            input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME)
+                            syntax: i.e. "$$(VAR_NAME)" will produce the string literal
+                            "$(VAR_NAME)". Escaped references will never be expanded,
+                            regardless of whether the variable exists or not. Cannot
+                            be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: 'Entrypoint array. Not executed within a shell.
+                            The image''s ENTRYPOINT is used if this is not provided.
+                            Variable references $(VAR_NAME) are expanded using the
+                            container''s environment. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double
+                            $$ are reduced to a single $, which allows for escaping
+                            the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                            the string literal "$(VAR_NAME)". Escaped references will
+                            never be expanded, regardless of whether the variable
+                            exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the
+                            container. Cannot be updated.
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previously defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  Double $$ are reduced to a single $, which allows
+                                  for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                  will produce the string literal "$(VAR_NAME)". Escaped
+                                  references will never be expanded, regardless of
+                                  whether the variable exists or not. Defaults to
+                                  "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's
+                                  value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container. The keys defined within a source must
+                            be a C_IDENTIFIER. All invalid keys will be reported as
+                            an event when the container is starting. When a key exists
+                            in multiple sources, the value associated with the last
+                            source will take precedence. Values defined by an Env
+                            with a duplicate key will take precedence. Cannot be updated.
+                          items:
+                            description: EnvFromSource represents the source of a
+                              set of ConfigMaps
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must
+                                      be defined
+                                    type: boolean
+                                type: object
+                              prefix:
+                                description: An optional identifier to prepend to
+                                  each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be
+                                      defined
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                          type: string
+                        imagePullPolicy:
+                          description: |-
+                            Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                            Possible enum values:
+                             - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                             - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                             - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                          type: string
+                        lifecycle:
+                          description: Lifecycle is not allowed for ephemeral containers.
+                          properties:
+                            postStart:
+                              description: 'PostStart is called immediately after
+                                a container is created. If the handler fails, the
+                                container is terminated and restarted according to
+                                its restart policy. Other management of the container
+                                blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            preStop:
+                              description: 'PreStop is called immediately before a
+                                container is terminated due to an API request or management
+                                event such as liveness/startup probe failure, preemption,
+                                resource contention, etc. The handler is not called
+                                if the container crashes or exits. The Pod''s termination
+                                grace period countdown begins before the PreStop hook
+                                is executed. Regardless of the outcome of the handler,
+                                the container will eventually terminate within the
+                                Pod''s termination grace period (unless delayed by
+                                finalizers). Other management of the container blocks
+                                until the hook completes or until the termination
+                                grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                          type: object
+                        livenessProbe:
+                          description: Probes are not allowed for ephemeral containers.
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: Name of the ephemeral container specified as
+                            a DNS_LABEL. This name must be unique among all containers,
+                            init containers and ephemeral containers.
+                          type: string
+                        ports:
+                          description: Ports are not allowed for ephemeral containers.
+                          items:
+                            description: ContainerPort represents a network port in
+                              a single container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's
+                                  IP address. This must be a valid port number, 0
+                                  < x < 65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port
+                                  to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host.
+                                  If specified, this must be a valid port number,
+                                  0 < x < 65536. If HostNetwork is specified, this
+                                  must match ContainerPort. Most containers do not
+                                  need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a
+                                  pod must have a unique name. Name for the port that
+                                  can be referred to by services.
+                                type: string
+                              protocol:
+                                default: TCP
+                                description: |-
+                                  Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                  Possible enum values:
+                                   - `"SCTP"` is the SCTP protocol.
+                                   - `"TCP"` is the TCP protocol.
+                                   - `"UDP"` is the UDP protocol.
+                                type: string
+                            required:
+                            - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - containerPort
+                          - protocol
+                          x-kubernetes-list-type: map
+                        readinessProbe:
+                          description: Probes are not allowed for ephemeral containers.
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          description: Resources are not allowed for ephemeral containers.
+                            Ephemeral containers use spare resources already allocated
+                            to the pod.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        securityContext:
+                          description: 'Optional: SecurityContext defines the security
+                            options the ephemeral container should be run with. If
+                            set, the fields of SecurityContext override the equivalent
+                            fields of PodSecurityContext.'
+                          properties:
+                            allowPrivilegeEscalation:
+                              description: 'AllowPrivilegeEscalation controls whether
+                                a process can gain more privileges than its parent
+                                process. This bool directly controls if the no_new_privs
+                                flag will be set on the container process. AllowPrivilegeEscalation
+                                is true always when the container is: 1) run as Privileged
+                                2) has CAP_SYS_ADMIN Note that this field cannot be
+                                set when spec.os.name is windows.'
+                              type: boolean
+                            capabilities:
+                              description: The capabilities to add/drop when running
+                                containers. Defaults to the default set of capabilities
+                                granted by the container runtime. Note that this field
+                                cannot be set when spec.os.name is windows.
+                              properties:
+                                add:
+                                  description: Added capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                                drop:
+                                  description: Removed capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            privileged:
+                              description: Run container in privileged mode. Processes
+                                in privileged containers are essentially equivalent
+                                to root on the host. Defaults to false. Note that
+                                this field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            procMount:
+                              description: procMount denotes the type of proc mount
+                                to use for the containers. The default is DefaultProcMount
+                                which uses the container runtime defaults for readonly
+                                paths and masked paths. This requires the ProcMountType
+                                feature flag to be enabled. Note that this field cannot
+                                be set when spec.os.name is windows.
+                              type: string
+                            readOnlyRootFilesystem:
+                              description: Whether this container has a read-only
+                                root filesystem. Default is false. Note that this
+                                field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            runAsGroup:
+                              description: The GID to run the entrypoint of the container
+                                process. Uses runtime default if unset. May also be
+                                set in PodSecurityContext.  If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is windows.
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              description: Indicates that the container must run as
+                                a non-root user. If true, the Kubelet will validate
+                                the image at runtime to ensure that it does not run
+                                as UID 0 (root) and fail to start the container if
+                                it does. If unset or false, no such validation will
+                                be performed. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                              type: boolean
+                            runAsUser:
+                              description: The UID to run the entrypoint of the container
+                                process. Defaults to user specified in image metadata
+                                if unspecified. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name
+                                is windows.
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              description: The SELinux context to be applied to the
+                                container. If unspecified, the container runtime will
+                                allocate a random SELinux context for each container.  May
+                                also be set in PodSecurityContext.  If set in both
+                                SecurityContext and PodSecurityContext, the value
+                                specified in SecurityContext takes precedence. Note
+                                that this field cannot be set when spec.os.name is
+                                windows.
+                              properties:
+                                level:
+                                  description: Level is SELinux level label that applies
+                                    to the container.
+                                  type: string
+                                role:
+                                  description: Role is a SELinux role label that applies
+                                    to the container.
+                                  type: string
+                                type:
+                                  description: Type is a SELinux type label that applies
+                                    to the container.
+                                  type: string
+                                user:
+                                  description: User is a SELinux user label that applies
+                                    to the container.
+                                  type: string
+                              type: object
+                            seccompProfile:
+                              description: The seccomp options to use by this container.
+                                If seccomp options are provided at both the pod &
+                                container level, the container options override the
+                                pod options. Note that this field cannot be set when
+                                spec.os.name is windows.
+                              properties:
+                                localhostProfile:
+                                  description: localhostProfile indicates a profile
+                                    defined in a file on the node should be used.
+                                    The profile must be preconfigured on the node
+                                    to work. Must be a descending path, relative to
+                                    the kubelet's configured seccomp profile location.
+                                    Must only be set if type is "Localhost".
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                    Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                    Possible enum values:
+                                     - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                     - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                     - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            windowsOptions:
+                              description: The Windows specific settings applied to
+                                all containers. If unspecified, the options from the
+                                PodSecurityContext will be used. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is linux.
+                              properties:
+                                gmsaCredentialSpec:
+                                  description: GMSACredentialSpec is where the GMSA
+                                    admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                    inlines the contents of the GMSA credential spec
+                                    named by the GMSACredentialSpecName field.
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  description: GMSACredentialSpecName is the name
+                                    of the GMSA credential spec to use.
+                                  type: string
+                                hostProcess:
+                                  description: HostProcess determines if a container
+                                    should be run as a 'Host Process' container. This
+                                    field is alpha-level and will only be honored
+                                    by components that enable the WindowsHostProcessContainers
+                                    feature flag. Setting this field without the feature
+                                    flag will result in errors when validating the
+                                    Pod. All of a Pod's containers must have the same
+                                    effective HostProcess value (it is not allowed
+                                    to have a mix of HostProcess containers and non-HostProcess
+                                    containers).  In addition, if HostProcess is true
+                                    then HostNetwork must also be set to true.
+                                  type: boolean
+                                runAsUserName:
+                                  description: The UserName in Windows to run the
+                                    entrypoint of the container process. Defaults
+                                    to the user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  type: string
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: Probes are not allowed for ephemeral containers.
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        stdin:
+                          description: Whether this container should allocate a buffer
+                            for stdin in the container runtime. If this is not set,
+                            reads from stdin in the container will always result in
+                            EOF. Default is false.
+                          type: boolean
+                        stdinOnce:
+                          description: Whether the container runtime should close
+                            the stdin channel after it has been opened by a single
+                            attach. When stdin is true the stdin stream will remain
+                            open across multiple attach sessions. If stdinOnce is
+                            set to true, stdin is opened on container start, is empty
+                            until the first client attaches to stdin, and then remains
+                            open and accepts data until the client disconnects, at
+                            which time stdin is closed and remains closed until the
+                            container is restarted. If this flag is false, a container
+                            processes that reads from stdin will never receive an
+                            EOF. Default is false
+                          type: boolean
+                        targetContainerName:
+                          description: |-
+                            If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+                            The container runtime must implement support for this feature. If the runtime does not support namespace targeting then the result of setting this field is undefined.
+                          type: string
+                        terminationMessagePath:
+                          description: 'Optional: Path at which the file to which
+                            the container''s termination message will be written is
+                            mounted into the container''s filesystem. Message written
+                            is intended to be brief final status, such as an assertion
+                            failure message. Will be truncated by the node if greater
+                            than 4096 bytes. The total message length across all containers
+                            will be limited to 12kb. Defaults to /dev/termination-log.
+                            Cannot be updated.'
+                          type: string
+                        terminationMessagePolicy:
+                          description: |-
+                            Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                            Possible enum values:
+                             - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                             - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                          type: string
+                        tty:
+                          description: Whether this container should allocate a TTY
+                            for itself, also requires 'stdin' to be true. Default
+                            is false.
+                          type: boolean
+                        volumeDevices:
+                          description: volumeDevices is the list of block devices
+                            to be used by the container.
+                          items:
+                            description: volumeDevice describes a mapping of a raw
+                              block device within a container.
+                            properties:
+                              devicePath:
+                                description: devicePath is the path inside of the
+                                  container that the device will be mapped to.
+                                type: string
+                              name:
+                                description: name must match the name of a persistentVolumeClaim
+                                  in the pod
+                                type: string
+                            required:
+                            - devicePath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - devicePath
+                          x-kubernetes-list-type: map
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                            Subpath mounts are not allowed for ephemeral containers.
+                            Cannot be updated.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write
+                                  otherwise (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the
+                                  container's volume should be mounted. Defaults to
+                                  "" (volume's root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from
+                                  which the container's volume should be mounted.
+                                  Behaves similarly to SubPath but environment variable
+                                  references $(VAR_NAME) are expanded using the container's
+                                  environment. Defaults to "" (volume's root). SubPathExpr
+                                  and SubPath are mutually exclusive.
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - mountPath
+                          x-kubernetes-list-type: map
+                        workingDir:
+                          description: Container's working directory. If not specified,
+                            the container runtime's default will be used, which might
+                            be configured in the container image. Cannot be updated.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  hostAliases:
+                    description: HostAliases is an optional list of hosts and IPs
+                      that will be injected into the pod's hosts file if specified.
+                      This is only valid for non-hostNetwork pods.
+                    items:
+                      description: HostAlias holds the mapping between IP and hostnames
+                        that will be injected as an entry in the pod's hosts file.
+                      properties:
+                        hostnames:
+                          description: Hostnames for the above IP address.
+                          items:
+                            type: string
+                          type: array
+                        ip:
+                          description: IP address of the host file entry.
+                          type: string
+                      required:
+                      - ip
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - ip
+                    x-kubernetes-list-type: map
+                  hostIPC:
+                    description: 'Use the host''s ipc namespace. Optional: Default
+                      to false.'
+                    type: boolean
+                  hostNetwork:
+                    description: Host networking requested for this pod. Use the host's
+                      network namespace. If this option is set, the ports that will
+                      be used must be specified. Default to false.
+                    type: boolean
+                  hostPID:
+                    description: 'Use the host''s pid namespace. Optional: Default
+                      to false.'
+                    type: boolean
+                  hostUsers:
+                    description: 'Use the host''s user namespace. Optional: Default
+                      to true. If set to true or not present, the pod will be run
+                      in the host user namespace, useful for when the pod needs a
+                      feature only available to the host user namespace, such as loading
+                      a kernel module with CAP_SYS_MODULE. When set to false, a new
+                      userns is created for the pod. Setting false is useful for mitigating
+                      container breakout vulnerabilities even allowing users to run
+                      their containers as root without actually having root privileges
+                      on the host. This field is alpha-level and is only honored by
+                      servers that enable the UserNamespacesSupport feature.'
+                    type: boolean
+                  hostname:
+                    description: Specifies the hostname of the Pod If not specified,
+                      the pod's hostname will be set to a system-defined value.
+                    type: string
+                  imagePullSecrets:
+                    description: 'ImagePullSecrets is an optional list of references
+                      to secrets in the same namespace to use for pulling any of the
+                      images used by this PodSpec. If specified, these secrets will
+                      be passed to individual puller implementations for them to use.
+                      More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                    items:
+                      description: LocalObjectReference contains enough information
+                        to let you locate the referenced object inside the same namespace.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  initContainers:
+                    description: 'List of initialization containers belonging to the
+                      pod. Init containers are executed in order prior to containers
+                      being started. If any init container fails, the pod is considered
+                      to have failed and is handled according to its restartPolicy.
+                      The name for an init container or normal container must be unique
+                      among all containers. Init containers may not have Lifecycle
+                      actions, Readiness probes, Liveness probes, or Startup probes.
+                      The resourceRequirements of an init container are taken into
+                      account during scheduling by finding the highest request/limit
+                      for each resource type, and then using the max of of that value
+                      or the sum of the normal containers. Limits are applied to init
+                      containers in a similar fashion. Init containers cannot currently
+                      be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                    items:
+                      description: A single application container that you want to
+                        run within a pod.
+                      properties:
+                        args:
+                          description: 'Arguments to the entrypoint. The container
+                            image''s CMD is used if this is not provided. Variable
+                            references $(VAR_NAME) are expanded using the container''s
+                            environment. If a variable cannot be resolved, the reference
+                            in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME)
+                            syntax: i.e. "$$(VAR_NAME)" will produce the string literal
+                            "$(VAR_NAME)". Escaped references will never be expanded,
+                            regardless of whether the variable exists or not. Cannot
+                            be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: 'Entrypoint array. Not executed within a shell.
+                            The container image''s ENTRYPOINT is used if this is not
+                            provided. Variable references $(VAR_NAME) are expanded
+                            using the container''s environment. If a variable cannot
+                            be resolved, the reference in the input string will be
+                            unchanged. Double $$ are reduced to a single $, which
+                            allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                            will produce the string literal "$(VAR_NAME)". Escaped
+                            references will never be expanded, regardless of whether
+                            the variable exists or not. Cannot be updated. More info:
+                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the
+                            container. Cannot be updated.
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previously defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  Double $$ are reduced to a single $, which allows
+                                  for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                  will produce the string literal "$(VAR_NAME)". Escaped
+                                  references will never be expanded, regardless of
+                                  whether the variable exists or not. Defaults to
+                                  "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's
+                                  value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container. The keys defined within a source must
+                            be a C_IDENTIFIER. All invalid keys will be reported as
+                            an event when the container is starting. When a key exists
+                            in multiple sources, the value associated with the last
+                            source will take precedence. Values defined by an Env
+                            with a duplicate key will take precedence. Cannot be updated.
+                          items:
+                            description: EnvFromSource represents the source of a
+                              set of ConfigMaps
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must
+                                      be defined
+                                    type: boolean
+                                type: object
+                              prefix:
+                                description: An optional identifier to prepend to
+                                  each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be
+                                      defined
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                            This field is optional to allow higher level config management
+                            to default or override container images in workload controllers
+                            like Deployments and StatefulSets.'
+                          type: string
+                        imagePullPolicy:
+                          description: |-
+                            Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                            Possible enum values:
+                             - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                             - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                             - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                          type: string
+                        lifecycle:
+                          description: Actions that the management system should take
+                            in response to container lifecycle events. Cannot be updated.
+                          properties:
+                            postStart:
+                              description: 'PostStart is called immediately after
+                                a container is created. If the handler fails, the
+                                container is terminated and restarted according to
+                                its restart policy. Other management of the container
+                                blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            preStop:
+                              description: 'PreStop is called immediately before a
+                                container is terminated due to an API request or management
+                                event such as liveness/startup probe failure, preemption,
+                                resource contention, etc. The handler is not called
+                                if the container crashes or exits. The Pod''s termination
+                                grace period countdown begins before the PreStop hook
+                                is executed. Regardless of the outcome of the handler,
+                                the container will eventually terminate within the
+                                Pod''s termination grace period (unless delayed by
+                                finalizers). Other management of the container blocks
+                                until the hook completes or until the termination
+                                grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                          type: object
+                        livenessProbe:
+                          description: 'Periodic probe of container liveness. Container
+                            will be restarted if the probe fails. Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: Name of the container specified as a DNS_LABEL.
+                            Each container in a pod must have a unique name (DNS_LABEL).
+                            Cannot be updated.
+                          type: string
+                        ports:
+                          description: List of ports to expose from the container.
+                            Not specifying a port here DOES NOT prevent that port
+                            from being exposed. Any port which is listening on the
+                            default "0.0.0.0" address inside a container will be accessible
+                            from the network. Modifying this array with strategic
+                            merge patch may corrupt the data. For more information
+                            See https://github.com/kubernetes/kubernetes/issues/108255.
+                            Cannot be updated.
+                          items:
+                            description: ContainerPort represents a network port in
+                              a single container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's
+                                  IP address. This must be a valid port number, 0
+                                  < x < 65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port
+                                  to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host.
+                                  If specified, this must be a valid port number,
+                                  0 < x < 65536. If HostNetwork is specified, this
+                                  must match ContainerPort. Most containers do not
+                                  need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a
+                                  pod must have a unique name. Name for the port that
+                                  can be referred to by services.
+                                type: string
+                              protocol:
+                                default: TCP
+                                description: |-
+                                  Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                  Possible enum values:
+                                   - `"SCTP"` is the SCTP protocol.
+                                   - `"TCP"` is the TCP protocol.
+                                   - `"UDP"` is the UDP protocol.
+                                type: string
+                            required:
+                            - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - containerPort
+                          - protocol
+                          x-kubernetes-list-type: map
+                        readinessProbe:
+                          description: 'Periodic probe of container service readiness.
+                            Container will be removed from service endpoints if the
+                            probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          description: 'Compute Resources required by this container.
+                            Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        securityContext:
+                          description: 'SecurityContext defines the security options
+                            the container should be run with. If set, the fields of
+                            SecurityContext override the equivalent fields of PodSecurityContext.
+                            More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                          properties:
+                            allowPrivilegeEscalation:
+                              description: 'AllowPrivilegeEscalation controls whether
+                                a process can gain more privileges than its parent
+                                process. This bool directly controls if the no_new_privs
+                                flag will be set on the container process. AllowPrivilegeEscalation
+                                is true always when the container is: 1) run as Privileged
+                                2) has CAP_SYS_ADMIN Note that this field cannot be
+                                set when spec.os.name is windows.'
+                              type: boolean
+                            capabilities:
+                              description: The capabilities to add/drop when running
+                                containers. Defaults to the default set of capabilities
+                                granted by the container runtime. Note that this field
+                                cannot be set when spec.os.name is windows.
+                              properties:
+                                add:
+                                  description: Added capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                                drop:
+                                  description: Removed capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            privileged:
+                              description: Run container in privileged mode. Processes
+                                in privileged containers are essentially equivalent
+                                to root on the host. Defaults to false. Note that
+                                this field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            procMount:
+                              description: procMount denotes the type of proc mount
+                                to use for the containers. The default is DefaultProcMount
+                                which uses the container runtime defaults for readonly
+                                paths and masked paths. This requires the ProcMountType
+                                feature flag to be enabled. Note that this field cannot
+                                be set when spec.os.name is windows.
+                              type: string
+                            readOnlyRootFilesystem:
+                              description: Whether this container has a read-only
+                                root filesystem. Default is false. Note that this
+                                field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            runAsGroup:
+                              description: The GID to run the entrypoint of the container
+                                process. Uses runtime default if unset. May also be
+                                set in PodSecurityContext.  If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is windows.
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              description: Indicates that the container must run as
+                                a non-root user. If true, the Kubelet will validate
+                                the image at runtime to ensure that it does not run
+                                as UID 0 (root) and fail to start the container if
+                                it does. If unset or false, no such validation will
+                                be performed. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                              type: boolean
+                            runAsUser:
+                              description: The UID to run the entrypoint of the container
+                                process. Defaults to user specified in image metadata
+                                if unspecified. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name
+                                is windows.
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              description: The SELinux context to be applied to the
+                                container. If unspecified, the container runtime will
+                                allocate a random SELinux context for each container.  May
+                                also be set in PodSecurityContext.  If set in both
+                                SecurityContext and PodSecurityContext, the value
+                                specified in SecurityContext takes precedence. Note
+                                that this field cannot be set when spec.os.name is
+                                windows.
+                              properties:
+                                level:
+                                  description: Level is SELinux level label that applies
+                                    to the container.
+                                  type: string
+                                role:
+                                  description: Role is a SELinux role label that applies
+                                    to the container.
+                                  type: string
+                                type:
+                                  description: Type is a SELinux type label that applies
+                                    to the container.
+                                  type: string
+                                user:
+                                  description: User is a SELinux user label that applies
+                                    to the container.
+                                  type: string
+                              type: object
+                            seccompProfile:
+                              description: The seccomp options to use by this container.
+                                If seccomp options are provided at both the pod &
+                                container level, the container options override the
+                                pod options. Note that this field cannot be set when
+                                spec.os.name is windows.
+                              properties:
+                                localhostProfile:
+                                  description: localhostProfile indicates a profile
+                                    defined in a file on the node should be used.
+                                    The profile must be preconfigured on the node
+                                    to work. Must be a descending path, relative to
+                                    the kubelet's configured seccomp profile location.
+                                    Must only be set if type is "Localhost".
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                    Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                    Possible enum values:
+                                     - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                     - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                     - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            windowsOptions:
+                              description: The Windows specific settings applied to
+                                all containers. If unspecified, the options from the
+                                PodSecurityContext will be used. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is linux.
+                              properties:
+                                gmsaCredentialSpec:
+                                  description: GMSACredentialSpec is where the GMSA
+                                    admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                    inlines the contents of the GMSA credential spec
+                                    named by the GMSACredentialSpecName field.
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  description: GMSACredentialSpecName is the name
+                                    of the GMSA credential spec to use.
+                                  type: string
+                                hostProcess:
+                                  description: HostProcess determines if a container
+                                    should be run as a 'Host Process' container. This
+                                    field is alpha-level and will only be honored
+                                    by components that enable the WindowsHostProcessContainers
+                                    feature flag. Setting this field without the feature
+                                    flag will result in errors when validating the
+                                    Pod. All of a Pod's containers must have the same
+                                    effective HostProcess value (it is not allowed
+                                    to have a mix of HostProcess containers and non-HostProcess
+                                    containers).  In addition, if HostProcess is true
+                                    then HostNetwork must also be set to true.
+                                  type: boolean
+                                runAsUserName:
+                                  description: The UserName in Windows to run the
+                                    entrypoint of the container process. Defaults
+                                    to the user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  type: string
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: 'StartupProbe indicates that the Pod has successfully
+                            initialized. If specified, no other probes are executed
+                            until this completes successfully. If this probe fails,
+                            the Pod will be restarted, just as if the livenessProbe
+                            failed. This can be used to provide different probe parameters
+                            at the beginning of a Pod''s lifecycle, when it might
+                            take a long time to load data or warm a cache, than during
+                            steady-state operation. This cannot be updated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        stdin:
+                          description: Whether this container should allocate a buffer
+                            for stdin in the container runtime. If this is not set,
+                            reads from stdin in the container will always result in
+                            EOF. Default is false.
+                          type: boolean
+                        stdinOnce:
+                          description: Whether the container runtime should close
+                            the stdin channel after it has been opened by a single
+                            attach. When stdin is true the stdin stream will remain
+                            open across multiple attach sessions. If stdinOnce is
+                            set to true, stdin is opened on container start, is empty
+                            until the first client attaches to stdin, and then remains
+                            open and accepts data until the client disconnects, at
+                            which time stdin is closed and remains closed until the
+                            container is restarted. If this flag is false, a container
+                            processes that reads from stdin will never receive an
+                            EOF. Default is false
+                          type: boolean
+                        terminationMessagePath:
+                          description: 'Optional: Path at which the file to which
+                            the container''s termination message will be written is
+                            mounted into the container''s filesystem. Message written
+                            is intended to be brief final status, such as an assertion
+                            failure message. Will be truncated by the node if greater
+                            than 4096 bytes. The total message length across all containers
+                            will be limited to 12kb. Defaults to /dev/termination-log.
+                            Cannot be updated.'
+                          type: string
+                        terminationMessagePolicy:
+                          description: |-
+                            Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                            Possible enum values:
+                             - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                             - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                          type: string
+                        tty:
+                          description: Whether this container should allocate a TTY
+                            for itself, also requires 'stdin' to be true. Default
+                            is false.
+                          type: boolean
+                        volumeDevices:
+                          description: volumeDevices is the list of block devices
+                            to be used by the container.
+                          items:
+                            description: volumeDevice describes a mapping of a raw
+                              block device within a container.
+                            properties:
+                              devicePath:
+                                description: devicePath is the path inside of the
+                                  container that the device will be mapped to.
+                                type: string
+                              name:
+                                description: name must match the name of a persistentVolumeClaim
+                                  in the pod
+                                type: string
+                            required:
+                            - devicePath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - devicePath
+                          x-kubernetes-list-type: map
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                            Cannot be updated.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write
+                                  otherwise (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the
+                                  container's volume should be mounted. Defaults to
+                                  "" (volume's root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from
+                                  which the container's volume should be mounted.
+                                  Behaves similarly to SubPath but environment variable
+                                  references $(VAR_NAME) are expanded using the container's
+                                  environment. Defaults to "" (volume's root). SubPathExpr
+                                  and SubPath are mutually exclusive.
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - mountPath
+                          x-kubernetes-list-type: map
+                        workingDir:
+                          description: Container's working directory. If not specified,
+                            the container runtime's default will be used, which might
+                            be configured in the container image. Cannot be updated.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  nodeName:
+                    description: NodeName is a request to schedule this pod onto a
+                      specific node. If it is non-empty, the scheduler simply schedules
+                      this pod onto that node, assuming that it fits resource requirements.
+                    type: string
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'NodeSelector is a selector which must be true for
+                      the pod to fit on a node. Selector which must match a node''s
+                      labels for the pod to be scheduled on that node. More info:
+                      https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                    type: object
+                  os:
+                    description: |-
+                      Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set.
+
+                      If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions
+
+                      If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup
+                    properties:
+                      name:
+                        description: 'Name is the name of the operating system. The
+                          currently supported values are linux and windows. Additional
+                          value may be defined in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                          Clients should expect to handle additional values and treat
+                          unrecognized values in this field as os: null'
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  overhead:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Overhead represents the resource overhead associated
+                      with running a pod for a given RuntimeClass. This field will
+                      be autopopulated at admission time by the RuntimeClass admission
+                      controller. If the RuntimeClass admission controller is enabled,
+                      overhead must not be set in Pod create requests. The RuntimeClass
+                      admission controller will reject Pod create requests which have
+                      the overhead already set. If RuntimeClass is configured and
+                      selected in the PodSpec, Overhead will be set to the value defined
+                      in the corresponding RuntimeClass, otherwise it will remain
+                      unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
+                    type: object
+                  preemptionPolicy:
+                    description: PreemptionPolicy is the Policy for preempting pods
+                      with lower priority. One of Never, PreemptLowerPriority. Defaults
+                      to PreemptLowerPriority if unset.
+                    type: string
+                  priority:
+                    description: The priority value. Various system components use
+                      this field to find the priority of the pod. When Priority Admission
+                      Controller is enabled, it prevents users from setting this field.
+                      The admission controller populates this field from PriorityClassName.
+                      The higher the value, the higher the priority.
+                    format: int32
+                    type: integer
+                  priorityClassName:
+                    description: If specified, indicates the pod's priority. "system-node-critical"
+                      and "system-cluster-critical" are two special keywords which
+                      indicate the highest priorities with the former being the highest
+                      priority. Any other name must be defined by creating a PriorityClass
+                      object with that name. If not specified, the pod priority will
+                      be default or zero if there is no default.
+                    type: string
+                  readinessGates:
+                    description: 'If specified, all readiness gates will be evaluated
+                      for pod readiness. A pod is ready when all its containers are
+                      ready AND all conditions specified in the readiness gates have
+                      status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
+                    items:
+                      description: PodReadinessGate contains the reference to a pod
+                        condition
+                      properties:
+                        conditionType:
+                          description: ConditionType refers to a condition in the
+                            pod's condition list with matching type.
+                          type: string
+                      required:
+                      - conditionType
+                      type: object
+                    type: array
+                  restartPolicy:
+                    description: |-
+                      Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+
+                      Possible enum values:
+                       - `"Always"`
+                       - `"Never"`
+                       - `"OnFailure"`
+                    type: string
+                  runtimeClassName:
+                    description: 'RuntimeClassName refers to a RuntimeClass object
+                      in the node.k8s.io group, which should be used to run this pod.  If
+                      no RuntimeClass resource matches the named class, the pod will
+                      not be run. If unset or empty, the "legacy" RuntimeClass will
+                      be used, which is an implicit class with an empty definition
+                      that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
+                    type: string
+                  schedulerName:
+                    description: If specified, the pod will be dispatched by specified
+                      scheduler. If not specified, the pod will be dispatched by default
+                      scheduler.
+                    type: string
+                  securityContext:
+                    description: 'SecurityContext holds pod-level security attributes
+                      and common container settings. Optional: Defaults to empty.  See
+                      type description for default values of each field.'
+                    properties:
+                      fsGroup:
+                        description: |-
+                          A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
+                          1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
+                          If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      fsGroupChangePolicy:
+                        description: 'fsGroupChangePolicy defines behavior of changing
+                          ownership and permission of the volume before being exposed
+                          inside Pod. This field will only apply to volume types which
+                          support fsGroup based ownership(and permissions). It will
+                          have no effect on ephemeral volume types such as: secret,
+                          configmaps and emptydir. Valid values are "OnRootMismatch"
+                          and "Always". If not specified, "Always" is used. Note that
+                          this field cannot be set when spec.os.name is windows.'
+                        type: string
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence for that container. Note that this field
+                          cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in SecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in SecurityContext.  If set
+                          in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence for that container.
+                          Note that this field cannot be set when spec.os.name is
+                          windows.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to all containers.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          SecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence
+                          for that container. Note that this field cannot be set when
+                          spec.os.name is windows.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: The seccomp options to use by the containers
+                          in this pod. Note that this field cannot be set when spec.os.name
+                          is windows.
+                        properties:
+                          localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used. The profile must
+                              be preconfigured on the node to work. Must be a descending
+                              path, relative to the kubelet's configured seccomp profile
+                              location. Must only be set if type is "Localhost".
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                              Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                              Possible enum values:
+                               - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                               - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                               - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      supplementalGroups:
+                        description: A list of groups applied to the first process
+                          run in each container, in addition to the container's primary
+                          GID.  If unspecified, no groups will be added to any container.
+                          Note that this field cannot be set when spec.os.name is
+                          windows.
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      sysctls:
+                        description: Sysctls hold a list of namespaced sysctls used
+                          for the pod. Pods with unsupported sysctls (by the container
+                          runtime) might fail to launch. Note that this field cannot
+                          be set when spec.os.name is windows.
+                        items:
+                          description: Sysctl defines a kernel parameter to be set
+                          properties:
+                            name:
+                              description: Name of a property to set
+                              type: string
+                            value:
+                              description: Value of a property to set
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options within a container's
+                          SecurityContext will be used. If set in both SecurityContext
+                          and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence. Note that this field cannot be set when
+                          spec.os.name is linux.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: HostProcess determines if a container should
+                              be run as a 'Host Process' container. This field is
+                              alpha-level and will only be honored by components that
+                              enable the WindowsHostProcessContainers feature flag.
+                              Setting this field without the feature flag will result
+                              in errors when validating the Pod. All of a Pod's containers
+                              must have the same effective HostProcess value (it is
+                              not allowed to have a mix of HostProcess containers
+                              and non-HostProcess containers).  In addition, if HostProcess
+                              is true then HostNetwork must also be set to true.
+                            type: boolean
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  serviceAccount:
+                    description: 'DeprecatedServiceAccount is a depreciated alias
+                      for ServiceAccountName. Deprecated: Use serviceAccountName instead.'
+                    type: string
+                  serviceAccountName:
+                    description: 'ServiceAccountName is the name of the ServiceAccount
+                      to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                    type: string
+                  setHostnameAsFQDN:
+                    description: If true the pod's hostname will be configured as
+                      the pod's FQDN, rather than the leaf name (the default). In
+                      Linux containers, this means setting the FQDN in the hostname
+                      field of the kernel (the nodename field of struct utsname).
+                      In Windows containers, this means setting the registry value
+                      of hostname for the registry key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters
+                      to FQDN. If a pod does not have FQDN, this has no effect. Default
+                      to false.
+                    type: boolean
+                  shareProcessNamespace:
+                    description: 'Share a single process namespace between all of
+                      the containers in a pod. When this is set containers will be
+                      able to view and signal processes from other containers in the
+                      same pod, and the first process in each container will not be
+                      assigned PID 1. HostPID and ShareProcessNamespace cannot both
+                      be set. Optional: Default to false.'
+                    type: boolean
+                  subdomain:
+                    description: If specified, the fully qualified Pod hostname will
+                      be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+                      If not specified, the pod will not have a domainname at all.
+                    type: string
+                  terminationGracePeriodSeconds:
+                    description: Optional duration in seconds the pod needs to terminate
+                      gracefully. May be decreased in delete request. Value must be
+                      non-negative integer. The value zero indicates stop immediately
+                      via the kill signal (no opportunity to shut down). If this value
+                      is nil, the default grace period will be used instead. The grace
+                      period is the duration in seconds after the processes running
+                      in the pod are sent a termination signal and the time when the
+                      processes are forcibly halted with a kill signal. Set this value
+                      longer than the expected cleanup time for your process. Defaults
+                      to 30 seconds.
+                    format: int64
+                    type: integer
+                  tolerations:
+                    description: If specified, the pod's tolerations.
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using
+                        the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+                            Possible enum values:
+                             - `"NoExecute"` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+                             - `"NoSchedule"` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+                             - `"PreferNoSchedule"` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+
+                            Possible enum values:
+                             - `"Equal"`
+                             - `"Exists"`
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of
+                            time the toleration (which must be of effect NoExecute,
+                            otherwise this field is ignored) tolerates the taint.
+                            By default, it is not set, which means tolerate the taint
+                            forever (do not evict). Zero and negative values will
+                            be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  topologySpreadConstraints:
+                    description: TopologySpreadConstraints describes how a group of
+                      pods ought to spread across topology domains. Scheduler will
+                      schedule pods in a way which abides by the constraints. All
+                      topologySpreadConstraints are ANDed.
+                    items:
+                      description: TopologySpreadConstraint specifies how to spread
+                        matching pods among the given topology.
+                      properties:
+                        labelSelector:
+                          description: LabelSelector is used to find matching pods.
+                            Pods that match this label selector are counted to determine
+                            the number of pods in their corresponding topology domain.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        matchLabelKeys:
+                          description: MatchLabelKeys is a set of pod label keys to
+                            select the pods over which spreading will be calculated.
+                            The keys are used to lookup values from the incoming pod
+                            labels, those key-value labels are ANDed with labelSelector
+                            to select the group of existing pods over which spreading
+                            will be calculated for the incoming pod. Keys that don't
+                            exist in the incoming pod labels will be ignored. A null
+                            or empty list means only match against labelSelector.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        maxSkew:
+                          description: 'MaxSkew describes the degree to which pods
+                            may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                            it is the maximum permitted difference between the number
+                            of matching pods in the target topology and the global
+                            minimum. The global minimum is the minimum number of matching
+                            pods in an eligible domain or zero if the number of eligible
+                            domains is less than MinDomains. For example, in a 3-zone
+                            cluster, MaxSkew is set to 1, and pods with the same labelSelector
+                            spread as 2/2/1: In this case, the global minimum is 1.
+                            | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | -
+                            if MaxSkew is 1, incoming pod can only be scheduled to
+                            zone3 to become 2/2/2; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(3-1) on zone1(zone2) violate
+                            MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
+                            onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                            it is used to give higher precedence to topologies that
+                            satisfy it. It''s a required field. Default value is 1
+                            and 0 is not allowed.'
+                          format: int32
+                          type: integer
+                        minDomains:
+                          description: |-
+                            MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                            For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew.
+
+                            This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
+                          format: int32
+                          type: integer
+                        nodeAffinityPolicy:
+                          description: |-
+                            NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                            If this value is nil, the behavior is equivalent to the Honor policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                          type: string
+                        nodeTaintsPolicy:
+                          description: |-
+                            NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included.
+
+                            If this value is nil, the behavior is equivalent to the Ignore policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                          type: string
+                        topologyKey:
+                          description: TopologyKey is the key of node labels. Nodes
+                            that have a label with this key and identical values are
+                            considered to be in the same topology. We consider each
+                            <key, value> as a "bucket", and try to put balanced number
+                            of pods into each bucket. We define a domain as a particular
+                            instance of a topology. Also, we define an eligible domain
+                            as a domain whose nodes meet the requirements of nodeAffinityPolicy
+                            and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
+                            each Node is a domain of that topology. And, if TopologyKey
+                            is "topology.kubernetes.io/zone", each zone is a domain
+                            of that topology. It's a required field.
+                          type: string
+                        whenUnsatisfiable:
+                          description: |-
+                            WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                              but giving higher precedence to topologies that would help reduce the
+                              skew.
+                            A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
+
+                            Possible enum values:
+                             - `"DoNotSchedule"` instructs the scheduler not to schedule the pod when constraints are not satisfied.
+                             - `"ScheduleAnyway"` instructs the scheduler to schedule the pod even if constraints are not satisfied.
+                          type: string
+                      required:
+                      - maxSkew
+                      - topologyKey
+                      - whenUnsatisfiable
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - topologyKey
+                    - whenUnsatisfiable
+                    x-kubernetes-list-type: map
+                  volumes:
+                    description: 'List of volumes that can be mounted by containers
+                      belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                    items:
+                      description: Volume represents a named volume in a pod that
+                        may be accessed by any container in the pod.
+                      properties:
+                        awsElasticBlockStore:
+                          description: 'awsElasticBlockStore represents an AWS Disk
+                            resource that is attached to a kubelet''s host machine
+                            and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                          properties:
+                            fsType:
+                              description: 'fsType is the filesystem type of the volume
+                                that you want to mount. Tip: Ensure that the filesystem
+                                type is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              type: string
+                            partition:
+                              description: 'partition is the partition in the volume
+                                that you want to mount. If omitted, the default is
+                                to mount by volume name. Examples: For volume /dev/sda1,
+                                you specify the partition as "1". Similarly, the volume
+                                partition for /dev/sda is "0" (or you can leave the
+                                property empty).'
+                              format: int32
+                              type: integer
+                            readOnly:
+                              description: 'readOnly value true will force the readOnly
+                                setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              type: boolean
+                            volumeID:
+                              description: 'volumeID is unique ID of the persistent
+                                disk resource in AWS (Amazon EBS volume). More info:
+                                https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        azureDisk:
+                          description: azureDisk represents an Azure Data Disk mount
+                            on the host and bind mount to the pod.
+                          properties:
+                            cachingMode:
+                              description: 'cachingMode is the Host Caching mode:
+                                None, Read Only, Read Write.'
+                              type: string
+                            diskName:
+                              description: diskName is the Name of the data disk in
+                                the blob storage
+                              type: string
+                            diskURI:
+                              description: diskURI is the URI of data disk in the
+                                blob storage
+                              type: string
+                            fsType:
+                              description: fsType is Filesystem type to mount. Must
+                                be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified.
+                              type: string
+                            kind:
+                              description: 'kind expected values are Shared: multiple
+                                blob disks per storage account  Dedicated: single
+                                blob disk per storage account  Managed: azure managed
+                                data disk (only in managed availability set). defaults
+                                to shared'
+                              type: string
+                            readOnly:
+                              description: readOnly Defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                          required:
+                          - diskName
+                          - diskURI
+                          type: object
+                        azureFile:
+                          description: azureFile represents an Azure File Service
+                            mount on the host and bind mount to the pod.
+                          properties:
+                            readOnly:
+                              description: readOnly defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretName:
+                              description: secretName is the  name of secret that
+                                contains Azure Storage Account Name and Key
+                              type: string
+                            shareName:
+                              description: shareName is the azure share Name
+                              type: string
+                          required:
+                          - secretName
+                          - shareName
+                          type: object
+                        cephfs:
+                          description: cephFS represents a Ceph FS mount on the host
+                            that shares a pod's lifetime
+                          properties:
+                            monitors:
+                              description: 'monitors is Required: Monitors is a collection
+                                of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              items:
+                                type: string
+                              type: array
+                            path:
+                              description: 'path is Optional: Used as the mounted
+                                root, rather than the full Ceph tree, default is /'
+                              type: string
+                            readOnly:
+                              description: 'readOnly is Optional: Defaults to false
+                                (read/write). ReadOnly here will force the ReadOnly
+                                setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              type: boolean
+                            secretFile:
+                              description: 'secretFile is Optional: SecretFile is
+                                the path to key ring for User, default is /etc/ceph/user.secret
+                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              type: string
+                            secretRef:
+                              description: 'secretRef is Optional: SecretRef is reference
+                                to the authentication secret for User, default is
+                                empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            user:
+                              description: 'user is optional: User is the rados user
+                                name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              type: string
+                          required:
+                          - monitors
+                          type: object
+                        cinder:
+                          description: 'cinder represents a cinder volume attached
+                            and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                          properties:
+                            fsType:
+                              description: 'fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              type: string
+                            readOnly:
+                              description: 'readOnly defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              type: boolean
+                            secretRef:
+                              description: 'secretRef is optional: points to a secret
+                                object containing parameters used to connect to OpenStack.'
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            volumeID:
+                              description: 'volumeID used to identify the volume in
+                                cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        configMap:
+                          description: configMap represents a configMap that should
+                            populate this volume
+                          properties:
+                            defaultMode:
+                              description: 'defaultMode is optional: mode bits used
+                                to set permissions on created files by default. Must
+                                be an octal value between 0000 and 0777 or a decimal
+                                value between 0 and 511. YAML accepts both octal and
+                                decimal values, JSON requires decimal values for mode
+                                bits. Defaults to 0644. Directories within the path
+                                are not affected by this setting. This might be in
+                                conflict with other options that affect the file mode,
+                                like fsGroup, and the result can be other mode bits
+                                set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: items if unspecified, each key-value pair
+                                in the Data field of the referenced ConfigMap will
+                                be projected into the volume as a file whose name
+                                is the key and content is the value. If specified,
+                                the listed keys will be projected into the specified
+                                paths, and unlisted keys will not be present. If a
+                                key is specified which is not present in the ConfigMap,
+                                the volume setup will error unless it is marked optional.
+                                Paths must be relative and may not contain the '..'
+                                path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a
+                                  volume.
+                                properties:
+                                  key:
+                                    description: key is the key to project.
+                                    type: string
+                                  mode:
+                                    description: 'mode is Optional: mode bits used
+                                      to set permissions on this file. Must be an
+                                      octal value between 0000 and 0777 or a decimal
+                                      value between 0 and 511. YAML accepts both octal
+                                      and decimal values, JSON requires decimal values
+                                      for mode bits. If not specified, the volume
+                                      defaultMode will be used. This might be in conflict
+                                      with other options that affect the file mode,
+                                      like fsGroup, and the result can be other mode
+                                      bits set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: path is the relative path of the
+                                      file to map the key to. May not be an absolute
+                                      path. May not contain the path element '..'.
+                                      May not start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            optional:
+                              description: optional specify whether the ConfigMap
+                                or its keys must be defined
+                              type: boolean
+                          type: object
+                        csi:
+                          description: csi (Container Storage Interface) represents
+                            ephemeral storage that is handled by certain external
+                            CSI drivers (Beta feature).
+                          properties:
+                            driver:
+                              description: driver is the name of the CSI driver that
+                                handles this volume. Consult with your admin for the
+                                correct name as registered in the cluster.
+                              type: string
+                            fsType:
+                              description: fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                If not provided, the empty value is passed to the
+                                associated CSI driver which will determine the default
+                                filesystem to apply.
+                              type: string
+                            nodePublishSecretRef:
+                              description: nodePublishSecretRef is a reference to
+                                the secret object containing sensitive information
+                                to pass to the CSI driver to complete the CSI NodePublishVolume
+                                and NodeUnpublishVolume calls. This field is optional,
+                                and  may be empty if no secret is required. If the
+                                secret object contains more than one secret, all secret
+                                references are passed.
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            readOnly:
+                              description: readOnly specifies a read-only configuration
+                                for the volume. Defaults to false (read/write).
+                              type: boolean
+                            volumeAttributes:
+                              additionalProperties:
+                                type: string
+                              description: volumeAttributes stores driver-specific
+                                properties that are passed to the CSI driver. Consult
+                                your driver's documentation for supported values.
+                              type: object
+                          required:
+                          - driver
+                          type: object
+                        downwardAPI:
+                          description: downwardAPI represents downward API about the
+                            pod that should populate this volume
+                          properties:
+                            defaultMode:
+                              description: 'Optional: mode bits to use on created
+                                files by default. Must be a Optional: mode bits used
+                                to set permissions on created files by default. Must
+                                be an octal value between 0000 and 0777 or a decimal
+                                value between 0 and 511. YAML accepts both octal and
+                                decimal values, JSON requires decimal values for mode
+                                bits. Defaults to 0644. Directories within the path
+                                are not affected by this setting. This might be in
+                                conflict with other options that affect the file mode,
+                                like fsGroup, and the result can be other mode bits
+                                set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: Items is a list of downward API volume
+                                file
+                              items:
+                                description: DownwardAPIVolumeFile represents information
+                                  to create the file containing the pod field
+                                properties:
+                                  fieldRef:
+                                    description: 'Required: Selects a field of the
+                                      pod: only annotations, labels, name and namespace
+                                      are supported.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  mode:
+                                    description: 'Optional: mode bits used to set
+                                      permissions on this file, must be an octal value
+                                      between 0000 and 0777 or a decimal value between
+                                      0 and 511. YAML accepts both octal and decimal
+                                      values, JSON requires decimal values for mode
+                                      bits. If not specified, the volume defaultMode
+                                      will be used. This might be in conflict with
+                                      other options that affect the file mode, like
+                                      fsGroup, and the result can be other mode bits
+                                      set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: 'Required: Path is  the relative
+                                      path name of the file to be created. Must not
+                                      be absolute or contain the ''..'' path. Must
+                                      be utf-8 encoded. The first item of the relative
+                                      path must not start with ''..'''
+                                    type: string
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, requests.cpu and requests.memory)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                required:
+                                - path
+                                type: object
+                              type: array
+                          type: object
+                        emptyDir:
+                          description: 'emptyDir represents a temporary directory
+                            that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                          properties:
+                            medium:
+                              description: 'medium represents what type of storage
+                                medium should back this directory. The default is
+                                "" which means to use the node''s default medium.
+                                Must be an empty string (default) or Memory. More
+                                info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              type: string
+                            sizeLimit:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: 'sizeLimit is the total amount of local
+                                storage required for this EmptyDir volume. The size
+                                limit is also applicable for memory medium. The maximum
+                                usage on memory medium EmptyDir would be the minimum
+                                value between the SizeLimit specified here and the
+                                sum of memory limits of all containers in a pod. The
+                                default is nil which means that the limit is undefined.
+                                More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          type: object
+                        ephemeral:
+                          description: |-
+                            ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+
+                            Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+                               tracking are needed,
+                            c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+                               a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                               information on the connection between this volume type
+                               and PersistentVolumeClaim).
+
+                            Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+
+                            Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+
+                            A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+                          properties:
+                            volumeClaimTemplate:
+                              description: |-
+                                Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+
+                                An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+
+                                This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+
+                                Required, must not be nil.
+                              properties:
+                                metadata:
+                                  description: May contain labels and annotations
+                                    that will be copied into the PVC when creating
+                                    it. No other fields are allowed and will be rejected
+                                    during validation.
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                spec:
+                                  description: The specification for the PersistentVolumeClaim.
+                                    The entire content is copied unchanged into the
+                                    PVC that gets created from this template. The
+                                    same fields as in a PersistentVolumeClaim are
+                                    also valid here.
+                                  properties:
+                                    accessModes:
+                                      description: 'accessModes contains the desired
+                                        access modes the volume should have. More
+                                        info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                      items:
+                                        type: string
+                                      type: array
+                                    dataSource:
+                                      description: 'dataSource field can be used to
+                                        specify either: * An existing VolumeSnapshot
+                                        object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                        * An existing PVC (PersistentVolumeClaim)
+                                        If the provisioner or an external controller
+                                        can support the specified data source, it
+                                        will create a new volume based on the contents
+                                        of the specified data source. If the AnyVolumeDataSource
+                                        feature gate is enabled, this field will always
+                                        have the same contents as the DataSourceRef
+                                        field.'
+                                      properties:
+                                        apiGroup:
+                                          description: APIGroup is the group for the
+                                            resource being referenced. If APIGroup
+                                            is not specified, the specified Kind must
+                                            be in the core API group. For any other
+                                            third-party types, APIGroup is required.
+                                          type: string
+                                        kind:
+                                          description: Kind is the type of resource
+                                            being referenced
+                                          type: string
+                                        name:
+                                          description: Name is the name of resource
+                                            being referenced
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                    dataSourceRef:
+                                      description: |-
+                                        dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef
+                                          allows any non-core object, as well as PersistentVolumeClaim objects.
+                                        * While DataSource ignores disallowed values (dropping them), DataSourceRef
+                                          preserves all values, and generates an error if a disallowed value is
+                                          specified.
+                                        (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                      properties:
+                                        apiGroup:
+                                          description: APIGroup is the group for the
+                                            resource being referenced. If APIGroup
+                                            is not specified, the specified Kind must
+                                            be in the core API group. For any other
+                                            third-party types, APIGroup is required.
+                                          type: string
+                                        kind:
+                                          description: Kind is the type of resource
+                                            being referenced
+                                          type: string
+                                        name:
+                                          description: Name is the name of resource
+                                            being referenced
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                    resources:
+                                      description: 'resources represents the minimum
+                                        resources the volume should have. If RecoverVolumeExpansionFailure
+                                        feature is enabled users are allowed to specify
+                                        resource requirements that are lower than
+                                        previous value but must still be higher than
+                                        capacity recorded in the status field of the
+                                        claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Limits describes the maximum
+                                            amount of compute resources allowed. More
+                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Requests describes the minimum
+                                            amount of compute resources required.
+                                            If Requests is omitted for a container,
+                                            it defaults to Limits if that is explicitly
+                                            specified, otherwise to an implementation-defined
+                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                      type: object
+                                    selector:
+                                      description: selector is a label query over
+                                        volumes to consider for binding.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    storageClassName:
+                                      description: 'storageClassName is the name of
+                                        the StorageClass required by the claim. More
+                                        info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                      type: string
+                                    volumeMode:
+                                      description: volumeMode defines what type of
+                                        volume is required by the claim. Value of
+                                        Filesystem is implied when not included in
+                                        claim spec.
+                                      type: string
+                                    volumeName:
+                                      description: volumeName is the binding reference
+                                        to the PersistentVolume backing this claim.
+                                      type: string
+                                  type: object
+                              required:
+                              - spec
+                              type: object
+                          type: object
+                        fc:
+                          description: fc represents a Fibre Channel resource that
+                            is attached to a kubelet's host machine and then exposed
+                            to the pod.
+                          properties:
+                            fsType:
+                              description: fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified.
+                              type: string
+                            lun:
+                              description: 'lun is Optional: FC target lun number'
+                              format: int32
+                              type: integer
+                            readOnly:
+                              description: 'readOnly is Optional: Defaults to false
+                                (read/write). ReadOnly here will force the ReadOnly
+                                setting in VolumeMounts.'
+                              type: boolean
+                            targetWWNs:
+                              description: 'targetWWNs is Optional: FC target worldwide
+                                names (WWNs)'
+                              items:
+                                type: string
+                              type: array
+                            wwids:
+                              description: 'wwids Optional: FC volume world wide identifiers
+                                (wwids) Either wwids or combination of targetWWNs
+                                and lun must be set, but not both simultaneously.'
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        flexVolume:
+                          description: flexVolume represents a generic volume resource
+                            that is provisioned/attached using an exec based plugin.
+                          properties:
+                            driver:
+                              description: driver is the name of the driver to use
+                                for this volume.
+                              type: string
+                            fsType:
+                              description: fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". The default filesystem
+                                depends on FlexVolume script.
+                              type: string
+                            options:
+                              additionalProperties:
+                                type: string
+                              description: 'options is Optional: this field holds
+                                extra command options if any.'
+                              type: object
+                            readOnly:
+                              description: 'readOnly is Optional: defaults to false
+                                (read/write). ReadOnly here will force the ReadOnly
+                                setting in VolumeMounts.'
+                              type: boolean
+                            secretRef:
+                              description: 'secretRef is Optional: secretRef is reference
+                                to the secret object containing sensitive information
+                                to pass to the plugin scripts. This may be empty if
+                                no secret object is specified. If the secret object
+                                contains more than one secret, all secrets are passed
+                                to the plugin scripts.'
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                          required:
+                          - driver
+                          type: object
+                        flocker:
+                          description: flocker represents a Flocker volume attached
+                            to a kubelet's host machine. This depends on the Flocker
+                            control service being running
+                          properties:
+                            datasetName:
+                              description: datasetName is Name of the dataset stored
+                                as metadata -> name on the dataset for Flocker should
+                                be considered as deprecated
+                              type: string
+                            datasetUUID:
+                              description: datasetUUID is the UUID of the dataset.
+                                This is unique identifier of a Flocker dataset
+                              type: string
+                          type: object
+                        gcePersistentDisk:
+                          description: 'gcePersistentDisk represents a GCE Disk resource
+                            that is attached to a kubelet''s host machine and then
+                            exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                          properties:
+                            fsType:
+                              description: 'fsType is filesystem type of the volume
+                                that you want to mount. Tip: Ensure that the filesystem
+                                type is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              type: string
+                            partition:
+                              description: 'partition is the partition in the volume
+                                that you want to mount. If omitted, the default is
+                                to mount by volume name. Examples: For volume /dev/sda1,
+                                you specify the partition as "1". Similarly, the volume
+                                partition for /dev/sda is "0" (or you can leave the
+                                property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              format: int32
+                              type: integer
+                            pdName:
+                              description: 'pdName is unique name of the PD resource
+                                in GCE. Used to identify the disk in GCE. More info:
+                                https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              type: string
+                            readOnly:
+                              description: 'readOnly here will force the ReadOnly
+                                setting in VolumeMounts. Defaults to false. More info:
+                                https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              type: boolean
+                          required:
+                          - pdName
+                          type: object
+                        gitRepo:
+                          description: 'gitRepo represents a git repository at a particular
+                            revision. DEPRECATED: GitRepo is deprecated. To provision
+                            a container with a git repo, mount an EmptyDir into an
+                            InitContainer that clones the repo using git, then mount
+                            the EmptyDir into the Pod''s container.'
+                          properties:
+                            directory:
+                              description: directory is the target directory name.
+                                Must not contain or start with '..'.  If '.' is supplied,
+                                the volume directory will be the git repository.  Otherwise,
+                                if specified, the volume will contain the git repository
+                                in the subdirectory with the given name.
+                              type: string
+                            repository:
+                              description: repository is the URL
+                              type: string
+                            revision:
+                              description: revision is the commit hash for the specified
+                                revision.
+                              type: string
+                          required:
+                          - repository
+                          type: object
+                        glusterfs:
+                          description: 'glusterfs represents a Glusterfs mount on
+                            the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                          properties:
+                            endpoints:
+                              description: 'endpoints is the endpoint name that details
+                                Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                              type: string
+                            path:
+                              description: 'path is the Glusterfs volume path. More
+                                info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                              type: string
+                            readOnly:
+                              description: 'readOnly here will force the Glusterfs
+                                volume to be mounted with read-only permissions. Defaults
+                                to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                              type: boolean
+                          required:
+                          - endpoints
+                          - path
+                          type: object
+                        hostPath:
+                          description: 'hostPath represents a pre-existing file or
+                            directory on the host machine that is directly exposed
+                            to the container. This is generally used for system agents
+                            or other privileged things that are allowed to see the
+                            host machine. Most containers will NOT need this. More
+                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                          properties:
+                            path:
+                              description: 'path of the directory on the host. If
+                                the path is a symlink, it will follow the link to
+                                the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                              type: string
+                            type:
+                              description: 'type for HostPath Volume Defaults to ""
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        iscsi:
+                          description: 'iscsi represents an ISCSI Disk resource that
+                            is attached to a kubelet''s host machine and then exposed
+                            to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                          properties:
+                            chapAuthDiscovery:
+                              description: chapAuthDiscovery defines whether support
+                                iSCSI Discovery CHAP authentication
+                              type: boolean
+                            chapAuthSession:
+                              description: chapAuthSession defines whether support
+                                iSCSI Session CHAP authentication
+                              type: boolean
+                            fsType:
+                              description: 'fsType is the filesystem type of the volume
+                                that you want to mount. Tip: Ensure that the filesystem
+                                type is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                              type: string
+                            initiatorName:
+                              description: initiatorName is the custom iSCSI Initiator
+                                Name. If initiatorName is specified with iscsiInterface
+                                simultaneously, new iSCSI interface <target portal>:<volume
+                                name> will be created for the connection.
+                              type: string
+                            iqn:
+                              description: iqn is the target iSCSI Qualified Name.
+                              type: string
+                            iscsiInterface:
+                              description: iscsiInterface is the interface Name that
+                                uses an iSCSI transport. Defaults to 'default' (tcp).
+                              type: string
+                            lun:
+                              description: lun represents iSCSI Target Lun number.
+                              format: int32
+                              type: integer
+                            portals:
+                              description: portals is the iSCSI Target Portal List.
+                                The portal is either an IP or ip_addr:port if the
+                                port is other than default (typically TCP ports 860
+                                and 3260).
+                              items:
+                                type: string
+                              type: array
+                            readOnly:
+                              description: readOnly here will force the ReadOnly setting
+                                in VolumeMounts. Defaults to false.
+                              type: boolean
+                            secretRef:
+                              description: secretRef is the CHAP Secret for iSCSI
+                                target and initiator authentication
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            targetPortal:
+                              description: targetPortal is iSCSI Target Portal. The
+                                Portal is either an IP or ip_addr:port if the port
+                                is other than default (typically TCP ports 860 and
+                                3260).
+                              type: string
+                          required:
+                          - targetPortal
+                          - iqn
+                          - lun
+                          type: object
+                        name:
+                          description: 'name of the volume. Must be a DNS_LABEL and
+                            unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        nfs:
+                          description: 'nfs represents an NFS mount on the host that
+                            shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                          properties:
+                            path:
+                              description: 'path that is exported by the NFS server.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              type: string
+                            readOnly:
+                              description: 'readOnly here will force the NFS export
+                                to be mounted with read-only permissions. Defaults
+                                to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              type: boolean
+                            server:
+                              description: 'server is the hostname or IP address of
+                                the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              type: string
+                          required:
+                          - server
+                          - path
+                          type: object
+                        persistentVolumeClaim:
+                          description: 'persistentVolumeClaimVolumeSource represents
+                            a reference to a PersistentVolumeClaim in the same namespace.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          properties:
+                            claimName:
+                              description: 'claimName is the name of a PersistentVolumeClaim
+                                in the same namespace as the pod using this volume.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              type: string
+                            readOnly:
+                              description: readOnly Will force the ReadOnly setting
+                                in VolumeMounts. Default false.
+                              type: boolean
+                          required:
+                          - claimName
+                          type: object
+                        photonPersistentDisk:
+                          description: photonPersistentDisk represents a PhotonController
+                            persistent disk attached and mounted on kubelets host
+                            machine
+                          properties:
+                            fsType:
+                              description: fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified.
+                              type: string
+                            pdID:
+                              description: pdID is the ID that identifies Photon Controller
+                                persistent disk
+                              type: string
+                          required:
+                          - pdID
+                          type: object
+                        portworxVolume:
+                          description: portworxVolume represents a portworx volume
+                            attached and mounted on kubelets host machine
+                          properties:
+                            fsType:
+                              description: fSType represents the filesystem type to
+                                mount Must be a filesystem type supported by the host
+                                operating system. Ex. "ext4", "xfs". Implicitly inferred
+                                to be "ext4" if unspecified.
+                              type: string
+                            readOnly:
+                              description: readOnly defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            volumeID:
+                              description: volumeID uniquely identifies a Portworx
+                                volume
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        projected:
+                          description: projected items for all in one resources secrets,
+                            configmaps, and downward API
+                          properties:
+                            defaultMode:
+                              description: defaultMode are the mode bits used to set
+                                permissions on created files by default. Must be an
+                                octal value between 0000 and 0777 or a decimal value
+                                between 0 and 511. YAML accepts both octal and decimal
+                                values, JSON requires decimal values for mode bits.
+                                Directories within the path are not affected by this
+                                setting. This might be in conflict with other options
+                                that affect the file mode, like fsGroup, and the result
+                                can be other mode bits set.
+                              format: int32
+                              type: integer
+                            sources:
+                              description: sources is the list of volume projections
+                              items:
+                                description: Projection that may be projected along
+                                  with other supported volume types
+                                properties:
+                                  configMap:
+                                    description: configMap information about the configMap
+                                      data to project
+                                    properties:
+                                      items:
+                                        description: items if unspecified, each key-value
+                                          pair in the Data field of the referenced
+                                          ConfigMap will be projected into the volume
+                                          as a file whose name is the key and content
+                                          is the value. If specified, the listed keys
+                                          will be projected into the specified paths,
+                                          and unlisted keys will not be present. If
+                                          a key is specified which is not present
+                                          in the ConfigMap, the volume setup will
+                                          error unless it is marked optional. Paths
+                                          must be relative and may not contain the
+                                          '..' path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: key is the key to project.
+                                              type: string
+                                            mode:
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: path is the relative path
+                                                of the file to map the key to. May
+                                                not be an absolute path. May not contain
+                                                the path element '..'. May not start
+                                                with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: optional specify whether the
+                                          ConfigMap or its keys must be defined
+                                        type: boolean
+                                    type: object
+                                  downwardAPI:
+                                    description: downwardAPI information about the
+                                      downwardAPI data to project
+                                    properties:
+                                      items:
+                                        description: Items is a list of DownwardAPIVolume
+                                          file
+                                        items:
+                                          description: DownwardAPIVolumeFile represents
+                                            information to create the file containing
+                                            the pod field
+                                          properties:
+                                            fieldRef:
+                                              description: 'Required: Selects a field
+                                                of the pod: only annotations, labels,
+                                                name and namespace are supported.'
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                            mode:
+                                              description: 'Optional: mode bits used
+                                                to set permissions on this file, must
+                                                be an octal value between 0000 and
+                                                0777 or a decimal value between 0
+                                                and 511. YAML accepts both octal and
+                                                decimal values, JSON requires decimal
+                                                values for mode bits. If not specified,
+                                                the volume defaultMode will be used.
+                                                This might be in conflict with other
+                                                options that affect the file mode,
+                                                like fsGroup, and the result can be
+                                                other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: 'Required: Path is  the
+                                                relative path name of the file to
+                                                be created. Must not be absolute or
+                                                contain the ''..'' path. Must be utf-8
+                                                encoded. The first item of the relative
+                                                path must not start with ''..'''
+                                              type: string
+                                            resourceFieldRef:
+                                              description: 'Selects a resource of
+                                                the container: only resources limits
+                                                and requests (limits.cpu, limits.memory,
+                                                requests.cpu and requests.memory)
+                                                are currently supported.'
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                          required:
+                                          - path
+                                          type: object
+                                        type: array
+                                    type: object
+                                  secret:
+                                    description: secret information about the secret
+                                      data to project
+                                    properties:
+                                      items:
+                                        description: items if unspecified, each key-value
+                                          pair in the Data field of the referenced
+                                          Secret will be projected into the volume
+                                          as a file whose name is the key and content
+                                          is the value. If specified, the listed keys
+                                          will be projected into the specified paths,
+                                          and unlisted keys will not be present. If
+                                          a key is specified which is not present
+                                          in the Secret, the volume setup will error
+                                          unless it is marked optional. Paths must
+                                          be relative and may not contain the '..'
+                                          path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: key is the key to project.
+                                              type: string
+                                            mode:
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: path is the relative path
+                                                of the file to map the key to. May
+                                                not be an absolute path. May not contain
+                                                the path element '..'. May not start
+                                                with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: optional field specify whether
+                                          the Secret or its key must be defined
+                                        type: boolean
+                                    type: object
+                                  serviceAccountToken:
+                                    description: serviceAccountToken is information
+                                      about the serviceAccountToken data to project
+                                    properties:
+                                      audience:
+                                        description: audience is the intended audience
+                                          of the token. A recipient of a token must
+                                          identify itself with an identifier specified
+                                          in the audience of the token, and otherwise
+                                          should reject the token. The audience defaults
+                                          to the identifier of the apiserver.
+                                        type: string
+                                      expirationSeconds:
+                                        description: expirationSeconds is the requested
+                                          duration of validity of the service account
+                                          token. As the token approaches expiration,
+                                          the kubelet volume plugin will proactively
+                                          rotate the service account token. The kubelet
+                                          will start trying to rotate the token if
+                                          the token is older than 80 percent of its
+                                          time to live or if the token is older than
+                                          24 hours.Defaults to 1 hour and must be
+                                          at least 10 minutes.
+                                        format: int64
+                                        type: integer
+                                      path:
+                                        description: path is the path relative to
+                                          the mount point of the file to project the
+                                          token into.
+                                        type: string
+                                    required:
+                                    - path
+                                    type: object
+                                type: object
+                              type: array
+                          type: object
+                        quobyte:
+                          description: quobyte represents a Quobyte mount on the host
+                            that shares a pod's lifetime
+                          properties:
+                            group:
+                              description: group to map volume access to Default is
+                                no group
+                              type: string
+                            readOnly:
+                              description: readOnly here will force the Quobyte volume
+                                to be mounted with read-only permissions. Defaults
+                                to false.
+                              type: boolean
+                            registry:
+                              description: registry represents a single or multiple
+                                Quobyte Registry services specified as a string as
+                                host:port pair (multiple entries are separated with
+                                commas) which acts as the central registry for volumes
+                              type: string
+                            tenant:
+                              description: tenant owning the given Quobyte volume
+                                in the Backend Used with dynamically provisioned Quobyte
+                                volumes, value is set by the plugin
+                              type: string
+                            user:
+                              description: user to map volume access to Defaults to
+                                serivceaccount user
+                              type: string
+                            volume:
+                              description: volume is a string that references an already
+                                created Quobyte volume by name.
+                              type: string
+                          required:
+                          - registry
+                          - volume
+                          type: object
+                        rbd:
+                          description: 'rbd represents a Rados Block Device mount
+                            on the host that shares a pod''s lifetime. More info:
+                            https://examples.k8s.io/volumes/rbd/README.md'
+                          properties:
+                            fsType:
+                              description: 'fsType is the filesystem type of the volume
+                                that you want to mount. Tip: Ensure that the filesystem
+                                type is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                              type: string
+                            image:
+                              description: 'image is the rados image name. More info:
+                                https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: string
+                            keyring:
+                              description: 'keyring is the path to key ring for RBDUser.
+                                Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: string
+                            monitors:
+                              description: 'monitors is a collection of Ceph monitors.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              items:
+                                type: string
+                              type: array
+                            pool:
+                              description: 'pool is the rados pool name. Default is
+                                rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: string
+                            readOnly:
+                              description: 'readOnly here will force the ReadOnly
+                                setting in VolumeMounts. Defaults to false. More info:
+                                https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: boolean
+                            secretRef:
+                              description: 'secretRef is name of the authentication
+                                secret for RBDUser. If provided overrides keyring.
+                                Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            user:
+                              description: 'user is the rados user name. Default is
+                                admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: string
+                          required:
+                          - monitors
+                          - image
+                          type: object
+                        scaleIO:
+                          description: scaleIO represents a ScaleIO persistent volume
+                            attached and mounted on Kubernetes nodes.
+                          properties:
+                            fsType:
+                              description: fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                              type: string
+                            gateway:
+                              description: gateway is the host address of the ScaleIO
+                                API Gateway.
+                              type: string
+                            protectionDomain:
+                              description: protectionDomain is the name of the ScaleIO
+                                Protection Domain for the configured storage.
+                              type: string
+                            readOnly:
+                              description: readOnly Defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretRef:
+                              description: secretRef references to the secret for
+                                ScaleIO user and other sensitive information. If this
+                                is not provided, Login operation will fail.
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            sslEnabled:
+                              description: sslEnabled Flag enable/disable SSL communication
+                                with Gateway, default false
+                              type: boolean
+                            storageMode:
+                              description: storageMode indicates whether the storage
+                                for a volume should be ThickProvisioned or ThinProvisioned.
+                                Default is ThinProvisioned.
+                              type: string
+                            storagePool:
+                              description: storagePool is the ScaleIO Storage Pool
+                                associated with the protection domain.
+                              type: string
+                            system:
+                              description: system is the name of the storage system
+                                as configured in ScaleIO.
+                              type: string
+                            volumeName:
+                              description: volumeName is the name of a volume already
+                                created in the ScaleIO system that is associated with
+                                this volume source.
+                              type: string
+                          required:
+                          - gateway
+                          - system
+                          - secretRef
+                          type: object
+                        secret:
+                          description: 'secret represents a secret that should populate
+                            this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                          properties:
+                            defaultMode:
+                              description: 'defaultMode is Optional: mode bits used
+                                to set permissions on created files by default. Must
+                                be an octal value between 0000 and 0777 or a decimal
+                                value between 0 and 511. YAML accepts both octal and
+                                decimal values, JSON requires decimal values for mode
+                                bits. Defaults to 0644. Directories within the path
+                                are not affected by this setting. This might be in
+                                conflict with other options that affect the file mode,
+                                like fsGroup, and the result can be other mode bits
+                                set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: items If unspecified, each key-value pair
+                                in the Data field of the referenced Secret will be
+                                projected into the volume as a file whose name is
+                                the key and content is the value. If specified, the
+                                listed keys will be projected into the specified paths,
+                                and unlisted keys will not be present. If a key is
+                                specified which is not present in the Secret, the
+                                volume setup will error unless it is marked optional.
+                                Paths must be relative and may not contain the '..'
+                                path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a
+                                  volume.
+                                properties:
+                                  key:
+                                    description: key is the key to project.
+                                    type: string
+                                  mode:
+                                    description: 'mode is Optional: mode bits used
+                                      to set permissions on this file. Must be an
+                                      octal value between 0000 and 0777 or a decimal
+                                      value between 0 and 511. YAML accepts both octal
+                                      and decimal values, JSON requires decimal values
+                                      for mode bits. If not specified, the volume
+                                      defaultMode will be used. This might be in conflict
+                                      with other options that affect the file mode,
+                                      like fsGroup, and the result can be other mode
+                                      bits set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: path is the relative path of the
+                                      file to map the key to. May not be an absolute
+                                      path. May not contain the path element '..'.
+                                      May not start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                            optional:
+                              description: optional field specify whether the Secret
+                                or its keys must be defined
+                              type: boolean
+                            secretName:
+                              description: 'secretName is the name of the secret in
+                                the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              type: string
+                          type: object
+                        storageos:
+                          description: storageOS represents a StorageOS volume attached
+                            and mounted on Kubernetes nodes.
+                          properties:
+                            fsType:
+                              description: fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified.
+                              type: string
+                            readOnly:
+                              description: readOnly defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretRef:
+                              description: secretRef specifies the secret to use for
+                                obtaining the StorageOS API credentials.  If not specified,
+                                default values will be attempted.
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            volumeName:
+                              description: volumeName is the human-readable name of
+                                the StorageOS volume.  Volume names are only unique
+                                within a namespace.
+                              type: string
+                            volumeNamespace:
+                              description: volumeNamespace specifies the scope of
+                                the volume within StorageOS.  If no namespace is specified
+                                then the Pod's namespace will be used.  This allows
+                                the Kubernetes name scoping to be mirrored within
+                                StorageOS for tighter integration. Set VolumeName
+                                to any name to override the default behaviour. Set
+                                to "default" if you are not using namespaces within
+                                StorageOS. Namespaces that do not pre-exist within
+                                StorageOS will be created.
+                              type: string
+                          type: object
+                        vsphereVolume:
+                          description: vsphereVolume represents a vSphere volume attached
+                            and mounted on kubelets host machine
+                          properties:
+                            fsType:
+                              description: fsType is filesystem type to mount. Must
+                                be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified.
+                              type: string
+                            storagePolicyID:
+                              description: storagePolicyID is the storage Policy Based
+                                Management (SPBM) profile ID associated with the StoragePolicyName.
+                              type: string
+                            storagePolicyName:
+                              description: storagePolicyName is the storage Policy
+                                Based Management (SPBM) profile name.
+                              type: string
+                            volumePath:
+                              description: volumePath is the path that identifies
+                                vSphere volume vmdk
+                              type: string
+                          required:
+                          - volumePath
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                required:
+                - containers
+                type: object
+            type: object
+        required:
+        - selector
+        - template
+        type: object
+      status:
+        description: Most recently observed status of the Deployment.
+        properties:
+          availableReplicas:
+            description: Total number of available pods (ready for at least minReadySeconds)
+              targeted by this deployment.
+            format: int32
+            type: integer
+          collisionCount:
+            description: Count of hash collisions for the Deployment. The Deployment
+              controller uses this field as a collision avoidance mechanism when it
+              needs to create the name for the newest ReplicaSet.
+            format: int32
+            type: integer
+          conditions:
+            description: Represents the latest available observations of a deployment's
+              current state.
+            items:
+              description: DeploymentCondition describes the state of a deployment
+                at a certain point.
+              properties:
+                lastTransitionTime:
+                  description: Last time the condition transitioned from one status
+                    to another.
+                  format: date-time
+                  type: string
+                lastUpdateTime:
+                  description: The last time this condition was updated.
+                  format: date-time
+                  type: string
+                message:
+                  description: A human readable message indicating details about the
+                    transition.
+                  type: string
+                reason:
+                  description: The reason for the condition's last transition.
+                  type: string
+                status:
+                  description: Status of the condition, one of True, False, Unknown.
+                  type: string
+                type:
+                  description: Type of deployment condition.
+                  type: string
+              required:
+              - status
+              - type
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - type
+            x-kubernetes-list-type: map
+          observedGeneration:
+            description: The generation observed by the deployment controller.
+            format: int64
+            type: integer
+          readyReplicas:
+            description: readyReplicas is the number of pods targeted by this Deployment
+              with a Ready Condition.
+            format: int32
+            type: integer
+          replicas:
+            description: Total number of non-terminated pods targeted by this deployment
+              (their labels match the selector).
+            format: int32
+            type: integer
+          unavailableReplicas:
+            description: Total number of unavailable pods targeted by this deployment.
+              This is the total number of pods that are still required for the deployment
+              to have 100% available capacity. They may either be pods that are running
+              but not yet available or pods that still have not been created.
+            format: int32
+            type: integer
+          updatedReplicas:
+            description: Total number of non-terminated pods targeted by this deployment
+              that have the desired template spec.
+            format: int32
+            type: integer
+        type: object
+    type: object
+  plural: deployments
+  scope: Namespaced
+  shortNames:
+  - deploy
+  singular: deployment
+  subResources:
+  - name: scale
+  - name: status

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/4-NegotiatedAPIResource-ingresses.v1.networking.k8s.io.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/4-NegotiatedAPIResource-ingresses.v1.networking.k8s.io.yaml
@@ -1,0 +1,343 @@
+apiVersion: apiresource.kcp.io/v1alpha1
+kind: NegotiatedAPIResource
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kcp-dev/kubernetes/pull/4
+    apiresource.kcp.io/apiVersion: networking.k8s.io/v1
+    kcp.io/cluster: br3qimk2t1o3jb70
+  creationTimestamp: "2023-03-21T17:10:10Z"
+  generation: 1
+  name: ingresses.v1.networking.k8s.io
+  resourceVersion: "9152"
+  uid: 2e87e262-ba6b-4de5-8df0-a6fa1bc7368f
+spec:
+  groupVersion:
+    group: networking.k8s.io
+    version: v1
+  kind: Ingress
+  listKind: IngressList
+  openAPIV3Schema:
+    description: Ingress is a collection of rules that allow inbound connections to
+      reach the endpoints defined by a backend. An Ingress can be configured to give
+      services externally-reachable urls, load balance traffic, terminate SSL, offer
+      name based virtual hosting etc.
+    properties:
+      apiVersion:
+        description: 'APIVersion defines the versioned schema of this representation
+          of an object. Servers should convert recognized schemas to the latest internal
+          value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+        type: string
+      kind:
+        description: 'Kind is a string value representing the REST resource this object
+          represents. Servers may infer this from the endpoint the client submits
+          requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+        type: string
+      metadata:
+        type: object
+      spec:
+        description: 'Spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+        properties:
+          defaultBackend:
+            description: DefaultBackend is the backend that should handle requests
+              that don't match any rule. If Rules are not specified, DefaultBackend
+              must be specified. If DefaultBackend is not set, the handling of requests
+              that do not match any of the rules will be up to the Ingress controller.
+            properties:
+              resource:
+                description: Resource is an ObjectRef to another Kubernetes resource
+                  in the namespace of the Ingress object. If resource is specified,
+                  a service.Name and service.Port must not be specified. This is a
+                  mutually exclusive setting with "Service".
+                properties:
+                  apiGroup:
+                    description: APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in
+                      the core API group. For any other third-party types, APIGroup
+                      is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              service:
+                description: Service references a Service as a Backend. This is a
+                  mutually exclusive setting with "Resource".
+                properties:
+                  name:
+                    description: Name is the referenced service. The service must
+                      exist in the same namespace as the Ingress object.
+                    type: string
+                  port:
+                    description: Port of the referenced service. A port name or port
+                      number is required for a IngressServiceBackend.
+                    properties:
+                      name:
+                        description: Name is the name of the port on the Service.
+                          This is a mutually exclusive setting with "Number".
+                        type: string
+                      number:
+                        description: Number is the numerical port number (e.g. 80)
+                          on the Service. This is a mutually exclusive setting with
+                          "Name".
+                        format: int32
+                        type: integer
+                    type: object
+                required:
+                - name
+                type: object
+            type: object
+          ingressClassName:
+            description: IngressClassName is the name of an IngressClass cluster resource.
+              Ingress controller implementations use this field to know whether they
+              should be serving this Ingress resource, by a transitive connection
+              (controller -> IngressClass -> Ingress resource). Although the `kubernetes.io/ingress.class`
+              annotation (simple constant name) was never formally defined, it was
+              widely supported by Ingress controllers to create a direct binding between
+              Ingress controller and Ingress resources. Newly created Ingress resources
+              should prefer using the field. However, even though the annotation is
+              officially deprecated, for backwards compatibility reasons, ingress
+              controllers should still honor that annotation if present.
+            type: string
+          rules:
+            description: A list of host rules used to configure the Ingress. If unspecified,
+              or no rule matches, all traffic is sent to the default backend.
+            items:
+              description: IngressRule represents the rules mapping the paths under
+                a specified host to the related backend services. Incoming requests
+                are first evaluated for a host match, then routed to the backend associated
+                with the matching IngressRuleValue.
+              properties:
+                host:
+                  description: "Host is the fully qualified domain name of a network
+                    host, as defined by RFC 3986. Note the following deviations from
+                    the \"host\" part of the URI as defined in RFC 3986: 1. IPs are
+                    not allowed. Currently an IngressRuleValue can only apply to\n
+                    \  the IP in the Spec of the parent Ingress.\n2. The `:` delimiter
+                    is not respected because ports are not allowed.\n\t  Currently
+                    the port of an Ingress is implicitly :80 for http and\n\t  :443
+                    for https.\nBoth these may change in the future. Incoming requests
+                    are matched against the host before the IngressRuleValue. If the
+                    host is unspecified, the Ingress routes all traffic based on the
+                    specified IngressRuleValue.\n\nHost can be \"precise\" which is
+                    a domain name without the terminating dot of a network host (e.g.
+                    \"foo.bar.com\") or \"wildcard\", which is a domain name prefixed
+                    with a single wildcard label (e.g. \"*.foo.com\"). The wildcard
+                    character '*' must appear by itself as the first DNS label and
+                    matches only a single label. You cannot have a wildcard label
+                    by itself (e.g. Host == \"*\"). Requests will be matched against
+                    the Host field in the following way: 1. If Host is precise, the
+                    request matches this rule if the http host header is equal to
+                    Host. 2. If Host is a wildcard, then the request matches this
+                    rule if the http host header is to equal to the suffix (removing
+                    the first label) of the wildcard rule."
+                  type: string
+                http:
+                  description: 'HTTPIngressRuleValue is a list of http selectors pointing
+                    to backends. In the example: http://<host>/<path>?<searchpart>
+                    -> backend where where parts of the url correspond to RFC 3986,
+                    this resource will be used to match against everything after the
+                    last ''/'' and before the first ''?'' or ''#''.'
+                  properties:
+                    paths:
+                      description: A collection of paths that map requests to backends.
+                      items:
+                        description: HTTPIngressPath associates a path with a backend.
+                          Incoming urls matching the path are forwarded to the backend.
+                        properties:
+                          backend:
+                            description: Backend defines the referenced service endpoint
+                              to which the traffic will be forwarded to.
+                            properties:
+                              resource:
+                                description: Resource is an ObjectRef to another Kubernetes
+                                  resource in the namespace of the Ingress object.
+                                  If resource is specified, a service.Name and service.Port
+                                  must not be specified. This is a mutually exclusive
+                                  setting with "Service".
+                                properties:
+                                  apiGroup:
+                                    description: APIGroup is the group for the resource
+                                      being referenced. If APIGroup is not specified,
+                                      the specified Kind must be in the core API group.
+                                      For any other third-party types, APIGroup is
+                                      required.
+                                    type: string
+                                  kind:
+                                    description: Kind is the type of resource being
+                                      referenced
+                                    type: string
+                                  name:
+                                    description: Name is the name of resource being
+                                      referenced
+                                    type: string
+                                required:
+                                - kind
+                                - name
+                                type: object
+                              service:
+                                description: Service references a Service as a Backend.
+                                  This is a mutually exclusive setting with "Resource".
+                                properties:
+                                  name:
+                                    description: Name is the referenced service. The
+                                      service must exist in the same namespace as
+                                      the Ingress object.
+                                    type: string
+                                  port:
+                                    description: Port of the referenced service. A
+                                      port name or port number is required for a IngressServiceBackend.
+                                    properties:
+                                      name:
+                                        description: Name is the name of the port
+                                          on the Service. This is a mutually exclusive
+                                          setting with "Number".
+                                        type: string
+                                      number:
+                                        description: Number is the numerical port
+                                          number (e.g. 80) on the Service. This is
+                                          a mutually exclusive setting with "Name".
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                            type: object
+                          path:
+                            description: Path is matched against the path of an incoming
+                              request. Currently it can contain characters disallowed
+                              from the conventional "path" part of a URL as defined
+                              by RFC 3986. Paths must begin with a '/' and must be
+                              present when using PathType with value "Exact" or "Prefix".
+                            type: string
+                          pathType:
+                            description: |-
+                              PathType determines the interpretation of the Path matching. PathType can be one of the following values: * Exact: Matches the URL path exactly. * Prefix: Matches based on a URL path prefix split by '/'. Matching is
+                                done on a path element by element basis. A path element refers is the
+                                list of labels in the path split by the '/' separator. A request is a
+                                match for path p if every p is an element-wise prefix of p of the
+                                request path. Note that if the last element of the path is a substring
+                                of the last element in request path, it is not a match (e.g. /foo/bar
+                                matches /foo/bar/baz, but does not match /foo/barbaz).
+                              * ImplementationSpecific: Interpretation of the Path matching is up to
+                                the IngressClass. Implementations can treat this as a separate PathType
+                                or treat it identically to Prefix or Exact path types.
+                              Implementations are required to support all path types.
+                            type: string
+                        required:
+                        - pathType
+                        - backend
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  required:
+                  - paths
+                  type: object
+              type: object
+            type: array
+            x-kubernetes-list-type: atomic
+          tls:
+            description: TLS configuration. Currently the Ingress only supports a
+              single TLS port, 443. If multiple members of this list specify different
+              hosts, they will be multiplexed on the same port according to the hostname
+              specified through the SNI TLS extension, if the ingress controller fulfilling
+              the ingress supports SNI.
+            items:
+              description: IngressTLS describes the transport layer security associated
+                with an Ingress.
+              properties:
+                hosts:
+                  description: Hosts are a list of hosts included in the TLS certificate.
+                    The values in this list must match the name/s used in the tlsSecret.
+                    Defaults to the wildcard host setting for the loadbalancer controller
+                    fulfilling this Ingress, if left unspecified.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: atomic
+                secretName:
+                  description: SecretName is the name of the secret used to terminate
+                    TLS traffic on port 443. Field is left optional to allow TLS routing
+                    based on SNI hostname alone. If the SNI host in a listener conflicts
+                    with the "Host" header field used by an IngressRule, the SNI host
+                    is used for termination and value of the Host header is used for
+                    routing.
+                  type: string
+              type: object
+            type: array
+            x-kubernetes-list-type: atomic
+        type: object
+      status:
+        description: 'Status is the current state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+        properties:
+          loadBalancer:
+            description: LoadBalancer contains the current status of the load-balancer.
+            properties:
+              ingress:
+                description: Ingress is a list containing ingress points for the load-balancer.
+                  Traffic intended for the service should be sent to these ingress
+                  points.
+                items:
+                  description: 'LoadBalancerIngress represents the status of a load-balancer
+                    ingress point: traffic intended for the service should be sent
+                    to an ingress point.'
+                  properties:
+                    hostname:
+                      description: Hostname is set for load-balancer ingress points
+                        that are DNS based (typically AWS load-balancers)
+                      type: string
+                    ip:
+                      description: IP is set for load-balancer ingress points that
+                        are IP based (typically GCE or OpenStack load-balancers)
+                      type: string
+                    ports:
+                      description: Ports is a list of records of service ports If
+                        used, every port defined in the service should have an entry
+                        in it
+                      items:
+                        properties:
+                          error:
+                            description: |-
+                              Error is to record the problem with the service port The format of the error shall comply with the following rules: - built-in error values shall be specified in this file and those shall use
+                                CamelCase names
+                              - cloud provider specific error values must have names that comply with the
+                                format foo.example.com/CamelCase.
+                            type: string
+                          port:
+                            description: Port is the port number of the service port
+                              of which status is recorded here
+                            format: int32
+                            type: integer
+                          protocol:
+                            description: |-
+                              Protocol is the protocol of the service port of which status is recorded here The supported values are: "TCP", "UDP", "SCTP"
+
+                              Possible enum values:
+                               - `"SCTP"` is the SCTP protocol.
+                               - `"TCP"` is the TCP protocol.
+                               - `"UDP"` is the UDP protocol.
+                            type: string
+                        required:
+                        - port
+                        - protocol
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  type: object
+                type: array
+            type: object
+        type: object
+    type: object
+  plural: ingresses
+  scope: Namespaced
+  shortNames:
+  - ing
+  singular: ingress
+  subResources:
+  - name: status

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/4-NegotiatedAPIResource-pods.v1.core.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/4-NegotiatedAPIResource-pods.v1.core.yaml
@@ -1,0 +1,7092 @@
+apiVersion: apiresource.kcp.io/v1alpha1
+kind: NegotiatedAPIResource
+metadata:
+  annotations:
+    apiresource.kcp.io/apiVersion: v1
+    kcp.io/cluster: br3qimk2t1o3jb70
+  creationTimestamp: "2023-03-21T17:10:10Z"
+  generation: 1
+  name: pods.v1.core
+  resourceVersion: "9148"
+  uid: 83dcb300-05ce-4975-8a94-b30afec3a458
+spec:
+  categories:
+  - all
+  groupVersion:
+    version: v1
+  kind: Pod
+  listKind: PodList
+  openAPIV3Schema:
+    description: Pod is a collection of containers that can run on a host. This resource
+      is created by clients and scheduled onto hosts.
+    properties:
+      apiVersion:
+        description: 'APIVersion defines the versioned schema of this representation
+          of an object. Servers should convert recognized schemas to the latest internal
+          value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+        type: string
+      kind:
+        description: 'Kind is a string value representing the REST resource this object
+          represents. Servers may infer this from the endpoint the client submits
+          requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+        type: string
+      metadata:
+        type: object
+      spec:
+        description: 'Specification of the desired behavior of the pod. More info:
+          https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+        properties:
+          activeDeadlineSeconds:
+            description: Optional duration in seconds the pod may be active on the
+              node relative to StartTime before the system will actively try to mark
+              it failed and kill associated containers. Value must be a positive integer.
+            format: int64
+            type: integer
+          affinity:
+            description: If specified, the pod's scheduling constraints
+            properties:
+              nodeAffinity:
+                description: Describes node affinity scheduling rules for the pod.
+                properties:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    description: The scheduler will prefer to schedule pods to nodes
+                      that satisfy the affinity expressions specified by this field,
+                      but it may choose a node that violates one or more of the expressions.
+                      The node that is most preferred is the one with the greatest
+                      sum of weights, i.e. for each node that meets all of the scheduling
+                      requirements (resource request, requiredDuringScheduling affinity
+                      expressions, etc.), compute a sum by iterating through the elements
+                      of this field and adding "weight" to the sum if the node matches
+                      the corresponding matchExpressions; the node(s) with the highest
+                      sum are the most preferred.
+                    items:
+                      description: An empty preferred scheduling term matches all
+                        objects with implicit weight 0 (i.e. it's a no-op). A null
+                        preferred scheduling term matches no objects (i.e. is also
+                        a no-op).
+                      properties:
+                        preference:
+                          description: A node selector term, associated with the corresponding
+                            weight.
+                          properties:
+                            matchExpressions:
+                              description: A list of node selector requirements by
+                                node's labels.
+                              items:
+                                description: A node selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: The label key that the selector applies
+                                      to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                      Possible enum values:
+                                       - `"DoesNotExist"`
+                                       - `"Exists"`
+                                       - `"Gt"`
+                                       - `"In"`
+                                       - `"Lt"`
+                                       - `"NotIn"`
+                                    type: string
+                                  values:
+                                    description: An array of string values. If the
+                                      operator is In or NotIn, the values array must
+                                      be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator
+                                      is Gt or Lt, the values array must have a single
+                                      element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchFields:
+                              description: A list of node selector requirements by
+                                node's fields.
+                              items:
+                                description: A node selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: The label key that the selector applies
+                                      to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                      Possible enum values:
+                                       - `"DoesNotExist"`
+                                       - `"Exists"`
+                                       - `"Gt"`
+                                       - `"In"`
+                                       - `"Lt"`
+                                       - `"NotIn"`
+                                    type: string
+                                  values:
+                                    description: An array of string values. If the
+                                      operator is In or NotIn, the values array must
+                                      be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator
+                                      is Gt or Lt, the values array must have a single
+                                      element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                          type: object
+                        weight:
+                          description: Weight associated with matching the corresponding
+                            nodeSelectorTerm, in the range 1-100.
+                          format: int32
+                          type: integer
+                      required:
+                      - weight
+                      - preference
+                      type: object
+                    type: array
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    description: If the affinity requirements specified by this field
+                      are not met at scheduling time, the pod will not be scheduled
+                      onto the node. If the affinity requirements specified by this
+                      field cease to be met at some point during pod execution (e.g.
+                      due to an update), the system may or may not try to eventually
+                      evict the pod from its node.
+                    properties:
+                      nodeSelectorTerms:
+                        description: Required. A list of node selector terms. The
+                          terms are ORed.
+                        items:
+                          description: A null or empty node selector term matches
+                            no objects. The requirements of them are ANDed. The TopologySelectorTerm
+                            type implements a subset of the NodeSelectorTerm.
+                          properties:
+                            matchExpressions:
+                              description: A list of node selector requirements by
+                                node's labels.
+                              items:
+                                description: A node selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: The label key that the selector applies
+                                      to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                      Possible enum values:
+                                       - `"DoesNotExist"`
+                                       - `"Exists"`
+                                       - `"Gt"`
+                                       - `"In"`
+                                       - `"Lt"`
+                                       - `"NotIn"`
+                                    type: string
+                                  values:
+                                    description: An array of string values. If the
+                                      operator is In or NotIn, the values array must
+                                      be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator
+                                      is Gt or Lt, the values array must have a single
+                                      element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchFields:
+                              description: A list of node selector requirements by
+                                node's fields.
+                              items:
+                                description: A node selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: The label key that the selector applies
+                                      to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                      Possible enum values:
+                                       - `"DoesNotExist"`
+                                       - `"Exists"`
+                                       - `"Gt"`
+                                       - `"In"`
+                                       - `"Lt"`
+                                       - `"NotIn"`
+                                    type: string
+                                  values:
+                                    description: An array of string values. If the
+                                      operator is In or NotIn, the values array must
+                                      be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator
+                                      is Gt or Lt, the values array must have a single
+                                      element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                          type: object
+                        type: array
+                    required:
+                    - nodeSelectorTerms
+                    type: object
+                type: object
+              podAffinity:
+                description: Describes pod affinity scheduling rules (e.g. co-locate
+                  this pod in the same node, zone, etc. as some other pod(s)).
+                properties:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    description: The scheduler will prefer to schedule pods to nodes
+                      that satisfy the affinity expressions specified by this field,
+                      but it may choose a node that violates one or more of the expressions.
+                      The node that is most preferred is the one with the greatest
+                      sum of weights, i.e. for each node that meets all of the scheduling
+                      requirements (resource request, requiredDuringScheduling affinity
+                      expressions, etc.), compute a sum by iterating through the elements
+                      of this field and adding "weight" to the sum if the node has
+                      pods which matches the corresponding podAffinityTerm; the node(s)
+                      with the highest sum are the most preferred.
+                    items:
+                      description: The weights of all of the matched WeightedPodAffinityTerm
+                        fields are added per-node to find the most preferred node(s)
+                      properties:
+                        podAffinityTerm:
+                          description: Required. A pod affinity term, associated with
+                            the corresponding weight.
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field. null selector
+                                and null or empty namespaces list means "this pod's
+                                namespace". An empty selector ({}) matches all namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector. null or
+                                empty namespaces list and null namespaceSelector means
+                                "this pod's namespace".
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        weight:
+                          description: weight associated with matching the corresponding
+                            podAffinityTerm, in the range 1-100.
+                          format: int32
+                          type: integer
+                      required:
+                      - weight
+                      - podAffinityTerm
+                      type: object
+                    type: array
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    description: If the affinity requirements specified by this field
+                      are not met at scheduling time, the pod will not be scheduled
+                      onto the node. If the affinity requirements specified by this
+                      field cease to be met at some point during pod execution (e.g.
+                      due to a pod label update), the system may or may not try to
+                      eventually evict the pod from its node. When there are multiple
+                      elements, the lists of nodes corresponding to each podAffinityTerm
+                      are intersected, i.e. all terms must be satisfied.
+                    items:
+                      description: Defines a set of pods (namely those matching the
+                        labelSelector relative to the given namespace(s)) that this
+                        pod should be co-located (affinity) or not co-located (anti-affinity)
+                        with, where co-located is defined as running on a node whose
+                        value of the label with key <topologyKey> matches that of
+                        any node on which a pod of the set of pods is running
+                      properties:
+                        labelSelector:
+                          description: A label query over a set of resources, in this
+                            case pods.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        namespaceSelector:
+                          description: A label query over the set of namespaces that
+                            the term applies to. The term is applied to the union
+                            of the namespaces selected by this field and the ones
+                            listed in the namespaces field. null selector and null
+                            or empty namespaces list means "this pod's namespace".
+                            An empty selector ({}) matches all namespaces.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        namespaces:
+                          description: namespaces specifies a static list of namespace
+                            names that the term applies to. The term is applied to
+                            the union of the namespaces listed in this field and the
+                            ones selected by namespaceSelector. null or empty namespaces
+                            list and null namespaceSelector means "this pod's namespace".
+                          items:
+                            type: string
+                          type: array
+                        topologyKey:
+                          description: This pod should be co-located (affinity) or
+                            not co-located (anti-affinity) with the pods matching
+                            the labelSelector in the specified namespaces, where co-located
+                            is defined as running on a node whose value of the label
+                            with key topologyKey matches that of any node on which
+                            any of the selected pods is running. Empty topologyKey
+                            is not allowed.
+                          type: string
+                      required:
+                      - topologyKey
+                      type: object
+                    type: array
+                type: object
+              podAntiAffinity:
+                description: Describes pod anti-affinity scheduling rules (e.g. avoid
+                  putting this pod in the same node, zone, etc. as some other pod(s)).
+                properties:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    description: The scheduler will prefer to schedule pods to nodes
+                      that satisfy the anti-affinity expressions specified by this
+                      field, but it may choose a node that violates one or more of
+                      the expressions. The node that is most preferred is the one
+                      with the greatest sum of weights, i.e. for each node that meets
+                      all of the scheduling requirements (resource request, requiredDuringScheduling
+                      anti-affinity expressions, etc.), compute a sum by iterating
+                      through the elements of this field and adding "weight" to the
+                      sum if the node has pods which matches the corresponding podAffinityTerm;
+                      the node(s) with the highest sum are the most preferred.
+                    items:
+                      description: The weights of all of the matched WeightedPodAffinityTerm
+                        fields are added per-node to find the most preferred node(s)
+                      properties:
+                        podAffinityTerm:
+                          description: Required. A pod affinity term, associated with
+                            the corresponding weight.
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field. null selector
+                                and null or empty namespaces list means "this pod's
+                                namespace". An empty selector ({}) matches all namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector. null or
+                                empty namespaces list and null namespaceSelector means
+                                "this pod's namespace".
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        weight:
+                          description: weight associated with matching the corresponding
+                            podAffinityTerm, in the range 1-100.
+                          format: int32
+                          type: integer
+                      required:
+                      - weight
+                      - podAffinityTerm
+                      type: object
+                    type: array
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    description: If the anti-affinity requirements specified by this
+                      field are not met at scheduling time, the pod will not be scheduled
+                      onto the node. If the anti-affinity requirements specified by
+                      this field cease to be met at some point during pod execution
+                      (e.g. due to a pod label update), the system may or may not
+                      try to eventually evict the pod from its node. When there are
+                      multiple elements, the lists of nodes corresponding to each
+                      podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                    items:
+                      description: Defines a set of pods (namely those matching the
+                        labelSelector relative to the given namespace(s)) that this
+                        pod should be co-located (affinity) or not co-located (anti-affinity)
+                        with, where co-located is defined as running on a node whose
+                        value of the label with key <topologyKey> matches that of
+                        any node on which a pod of the set of pods is running
+                      properties:
+                        labelSelector:
+                          description: A label query over a set of resources, in this
+                            case pods.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        namespaceSelector:
+                          description: A label query over the set of namespaces that
+                            the term applies to. The term is applied to the union
+                            of the namespaces selected by this field and the ones
+                            listed in the namespaces field. null selector and null
+                            or empty namespaces list means "this pod's namespace".
+                            An empty selector ({}) matches all namespaces.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        namespaces:
+                          description: namespaces specifies a static list of namespace
+                            names that the term applies to. The term is applied to
+                            the union of the namespaces listed in this field and the
+                            ones selected by namespaceSelector. null or empty namespaces
+                            list and null namespaceSelector means "this pod's namespace".
+                          items:
+                            type: string
+                          type: array
+                        topologyKey:
+                          description: This pod should be co-located (affinity) or
+                            not co-located (anti-affinity) with the pods matching
+                            the labelSelector in the specified namespaces, where co-located
+                            is defined as running on a node whose value of the label
+                            with key topologyKey matches that of any node on which
+                            any of the selected pods is running. Empty topologyKey
+                            is not allowed.
+                          type: string
+                      required:
+                      - topologyKey
+                      type: object
+                    type: array
+                type: object
+            type: object
+          automountServiceAccountToken:
+            description: AutomountServiceAccountToken indicates whether a service
+              account token should be automatically mounted.
+            type: boolean
+          containers:
+            description: List of containers belonging to the pod. Containers cannot
+              currently be added or removed. There must be at least one container
+              in a Pod. Cannot be updated.
+            items:
+              description: A single application container that you want to run within
+                a pod.
+              properties:
+                args:
+                  description: 'Arguments to the entrypoint. The container image''s
+                    CMD is used if this is not provided. Variable references $(VAR_NAME)
+                    are expanded using the container''s environment. If a variable
+                    cannot be resolved, the reference in the input string will be
+                    unchanged. Double $$ are reduced to a single $, which allows for
+                    escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                    the string literal "$(VAR_NAME)". Escaped references will never
+                    be expanded, regardless of whether the variable exists or not.
+                    Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                command:
+                  description: 'Entrypoint array. Not executed within a shell. The
+                    container image''s ENTRYPOINT is used if this is not provided.
+                    Variable references $(VAR_NAME) are expanded using the container''s
+                    environment. If a variable cannot be resolved, the reference in
+                    the input string will be unchanged. Double $$ are reduced to a
+                    single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                    Escaped references will never be expanded, regardless of whether
+                    the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                env:
+                  description: List of environment variables to set in the container.
+                    Cannot be updated.
+                  items:
+                    description: EnvVar represents an environment variable present
+                      in a Container.
+                    properties:
+                      name:
+                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        type: string
+                      value:
+                        description: 'Variable references $(VAR_NAME) are expanded
+                          using the previously defined environment variables in the
+                          container and any service environment variables. If a variable
+                          cannot be resolved, the reference in the input string will
+                          be unchanged. Double $$ are reduced to a single $, which
+                          allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                          will produce the string literal "$(VAR_NAME)". Escaped references
+                          will never be expanded, regardless of whether the variable
+                          exists or not. Defaults to "".'
+                        type: string
+                      valueFrom:
+                        description: Source for the environment variable's value.
+                          Cannot be used if value is not empty.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          fieldRef:
+                            description: 'Selects a field of the pod: supports metadata.name,
+                              metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                              spec.nodeName, spec.serviceAccountName, status.hostIP,
+                              status.podIP, status.podIPs.'
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                            - fieldPath
+                            type: object
+                          resourceFieldRef:
+                            description: 'Selects a resource of the container: only
+                              resources limits and requests (limits.cpu, limits.memory,
+                              limits.ephemeral-storage, requests.cpu, requests.memory
+                              and requests.ephemeral-storage) are currently supported.'
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Specifies the output format of the exposed
+                                  resources, defaults to "1"
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                            - resource
+                            type: object
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - name
+                  x-kubernetes-list-type: map
+                envFrom:
+                  description: List of sources to populate environment variables in
+                    the container. The keys defined within a source must be a C_IDENTIFIER.
+                    All invalid keys will be reported as an event when the container
+                    is starting. When a key exists in multiple sources, the value
+                    associated with the last source will take precedence. Values defined
+                    by an Env with a duplicate key will take precedence. Cannot be
+                    updated.
+                  items:
+                    description: EnvFromSource represents the source of a set of ConfigMaps
+                    properties:
+                      configMapRef:
+                        description: The ConfigMap to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the ConfigMap must be defined
+                            type: boolean
+                        type: object
+                      prefix:
+                        description: An optional identifier to prepend to each key
+                          in the ConfigMap. Must be a C_IDENTIFIER.
+                        type: string
+                      secretRef:
+                        description: The Secret to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret must be defined
+                            type: boolean
+                        type: object
+                    type: object
+                  type: array
+                image:
+                  description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                    This field is optional to allow higher level config management
+                    to default or override container images in workload controllers
+                    like Deployments and StatefulSets.'
+                  type: string
+                imagePullPolicy:
+                  description: |-
+                    Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                    Possible enum values:
+                     - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                     - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                     - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                  type: string
+                lifecycle:
+                  description: Actions that the management system should take in response
+                    to container lifecycle events. Cannot be updated.
+                  properties:
+                    postStart:
+                      description: 'PostStart is called immediately after a container
+                        is created. If the handler fails, the container is terminated
+                        and restarted according to its restart policy. Other management
+                        of the container blocks until the hook completes. More info:
+                        https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: |-
+                                Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                Possible enum values:
+                                 - `"HTTP"` means that the scheme used will be http://
+                                 - `"HTTPS"` means that the scheme used will be https://
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: Deprecated. TCPSocket is NOT supported as a
+                            LifecycleHandler and kept for the backward compatibility.
+                            There are no validation of this field and lifecycle hooks
+                            will fail in runtime when tcp handler is specified.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                    preStop:
+                      description: 'PreStop is called immediately before a container
+                        is terminated due to an API request or management event such
+                        as liveness/startup probe failure, preemption, resource contention,
+                        etc. The handler is not called if the container crashes or
+                        exits. The Pod''s termination grace period countdown begins
+                        before the PreStop hook is executed. Regardless of the outcome
+                        of the handler, the container will eventually terminate within
+                        the Pod''s termination grace period (unless delayed by finalizers).
+                        Other management of the container blocks until the hook completes
+                        or until the termination grace period is reached. More info:
+                        https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: |-
+                                Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                Possible enum values:
+                                 - `"HTTP"` means that the scheme used will be http://
+                                 - `"HTTPS"` means that the scheme used will be https://
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: Deprecated. TCPSocket is NOT supported as a
+                            LifecycleHandler and kept for the backward compatibility.
+                            There are no validation of this field and lifecycle hooks
+                            will fail in runtime when tcp handler is specified.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                  type: object
+                livenessProbe:
+                  description: 'Periodic probe of container liveness. Container will
+                    be restarted if the probe fails. Cannot be updated. More info:
+                    https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                name:
+                  description: Name of the container specified as a DNS_LABEL. Each
+                    container in a pod must have a unique name (DNS_LABEL). Cannot
+                    be updated.
+                  type: string
+                ports:
+                  description: List of ports to expose from the container. Not specifying
+                    a port here DOES NOT prevent that port from being exposed. Any
+                    port which is listening on the default "0.0.0.0" address inside
+                    a container will be accessible from the network. Modifying this
+                    array with strategic merge patch may corrupt the data. For more
+                    information See https://github.com/kubernetes/kubernetes/issues/108255.
+                    Cannot be updated.
+                  items:
+                    description: ContainerPort represents a network port in a single
+                      container.
+                    properties:
+                      containerPort:
+                        description: Number of port to expose on the pod's IP address.
+                          This must be a valid port number, 0 < x < 65536.
+                        format: int32
+                        type: integer
+                      hostIP:
+                        description: What host IP to bind the external port to.
+                        type: string
+                      hostPort:
+                        description: Number of port to expose on the host. If specified,
+                          this must be a valid port number, 0 < x < 65536. If HostNetwork
+                          is specified, this must match ContainerPort. Most containers
+                          do not need this.
+                        format: int32
+                        type: integer
+                      name:
+                        description: If specified, this must be an IANA_SVC_NAME and
+                          unique within the pod. Each named port in a pod must have
+                          a unique name. Name for the port that can be referred to
+                          by services.
+                        type: string
+                      protocol:
+                        default: TCP
+                        description: |-
+                          Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                          Possible enum values:
+                           - `"SCTP"` is the SCTP protocol.
+                           - `"TCP"` is the TCP protocol.
+                           - `"UDP"` is the UDP protocol.
+                        type: string
+                    required:
+                    - containerPort
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - containerPort
+                  - protocol
+                  x-kubernetes-list-type: map
+                readinessProbe:
+                  description: 'Periodic probe of container service readiness. Container
+                    will be removed from service endpoints if the probe fails. Cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                resources:
+                  description: 'Compute Resources required by this container. Cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                  type: object
+                securityContext:
+                  description: 'SecurityContext defines the security options the container
+                    should be run with. If set, the fields of SecurityContext override
+                    the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                  properties:
+                    allowPrivilegeEscalation:
+                      description: 'AllowPrivilegeEscalation controls whether a process
+                        can gain more privileges than its parent process. This bool
+                        directly controls if the no_new_privs flag will be set on
+                        the container process. AllowPrivilegeEscalation is true always
+                        when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
+                        Note that this field cannot be set when spec.os.name is windows.'
+                      type: boolean
+                    capabilities:
+                      description: The capabilities to add/drop when running containers.
+                        Defaults to the default set of capabilities granted by the
+                        container runtime. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      properties:
+                        add:
+                          description: Added capabilities
+                          items:
+                            type: string
+                          type: array
+                        drop:
+                          description: Removed capabilities
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    privileged:
+                      description: Run container in privileged mode. Processes in
+                        privileged containers are essentially equivalent to root on
+                        the host. Defaults to false. Note that this field cannot be
+                        set when spec.os.name is windows.
+                      type: boolean
+                    procMount:
+                      description: procMount denotes the type of proc mount to use
+                        for the containers. The default is DefaultProcMount which
+                        uses the container runtime defaults for readonly paths and
+                        masked paths. This requires the ProcMountType feature flag
+                        to be enabled. Note that this field cannot be set when spec.os.name
+                        is windows.
+                      type: string
+                    readOnlyRootFilesystem:
+                      description: Whether this container has a read-only root filesystem.
+                        Default is false. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      type: boolean
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container
+                        process. Uses runtime default if unset. May also be set in
+                        PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence. Note
+                        that this field cannot be set when spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to
+                        start the container if it does. If unset or false, no such
+                        validation will be performed. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container
+                        process. Defaults to user specified in image metadata if unspecified.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: The SELinux context to be applied to the container.
+                        If unspecified, the container runtime will allocate a random
+                        SELinux context for each container.  May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence. Note that this
+                        field cannot be set when spec.os.name is windows.
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
+                      type: object
+                    seccompProfile:
+                      description: The seccomp options to use by this container. If
+                        seccomp options are provided at both the pod & container level,
+                        the container options override the pod options. Note that
+                        this field cannot be set when spec.os.name is windows.
+                      properties:
+                        localhostProfile:
+                          description: localhostProfile indicates a profile defined
+                            in a file on the node should be used. The profile must
+                            be preconfigured on the node to work. Must be a descending
+                            path, relative to the kubelet's configured seccomp profile
+                            location. Must only be set if type is "Localhost".
+                          type: string
+                        type:
+                          description: |-
+                            type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                            Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                            Possible enum values:
+                             - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                             - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                             - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    windowsOptions:
+                      description: The Windows specific settings applied to all containers.
+                        If unspecified, the options from the PodSecurityContext will
+                        be used. If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence. Note
+                        that this field cannot be set when spec.os.name is linux.
+                      properties:
+                        gmsaCredentialSpec:
+                          description: GMSACredentialSpec is where the GMSA admission
+                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                            inlines the contents of the GMSA credential spec named
+                            by the GMSACredentialSpecName field.
+                          type: string
+                        gmsaCredentialSpecName:
+                          description: GMSACredentialSpecName is the name of the GMSA
+                            credential spec to use.
+                          type: string
+                        hostProcess:
+                          description: HostProcess determines if a container should
+                            be run as a 'Host Process' container. This field is alpha-level
+                            and will only be honored by components that enable the
+                            WindowsHostProcessContainers feature flag. Setting this
+                            field without the feature flag will result in errors when
+                            validating the Pod. All of a Pod's containers must have
+                            the same effective HostProcess value (it is not allowed
+                            to have a mix of HostProcess containers and non-HostProcess
+                            containers).  In addition, if HostProcess is true then
+                            HostNetwork must also be set to true.
+                          type: boolean
+                        runAsUserName:
+                          description: The UserName in Windows to run the entrypoint
+                            of the container process. Defaults to the user specified
+                            in image metadata if unspecified. May also be set in PodSecurityContext.
+                            If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence.
+                          type: string
+                      type: object
+                  type: object
+                startupProbe:
+                  description: 'StartupProbe indicates that the Pod has successfully
+                    initialized. If specified, no other probes are executed until
+                    this completes successfully. If this probe fails, the Pod will
+                    be restarted, just as if the livenessProbe failed. This can be
+                    used to provide different probe parameters at the beginning of
+                    a Pod''s lifecycle, when it might take a long time to load data
+                    or warm a cache, than during steady-state operation. This cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                stdin:
+                  description: Whether this container should allocate a buffer for
+                    stdin in the container runtime. If this is not set, reads from
+                    stdin in the container will always result in EOF. Default is false.
+                  type: boolean
+                stdinOnce:
+                  description: Whether the container runtime should close the stdin
+                    channel after it has been opened by a single attach. When stdin
+                    is true the stdin stream will remain open across multiple attach
+                    sessions. If stdinOnce is set to true, stdin is opened on container
+                    start, is empty until the first client attaches to stdin, and
+                    then remains open and accepts data until the client disconnects,
+                    at which time stdin is closed and remains closed until the container
+                    is restarted. If this flag is false, a container processes that
+                    reads from stdin will never receive an EOF. Default is false
+                  type: boolean
+                terminationMessagePath:
+                  description: 'Optional: Path at which the file to which the container''s
+                    termination message will be written is mounted into the container''s
+                    filesystem. Message written is intended to be brief final status,
+                    such as an assertion failure message. Will be truncated by the
+                    node if greater than 4096 bytes. The total message length across
+                    all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                    Cannot be updated.'
+                  type: string
+                terminationMessagePolicy:
+                  description: |-
+                    Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                    Possible enum values:
+                     - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                     - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                  type: string
+                tty:
+                  description: Whether this container should allocate a TTY for itself,
+                    also requires 'stdin' to be true. Default is false.
+                  type: boolean
+                volumeDevices:
+                  description: volumeDevices is the list of block devices to be used
+                    by the container.
+                  items:
+                    description: volumeDevice describes a mapping of a raw block device
+                      within a container.
+                    properties:
+                      devicePath:
+                        description: devicePath is the path inside of the container
+                          that the device will be mapped to.
+                        type: string
+                      name:
+                        description: name must match the name of a persistentVolumeClaim
+                          in the pod
+                        type: string
+                    required:
+                    - devicePath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - devicePath
+                  x-kubernetes-list-type: map
+                volumeMounts:
+                  description: Pod volumes to mount into the container's filesystem.
+                    Cannot be updated.
+                  items:
+                    description: VolumeMount describes a mounting of a Volume within
+                      a container.
+                    properties:
+                      mountPath:
+                        description: Path within the container at which the volume
+                          should be mounted.  Must not contain ':'.
+                        type: string
+                      mountPropagation:
+                        description: mountPropagation determines how mounts are propagated
+                          from the host to container and the other way around. When
+                          not set, MountPropagationNone is used. This field is beta
+                          in 1.10.
+                        type: string
+                      name:
+                        description: This must match the Name of a Volume.
+                        type: string
+                      readOnly:
+                        description: Mounted read-only if true, read-write otherwise
+                          (false or unspecified). Defaults to false.
+                        type: boolean
+                      subPath:
+                        description: Path within the volume from which the container's
+                          volume should be mounted. Defaults to "" (volume's root).
+                        type: string
+                      subPathExpr:
+                        description: Expanded path within the volume from which the
+                          container's volume should be mounted. Behaves similarly
+                          to SubPath but environment variable references $(VAR_NAME)
+                          are expanded using the container's environment. Defaults
+                          to "" (volume's root). SubPathExpr and SubPath are mutually
+                          exclusive.
+                        type: string
+                    required:
+                    - mountPath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - mountPath
+                  x-kubernetes-list-type: map
+                workingDir:
+                  description: Container's working directory. If not specified, the
+                    container runtime's default will be used, which might be configured
+                    in the container image. Cannot be updated.
+                  type: string
+              required:
+              - name
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - name
+            x-kubernetes-list-type: map
+          dnsConfig:
+            description: Specifies the DNS parameters of a pod. Parameters specified
+              here will be merged to the generated DNS configuration based on DNSPolicy.
+            properties:
+              nameservers:
+                description: A list of DNS name server IP addresses. This will be
+                  appended to the base nameservers generated from DNSPolicy. Duplicated
+                  nameservers will be removed.
+                items:
+                  type: string
+                type: array
+              options:
+                description: A list of DNS resolver options. This will be merged with
+                  the base options generated from DNSPolicy. Duplicated entries will
+                  be removed. Resolution options given in Options will override those
+                  that appear in the base DNSPolicy.
+                items:
+                  description: PodDNSConfigOption defines DNS resolver options of
+                    a pod.
+                  properties:
+                    name:
+                      description: Required.
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
+              searches:
+                description: A list of DNS search domains for host-name lookup. This
+                  will be appended to the base search paths generated from DNSPolicy.
+                  Duplicated search paths will be removed.
+                items:
+                  type: string
+                type: array
+            type: object
+          dnsPolicy:
+            description: |-
+              Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+
+              Possible enum values:
+               - `"ClusterFirst"` indicates that the pod should use cluster DNS first unless hostNetwork is true, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+               - `"ClusterFirstWithHostNet"` indicates that the pod should use cluster DNS first, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+               - `"Default"` indicates that the pod should use the default (as determined by kubelet) DNS settings.
+               - `"None"` indicates that the pod should use empty DNS settings. DNS parameters such as nameservers and search paths should be defined via DNSConfig.
+            type: string
+          enableServiceLinks:
+            description: 'EnableServiceLinks indicates whether information about services
+              should be injected into pod''s environment variables, matching the syntax
+              of Docker links. Optional: Defaults to true.'
+            type: boolean
+          ephemeralContainers:
+            description: List of ephemeral containers run in this pod. Ephemeral containers
+              may be run in an existing pod to perform user-initiated actions such
+              as debugging. This list cannot be specified when creating a pod, and
+              it cannot be modified by updating the pod spec. In order to add an ephemeral
+              container to an existing pod, use the pod's ephemeralcontainers subresource.
+            items:
+              description: |-
+                An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation.
+
+                To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.
+              properties:
+                args:
+                  description: 'Arguments to the entrypoint. The image''s CMD is used
+                    if this is not provided. Variable references $(VAR_NAME) are expanded
+                    using the container''s environment. If a variable cannot be resolved,
+                    the reference in the input string will be unchanged. Double $$
+                    are reduced to a single $, which allows for escaping the $(VAR_NAME)
+                    syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                    Escaped references will never be expanded, regardless of whether
+                    the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                command:
+                  description: 'Entrypoint array. Not executed within a shell. The
+                    image''s ENTRYPOINT is used if this is not provided. Variable
+                    references $(VAR_NAME) are expanded using the container''s environment.
+                    If a variable cannot be resolved, the reference in the input string
+                    will be unchanged. Double $$ are reduced to a single $, which
+                    allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                    will produce the string literal "$(VAR_NAME)". Escaped references
+                    will never be expanded, regardless of whether the variable exists
+                    or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                env:
+                  description: List of environment variables to set in the container.
+                    Cannot be updated.
+                  items:
+                    description: EnvVar represents an environment variable present
+                      in a Container.
+                    properties:
+                      name:
+                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        type: string
+                      value:
+                        description: 'Variable references $(VAR_NAME) are expanded
+                          using the previously defined environment variables in the
+                          container and any service environment variables. If a variable
+                          cannot be resolved, the reference in the input string will
+                          be unchanged. Double $$ are reduced to a single $, which
+                          allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                          will produce the string literal "$(VAR_NAME)". Escaped references
+                          will never be expanded, regardless of whether the variable
+                          exists or not. Defaults to "".'
+                        type: string
+                      valueFrom:
+                        description: Source for the environment variable's value.
+                          Cannot be used if value is not empty.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          fieldRef:
+                            description: 'Selects a field of the pod: supports metadata.name,
+                              metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                              spec.nodeName, spec.serviceAccountName, status.hostIP,
+                              status.podIP, status.podIPs.'
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                            - fieldPath
+                            type: object
+                          resourceFieldRef:
+                            description: 'Selects a resource of the container: only
+                              resources limits and requests (limits.cpu, limits.memory,
+                              limits.ephemeral-storage, requests.cpu, requests.memory
+                              and requests.ephemeral-storage) are currently supported.'
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Specifies the output format of the exposed
+                                  resources, defaults to "1"
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                            - resource
+                            type: object
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - name
+                  x-kubernetes-list-type: map
+                envFrom:
+                  description: List of sources to populate environment variables in
+                    the container. The keys defined within a source must be a C_IDENTIFIER.
+                    All invalid keys will be reported as an event when the container
+                    is starting. When a key exists in multiple sources, the value
+                    associated with the last source will take precedence. Values defined
+                    by an Env with a duplicate key will take precedence. Cannot be
+                    updated.
+                  items:
+                    description: EnvFromSource represents the source of a set of ConfigMaps
+                    properties:
+                      configMapRef:
+                        description: The ConfigMap to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the ConfigMap must be defined
+                            type: boolean
+                        type: object
+                      prefix:
+                        description: An optional identifier to prepend to each key
+                          in the ConfigMap. Must be a C_IDENTIFIER.
+                        type: string
+                      secretRef:
+                        description: The Secret to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret must be defined
+                            type: boolean
+                        type: object
+                    type: object
+                  type: array
+                image:
+                  description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                  type: string
+                imagePullPolicy:
+                  description: |-
+                    Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                    Possible enum values:
+                     - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                     - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                     - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                  type: string
+                lifecycle:
+                  description: Lifecycle is not allowed for ephemeral containers.
+                  properties:
+                    postStart:
+                      description: 'PostStart is called immediately after a container
+                        is created. If the handler fails, the container is terminated
+                        and restarted according to its restart policy. Other management
+                        of the container blocks until the hook completes. More info:
+                        https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: |-
+                                Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                Possible enum values:
+                                 - `"HTTP"` means that the scheme used will be http://
+                                 - `"HTTPS"` means that the scheme used will be https://
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: Deprecated. TCPSocket is NOT supported as a
+                            LifecycleHandler and kept for the backward compatibility.
+                            There are no validation of this field and lifecycle hooks
+                            will fail in runtime when tcp handler is specified.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                    preStop:
+                      description: 'PreStop is called immediately before a container
+                        is terminated due to an API request or management event such
+                        as liveness/startup probe failure, preemption, resource contention,
+                        etc. The handler is not called if the container crashes or
+                        exits. The Pod''s termination grace period countdown begins
+                        before the PreStop hook is executed. Regardless of the outcome
+                        of the handler, the container will eventually terminate within
+                        the Pod''s termination grace period (unless delayed by finalizers).
+                        Other management of the container blocks until the hook completes
+                        or until the termination grace period is reached. More info:
+                        https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: |-
+                                Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                Possible enum values:
+                                 - `"HTTP"` means that the scheme used will be http://
+                                 - `"HTTPS"` means that the scheme used will be https://
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: Deprecated. TCPSocket is NOT supported as a
+                            LifecycleHandler and kept for the backward compatibility.
+                            There are no validation of this field and lifecycle hooks
+                            will fail in runtime when tcp handler is specified.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                  type: object
+                livenessProbe:
+                  description: Probes are not allowed for ephemeral containers.
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                name:
+                  description: Name of the ephemeral container specified as a DNS_LABEL.
+                    This name must be unique among all containers, init containers
+                    and ephemeral containers.
+                  type: string
+                ports:
+                  description: Ports are not allowed for ephemeral containers.
+                  items:
+                    description: ContainerPort represents a network port in a single
+                      container.
+                    properties:
+                      containerPort:
+                        description: Number of port to expose on the pod's IP address.
+                          This must be a valid port number, 0 < x < 65536.
+                        format: int32
+                        type: integer
+                      hostIP:
+                        description: What host IP to bind the external port to.
+                        type: string
+                      hostPort:
+                        description: Number of port to expose on the host. If specified,
+                          this must be a valid port number, 0 < x < 65536. If HostNetwork
+                          is specified, this must match ContainerPort. Most containers
+                          do not need this.
+                        format: int32
+                        type: integer
+                      name:
+                        description: If specified, this must be an IANA_SVC_NAME and
+                          unique within the pod. Each named port in a pod must have
+                          a unique name. Name for the port that can be referred to
+                          by services.
+                        type: string
+                      protocol:
+                        default: TCP
+                        description: |-
+                          Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                          Possible enum values:
+                           - `"SCTP"` is the SCTP protocol.
+                           - `"TCP"` is the TCP protocol.
+                           - `"UDP"` is the UDP protocol.
+                        type: string
+                    required:
+                    - containerPort
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - containerPort
+                  - protocol
+                  x-kubernetes-list-type: map
+                readinessProbe:
+                  description: Probes are not allowed for ephemeral containers.
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                resources:
+                  description: Resources are not allowed for ephemeral containers.
+                    Ephemeral containers use spare resources already allocated to
+                    the pod.
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                  type: object
+                securityContext:
+                  description: 'Optional: SecurityContext defines the security options
+                    the ephemeral container should be run with. If set, the fields
+                    of SecurityContext override the equivalent fields of PodSecurityContext.'
+                  properties:
+                    allowPrivilegeEscalation:
+                      description: 'AllowPrivilegeEscalation controls whether a process
+                        can gain more privileges than its parent process. This bool
+                        directly controls if the no_new_privs flag will be set on
+                        the container process. AllowPrivilegeEscalation is true always
+                        when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
+                        Note that this field cannot be set when spec.os.name is windows.'
+                      type: boolean
+                    capabilities:
+                      description: The capabilities to add/drop when running containers.
+                        Defaults to the default set of capabilities granted by the
+                        container runtime. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      properties:
+                        add:
+                          description: Added capabilities
+                          items:
+                            type: string
+                          type: array
+                        drop:
+                          description: Removed capabilities
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    privileged:
+                      description: Run container in privileged mode. Processes in
+                        privileged containers are essentially equivalent to root on
+                        the host. Defaults to false. Note that this field cannot be
+                        set when spec.os.name is windows.
+                      type: boolean
+                    procMount:
+                      description: procMount denotes the type of proc mount to use
+                        for the containers. The default is DefaultProcMount which
+                        uses the container runtime defaults for readonly paths and
+                        masked paths. This requires the ProcMountType feature flag
+                        to be enabled. Note that this field cannot be set when spec.os.name
+                        is windows.
+                      type: string
+                    readOnlyRootFilesystem:
+                      description: Whether this container has a read-only root filesystem.
+                        Default is false. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      type: boolean
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container
+                        process. Uses runtime default if unset. May also be set in
+                        PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence. Note
+                        that this field cannot be set when spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to
+                        start the container if it does. If unset or false, no such
+                        validation will be performed. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container
+                        process. Defaults to user specified in image metadata if unspecified.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: The SELinux context to be applied to the container.
+                        If unspecified, the container runtime will allocate a random
+                        SELinux context for each container.  May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence. Note that this
+                        field cannot be set when spec.os.name is windows.
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
+                      type: object
+                    seccompProfile:
+                      description: The seccomp options to use by this container. If
+                        seccomp options are provided at both the pod & container level,
+                        the container options override the pod options. Note that
+                        this field cannot be set when spec.os.name is windows.
+                      properties:
+                        localhostProfile:
+                          description: localhostProfile indicates a profile defined
+                            in a file on the node should be used. The profile must
+                            be preconfigured on the node to work. Must be a descending
+                            path, relative to the kubelet's configured seccomp profile
+                            location. Must only be set if type is "Localhost".
+                          type: string
+                        type:
+                          description: |-
+                            type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                            Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                            Possible enum values:
+                             - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                             - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                             - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    windowsOptions:
+                      description: The Windows specific settings applied to all containers.
+                        If unspecified, the options from the PodSecurityContext will
+                        be used. If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence. Note
+                        that this field cannot be set when spec.os.name is linux.
+                      properties:
+                        gmsaCredentialSpec:
+                          description: GMSACredentialSpec is where the GMSA admission
+                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                            inlines the contents of the GMSA credential spec named
+                            by the GMSACredentialSpecName field.
+                          type: string
+                        gmsaCredentialSpecName:
+                          description: GMSACredentialSpecName is the name of the GMSA
+                            credential spec to use.
+                          type: string
+                        hostProcess:
+                          description: HostProcess determines if a container should
+                            be run as a 'Host Process' container. This field is alpha-level
+                            and will only be honored by components that enable the
+                            WindowsHostProcessContainers feature flag. Setting this
+                            field without the feature flag will result in errors when
+                            validating the Pod. All of a Pod's containers must have
+                            the same effective HostProcess value (it is not allowed
+                            to have a mix of HostProcess containers and non-HostProcess
+                            containers).  In addition, if HostProcess is true then
+                            HostNetwork must also be set to true.
+                          type: boolean
+                        runAsUserName:
+                          description: The UserName in Windows to run the entrypoint
+                            of the container process. Defaults to the user specified
+                            in image metadata if unspecified. May also be set in PodSecurityContext.
+                            If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence.
+                          type: string
+                      type: object
+                  type: object
+                startupProbe:
+                  description: Probes are not allowed for ephemeral containers.
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                stdin:
+                  description: Whether this container should allocate a buffer for
+                    stdin in the container runtime. If this is not set, reads from
+                    stdin in the container will always result in EOF. Default is false.
+                  type: boolean
+                stdinOnce:
+                  description: Whether the container runtime should close the stdin
+                    channel after it has been opened by a single attach. When stdin
+                    is true the stdin stream will remain open across multiple attach
+                    sessions. If stdinOnce is set to true, stdin is opened on container
+                    start, is empty until the first client attaches to stdin, and
+                    then remains open and accepts data until the client disconnects,
+                    at which time stdin is closed and remains closed until the container
+                    is restarted. If this flag is false, a container processes that
+                    reads from stdin will never receive an EOF. Default is false
+                  type: boolean
+                targetContainerName:
+                  description: |-
+                    If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+                    The container runtime must implement support for this feature. If the runtime does not support namespace targeting then the result of setting this field is undefined.
+                  type: string
+                terminationMessagePath:
+                  description: 'Optional: Path at which the file to which the container''s
+                    termination message will be written is mounted into the container''s
+                    filesystem. Message written is intended to be brief final status,
+                    such as an assertion failure message. Will be truncated by the
+                    node if greater than 4096 bytes. The total message length across
+                    all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                    Cannot be updated.'
+                  type: string
+                terminationMessagePolicy:
+                  description: |-
+                    Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                    Possible enum values:
+                     - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                     - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                  type: string
+                tty:
+                  description: Whether this container should allocate a TTY for itself,
+                    also requires 'stdin' to be true. Default is false.
+                  type: boolean
+                volumeDevices:
+                  description: volumeDevices is the list of block devices to be used
+                    by the container.
+                  items:
+                    description: volumeDevice describes a mapping of a raw block device
+                      within a container.
+                    properties:
+                      devicePath:
+                        description: devicePath is the path inside of the container
+                          that the device will be mapped to.
+                        type: string
+                      name:
+                        description: name must match the name of a persistentVolumeClaim
+                          in the pod
+                        type: string
+                    required:
+                    - devicePath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - devicePath
+                  x-kubernetes-list-type: map
+                volumeMounts:
+                  description: Pod volumes to mount into the container's filesystem.
+                    Subpath mounts are not allowed for ephemeral containers. Cannot
+                    be updated.
+                  items:
+                    description: VolumeMount describes a mounting of a Volume within
+                      a container.
+                    properties:
+                      mountPath:
+                        description: Path within the container at which the volume
+                          should be mounted.  Must not contain ':'.
+                        type: string
+                      mountPropagation:
+                        description: mountPropagation determines how mounts are propagated
+                          from the host to container and the other way around. When
+                          not set, MountPropagationNone is used. This field is beta
+                          in 1.10.
+                        type: string
+                      name:
+                        description: This must match the Name of a Volume.
+                        type: string
+                      readOnly:
+                        description: Mounted read-only if true, read-write otherwise
+                          (false or unspecified). Defaults to false.
+                        type: boolean
+                      subPath:
+                        description: Path within the volume from which the container's
+                          volume should be mounted. Defaults to "" (volume's root).
+                        type: string
+                      subPathExpr:
+                        description: Expanded path within the volume from which the
+                          container's volume should be mounted. Behaves similarly
+                          to SubPath but environment variable references $(VAR_NAME)
+                          are expanded using the container's environment. Defaults
+                          to "" (volume's root). SubPathExpr and SubPath are mutually
+                          exclusive.
+                        type: string
+                    required:
+                    - mountPath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - mountPath
+                  x-kubernetes-list-type: map
+                workingDir:
+                  description: Container's working directory. If not specified, the
+                    container runtime's default will be used, which might be configured
+                    in the container image. Cannot be updated.
+                  type: string
+              required:
+              - name
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - name
+            x-kubernetes-list-type: map
+          hostAliases:
+            description: HostAliases is an optional list of hosts and IPs that will
+              be injected into the pod's hosts file if specified. This is only valid
+              for non-hostNetwork pods.
+            items:
+              description: HostAlias holds the mapping between IP and hostnames that
+                will be injected as an entry in the pod's hosts file.
+              properties:
+                hostnames:
+                  description: Hostnames for the above IP address.
+                  items:
+                    type: string
+                  type: array
+                ip:
+                  description: IP address of the host file entry.
+                  type: string
+              required:
+              - ip
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - ip
+            x-kubernetes-list-type: map
+          hostIPC:
+            description: 'Use the host''s ipc namespace. Optional: Default to false.'
+            type: boolean
+          hostNetwork:
+            description: Host networking requested for this pod. Use the host's network
+              namespace. If this option is set, the ports that will be used must be
+              specified. Default to false.
+            type: boolean
+          hostPID:
+            description: 'Use the host''s pid namespace. Optional: Default to false.'
+            type: boolean
+          hostUsers:
+            description: 'Use the host''s user namespace. Optional: Default to true.
+              If set to true or not present, the pod will be run in the host user
+              namespace, useful for when the pod needs a feature only available to
+              the host user namespace, such as loading a kernel module with CAP_SYS_MODULE.
+              When set to false, a new userns is created for the pod. Setting false
+              is useful for mitigating container breakout vulnerabilities even allowing
+              users to run their containers as root without actually having root privileges
+              on the host. This field is alpha-level and is only honored by servers
+              that enable the UserNamespacesSupport feature.'
+            type: boolean
+          hostname:
+            description: Specifies the hostname of the Pod If not specified, the pod's
+              hostname will be set to a system-defined value.
+            type: string
+          imagePullSecrets:
+            description: 'ImagePullSecrets is an optional list of references to secrets
+              in the same namespace to use for pulling any of the images used by this
+              PodSpec. If specified, these secrets will be passed to individual puller
+              implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+            items:
+              description: LocalObjectReference contains enough information to let
+                you locate the referenced object inside the same namespace.
+              properties:
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+              required:
+              - name
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - name
+            x-kubernetes-list-type: map
+          initContainers:
+            description: 'List of initialization containers belonging to the pod.
+              Init containers are executed in order prior to containers being started.
+              If any init container fails, the pod is considered to have failed and
+              is handled according to its restartPolicy. The name for an init container
+              or normal container must be unique among all containers. Init containers
+              may not have Lifecycle actions, Readiness probes, Liveness probes, or
+              Startup probes. The resourceRequirements of an init container are taken
+              into account during scheduling by finding the highest request/limit
+              for each resource type, and then using the max of of that value or the
+              sum of the normal containers. Limits are applied to init containers
+              in a similar fashion. Init containers cannot currently be added or removed.
+              Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+            items:
+              description: A single application container that you want to run within
+                a pod.
+              properties:
+                args:
+                  description: 'Arguments to the entrypoint. The container image''s
+                    CMD is used if this is not provided. Variable references $(VAR_NAME)
+                    are expanded using the container''s environment. If a variable
+                    cannot be resolved, the reference in the input string will be
+                    unchanged. Double $$ are reduced to a single $, which allows for
+                    escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                    the string literal "$(VAR_NAME)". Escaped references will never
+                    be expanded, regardless of whether the variable exists or not.
+                    Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                command:
+                  description: 'Entrypoint array. Not executed within a shell. The
+                    container image''s ENTRYPOINT is used if this is not provided.
+                    Variable references $(VAR_NAME) are expanded using the container''s
+                    environment. If a variable cannot be resolved, the reference in
+                    the input string will be unchanged. Double $$ are reduced to a
+                    single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                    Escaped references will never be expanded, regardless of whether
+                    the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                env:
+                  description: List of environment variables to set in the container.
+                    Cannot be updated.
+                  items:
+                    description: EnvVar represents an environment variable present
+                      in a Container.
+                    properties:
+                      name:
+                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        type: string
+                      value:
+                        description: 'Variable references $(VAR_NAME) are expanded
+                          using the previously defined environment variables in the
+                          container and any service environment variables. If a variable
+                          cannot be resolved, the reference in the input string will
+                          be unchanged. Double $$ are reduced to a single $, which
+                          allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                          will produce the string literal "$(VAR_NAME)". Escaped references
+                          will never be expanded, regardless of whether the variable
+                          exists or not. Defaults to "".'
+                        type: string
+                      valueFrom:
+                        description: Source for the environment variable's value.
+                          Cannot be used if value is not empty.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          fieldRef:
+                            description: 'Selects a field of the pod: supports metadata.name,
+                              metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                              spec.nodeName, spec.serviceAccountName, status.hostIP,
+                              status.podIP, status.podIPs.'
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                            - fieldPath
+                            type: object
+                          resourceFieldRef:
+                            description: 'Selects a resource of the container: only
+                              resources limits and requests (limits.cpu, limits.memory,
+                              limits.ephemeral-storage, requests.cpu, requests.memory
+                              and requests.ephemeral-storage) are currently supported.'
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Specifies the output format of the exposed
+                                  resources, defaults to "1"
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                            - resource
+                            type: object
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - name
+                  x-kubernetes-list-type: map
+                envFrom:
+                  description: List of sources to populate environment variables in
+                    the container. The keys defined within a source must be a C_IDENTIFIER.
+                    All invalid keys will be reported as an event when the container
+                    is starting. When a key exists in multiple sources, the value
+                    associated with the last source will take precedence. Values defined
+                    by an Env with a duplicate key will take precedence. Cannot be
+                    updated.
+                  items:
+                    description: EnvFromSource represents the source of a set of ConfigMaps
+                    properties:
+                      configMapRef:
+                        description: The ConfigMap to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the ConfigMap must be defined
+                            type: boolean
+                        type: object
+                      prefix:
+                        description: An optional identifier to prepend to each key
+                          in the ConfigMap. Must be a C_IDENTIFIER.
+                        type: string
+                      secretRef:
+                        description: The Secret to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret must be defined
+                            type: boolean
+                        type: object
+                    type: object
+                  type: array
+                image:
+                  description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                    This field is optional to allow higher level config management
+                    to default or override container images in workload controllers
+                    like Deployments and StatefulSets.'
+                  type: string
+                imagePullPolicy:
+                  description: |-
+                    Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                    Possible enum values:
+                     - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                     - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                     - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                  type: string
+                lifecycle:
+                  description: Actions that the management system should take in response
+                    to container lifecycle events. Cannot be updated.
+                  properties:
+                    postStart:
+                      description: 'PostStart is called immediately after a container
+                        is created. If the handler fails, the container is terminated
+                        and restarted according to its restart policy. Other management
+                        of the container blocks until the hook completes. More info:
+                        https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: |-
+                                Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                Possible enum values:
+                                 - `"HTTP"` means that the scheme used will be http://
+                                 - `"HTTPS"` means that the scheme used will be https://
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: Deprecated. TCPSocket is NOT supported as a
+                            LifecycleHandler and kept for the backward compatibility.
+                            There are no validation of this field and lifecycle hooks
+                            will fail in runtime when tcp handler is specified.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                    preStop:
+                      description: 'PreStop is called immediately before a container
+                        is terminated due to an API request or management event such
+                        as liveness/startup probe failure, preemption, resource contention,
+                        etc. The handler is not called if the container crashes or
+                        exits. The Pod''s termination grace period countdown begins
+                        before the PreStop hook is executed. Regardless of the outcome
+                        of the handler, the container will eventually terminate within
+                        the Pod''s termination grace period (unless delayed by finalizers).
+                        Other management of the container blocks until the hook completes
+                        or until the termination grace period is reached. More info:
+                        https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: |-
+                                Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                Possible enum values:
+                                 - `"HTTP"` means that the scheme used will be http://
+                                 - `"HTTPS"` means that the scheme used will be https://
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: Deprecated. TCPSocket is NOT supported as a
+                            LifecycleHandler and kept for the backward compatibility.
+                            There are no validation of this field and lifecycle hooks
+                            will fail in runtime when tcp handler is specified.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                  type: object
+                livenessProbe:
+                  description: 'Periodic probe of container liveness. Container will
+                    be restarted if the probe fails. Cannot be updated. More info:
+                    https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                name:
+                  description: Name of the container specified as a DNS_LABEL. Each
+                    container in a pod must have a unique name (DNS_LABEL). Cannot
+                    be updated.
+                  type: string
+                ports:
+                  description: List of ports to expose from the container. Not specifying
+                    a port here DOES NOT prevent that port from being exposed. Any
+                    port which is listening on the default "0.0.0.0" address inside
+                    a container will be accessible from the network. Modifying this
+                    array with strategic merge patch may corrupt the data. For more
+                    information See https://github.com/kubernetes/kubernetes/issues/108255.
+                    Cannot be updated.
+                  items:
+                    description: ContainerPort represents a network port in a single
+                      container.
+                    properties:
+                      containerPort:
+                        description: Number of port to expose on the pod's IP address.
+                          This must be a valid port number, 0 < x < 65536.
+                        format: int32
+                        type: integer
+                      hostIP:
+                        description: What host IP to bind the external port to.
+                        type: string
+                      hostPort:
+                        description: Number of port to expose on the host. If specified,
+                          this must be a valid port number, 0 < x < 65536. If HostNetwork
+                          is specified, this must match ContainerPort. Most containers
+                          do not need this.
+                        format: int32
+                        type: integer
+                      name:
+                        description: If specified, this must be an IANA_SVC_NAME and
+                          unique within the pod. Each named port in a pod must have
+                          a unique name. Name for the port that can be referred to
+                          by services.
+                        type: string
+                      protocol:
+                        default: TCP
+                        description: |-
+                          Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                          Possible enum values:
+                           - `"SCTP"` is the SCTP protocol.
+                           - `"TCP"` is the TCP protocol.
+                           - `"UDP"` is the UDP protocol.
+                        type: string
+                    required:
+                    - containerPort
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - containerPort
+                  - protocol
+                  x-kubernetes-list-type: map
+                readinessProbe:
+                  description: 'Periodic probe of container service readiness. Container
+                    will be removed from service endpoints if the probe fails. Cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                resources:
+                  description: 'Compute Resources required by this container. Cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                  type: object
+                securityContext:
+                  description: 'SecurityContext defines the security options the container
+                    should be run with. If set, the fields of SecurityContext override
+                    the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                  properties:
+                    allowPrivilegeEscalation:
+                      description: 'AllowPrivilegeEscalation controls whether a process
+                        can gain more privileges than its parent process. This bool
+                        directly controls if the no_new_privs flag will be set on
+                        the container process. AllowPrivilegeEscalation is true always
+                        when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
+                        Note that this field cannot be set when spec.os.name is windows.'
+                      type: boolean
+                    capabilities:
+                      description: The capabilities to add/drop when running containers.
+                        Defaults to the default set of capabilities granted by the
+                        container runtime. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      properties:
+                        add:
+                          description: Added capabilities
+                          items:
+                            type: string
+                          type: array
+                        drop:
+                          description: Removed capabilities
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    privileged:
+                      description: Run container in privileged mode. Processes in
+                        privileged containers are essentially equivalent to root on
+                        the host. Defaults to false. Note that this field cannot be
+                        set when spec.os.name is windows.
+                      type: boolean
+                    procMount:
+                      description: procMount denotes the type of proc mount to use
+                        for the containers. The default is DefaultProcMount which
+                        uses the container runtime defaults for readonly paths and
+                        masked paths. This requires the ProcMountType feature flag
+                        to be enabled. Note that this field cannot be set when spec.os.name
+                        is windows.
+                      type: string
+                    readOnlyRootFilesystem:
+                      description: Whether this container has a read-only root filesystem.
+                        Default is false. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      type: boolean
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container
+                        process. Uses runtime default if unset. May also be set in
+                        PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence. Note
+                        that this field cannot be set when spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to
+                        start the container if it does. If unset or false, no such
+                        validation will be performed. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container
+                        process. Defaults to user specified in image metadata if unspecified.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: The SELinux context to be applied to the container.
+                        If unspecified, the container runtime will allocate a random
+                        SELinux context for each container.  May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence. Note that this
+                        field cannot be set when spec.os.name is windows.
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
+                      type: object
+                    seccompProfile:
+                      description: The seccomp options to use by this container. If
+                        seccomp options are provided at both the pod & container level,
+                        the container options override the pod options. Note that
+                        this field cannot be set when spec.os.name is windows.
+                      properties:
+                        localhostProfile:
+                          description: localhostProfile indicates a profile defined
+                            in a file on the node should be used. The profile must
+                            be preconfigured on the node to work. Must be a descending
+                            path, relative to the kubelet's configured seccomp profile
+                            location. Must only be set if type is "Localhost".
+                          type: string
+                        type:
+                          description: |-
+                            type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                            Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                            Possible enum values:
+                             - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                             - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                             - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    windowsOptions:
+                      description: The Windows specific settings applied to all containers.
+                        If unspecified, the options from the PodSecurityContext will
+                        be used. If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence. Note
+                        that this field cannot be set when spec.os.name is linux.
+                      properties:
+                        gmsaCredentialSpec:
+                          description: GMSACredentialSpec is where the GMSA admission
+                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                            inlines the contents of the GMSA credential spec named
+                            by the GMSACredentialSpecName field.
+                          type: string
+                        gmsaCredentialSpecName:
+                          description: GMSACredentialSpecName is the name of the GMSA
+                            credential spec to use.
+                          type: string
+                        hostProcess:
+                          description: HostProcess determines if a container should
+                            be run as a 'Host Process' container. This field is alpha-level
+                            and will only be honored by components that enable the
+                            WindowsHostProcessContainers feature flag. Setting this
+                            field without the feature flag will result in errors when
+                            validating the Pod. All of a Pod's containers must have
+                            the same effective HostProcess value (it is not allowed
+                            to have a mix of HostProcess containers and non-HostProcess
+                            containers).  In addition, if HostProcess is true then
+                            HostNetwork must also be set to true.
+                          type: boolean
+                        runAsUserName:
+                          description: The UserName in Windows to run the entrypoint
+                            of the container process. Defaults to the user specified
+                            in image metadata if unspecified. May also be set in PodSecurityContext.
+                            If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence.
+                          type: string
+                      type: object
+                  type: object
+                startupProbe:
+                  description: 'StartupProbe indicates that the Pod has successfully
+                    initialized. If specified, no other probes are executed until
+                    this completes successfully. If this probe fails, the Pod will
+                    be restarted, just as if the livenessProbe failed. This can be
+                    used to provide different probe parameters at the beginning of
+                    a Pod''s lifecycle, when it might take a long time to load data
+                    or warm a cache, than during steady-state operation. This cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  properties:
+                    exec:
+                      description: Exec specifies the action to take.
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies an action involving a GRPC port.
+                        This is a beta field and requires enabling GRPCContainerProbe
+                        feature gate.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                            Possible enum values:
+                             - `"HTTP"` means that the scheme used will be http://
+                             - `"HTTPS"` means that the scheme used will be https://
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies an action involving a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the
+                        expected cleanup time for your process. If this value is nil,
+                        the pod's terminationGracePeriodSeconds will be used. Otherwise,
+                        this value overrides the value provided by the pod spec. Value
+                        must be non-negative integer. The value zero indicates stop
+                        immediately via the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                stdin:
+                  description: Whether this container should allocate a buffer for
+                    stdin in the container runtime. If this is not set, reads from
+                    stdin in the container will always result in EOF. Default is false.
+                  type: boolean
+                stdinOnce:
+                  description: Whether the container runtime should close the stdin
+                    channel after it has been opened by a single attach. When stdin
+                    is true the stdin stream will remain open across multiple attach
+                    sessions. If stdinOnce is set to true, stdin is opened on container
+                    start, is empty until the first client attaches to stdin, and
+                    then remains open and accepts data until the client disconnects,
+                    at which time stdin is closed and remains closed until the container
+                    is restarted. If this flag is false, a container processes that
+                    reads from stdin will never receive an EOF. Default is false
+                  type: boolean
+                terminationMessagePath:
+                  description: 'Optional: Path at which the file to which the container''s
+                    termination message will be written is mounted into the container''s
+                    filesystem. Message written is intended to be brief final status,
+                    such as an assertion failure message. Will be truncated by the
+                    node if greater than 4096 bytes. The total message length across
+                    all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                    Cannot be updated.'
+                  type: string
+                terminationMessagePolicy:
+                  description: |-
+                    Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                    Possible enum values:
+                     - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                     - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                  type: string
+                tty:
+                  description: Whether this container should allocate a TTY for itself,
+                    also requires 'stdin' to be true. Default is false.
+                  type: boolean
+                volumeDevices:
+                  description: volumeDevices is the list of block devices to be used
+                    by the container.
+                  items:
+                    description: volumeDevice describes a mapping of a raw block device
+                      within a container.
+                    properties:
+                      devicePath:
+                        description: devicePath is the path inside of the container
+                          that the device will be mapped to.
+                        type: string
+                      name:
+                        description: name must match the name of a persistentVolumeClaim
+                          in the pod
+                        type: string
+                    required:
+                    - devicePath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - devicePath
+                  x-kubernetes-list-type: map
+                volumeMounts:
+                  description: Pod volumes to mount into the container's filesystem.
+                    Cannot be updated.
+                  items:
+                    description: VolumeMount describes a mounting of a Volume within
+                      a container.
+                    properties:
+                      mountPath:
+                        description: Path within the container at which the volume
+                          should be mounted.  Must not contain ':'.
+                        type: string
+                      mountPropagation:
+                        description: mountPropagation determines how mounts are propagated
+                          from the host to container and the other way around. When
+                          not set, MountPropagationNone is used. This field is beta
+                          in 1.10.
+                        type: string
+                      name:
+                        description: This must match the Name of a Volume.
+                        type: string
+                      readOnly:
+                        description: Mounted read-only if true, read-write otherwise
+                          (false or unspecified). Defaults to false.
+                        type: boolean
+                      subPath:
+                        description: Path within the volume from which the container's
+                          volume should be mounted. Defaults to "" (volume's root).
+                        type: string
+                      subPathExpr:
+                        description: Expanded path within the volume from which the
+                          container's volume should be mounted. Behaves similarly
+                          to SubPath but environment variable references $(VAR_NAME)
+                          are expanded using the container's environment. Defaults
+                          to "" (volume's root). SubPathExpr and SubPath are mutually
+                          exclusive.
+                        type: string
+                    required:
+                    - mountPath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - mountPath
+                  x-kubernetes-list-type: map
+                workingDir:
+                  description: Container's working directory. If not specified, the
+                    container runtime's default will be used, which might be configured
+                    in the container image. Cannot be updated.
+                  type: string
+              required:
+              - name
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - name
+            x-kubernetes-list-type: map
+          nodeName:
+            description: NodeName is a request to schedule this pod onto a specific
+              node. If it is non-empty, the scheduler simply schedules this pod onto
+              that node, assuming that it fits resource requirements.
+            type: string
+          nodeSelector:
+            additionalProperties:
+              type: string
+            description: 'NodeSelector is a selector which must be true for the pod
+              to fit on a node. Selector which must match a node''s labels for the
+              pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+            type: object
+          os:
+            description: |-
+              Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set.
+
+              If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions
+
+              If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup
+            properties:
+              name:
+                description: 'Name is the name of the operating system. The currently
+                  supported values are linux and windows. Additional value may be
+                  defined in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                  Clients should expect to handle additional values and treat unrecognized
+                  values in this field as os: null'
+                type: string
+            required:
+            - name
+            type: object
+          overhead:
+            additionalProperties:
+              anyOf:
+              - type: integer
+              - type: string
+              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+              x-kubernetes-int-or-string: true
+            description: 'Overhead represents the resource overhead associated with
+              running a pod for a given RuntimeClass. This field will be autopopulated
+              at admission time by the RuntimeClass admission controller. If the RuntimeClass
+              admission controller is enabled, overhead must not be set in Pod create
+              requests. The RuntimeClass admission controller will reject Pod create
+              requests which have the overhead already set. If RuntimeClass is configured
+              and selected in the PodSpec, Overhead will be set to the value defined
+              in the corresponding RuntimeClass, otherwise it will remain unset and
+              treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
+            type: object
+          preemptionPolicy:
+            description: PreemptionPolicy is the Policy for preempting pods with lower
+              priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority
+              if unset.
+            type: string
+          priority:
+            description: The priority value. Various system components use this field
+              to find the priority of the pod. When Priority Admission Controller
+              is enabled, it prevents users from setting this field. The admission
+              controller populates this field from PriorityClassName. The higher the
+              value, the higher the priority.
+            format: int32
+            type: integer
+          priorityClassName:
+            description: If specified, indicates the pod's priority. "system-node-critical"
+              and "system-cluster-critical" are two special keywords which indicate
+              the highest priorities with the former being the highest priority. Any
+              other name must be defined by creating a PriorityClass object with that
+              name. If not specified, the pod priority will be default or zero if
+              there is no default.
+            type: string
+          readinessGates:
+            description: 'If specified, all readiness gates will be evaluated for
+              pod readiness. A pod is ready when all its containers are ready AND
+              all conditions specified in the readiness gates have status equal to
+              "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
+            items:
+              description: PodReadinessGate contains the reference to a pod condition
+              properties:
+                conditionType:
+                  description: ConditionType refers to a condition in the pod's condition
+                    list with matching type.
+                  type: string
+              required:
+              - conditionType
+              type: object
+            type: array
+          restartPolicy:
+            description: |-
+              Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+
+              Possible enum values:
+               - `"Always"`
+               - `"Never"`
+               - `"OnFailure"`
+            type: string
+          runtimeClassName:
+            description: 'RuntimeClassName refers to a RuntimeClass object in the
+              node.k8s.io group, which should be used to run this pod.  If no RuntimeClass
+              resource matches the named class, the pod will not be run. If unset
+              or empty, the "legacy" RuntimeClass will be used, which is an implicit
+              class with an empty definition that uses the default runtime handler.
+              More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
+            type: string
+          schedulerName:
+            description: If specified, the pod will be dispatched by specified scheduler.
+              If not specified, the pod will be dispatched by default scheduler.
+            type: string
+          securityContext:
+            description: 'SecurityContext holds pod-level security attributes and
+              common container settings. Optional: Defaults to empty.  See type description
+              for default values of each field.'
+            properties:
+              fsGroup:
+                description: |-
+                  A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
+                  1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
+                  If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.
+                format: int64
+                type: integer
+              fsGroupChangePolicy:
+                description: 'fsGroupChangePolicy defines behavior of changing ownership
+                  and permission of the volume before being exposed inside Pod. This
+                  field will only apply to volume types which support fsGroup based
+                  ownership(and permissions). It will have no effect on ephemeral
+                  volume types such as: secret, configmaps and emptydir. Valid values
+                  are "OnRootMismatch" and "Always". If not specified, "Always" is
+                  used. Note that this field cannot be set when spec.os.name is windows.'
+                type: string
+              runAsGroup:
+                description: The GID to run the entrypoint of the container process.
+                  Uses runtime default if unset. May also be set in SecurityContext.  If
+                  set in both SecurityContext and PodSecurityContext, the value specified
+                  in SecurityContext takes precedence for that container. Note that
+                  this field cannot be set when spec.os.name is windows.
+                format: int64
+                type: integer
+              runAsNonRoot:
+                description: Indicates that the container must run as a non-root user.
+                  If true, the Kubelet will validate the image at runtime to ensure
+                  that it does not run as UID 0 (root) and fail to start the container
+                  if it does. If unset or false, no such validation will be performed.
+                  May also be set in SecurityContext.  If set in both SecurityContext
+                  and PodSecurityContext, the value specified in SecurityContext takes
+                  precedence.
+                type: boolean
+              runAsUser:
+                description: The UID to run the entrypoint of the container process.
+                  Defaults to user specified in image metadata if unspecified. May
+                  also be set in SecurityContext.  If set in both SecurityContext
+                  and PodSecurityContext, the value specified in SecurityContext takes
+                  precedence for that container. Note that this field cannot be set
+                  when spec.os.name is windows.
+                format: int64
+                type: integer
+              seLinuxOptions:
+                description: The SELinux context to be applied to all containers.
+                  If unspecified, the container runtime will allocate a random SELinux
+                  context for each container.  May also be set in SecurityContext.  If
+                  set in both SecurityContext and PodSecurityContext, the value specified
+                  in SecurityContext takes precedence for that container. Note that
+                  this field cannot be set when spec.os.name is windows.
+                properties:
+                  level:
+                    description: Level is SELinux level label that applies to the
+                      container.
+                    type: string
+                  role:
+                    description: Role is a SELinux role label that applies to the
+                      container.
+                    type: string
+                  type:
+                    description: Type is a SELinux type label that applies to the
+                      container.
+                    type: string
+                  user:
+                    description: User is a SELinux user label that applies to the
+                      container.
+                    type: string
+                type: object
+              seccompProfile:
+                description: The seccomp options to use by the containers in this
+                  pod. Note that this field cannot be set when spec.os.name is windows.
+                properties:
+                  localhostProfile:
+                    description: localhostProfile indicates a profile defined in a
+                      file on the node should be used. The profile must be preconfigured
+                      on the node to work. Must be a descending path, relative to
+                      the kubelet's configured seccomp profile location. Must only
+                      be set if type is "Localhost".
+                    type: string
+                  type:
+                    description: |-
+                      type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                      Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                      Possible enum values:
+                       - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                       - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                       - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                    type: string
+                required:
+                - type
+                type: object
+              supplementalGroups:
+                description: A list of groups applied to the first process run in
+                  each container, in addition to the container's primary GID.  If
+                  unspecified, no groups will be added to any container. Note that
+                  this field cannot be set when spec.os.name is windows.
+                items:
+                  format: int64
+                  type: integer
+                type: array
+              sysctls:
+                description: Sysctls hold a list of namespaced sysctls used for the
+                  pod. Pods with unsupported sysctls (by the container runtime) might
+                  fail to launch. Note that this field cannot be set when spec.os.name
+                  is windows.
+                items:
+                  description: Sysctl defines a kernel parameter to be set
+                  properties:
+                    name:
+                      description: Name of a property to set
+                      type: string
+                    value:
+                      description: Value of a property to set
+                      type: string
+                  required:
+                  - name
+                  - value
+                  type: object
+                type: array
+              windowsOptions:
+                description: The Windows specific settings applied to all containers.
+                  If unspecified, the options within a container's SecurityContext
+                  will be used. If set in both SecurityContext and PodSecurityContext,
+                  the value specified in SecurityContext takes precedence. Note that
+                  this field cannot be set when spec.os.name is linux.
+                properties:
+                  gmsaCredentialSpec:
+                    description: GMSACredentialSpec is where the GMSA admission webhook
+                      (https://github.com/kubernetes-sigs/windows-gmsa) inlines the
+                      contents of the GMSA credential spec named by the GMSACredentialSpecName
+                      field.
+                    type: string
+                  gmsaCredentialSpecName:
+                    description: GMSACredentialSpecName is the name of the GMSA credential
+                      spec to use.
+                    type: string
+                  hostProcess:
+                    description: HostProcess determines if a container should be run
+                      as a 'Host Process' container. This field is alpha-level and
+                      will only be honored by components that enable the WindowsHostProcessContainers
+                      feature flag. Setting this field without the feature flag will
+                      result in errors when validating the Pod. All of a Pod's containers
+                      must have the same effective HostProcess value (it is not allowed
+                      to have a mix of HostProcess containers and non-HostProcess
+                      containers).  In addition, if HostProcess is true then HostNetwork
+                      must also be set to true.
+                    type: boolean
+                  runAsUserName:
+                    description: The UserName in Windows to run the entrypoint of
+                      the container process. Defaults to the user specified in image
+                      metadata if unspecified. May also be set in PodSecurityContext.
+                      If set in both SecurityContext and PodSecurityContext, the value
+                      specified in SecurityContext takes precedence.
+                    type: string
+                type: object
+            type: object
+          serviceAccount:
+            description: 'DeprecatedServiceAccount is a depreciated alias for ServiceAccountName.
+              Deprecated: Use serviceAccountName instead.'
+            type: string
+          serviceAccountName:
+            description: 'ServiceAccountName is the name of the ServiceAccount to
+              use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+            type: string
+          setHostnameAsFQDN:
+            description: If true the pod's hostname will be configured as the pod's
+              FQDN, rather than the leaf name (the default). In Linux containers,
+              this means setting the FQDN in the hostname field of the kernel (the
+              nodename field of struct utsname). In Windows containers, this means
+              setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters
+              to FQDN. If a pod does not have FQDN, this has no effect. Default to
+              false.
+            type: boolean
+          shareProcessNamespace:
+            description: 'Share a single process namespace between all of the containers
+              in a pod. When this is set containers will be able to view and signal
+              processes from other containers in the same pod, and the first process
+              in each container will not be assigned PID 1. HostPID and ShareProcessNamespace
+              cannot both be set. Optional: Default to false.'
+            type: boolean
+          subdomain:
+            description: If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod
+              namespace>.svc.<cluster domain>". If not specified, the pod will not
+              have a domainname at all.
+            type: string
+          terminationGracePeriodSeconds:
+            description: Optional duration in seconds the pod needs to terminate gracefully.
+              May be decreased in delete request. Value must be non-negative integer.
+              The value zero indicates stop immediately via the kill signal (no opportunity
+              to shut down). If this value is nil, the default grace period will be
+              used instead. The grace period is the duration in seconds after the
+              processes running in the pod are sent a termination signal and the time
+              when the processes are forcibly halted with a kill signal. Set this
+              value longer than the expected cleanup time for your process. Defaults
+              to 30 seconds.
+            format: int64
+            type: integer
+          tolerations:
+            description: If specified, the pod's tolerations.
+            items:
+              description: The pod this Toleration is attached to tolerates any taint
+                that matches the triple <key,value,effect> using the matching operator
+                <operator>.
+              properties:
+                effect:
+                  description: |-
+                    Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+                    Possible enum values:
+                     - `"NoExecute"` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+                     - `"NoSchedule"` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+                     - `"PreferNoSchedule"` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
+                  type: string
+                key:
+                  description: Key is the taint key that the toleration applies to.
+                    Empty means match all taint keys. If the key is empty, operator
+                    must be Exists; this combination means to match all values and
+                    all keys.
+                  type: string
+                operator:
+                  description: |-
+                    Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+
+                    Possible enum values:
+                     - `"Equal"`
+                     - `"Exists"`
+                  type: string
+                tolerationSeconds:
+                  description: TolerationSeconds represents the period of time the
+                    toleration (which must be of effect NoExecute, otherwise this
+                    field is ignored) tolerates the taint. By default, it is not set,
+                    which means tolerate the taint forever (do not evict). Zero and
+                    negative values will be treated as 0 (evict immediately) by the
+                    system.
+                  format: int64
+                  type: integer
+                value:
+                  description: Value is the taint value the toleration matches to.
+                    If the operator is Exists, the value should be empty, otherwise
+                    just a regular string.
+                  type: string
+              type: object
+            type: array
+          topologySpreadConstraints:
+            description: TopologySpreadConstraints describes how a group of pods ought
+              to spread across topology domains. Scheduler will schedule pods in a
+              way which abides by the constraints. All topologySpreadConstraints are
+              ANDed.
+            items:
+              description: TopologySpreadConstraint specifies how to spread matching
+                pods among the given topology.
+              properties:
+                labelSelector:
+                  description: LabelSelector is used to find matching pods. Pods that
+                    match this label selector are counted to determine the number
+                    of pods in their corresponding topology domain.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                matchLabelKeys:
+                  description: MatchLabelKeys is a set of pod label keys to select
+                    the pods over which spreading will be calculated. The keys are
+                    used to lookup values from the incoming pod labels, those key-value
+                    labels are ANDed with labelSelector to select the group of existing
+                    pods over which spreading will be calculated for the incoming
+                    pod. Keys that don't exist in the incoming pod labels will be
+                    ignored. A null or empty list means only match against labelSelector.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: atomic
+                maxSkew:
+                  description: 'MaxSkew describes the degree to which pods may be
+                    unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                    it is the maximum permitted difference between the number of matching
+                    pods in the target topology and the global minimum. The global
+                    minimum is the minimum number of matching pods in an eligible
+                    domain or zero if the number of eligible domains is less than
+                    MinDomains. For example, in a 3-zone cluster, MaxSkew is set to
+                    1, and pods with the same labelSelector spread as 2/2/1: In this
+                    case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P
+                    P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only
+                    be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2)
+                    would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1).
+                    - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                    When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher
+                    precedence to topologies that satisfy it. It''s a required field.
+                    Default value is 1 and 0 is not allowed.'
+                  format: int32
+                  type: integer
+                minDomains:
+                  description: |-
+                    MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                    For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew.
+
+                    This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
+                  format: int32
+                  type: integer
+                nodeAffinityPolicy:
+                  description: |-
+                    NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                    If this value is nil, the behavior is equivalent to the Honor policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                  type: string
+                nodeTaintsPolicy:
+                  description: |-
+                    NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included.
+
+                    If this value is nil, the behavior is equivalent to the Ignore policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                  type: string
+                topologyKey:
+                  description: TopologyKey is the key of node labels. Nodes that have
+                    a label with this key and identical values are considered to be
+                    in the same topology. We consider each <key, value> as a "bucket",
+                    and try to put balanced number of pods into each bucket. We define
+                    a domain as a particular instance of a topology. Also, we define
+                    an eligible domain as a domain whose nodes meet the requirements
+                    of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey
+                    is "kubernetes.io/hostname", each Node is a domain of that topology.
+                    And, if TopologyKey is "topology.kubernetes.io/zone", each zone
+                    is a domain of that topology. It's a required field.
+                  type: string
+                whenUnsatisfiable:
+                  description: |-
+                    WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                      but giving higher precedence to topologies that would help reduce the
+                      skew.
+                    A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
+
+                    Possible enum values:
+                     - `"DoNotSchedule"` instructs the scheduler not to schedule the pod when constraints are not satisfied.
+                     - `"ScheduleAnyway"` instructs the scheduler to schedule the pod even if constraints are not satisfied.
+                  type: string
+              required:
+              - maxSkew
+              - topologyKey
+              - whenUnsatisfiable
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - topologyKey
+            - whenUnsatisfiable
+            x-kubernetes-list-type: map
+          volumes:
+            description: 'List of volumes that can be mounted by containers belonging
+              to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+            items:
+              description: Volume represents a named volume in a pod that may be accessed
+                by any container in the pod.
+              properties:
+                awsElasticBlockStore:
+                  description: 'awsElasticBlockStore represents an AWS Disk resource
+                    that is attached to a kubelet''s host machine and then exposed
+                    to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                  properties:
+                    fsType:
+                      description: 'fsType is the filesystem type of the volume that
+                        you want to mount. Tip: Ensure that the filesystem type is
+                        supported by the host operating system. Examples: "ext4",
+                        "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                      type: string
+                    partition:
+                      description: 'partition is the partition in the volume that
+                        you want to mount. If omitted, the default is to mount by
+                        volume name. Examples: For volume /dev/sda1, you specify the
+                        partition as "1". Similarly, the volume partition for /dev/sda
+                        is "0" (or you can leave the property empty).'
+                      format: int32
+                      type: integer
+                    readOnly:
+                      description: 'readOnly value true will force the readOnly setting
+                        in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                      type: boolean
+                    volumeID:
+                      description: 'volumeID is unique ID of the persistent disk resource
+                        in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                      type: string
+                  required:
+                  - volumeID
+                  type: object
+                azureDisk:
+                  description: azureDisk represents an Azure Data Disk mount on the
+                    host and bind mount to the pod.
+                  properties:
+                    cachingMode:
+                      description: 'cachingMode is the Host Caching mode: None, Read
+                        Only, Read Write.'
+                      type: string
+                    diskName:
+                      description: diskName is the Name of the data disk in the blob
+                        storage
+                      type: string
+                    diskURI:
+                      description: diskURI is the URI of data disk in the blob storage
+                      type: string
+                    fsType:
+                      description: fsType is Filesystem type to mount. Must be a filesystem
+                        type supported by the host operating system. Ex. "ext4", "xfs",
+                        "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                      type: string
+                    kind:
+                      description: 'kind expected values are Shared: multiple blob
+                        disks per storage account  Dedicated: single blob disk per
+                        storage account  Managed: azure managed data disk (only in
+                        managed availability set). defaults to shared'
+                      type: string
+                    readOnly:
+                      description: readOnly Defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts.
+                      type: boolean
+                  required:
+                  - diskName
+                  - diskURI
+                  type: object
+                azureFile:
+                  description: azureFile represents an Azure File Service mount on
+                    the host and bind mount to the pod.
+                  properties:
+                    readOnly:
+                      description: readOnly defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts.
+                      type: boolean
+                    secretName:
+                      description: secretName is the  name of secret that contains
+                        Azure Storage Account Name and Key
+                      type: string
+                    shareName:
+                      description: shareName is the azure share Name
+                      type: string
+                  required:
+                  - secretName
+                  - shareName
+                  type: object
+                cephfs:
+                  description: cephFS represents a Ceph FS mount on the host that
+                    shares a pod's lifetime
+                  properties:
+                    monitors:
+                      description: 'monitors is Required: Monitors is a collection
+                        of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                      items:
+                        type: string
+                      type: array
+                    path:
+                      description: 'path is Optional: Used as the mounted root, rather
+                        than the full Ceph tree, default is /'
+                      type: string
+                    readOnly:
+                      description: 'readOnly is Optional: Defaults to false (read/write).
+                        ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                      type: boolean
+                    secretFile:
+                      description: 'secretFile is Optional: SecretFile is the path
+                        to key ring for User, default is /etc/ceph/user.secret More
+                        info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                      type: string
+                    secretRef:
+                      description: 'secretRef is Optional: SecretRef is reference
+                        to the authentication secret for User, default is empty. More
+                        info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    user:
+                      description: 'user is optional: User is the rados user name,
+                        default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                      type: string
+                  required:
+                  - monitors
+                  type: object
+                cinder:
+                  description: 'cinder represents a cinder volume attached and mounted
+                    on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                  properties:
+                    fsType:
+                      description: 'fsType is the filesystem type to mount. Must be
+                        a filesystem type supported by the host operating system.
+                        Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be
+                        "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                      type: string
+                    readOnly:
+                      description: 'readOnly defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts. More
+                        info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                      type: boolean
+                    secretRef:
+                      description: 'secretRef is optional: points to a secret object
+                        containing parameters used to connect to OpenStack.'
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    volumeID:
+                      description: 'volumeID used to identify the volume in cinder.
+                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                      type: string
+                  required:
+                  - volumeID
+                  type: object
+                configMap:
+                  description: configMap represents a configMap that should populate
+                    this volume
+                  properties:
+                    defaultMode:
+                      description: 'defaultMode is optional: mode bits used to set
+                        permissions on created files by default. Must be an octal
+                        value between 0000 and 0777 or a decimal value between 0 and
+                        511. YAML accepts both octal and decimal values, JSON requires
+                        decimal values for mode bits. Defaults to 0644. Directories
+                        within the path are not affected by this setting. This might
+                        be in conflict with other options that affect the file mode,
+                        like fsGroup, and the result can be other mode bits set.'
+                      format: int32
+                      type: integer
+                    items:
+                      description: items if unspecified, each key-value pair in the
+                        Data field of the referenced ConfigMap will be projected into
+                        the volume as a file whose name is the key and content is
+                        the value. If specified, the listed keys will be projected
+                        into the specified paths, and unlisted keys will not be present.
+                        If a key is specified which is not present in the ConfigMap,
+                        the volume setup will error unless it is marked optional.
+                        Paths must be relative and may not contain the '..' path or
+                        start with '..'.
+                      items:
+                        description: Maps a string key to a path within a volume.
+                        properties:
+                          key:
+                            description: key is the key to project.
+                            type: string
+                          mode:
+                            description: 'mode is Optional: mode bits used to set
+                              permissions on this file. Must be an octal value between
+                              0000 and 0777 or a decimal value between 0 and 511.
+                              YAML accepts both octal and decimal values, JSON requires
+                              decimal values for mode bits. If not specified, the
+                              volume defaultMode will be used. This might be in conflict
+                              with other options that affect the file mode, like fsGroup,
+                              and the result can be other mode bits set.'
+                            format: int32
+                            type: integer
+                          path:
+                            description: path is the relative path of the file to
+                              map the key to. May not be an absolute path. May not
+                              contain the path element '..'. May not start with the
+                              string '..'.
+                            type: string
+                        required:
+                        - key
+                        - path
+                        type: object
+                      type: array
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    optional:
+                      description: optional specify whether the ConfigMap or its keys
+                        must be defined
+                      type: boolean
+                  type: object
+                csi:
+                  description: csi (Container Storage Interface) represents ephemeral
+                    storage that is handled by certain external CSI drivers (Beta
+                    feature).
+                  properties:
+                    driver:
+                      description: driver is the name of the CSI driver that handles
+                        this volume. Consult with your admin for the correct name
+                        as registered in the cluster.
+                      type: string
+                    fsType:
+                      description: fsType to mount. Ex. "ext4", "xfs", "ntfs". If
+                        not provided, the empty value is passed to the associated
+                        CSI driver which will determine the default filesystem to
+                        apply.
+                      type: string
+                    nodePublishSecretRef:
+                      description: nodePublishSecretRef is a reference to the secret
+                        object containing sensitive information to pass to the CSI
+                        driver to complete the CSI NodePublishVolume and NodeUnpublishVolume
+                        calls. This field is optional, and  may be empty if no secret
+                        is required. If the secret object contains more than one secret,
+                        all secret references are passed.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    readOnly:
+                      description: readOnly specifies a read-only configuration for
+                        the volume. Defaults to false (read/write).
+                      type: boolean
+                    volumeAttributes:
+                      additionalProperties:
+                        type: string
+                      description: volumeAttributes stores driver-specific properties
+                        that are passed to the CSI driver. Consult your driver's documentation
+                        for supported values.
+                      type: object
+                  required:
+                  - driver
+                  type: object
+                downwardAPI:
+                  description: downwardAPI represents downward API about the pod that
+                    should populate this volume
+                  properties:
+                    defaultMode:
+                      description: 'Optional: mode bits to use on created files by
+                        default. Must be a Optional: mode bits used to set permissions
+                        on created files by default. Must be an octal value between
+                        0000 and 0777 or a decimal value between 0 and 511. YAML accepts
+                        both octal and decimal values, JSON requires decimal values
+                        for mode bits. Defaults to 0644. Directories within the path
+                        are not affected by this setting. This might be in conflict
+                        with other options that affect the file mode, like fsGroup,
+                        and the result can be other mode bits set.'
+                      format: int32
+                      type: integer
+                    items:
+                      description: Items is a list of downward API volume file
+                      items:
+                        description: DownwardAPIVolumeFile represents information
+                          to create the file containing the pod field
+                        properties:
+                          fieldRef:
+                            description: 'Required: Selects a field of the pod: only
+                              annotations, labels, name and namespace are supported.'
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                            - fieldPath
+                            type: object
+                          mode:
+                            description: 'Optional: mode bits used to set permissions
+                              on this file, must be an octal value between 0000 and
+                              0777 or a decimal value between 0 and 511. YAML accepts
+                              both octal and decimal values, JSON requires decimal
+                              values for mode bits. If not specified, the volume defaultMode
+                              will be used. This might be in conflict with other options
+                              that affect the file mode, like fsGroup, and the result
+                              can be other mode bits set.'
+                            format: int32
+                            type: integer
+                          path:
+                            description: 'Required: Path is  the relative path name
+                              of the file to be created. Must not be absolute or contain
+                              the ''..'' path. Must be utf-8 encoded. The first item
+                              of the relative path must not start with ''..'''
+                            type: string
+                          resourceFieldRef:
+                            description: 'Selects a resource of the container: only
+                              resources limits and requests (limits.cpu, limits.memory,
+                              requests.cpu and requests.memory) are currently supported.'
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Specifies the output format of the exposed
+                                  resources, defaults to "1"
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                            - resource
+                            type: object
+                        required:
+                        - path
+                        type: object
+                      type: array
+                  type: object
+                emptyDir:
+                  description: 'emptyDir represents a temporary directory that shares
+                    a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                  properties:
+                    medium:
+                      description: 'medium represents what type of storage medium
+                        should back this directory. The default is "" which means
+                        to use the node''s default medium. Must be an empty string
+                        (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                      type: string
+                    sizeLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: 'sizeLimit is the total amount of local storage
+                        required for this EmptyDir volume. The size limit is also
+                        applicable for memory medium. The maximum usage on memory
+                        medium EmptyDir would be the minimum value between the SizeLimit
+                        specified here and the sum of memory limits of all containers
+                        in a pod. The default is nil which means that the limit is
+                        undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  type: object
+                ephemeral:
+                  description: |-
+                    ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+
+                    Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+                       tracking are needed,
+                    c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+                       a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                       information on the connection between this volume type
+                       and PersistentVolumeClaim).
+
+                    Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+
+                    Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+
+                    A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+                  properties:
+                    volumeClaimTemplate:
+                      description: |-
+                        Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+
+                        An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+
+                        This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+
+                        Required, must not be nil.
+                      properties:
+                        metadata:
+                          description: May contain labels and annotations that will
+                            be copied into the PVC when creating it. No other fields
+                            are allowed and will be rejected during validation.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        spec:
+                          description: The specification for the PersistentVolumeClaim.
+                            The entire content is copied unchanged into the PVC that
+                            gets created from this template. The same fields as in
+                            a PersistentVolumeClaim are also valid here.
+                          properties:
+                            accessModes:
+                              description: 'accessModes contains the desired access
+                                modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                              items:
+                                type: string
+                              type: array
+                            dataSource:
+                              description: 'dataSource field can be used to specify
+                                either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                * An existing PVC (PersistentVolumeClaim) If the provisioner
+                                or an external controller can support the specified
+                                data source, it will create a new volume based on
+                                the contents of the specified data source. If the
+                                AnyVolumeDataSource feature gate is enabled, this
+                                field will always have the same contents as the DataSourceRef
+                                field.'
+                              properties:
+                                apiGroup:
+                                  description: APIGroup is the group for the resource
+                                    being referenced. If APIGroup is not specified,
+                                    the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being
+                                    referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being
+                                    referenced
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            dataSourceRef:
+                              description: |-
+                                dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef
+                                  allows any non-core object, as well as PersistentVolumeClaim objects.
+                                * While DataSource ignores disallowed values (dropping them), DataSourceRef
+                                  preserves all values, and generates an error if a disallowed value is
+                                  specified.
+                                (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                              properties:
+                                apiGroup:
+                                  description: APIGroup is the group for the resource
+                                    being referenced. If APIGroup is not specified,
+                                    the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being
+                                    referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being
+                                    referenced
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            resources:
+                              description: 'resources represents the minimum resources
+                                the volume should have. If RecoverVolumeExpansionFailure
+                                feature is enabled users are allowed to specify resource
+                                requirements that are lower than previous value but
+                                must still be higher than capacity recorded in the
+                                status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                              type: object
+                            selector:
+                              description: selector is a label query over volumes
+                                to consider for binding.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            storageClassName:
+                              description: 'storageClassName is the name of the StorageClass
+                                required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                              type: string
+                            volumeMode:
+                              description: volumeMode defines what type of volume
+                                is required by the claim. Value of Filesystem is implied
+                                when not included in claim spec.
+                              type: string
+                            volumeName:
+                              description: volumeName is the binding reference to
+                                the PersistentVolume backing this claim.
+                              type: string
+                          type: object
+                      required:
+                      - spec
+                      type: object
+                  type: object
+                fc:
+                  description: fc represents a Fibre Channel resource that is attached
+                    to a kubelet's host machine and then exposed to the pod.
+                  properties:
+                    fsType:
+                      description: fsType is the filesystem type to mount. Must be
+                        a filesystem type supported by the host operating system.
+                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                        if unspecified.
+                      type: string
+                    lun:
+                      description: 'lun is Optional: FC target lun number'
+                      format: int32
+                      type: integer
+                    readOnly:
+                      description: 'readOnly is Optional: Defaults to false (read/write).
+                        ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                      type: boolean
+                    targetWWNs:
+                      description: 'targetWWNs is Optional: FC target worldwide names
+                        (WWNs)'
+                      items:
+                        type: string
+                      type: array
+                    wwids:
+                      description: 'wwids Optional: FC volume world wide identifiers
+                        (wwids) Either wwids or combination of targetWWNs and lun
+                        must be set, but not both simultaneously.'
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                flexVolume:
+                  description: flexVolume represents a generic volume resource that
+                    is provisioned/attached using an exec based plugin.
+                  properties:
+                    driver:
+                      description: driver is the name of the driver to use for this
+                        volume.
+                      type: string
+                    fsType:
+                      description: fsType is the filesystem type to mount. Must be
+                        a filesystem type supported by the host operating system.
+                        Ex. "ext4", "xfs", "ntfs". The default filesystem depends
+                        on FlexVolume script.
+                      type: string
+                    options:
+                      additionalProperties:
+                        type: string
+                      description: 'options is Optional: this field holds extra command
+                        options if any.'
+                      type: object
+                    readOnly:
+                      description: 'readOnly is Optional: defaults to false (read/write).
+                        ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                      type: boolean
+                    secretRef:
+                      description: 'secretRef is Optional: secretRef is reference
+                        to the secret object containing sensitive information to pass
+                        to the plugin scripts. This may be empty if no secret object
+                        is specified. If the secret object contains more than one
+                        secret, all secrets are passed to the plugin scripts.'
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                  required:
+                  - driver
+                  type: object
+                flocker:
+                  description: flocker represents a Flocker volume attached to a kubelet's
+                    host machine. This depends on the Flocker control service being
+                    running
+                  properties:
+                    datasetName:
+                      description: datasetName is Name of the dataset stored as metadata
+                        -> name on the dataset for Flocker should be considered as
+                        deprecated
+                      type: string
+                    datasetUUID:
+                      description: datasetUUID is the UUID of the dataset. This is
+                        unique identifier of a Flocker dataset
+                      type: string
+                  type: object
+                gcePersistentDisk:
+                  description: 'gcePersistentDisk represents a GCE Disk resource that
+                    is attached to a kubelet''s host machine and then exposed to the
+                    pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                  properties:
+                    fsType:
+                      description: 'fsType is filesystem type of the volume that you
+                        want to mount. Tip: Ensure that the filesystem type is supported
+                        by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                        Implicitly inferred to be "ext4" if unspecified. More info:
+                        https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                      type: string
+                    partition:
+                      description: 'partition is the partition in the volume that
+                        you want to mount. If omitted, the default is to mount by
+                        volume name. Examples: For volume /dev/sda1, you specify the
+                        partition as "1". Similarly, the volume partition for /dev/sda
+                        is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                      format: int32
+                      type: integer
+                    pdName:
+                      description: 'pdName is unique name of the PD resource in GCE.
+                        Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                      type: string
+                    readOnly:
+                      description: 'readOnly here will force the ReadOnly setting
+                        in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                      type: boolean
+                  required:
+                  - pdName
+                  type: object
+                gitRepo:
+                  description: 'gitRepo represents a git repository at a particular
+                    revision. DEPRECATED: GitRepo is deprecated. To provision a container
+                    with a git repo, mount an EmptyDir into an InitContainer that
+                    clones the repo using git, then mount the EmptyDir into the Pod''s
+                    container.'
+                  properties:
+                    directory:
+                      description: directory is the target directory name. Must not
+                        contain or start with '..'.  If '.' is supplied, the volume
+                        directory will be the git repository.  Otherwise, if specified,
+                        the volume will contain the git repository in the subdirectory
+                        with the given name.
+                      type: string
+                    repository:
+                      description: repository is the URL
+                      type: string
+                    revision:
+                      description: revision is the commit hash for the specified revision.
+                      type: string
+                  required:
+                  - repository
+                  type: object
+                glusterfs:
+                  description: 'glusterfs represents a Glusterfs mount on the host
+                    that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                  properties:
+                    endpoints:
+                      description: 'endpoints is the endpoint name that details Glusterfs
+                        topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                      type: string
+                    path:
+                      description: 'path is the Glusterfs volume path. More info:
+                        https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                      type: string
+                    readOnly:
+                      description: 'readOnly here will force the Glusterfs volume
+                        to be mounted with read-only permissions. Defaults to false.
+                        More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                      type: boolean
+                  required:
+                  - endpoints
+                  - path
+                  type: object
+                hostPath:
+                  description: 'hostPath represents a pre-existing file or directory
+                    on the host machine that is directly exposed to the container.
+                    This is generally used for system agents or other privileged things
+                    that are allowed to see the host machine. Most containers will
+                    NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                  properties:
+                    path:
+                      description: 'path of the directory on the host. If the path
+                        is a symlink, it will follow the link to the real path. More
+                        info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                      type: string
+                    type:
+                      description: 'type for HostPath Volume Defaults to "" More info:
+                        https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                      type: string
+                  required:
+                  - path
+                  type: object
+                iscsi:
+                  description: 'iscsi represents an ISCSI Disk resource that is attached
+                    to a kubelet''s host machine and then exposed to the pod. More
+                    info: https://examples.k8s.io/volumes/iscsi/README.md'
+                  properties:
+                    chapAuthDiscovery:
+                      description: chapAuthDiscovery defines whether support iSCSI
+                        Discovery CHAP authentication
+                      type: boolean
+                    chapAuthSession:
+                      description: chapAuthSession defines whether support iSCSI Session
+                        CHAP authentication
+                      type: boolean
+                    fsType:
+                      description: 'fsType is the filesystem type of the volume that
+                        you want to mount. Tip: Ensure that the filesystem type is
+                        supported by the host operating system. Examples: "ext4",
+                        "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                      type: string
+                    initiatorName:
+                      description: initiatorName is the custom iSCSI Initiator Name.
+                        If initiatorName is specified with iscsiInterface simultaneously,
+                        new iSCSI interface <target portal>:<volume name> will be
+                        created for the connection.
+                      type: string
+                    iqn:
+                      description: iqn is the target iSCSI Qualified Name.
+                      type: string
+                    iscsiInterface:
+                      description: iscsiInterface is the interface Name that uses
+                        an iSCSI transport. Defaults to 'default' (tcp).
+                      type: string
+                    lun:
+                      description: lun represents iSCSI Target Lun number.
+                      format: int32
+                      type: integer
+                    portals:
+                      description: portals is the iSCSI Target Portal List. The portal
+                        is either an IP or ip_addr:port if the port is other than
+                        default (typically TCP ports 860 and 3260).
+                      items:
+                        type: string
+                      type: array
+                    readOnly:
+                      description: readOnly here will force the ReadOnly setting in
+                        VolumeMounts. Defaults to false.
+                      type: boolean
+                    secretRef:
+                      description: secretRef is the CHAP Secret for iSCSI target and
+                        initiator authentication
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    targetPortal:
+                      description: targetPortal is iSCSI Target Portal. The Portal
+                        is either an IP or ip_addr:port if the port is other than
+                        default (typically TCP ports 860 and 3260).
+                      type: string
+                  required:
+                  - targetPortal
+                  - iqn
+                  - lun
+                  type: object
+                name:
+                  description: 'name of the volume. Must be a DNS_LABEL and unique
+                    within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                nfs:
+                  description: 'nfs represents an NFS mount on the host that shares
+                    a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                  properties:
+                    path:
+                      description: 'path that is exported by the NFS server. More
+                        info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                      type: string
+                    readOnly:
+                      description: 'readOnly here will force the NFS export to be
+                        mounted with read-only permissions. Defaults to false. More
+                        info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                      type: boolean
+                    server:
+                      description: 'server is the hostname or IP address of the NFS
+                        server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                      type: string
+                  required:
+                  - server
+                  - path
+                  type: object
+                persistentVolumeClaim:
+                  description: 'persistentVolumeClaimVolumeSource represents a reference
+                    to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                  properties:
+                    claimName:
+                      description: 'claimName is the name of a PersistentVolumeClaim
+                        in the same namespace as the pod using this volume. More info:
+                        https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                      type: string
+                    readOnly:
+                      description: readOnly Will force the ReadOnly setting in VolumeMounts.
+                        Default false.
+                      type: boolean
+                  required:
+                  - claimName
+                  type: object
+                photonPersistentDisk:
+                  description: photonPersistentDisk represents a PhotonController
+                    persistent disk attached and mounted on kubelets host machine
+                  properties:
+                    fsType:
+                      description: fsType is the filesystem type to mount. Must be
+                        a filesystem type supported by the host operating system.
+                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                        if unspecified.
+                      type: string
+                    pdID:
+                      description: pdID is the ID that identifies Photon Controller
+                        persistent disk
+                      type: string
+                  required:
+                  - pdID
+                  type: object
+                portworxVolume:
+                  description: portworxVolume represents a portworx volume attached
+                    and mounted on kubelets host machine
+                  properties:
+                    fsType:
+                      description: fSType represents the filesystem type to mount
+                        Must be a filesystem type supported by the host operating
+                        system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
+                        if unspecified.
+                      type: string
+                    readOnly:
+                      description: readOnly defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts.
+                      type: boolean
+                    volumeID:
+                      description: volumeID uniquely identifies a Portworx volume
+                      type: string
+                  required:
+                  - volumeID
+                  type: object
+                projected:
+                  description: projected items for all in one resources secrets, configmaps,
+                    and downward API
+                  properties:
+                    defaultMode:
+                      description: defaultMode are the mode bits used to set permissions
+                        on created files by default. Must be an octal value between
+                        0000 and 0777 or a decimal value between 0 and 511. YAML accepts
+                        both octal and decimal values, JSON requires decimal values
+                        for mode bits. Directories within the path are not affected
+                        by this setting. This might be in conflict with other options
+                        that affect the file mode, like fsGroup, and the result can
+                        be other mode bits set.
+                      format: int32
+                      type: integer
+                    sources:
+                      description: sources is the list of volume projections
+                      items:
+                        description: Projection that may be projected along with other
+                          supported volume types
+                        properties:
+                          configMap:
+                            description: configMap information about the configMap
+                              data to project
+                            properties:
+                              items:
+                                description: items if unspecified, each key-value
+                                  pair in the Data field of the referenced ConfigMap
+                                  will be projected into the volume as a file whose
+                                  name is the key and content is the value. If specified,
+                                  the listed keys will be projected into the specified
+                                  paths, and unlisted keys will not be present. If
+                                  a key is specified which is not present in the ConfigMap,
+                                  the volume setup will error unless it is marked
+                                  optional. Paths must be relative and may not contain
+                                  the '..' path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: 'mode is Optional: mode bits used
+                                        to set permissions on this file. Must be an
+                                        octal value between 0000 and 0777 or a decimal
+                                        value between 0 and 511. YAML accepts both
+                                        octal and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: path is the relative path of the
+                                        file to map the key to. May not be an absolute
+                                        path. May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: optional specify whether the ConfigMap
+                                  or its keys must be defined
+                                type: boolean
+                            type: object
+                          downwardAPI:
+                            description: downwardAPI information about the downwardAPI
+                              data to project
+                            properties:
+                              items:
+                                description: Items is a list of DownwardAPIVolume
+                                  file
+                                items:
+                                  description: DownwardAPIVolumeFile represents information
+                                    to create the file containing the pod field
+                                  properties:
+                                    fieldRef:
+                                      description: 'Required: Selects a field of the
+                                        pod: only annotations, labels, name and namespace
+                                        are supported.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    mode:
+                                      description: 'Optional: mode bits used to set
+                                        permissions on this file, must be an octal
+                                        value between 0000 and 0777 or a decimal value
+                                        between 0 and 511. YAML accepts both octal
+                                        and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: 'Required: Path is  the relative
+                                        path name of the file to be created. Must
+                                        not be absolute or contain the ''..'' path.
+                                        Must be utf-8 encoded. The first item of the
+                                        relative path must not start with ''..'''
+                                      type: string
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, requests.cpu and requests.memory)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                  required:
+                                  - path
+                                  type: object
+                                type: array
+                            type: object
+                          secret:
+                            description: secret information about the secret data
+                              to project
+                            properties:
+                              items:
+                                description: items if unspecified, each key-value
+                                  pair in the Data field of the referenced Secret
+                                  will be projected into the volume as a file whose
+                                  name is the key and content is the value. If specified,
+                                  the listed keys will be projected into the specified
+                                  paths, and unlisted keys will not be present. If
+                                  a key is specified which is not present in the Secret,
+                                  the volume setup will error unless it is marked
+                                  optional. Paths must be relative and may not contain
+                                  the '..' path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: 'mode is Optional: mode bits used
+                                        to set permissions on this file. Must be an
+                                        octal value between 0000 and 0777 or a decimal
+                                        value between 0 and 511. YAML accepts both
+                                        octal and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: path is the relative path of the
+                                        file to map the key to. May not be an absolute
+                                        path. May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: optional field specify whether the Secret
+                                  or its key must be defined
+                                type: boolean
+                            type: object
+                          serviceAccountToken:
+                            description: serviceAccountToken is information about
+                              the serviceAccountToken data to project
+                            properties:
+                              audience:
+                                description: audience is the intended audience of
+                                  the token. A recipient of a token must identify
+                                  itself with an identifier specified in the audience
+                                  of the token, and otherwise should reject the token.
+                                  The audience defaults to the identifier of the apiserver.
+                                type: string
+                              expirationSeconds:
+                                description: expirationSeconds is the requested duration
+                                  of validity of the service account token. As the
+                                  token approaches expiration, the kubelet volume
+                                  plugin will proactively rotate the service account
+                                  token. The kubelet will start trying to rotate the
+                                  token if the token is older than 80 percent of its
+                                  time to live or if the token is older than 24 hours.Defaults
+                                  to 1 hour and must be at least 10 minutes.
+                                format: int64
+                                type: integer
+                              path:
+                                description: path is the path relative to the mount
+                                  point of the file to project the token into.
+                                type: string
+                            required:
+                            - path
+                            type: object
+                        type: object
+                      type: array
+                  type: object
+                quobyte:
+                  description: quobyte represents a Quobyte mount on the host that
+                    shares a pod's lifetime
+                  properties:
+                    group:
+                      description: group to map volume access to Default is no group
+                      type: string
+                    readOnly:
+                      description: readOnly here will force the Quobyte volume to
+                        be mounted with read-only permissions. Defaults to false.
+                      type: boolean
+                    registry:
+                      description: registry represents a single or multiple Quobyte
+                        Registry services specified as a string as host:port pair
+                        (multiple entries are separated with commas) which acts as
+                        the central registry for volumes
+                      type: string
+                    tenant:
+                      description: tenant owning the given Quobyte volume in the Backend
+                        Used with dynamically provisioned Quobyte volumes, value is
+                        set by the plugin
+                      type: string
+                    user:
+                      description: user to map volume access to Defaults to serivceaccount
+                        user
+                      type: string
+                    volume:
+                      description: volume is a string that references an already created
+                        Quobyte volume by name.
+                      type: string
+                  required:
+                  - registry
+                  - volume
+                  type: object
+                rbd:
+                  description: 'rbd represents a Rados Block Device mount on the host
+                    that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                  properties:
+                    fsType:
+                      description: 'fsType is the filesystem type of the volume that
+                        you want to mount. Tip: Ensure that the filesystem type is
+                        supported by the host operating system. Examples: "ext4",
+                        "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                      type: string
+                    image:
+                      description: 'image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      type: string
+                    keyring:
+                      description: 'keyring is the path to key ring for RBDUser. Default
+                        is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      type: string
+                    monitors:
+                      description: 'monitors is a collection of Ceph monitors. More
+                        info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      items:
+                        type: string
+                      type: array
+                    pool:
+                      description: 'pool is the rados pool name. Default is rbd. More
+                        info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      type: string
+                    readOnly:
+                      description: 'readOnly here will force the ReadOnly setting
+                        in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      type: boolean
+                    secretRef:
+                      description: 'secretRef is name of the authentication secret
+                        for RBDUser. If provided overrides keyring. Default is nil.
+                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    user:
+                      description: 'user is the rados user name. Default is admin.
+                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                      type: string
+                  required:
+                  - monitors
+                  - image
+                  type: object
+                scaleIO:
+                  description: scaleIO represents a ScaleIO persistent volume attached
+                    and mounted on Kubernetes nodes.
+                  properties:
+                    fsType:
+                      description: fsType is the filesystem type to mount. Must be
+                        a filesystem type supported by the host operating system.
+                        Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                      type: string
+                    gateway:
+                      description: gateway is the host address of the ScaleIO API
+                        Gateway.
+                      type: string
+                    protectionDomain:
+                      description: protectionDomain is the name of the ScaleIO Protection
+                        Domain for the configured storage.
+                      type: string
+                    readOnly:
+                      description: readOnly Defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts.
+                      type: boolean
+                    secretRef:
+                      description: secretRef references to the secret for ScaleIO
+                        user and other sensitive information. If this is not provided,
+                        Login operation will fail.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    sslEnabled:
+                      description: sslEnabled Flag enable/disable SSL communication
+                        with Gateway, default false
+                      type: boolean
+                    storageMode:
+                      description: storageMode indicates whether the storage for a
+                        volume should be ThickProvisioned or ThinProvisioned. Default
+                        is ThinProvisioned.
+                      type: string
+                    storagePool:
+                      description: storagePool is the ScaleIO Storage Pool associated
+                        with the protection domain.
+                      type: string
+                    system:
+                      description: system is the name of the storage system as configured
+                        in ScaleIO.
+                      type: string
+                    volumeName:
+                      description: volumeName is the name of a volume already created
+                        in the ScaleIO system that is associated with this volume
+                        source.
+                      type: string
+                  required:
+                  - gateway
+                  - system
+                  - secretRef
+                  type: object
+                secret:
+                  description: 'secret represents a secret that should populate this
+                    volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                  properties:
+                    defaultMode:
+                      description: 'defaultMode is Optional: mode bits used to set
+                        permissions on created files by default. Must be an octal
+                        value between 0000 and 0777 or a decimal value between 0 and
+                        511. YAML accepts both octal and decimal values, JSON requires
+                        decimal values for mode bits. Defaults to 0644. Directories
+                        within the path are not affected by this setting. This might
+                        be in conflict with other options that affect the file mode,
+                        like fsGroup, and the result can be other mode bits set.'
+                      format: int32
+                      type: integer
+                    items:
+                      description: items If unspecified, each key-value pair in the
+                        Data field of the referenced Secret will be projected into
+                        the volume as a file whose name is the key and content is
+                        the value. If specified, the listed keys will be projected
+                        into the specified paths, and unlisted keys will not be present.
+                        If a key is specified which is not present in the Secret,
+                        the volume setup will error unless it is marked optional.
+                        Paths must be relative and may not contain the '..' path or
+                        start with '..'.
+                      items:
+                        description: Maps a string key to a path within a volume.
+                        properties:
+                          key:
+                            description: key is the key to project.
+                            type: string
+                          mode:
+                            description: 'mode is Optional: mode bits used to set
+                              permissions on this file. Must be an octal value between
+                              0000 and 0777 or a decimal value between 0 and 511.
+                              YAML accepts both octal and decimal values, JSON requires
+                              decimal values for mode bits. If not specified, the
+                              volume defaultMode will be used. This might be in conflict
+                              with other options that affect the file mode, like fsGroup,
+                              and the result can be other mode bits set.'
+                            format: int32
+                            type: integer
+                          path:
+                            description: path is the relative path of the file to
+                              map the key to. May not be an absolute path. May not
+                              contain the path element '..'. May not start with the
+                              string '..'.
+                            type: string
+                        required:
+                        - key
+                        - path
+                        type: object
+                      type: array
+                    optional:
+                      description: optional field specify whether the Secret or its
+                        keys must be defined
+                      type: boolean
+                    secretName:
+                      description: 'secretName is the name of the secret in the pod''s
+                        namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                      type: string
+                  type: object
+                storageos:
+                  description: storageOS represents a StorageOS volume attached and
+                    mounted on Kubernetes nodes.
+                  properties:
+                    fsType:
+                      description: fsType is the filesystem type to mount. Must be
+                        a filesystem type supported by the host operating system.
+                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                        if unspecified.
+                      type: string
+                    readOnly:
+                      description: readOnly defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts.
+                      type: boolean
+                    secretRef:
+                      description: secretRef specifies the secret to use for obtaining
+                        the StorageOS API credentials.  If not specified, default
+                        values will be attempted.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      type: object
+                    volumeName:
+                      description: volumeName is the human-readable name of the StorageOS
+                        volume.  Volume names are only unique within a namespace.
+                      type: string
+                    volumeNamespace:
+                      description: volumeNamespace specifies the scope of the volume
+                        within StorageOS.  If no namespace is specified then the Pod's
+                        namespace will be used.  This allows the Kubernetes name scoping
+                        to be mirrored within StorageOS for tighter integration. Set
+                        VolumeName to any name to override the default behaviour.
+                        Set to "default" if you are not using namespaces within StorageOS.
+                        Namespaces that do not pre-exist within StorageOS will be
+                        created.
+                      type: string
+                  type: object
+                vsphereVolume:
+                  description: vsphereVolume represents a vSphere volume attached
+                    and mounted on kubelets host machine
+                  properties:
+                    fsType:
+                      description: fsType is filesystem type to mount. Must be a filesystem
+                        type supported by the host operating system. Ex. "ext4", "xfs",
+                        "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                      type: string
+                    storagePolicyID:
+                      description: storagePolicyID is the storage Policy Based Management
+                        (SPBM) profile ID associated with the StoragePolicyName.
+                      type: string
+                    storagePolicyName:
+                      description: storagePolicyName is the storage Policy Based Management
+                        (SPBM) profile name.
+                      type: string
+                    volumePath:
+                      description: volumePath is the path that identifies vSphere
+                        volume vmdk
+                      type: string
+                  required:
+                  - volumePath
+                  type: object
+              required:
+              - name
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - name
+            x-kubernetes-list-type: map
+        required:
+        - containers
+        type: object
+      status:
+        description: 'Most recently observed status of the pod. This data may not
+          be up to date. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+        properties:
+          conditions:
+            description: 'Current service state of pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions'
+            items:
+              description: PodCondition contains details for the current condition
+                of this pod.
+              properties:
+                lastProbeTime:
+                  description: Last time we probed the condition.
+                  format: date-time
+                  type: string
+                lastTransitionTime:
+                  description: Last time the condition transitioned from one status
+                    to another.
+                  format: date-time
+                  type: string
+                message:
+                  description: Human-readable message indicating details about last
+                    transition.
+                  type: string
+                reason:
+                  description: Unique, one-word, CamelCase reason for the condition's
+                    last transition.
+                  type: string
+                status:
+                  description: 'Status is the status of the condition. Can be True,
+                    False, Unknown. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions'
+                  type: string
+                type:
+                  description: 'Type is the type of the condition. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions'
+                  type: string
+              required:
+              - status
+              - type
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - type
+            x-kubernetes-list-type: map
+          containerStatuses:
+            description: 'The list has one entry per container in the manifest. More
+              info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status'
+            items:
+              description: ContainerStatus contains details for the current status
+                of this container.
+              properties:
+                containerID:
+                  description: Container's ID in the format '<type>://<container_id>'.
+                  type: string
+                image:
+                  description: 'The image the container is running. More info: https://kubernetes.io/docs/concepts/containers/images.'
+                  type: string
+                imageID:
+                  description: ImageID of the container's image.
+                  type: string
+                lastState:
+                  description: Details about the container's last termination condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format '<type>://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+                name:
+                  description: This must be a DNS_LABEL. Each container in a pod must
+                    have a unique name. Cannot be updated.
+                  type: string
+                ready:
+                  description: Specifies whether the container has passed its readiness
+                    probe.
+                  type: boolean
+                restartCount:
+                  description: The number of times the container has been restarted.
+                  format: int32
+                  type: integer
+                started:
+                  description: Specifies whether the container has passed its startup
+                    probe. Initialized as false, becomes true after startupProbe is
+                    considered successful. Resets to false when the container is restarted,
+                    or if kubelet loses state temporarily. Is always true when no
+                    startupProbe is defined.
+                  type: boolean
+                state:
+                  description: Details about the container's current condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format '<type>://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+              required:
+              - name
+              - ready
+              - restartCount
+              - image
+              - imageID
+              type: object
+            type: array
+          ephemeralContainerStatuses:
+            description: Status for any ephemeral containers that have run in this
+              pod.
+            items:
+              description: ContainerStatus contains details for the current status
+                of this container.
+              properties:
+                containerID:
+                  description: Container's ID in the format '<type>://<container_id>'.
+                  type: string
+                image:
+                  description: 'The image the container is running. More info: https://kubernetes.io/docs/concepts/containers/images.'
+                  type: string
+                imageID:
+                  description: ImageID of the container's image.
+                  type: string
+                lastState:
+                  description: Details about the container's last termination condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format '<type>://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+                name:
+                  description: This must be a DNS_LABEL. Each container in a pod must
+                    have a unique name. Cannot be updated.
+                  type: string
+                ready:
+                  description: Specifies whether the container has passed its readiness
+                    probe.
+                  type: boolean
+                restartCount:
+                  description: The number of times the container has been restarted.
+                  format: int32
+                  type: integer
+                started:
+                  description: Specifies whether the container has passed its startup
+                    probe. Initialized as false, becomes true after startupProbe is
+                    considered successful. Resets to false when the container is restarted,
+                    or if kubelet loses state temporarily. Is always true when no
+                    startupProbe is defined.
+                  type: boolean
+                state:
+                  description: Details about the container's current condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format '<type>://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+              required:
+              - name
+              - ready
+              - restartCount
+              - image
+              - imageID
+              type: object
+            type: array
+          hostIP:
+            description: IP address of the host to which the pod is assigned. Empty
+              if not yet scheduled.
+            type: string
+          initContainerStatuses:
+            description: 'The list has one entry per init container in the manifest.
+              The most recent successful init container will have ready = true, the
+              most recently started container will have startTime set. More info:
+              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status'
+            items:
+              description: ContainerStatus contains details for the current status
+                of this container.
+              properties:
+                containerID:
+                  description: Container's ID in the format '<type>://<container_id>'.
+                  type: string
+                image:
+                  description: 'The image the container is running. More info: https://kubernetes.io/docs/concepts/containers/images.'
+                  type: string
+                imageID:
+                  description: ImageID of the container's image.
+                  type: string
+                lastState:
+                  description: Details about the container's last termination condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format '<type>://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+                name:
+                  description: This must be a DNS_LABEL. Each container in a pod must
+                    have a unique name. Cannot be updated.
+                  type: string
+                ready:
+                  description: Specifies whether the container has passed its readiness
+                    probe.
+                  type: boolean
+                restartCount:
+                  description: The number of times the container has been restarted.
+                  format: int32
+                  type: integer
+                started:
+                  description: Specifies whether the container has passed its startup
+                    probe. Initialized as false, becomes true after startupProbe is
+                    considered successful. Resets to false when the container is restarted,
+                    or if kubelet loses state temporarily. Is always true when no
+                    startupProbe is defined.
+                  type: boolean
+                state:
+                  description: Details about the container's current condition.
+                  properties:
+                    running:
+                      description: Details about a running container
+                      properties:
+                        startedAt:
+                          description: Time at which the container was last (re-)started
+                          format: date-time
+                          type: string
+                      type: object
+                    terminated:
+                      description: Details about a terminated container
+                      properties:
+                        containerID:
+                          description: Container's ID in the format '<type>://<container_id>'
+                          type: string
+                        exitCode:
+                          description: Exit status from the last termination of the
+                            container
+                          format: int32
+                          type: integer
+                        finishedAt:
+                          description: Time at which the container last terminated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message regarding the last termination of the
+                            container
+                          type: string
+                        reason:
+                          description: (brief) reason from the last termination of
+                            the container
+                          type: string
+                        signal:
+                          description: Signal from the last termination of the container
+                          format: int32
+                          type: integer
+                        startedAt:
+                          description: Time at which previous execution of the container
+                            started
+                          format: date-time
+                          type: string
+                      required:
+                      - exitCode
+                      type: object
+                    waiting:
+                      description: Details about a waiting container
+                      properties:
+                        message:
+                          description: Message regarding why the container is not
+                            yet running.
+                          type: string
+                        reason:
+                          description: (brief) reason the container is not yet running.
+                          type: string
+                      type: object
+                  type: object
+              required:
+              - name
+              - ready
+              - restartCount
+              - image
+              - imageID
+              type: object
+            type: array
+          message:
+            description: A human readable message indicating details about why the
+              pod is in this condition.
+            type: string
+          nominatedNodeName:
+            description: nominatedNodeName is set only when this pod preempts other
+              pods on the node, but it cannot be scheduled right away as preemption
+              victims receive their graceful termination periods. This field does
+              not guarantee that the pod will be scheduled on this node. Scheduler
+              may decide to place the pod elsewhere if other nodes become available
+              sooner. Scheduler may also decide to give the resources on this node
+              to a higher priority pod that is created after preemption. As a result,
+              this field may be different than PodSpec.nodeName when the pod is scheduled.
+            type: string
+          phase:
+            description: |-
+              The phase of a Pod is a simple, high-level summary of where the Pod is in its lifecycle. The conditions array, the reason and message fields, and the individual container status arrays contain more detail about the pod's status. There are five possible phase values:
+
+              Pending: The pod has been accepted by the Kubernetes system, but one or more of the container images has not been created. This includes time before being scheduled as well as time spent downloading images over the network, which could take a while. Running: The pod has been bound to a node, and all of the containers have been created. At least one container is still running, or is in the process of starting or restarting. Succeeded: All containers in the pod have terminated in success, and will not be restarted. Failed: All containers in the pod have terminated, and at least one container has terminated in failure. The container either exited with non-zero status or was terminated by the system. Unknown: For some reason the state of the pod could not be obtained, typically due to an error in communicating with the host of the pod.
+
+              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-phase
+
+              Possible enum values:
+               - `"Failed"` means that all containers in the pod have terminated, and at least one container has terminated in a failure (exited with a non-zero exit code or was stopped by the system).
+               - `"Pending"` means the pod has been accepted by the system, but one or more of the containers has not been started. This includes time before being bound to a node, as well as time spent pulling images onto the host.
+               - `"Running"` means the pod has been bound to a node and all of the containers have been started. At least one container is still running or is in the process of being restarted.
+               - `"Succeeded"` means that all containers in the pod have voluntarily terminated with a container exit code of 0, and the system is not going to restart any of these containers.
+               - `"Unknown"` means that for some reason the state of the pod could not be obtained, typically due to an error in communicating with the host of the pod. Deprecated: It isn't being set since 2015 (74da3b14b0c0f658b3bb8d2def5094686d0e9095)
+            type: string
+          podIP:
+            description: IP address allocated to the pod. Routable at least within
+              the cluster. Empty if not yet allocated.
+            type: string
+          podIPs:
+            description: podIPs holds the IP addresses allocated to the pod. If this
+              field is specified, the 0th entry must match the podIP field. Pods may
+              be allocated at most 1 value for each of IPv4 and IPv6. This list is
+              empty if no IPs have been allocated yet.
+            items:
+              description: "IP address information for entries in the (plural) PodIPs
+                field. Each entry includes:\n\n\tIP: An IP address allocated to the
+                pod. Routable at least within the cluster."
+              properties:
+                ip:
+                  description: ip is an IP address (IPv4 or IPv6) assigned to the
+                    pod
+                  type: string
+              required:
+              - ip
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - ip
+            x-kubernetes-list-type: map
+          qosClass:
+            description: |-
+              The Quality of Service (QOS) classification assigned to the pod based on resource requirements See PodQOSClass type for available QOS classes More info: https://git.k8s.io/community/contributors/design-proposals/node/resource-qos.md
+
+              Possible enum values:
+               - `"BestEffort"` is the BestEffort qos class.
+               - `"Burstable"` is the Burstable qos class.
+               - `"Guaranteed"` is the Guaranteed qos class.
+            type: string
+          reason:
+            description: A brief CamelCase message indicating details about why the
+              pod is in this state. e.g. 'Evicted'
+            type: string
+          startTime:
+            description: RFC 3339 date and time at which the object was acknowledged
+              by the Kubelet. This is before the Kubelet pulled the container image(s)
+              for the pod.
+            format: date-time
+            type: string
+        type: object
+    type: object
+  plural: pods
+  scope: Namespaced
+  shortNames:
+  - po
+  singular: pod
+  subResources:
+  - name: status

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/4-NegotiatedAPIResource-services.v1.core.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/4-NegotiatedAPIResource-services.v1.core.yaml
@@ -1,0 +1,416 @@
+apiVersion: apiresource.kcp.io/v1alpha1
+kind: NegotiatedAPIResource
+metadata:
+  annotations:
+    apiresource.kcp.io/apiVersion: v1
+    kcp.io/cluster: br3qimk2t1o3jb70
+  creationTimestamp: "2023-03-21T17:10:09Z"
+  generation: 1
+  name: services.v1.core
+  resourceVersion: "9142"
+  uid: 00122015-6a42-4004-a98b-b226b4f9c290
+spec:
+  categories:
+  - all
+  groupVersion:
+    version: v1
+  kind: Service
+  listKind: ServiceList
+  openAPIV3Schema:
+    description: Service is a named abstraction of software service (for example,
+      mysql) consisting of local port (for example 3306) that the proxy listens on,
+      and the selector that determines which pods will answer requests sent through
+      the proxy.
+    properties:
+      apiVersion:
+        description: 'APIVersion defines the versioned schema of this representation
+          of an object. Servers should convert recognized schemas to the latest internal
+          value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+        type: string
+      kind:
+        description: 'Kind is a string value representing the REST resource this object
+          represents. Servers may infer this from the endpoint the client submits
+          requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+        type: string
+      metadata:
+        type: object
+      spec:
+        description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        properties:
+          allocateLoadBalancerNodePorts:
+            description: allocateLoadBalancerNodePorts defines if NodePorts will be
+              automatically allocated for services with type LoadBalancer.  Default
+              is "true". It may be set to "false" if the cluster load-balancer does
+              not rely on NodePorts.  If the caller requests specific NodePorts (by
+              specifying a value), those requests will be respected, regardless of
+              this field. This field may only be set for services with type LoadBalancer
+              and will be cleared if the type is changed to any other type.
+            type: boolean
+          clusterIP:
+            description: 'clusterIP is the IP address of the service and is usually
+              assigned randomly. If an address is specified manually, is in-range
+              (as per system configuration), and is not in use, it will be allocated
+              to the service; otherwise creation of the service will fail. This field
+              may not be changed through updates unless the type field is also being
+              changed to ExternalName (which requires this field to be blank) or the
+              type field is being changed from ExternalName (in which case this field
+              may optionally be specified, as describe above).  Valid values are "None",
+              empty string (""), or a valid IP address. Setting this to "None" makes
+              a "headless service" (no virtual IP), which is useful when direct endpoint
+              connections are preferred and proxying is not required.  Only applies
+              to types ClusterIP, NodePort, and LoadBalancer. If this field is specified
+              when creating a Service of type ExternalName, creation will fail. This
+              field will be wiped when updating a Service to type ExternalName. More
+              info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+            type: string
+          clusterIPs:
+            description: |-
+              ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address.  Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value.
+
+              This field may hold a maximum of two entries (dual-stack IPs, in either order). These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+            items:
+              type: string
+            type: array
+            x-kubernetes-list-type: atomic
+          externalIPs:
+            description: externalIPs is a list of IP addresses for which nodes in
+              the cluster will also accept traffic for this service.  These IPs are
+              not managed by Kubernetes.  The user is responsible for ensuring that
+              traffic arrives at a node with this IP.  A common example is external
+              load-balancers that are not part of the Kubernetes system.
+            items:
+              type: string
+            type: array
+          externalName:
+            description: externalName is the external reference that discovery mechanisms
+              will return as an alias for this service (e.g. a DNS CNAME record).
+              No proxying will be involved.  Must be a lowercase RFC-1123 hostname
+              (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
+            type: string
+          externalTrafficPolicy:
+            description: |-
+              externalTrafficPolicy describes how nodes distribute service traffic they receive on one of the Service's "externally-facing" addresses (NodePorts, ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure the service in a way that assumes that external load balancers will take care of balancing the service traffic between nodes, and so each node will deliver traffic only to the node-local endpoints of the service, without masquerading the client source IP. (Traffic mistakenly sent to a node with no endpoints will be dropped.) The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features). Note that traffic sent to an External IP or LoadBalancer IP from within the cluster will always get "Cluster" semantics, but clients sending to a NodePort from within the cluster may need to take traffic policy into account when picking a node.
+
+              Possible enum values:
+               - `"Cluster"` routes traffic to all endpoints.
+               - `"Local"` preserves the source IP of the traffic by routing only to endpoints on the same node as the traffic was received on (dropping the traffic if there are no local endpoints).
+            type: string
+          healthCheckNodePort:
+            description: healthCheckNodePort specifies the healthcheck nodePort for
+              the service. This only applies when type is set to LoadBalancer and
+              externalTrafficPolicy is set to Local. If a value is specified, is in-range,
+              and is not in use, it will be used.  If not specified, a value will
+              be automatically allocated.  External systems (e.g. load-balancers)
+              can use this port to determine if a given node holds endpoints for this
+              service or not.  If this field is specified when creating a Service
+              which does not need it, creation will fail. This field will be wiped
+              when updating a Service to no longer need it (e.g. changing type). This
+              field cannot be updated once set.
+            format: int32
+            type: integer
+          internalTrafficPolicy:
+            description: InternalTrafficPolicy describes how nodes distribute service
+              traffic they receive on the ClusterIP. If set to "Local", the proxy
+              will assume that pods only want to talk to endpoints of the service
+              on the same node as the pod, dropping the traffic if there are no local
+              endpoints. The default value, "Cluster", uses the standard behavior
+              of routing to all endpoints evenly (possibly modified by topology and
+              other features).
+            type: string
+          ipFamilies:
+            description: |-
+              IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service. This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail. This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service. Valid values are "IPv4" and "IPv6".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to "headless" services. This field will be wiped when updating a Service to type ExternalName.
+
+              This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field.
+            items:
+              type: string
+            type: array
+            x-kubernetes-list-type: atomic
+          ipFamilyPolicy:
+            description: IPFamilyPolicy represents the dual-stack-ness requested or
+              required by this Service. If there is no value provided, then this field
+              will be set to SingleStack. Services can be "SingleStack" (a single
+              IP family), "PreferDualStack" (two IP families on dual-stack configured
+              clusters or a single IP family on single-stack clusters), or "RequireDualStack"
+              (two IP families on dual-stack configured clusters, otherwise fail).
+              The ipFamilies and clusterIPs fields depend on the value of this field.
+              This field will be wiped when updating a service to type ExternalName.
+            type: string
+          loadBalancerClass:
+            description: loadBalancerClass is the class of the load balancer implementation
+              this Service belongs to. If specified, the value of this field must
+              be a label-style identifier, with an optional prefix, e.g. "internal-vip"
+              or "example.com/internal-vip". Unprefixed names are reserved for end-users.
+              This field can only be set when the Service type is 'LoadBalancer'.
+              If not set, the default load balancer implementation is used, today
+              this is typically done through the cloud provider integration, but should
+              apply for any default implementation. If set, it is assumed that a load
+              balancer implementation is watching for Services with a matching class.
+              Any default load balancer implementation (e.g. cloud providers) should
+              ignore Services that set this field. This field can only be set when
+              creating or updating a Service to type 'LoadBalancer'. Once set, it
+              can not be changed. This field will be wiped when a service is updated
+              to a non 'LoadBalancer' type.
+            type: string
+          loadBalancerIP:
+            description: 'Only applies to Service Type: LoadBalancer. This feature
+              depends on whether the underlying cloud-provider supports specifying
+              the loadBalancerIP when a load balancer is created. This field will
+              be ignored if the cloud-provider does not support the feature. Deprecated:
+              This field was under-specified and its meaning varies across implementations,
+              and it cannot support dual-stack. As of Kubernetes v1.24, users are
+              encouraged to use implementation-specific annotations when available.
+              This field may be removed in a future API version.'
+            type: string
+          loadBalancerSourceRanges:
+            description: 'If specified and supported by the platform, this will restrict
+              traffic through the cloud-provider load-balancer will be restricted
+              to the specified client IPs. This field will be ignored if the cloud-provider
+              does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/'
+            items:
+              type: string
+            type: array
+          ports:
+            description: 'The list of ports that are exposed by this service. More
+              info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+            items:
+              description: ServicePort contains information on service's port.
+              properties:
+                appProtocol:
+                  description: The application protocol for this port. This field
+                    follows standard Kubernetes label syntax. Un-prefixed names are
+                    reserved for IANA standard service names (as per RFC-6335 and
+                    https://www.iana.org/assignments/service-names). Non-standard
+                    protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+                  type: string
+                name:
+                  description: The name of this port within the service. This must
+                    be a DNS_LABEL. All ports within a ServiceSpec must have unique
+                    names. When considering the endpoints for a Service, this must
+                    match the 'name' field in the EndpointPort. Optional if only one
+                    ServicePort is defined on this service.
+                  type: string
+                nodePort:
+                  description: 'The port on each node on which this service is exposed
+                    when type is NodePort or LoadBalancer.  Usually assigned by the
+                    system. If a value is specified, in-range, and not in use it will
+                    be used, otherwise the operation will fail.  If not specified,
+                    a port will be allocated if this Service requires one.  If this
+                    field is specified when creating a Service which does not need
+                    it, creation will fail. This field will be wiped when updating
+                    a Service to no longer need it (e.g. changing type from NodePort
+                    to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                  format: int32
+                  type: integer
+                port:
+                  description: The port that will be exposed by this service.
+                  format: int32
+                  type: integer
+                protocol:
+                  default: TCP
+                  description: |-
+                    The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+
+                    Possible enum values:
+                     - `"SCTP"` is the SCTP protocol.
+                     - `"TCP"` is the TCP protocol.
+                     - `"UDP"` is the UDP protocol.
+                  type: string
+                targetPort:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: 'Number or name of the port to access on the pods targeted
+                    by the service. Number must be in the range 1 to 65535. Name must
+                    be an IANA_SVC_NAME. If this is a string, it will be looked up
+                    as a named port in the target Pod''s container ports. If this
+                    is not specified, the value of the ''port'' field is used (an
+                    identity map). This field is ignored for services with clusterIP=None,
+                    and should be omitted or set equal to the ''port'' field. More
+                    info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                  x-kubernetes-int-or-string: true
+              required:
+              - port
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - port
+            - protocol
+            x-kubernetes-list-type: map
+          publishNotReadyAddresses:
+            description: publishNotReadyAddresses indicates that any agent which deals
+              with endpoints for this Service should disregard any indications of
+              ready/not-ready. The primary use case for setting this field is for
+              a StatefulSet's Headless Service to propagate SRV DNS records for its
+              Pods for the purpose of peer discovery. The Kubernetes controllers that
+              generate Endpoints and EndpointSlice resources for Services interpret
+              this to mean that all endpoints are considered "ready" even if the Pods
+              themselves are not. Agents which consume only Kubernetes generated endpoints
+              through the Endpoints or EndpointSlice resources can safely assume this
+              behavior.
+            type: boolean
+          selector:
+            additionalProperties:
+              type: string
+            description: 'Route service traffic to pods with label keys and values
+              matching this selector. If empty or not present, the service is assumed
+              to have an external process managing its endpoints, which Kubernetes
+              will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer.
+              Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+            type: object
+          sessionAffinity:
+            description: |-
+              Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+
+              Possible enum values:
+               - `"ClientIP"` is the Client IP based.
+               - `"None"` - no session affinity.
+            type: string
+          sessionAffinityConfig:
+            description: sessionAffinityConfig contains the configurations of session
+              affinity.
+            properties:
+              clientIP:
+                description: clientIP contains the configurations of Client IP based
+                  session affinity.
+                properties:
+                  timeoutSeconds:
+                    description: timeoutSeconds specifies the seconds of ClientIP
+                      type session sticky time. The value must be >0 && <=86400(for
+                      1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for
+                      3 hours).
+                    format: int32
+                    type: integer
+                type: object
+            type: object
+          type:
+            description: |-
+              type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+
+              Possible enum values:
+               - `"ClusterIP"` means a service will only be accessible inside the cluster, via the cluster IP.
+               - `"ExternalName"` means a service consists of only a reference to an external name that kubedns or equivalent will return as a CNAME record, with no exposing or proxying of any pods involved.
+               - `"LoadBalancer"` means a service will be exposed via an external load balancer (if the cloud provider supports it), in addition to 'NodePort' type.
+               - `"NodePort"` means a service will be exposed on one port of every node, in addition to 'ClusterIP' type.
+            type: string
+        type: object
+      status:
+        description: 'Most recently observed status of the service. Populated by the
+          system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+        properties:
+          conditions:
+            description: Current service state
+            items:
+              description: Condition contains details for one aspect of the current
+                state of this API Resource.
+              properties:
+                lastTransitionTime:
+                  description: lastTransitionTime is the last time the condition transitioned
+                    from one status to another. This should be when the underlying
+                    condition changed.  If that is not known, then using the time
+                    when the API field changed is acceptable.
+                  format: date-time
+                  type: string
+                message:
+                  description: message is a human readable message indicating details
+                    about the transition. This may be an empty string.
+                  type: string
+                observedGeneration:
+                  description: observedGeneration represents the .metadata.generation
+                    that the condition was set based upon. For instance, if .metadata.generation
+                    is currently 12, but the .status.conditions[x].observedGeneration
+                    is 9, the condition is out of date with respect to the current
+                    state of the instance.
+                  format: int64
+                  type: integer
+                reason:
+                  description: reason contains a programmatic identifier indicating
+                    the reason for the condition's last transition. Producers of specific
+                    condition types may define expected values and meanings for this
+                    field, and whether the values are considered a guaranteed API.
+                    The value should be a CamelCase string. This field may not be
+                    empty.
+                  type: string
+                status:
+                  description: status of the condition, one of True, False, Unknown.
+                  type: string
+                type:
+                  description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                  type: string
+              required:
+              - lastTransitionTime
+              - message
+              - reason
+              - status
+              - type
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - type
+            x-kubernetes-list-type: map
+          loadBalancer:
+            description: LoadBalancer contains the current status of the load-balancer,
+              if one is present.
+            properties:
+              ingress:
+                description: Ingress is a list containing ingress points for the load-balancer.
+                  Traffic intended for the service should be sent to these ingress
+                  points.
+                items:
+                  description: 'LoadBalancerIngress represents the status of a load-balancer
+                    ingress point: traffic intended for the service should be sent
+                    to an ingress point.'
+                  properties:
+                    hostname:
+                      description: Hostname is set for load-balancer ingress points
+                        that are DNS based (typically AWS load-balancers)
+                      type: string
+                    ip:
+                      description: IP is set for load-balancer ingress points that
+                        are IP based (typically GCE or OpenStack load-balancers)
+                      type: string
+                    ports:
+                      description: Ports is a list of records of service ports If
+                        used, every port defined in the service should have an entry
+                        in it
+                      items:
+                        properties:
+                          error:
+                            description: |-
+                              Error is to record the problem with the service port The format of the error shall comply with the following rules: - built-in error values shall be specified in this file and those shall use
+                                CamelCase names
+                              - cloud provider specific error values must have names that comply with the
+                                format foo.example.com/CamelCase.
+                            type: string
+                          port:
+                            description: Port is the port number of the service port
+                              of which status is recorded here
+                            format: int32
+                            type: integer
+                          protocol:
+                            description: |-
+                              Protocol is the protocol of the service port of which status is recorded here The supported values are: "TCP", "UDP", "SCTP"
+
+                              Possible enum values:
+                               - `"SCTP"` is the SCTP protocol.
+                               - `"TCP"` is the TCP protocol.
+                               - `"UDP"` is the UDP protocol.
+                            type: string
+                        required:
+                        - port
+                        - protocol
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  type: object
+                type: array
+            type: object
+        type: object
+    type: object
+  plural: services
+  scope: Namespaced
+  shortNames:
+  - svc
+  singular: service
+  subResources:
+  - name: status

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/4-apibinding-kubernetes-1pre20xf.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/4-apibinding-kubernetes-1pre20xf.yaml
@@ -1,0 +1,76 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIBinding
+metadata:
+  annotations:
+    extra.apis.kcp.io/compute.workload.kcp.io: "true"
+    kcp.io/cluster: br3qimk2t1o3jb70
+  creationTimestamp: "2023-03-21T17:21:48Z"
+  finalizers:
+  - apis.kcp.io/apibinding-finalizer
+  generation: 1
+  labels:
+    claimed.internal.apis.kcp.io/77zi8i256rosNE0ykJyOOB4OwxAMrho27rckj3: LstvmbbzVDDOn90ZbhzSQO5U3DMCf88h1pZ
+    internal.apis.kcp.io/export: 77zi8i256rosNE0ykJyOOB4OwxAMrho27rckj3
+  name: kubernetes-1pre20xf
+  resourceVersion: "9320"
+  uid: 35bd2e6c-ebc4-411b-ab95-f706841c9441
+spec:
+  reference:
+    export:
+      name: kubernetes
+      path: root:compute
+status:
+  apiExportClusterName: 2ei017lw8ljpxp5x
+  boundResources:
+  - group: networking.k8s.io
+    resource: ingresses
+    schema:
+      UID: ac065681-9ce8-4798-956b-347dfe2610f2
+      identityHash: <id-hash>
+      name: v124.ingresses.networking.k8s.io
+    storageVersions:
+    - v1
+  - group: ""
+    resource: services
+    schema:
+      UID: 06b1ff23-56af-42bd-b3f9-d016dbbf6000
+      identityHash: <id-hash>
+      name: v124.services.core
+    storageVersions:
+    - v1
+  - group: apps
+    resource: deployments
+    schema:
+      UID: 8eb70a7d-6856-4b52-8a88-7adcf40b6c49
+      identityHash: <id-hash>
+      name: v124.deployments.apps
+    storageVersions:
+    - v1
+  - group: ""
+    resource: pods
+    schema:
+      UID: ad4c06b1-3d92-46d4-8ca7-78ee41548b40
+      identityHash: <id-hash>
+      name: v124.pods.core
+    storageVersions:
+    - v1
+  conditions:
+  - lastTransitionTime: "2023-03-21T17:21:48Z"
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2023-03-21T17:21:48Z"
+    status: "True"
+    type: APIExportValid
+  - lastTransitionTime: "2023-03-21T17:21:48Z"
+    status: "True"
+    type: BindingUpToDate
+  - lastTransitionTime: "2023-03-21T17:21:48Z"
+    status: "True"
+    type: InitialBindingCompleted
+  - lastTransitionTime: "2023-03-21T17:21:48Z"
+    status: "True"
+    type: PermissionClaimsApplied
+  - lastTransitionTime: "2023-03-21T17:21:48Z"
+    status: "True"
+    type: PermissionClaimsValid
+  phase: Bound

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/4-apibinding-kubernetes-1pre20xf.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/4-apibinding-kubernetes-1pre20xf.yaml
@@ -26,7 +26,7 @@ status:
     resource: ingresses
     schema:
       UID: ac065681-9ce8-4798-956b-347dfe2610f2
-      identityHash: <id-hash>
+      identityHash: 1215a6f9c5bad3a00c7af77b1bd715f81357d9238b1f4d2968b0a23cb3412217
       name: v124.ingresses.networking.k8s.io
     storageVersions:
     - v1
@@ -34,7 +34,7 @@ status:
     resource: services
     schema:
       UID: 06b1ff23-56af-42bd-b3f9-d016dbbf6000
-      identityHash: <id-hash>
+      identityHash: 1215a6f9c5bad3a00c7af77b1bd715f81357d9238b1f4d2968b0a23cb3412217
       name: v124.services.core
     storageVersions:
     - v1
@@ -42,7 +42,7 @@ status:
     resource: deployments
     schema:
       UID: 8eb70a7d-6856-4b52-8a88-7adcf40b6c49
-      identityHash: <id-hash>
+      identityHash: 1215a6f9c5bad3a00c7af77b1bd715f81357d9238b1f4d2968b0a23cb3412217
       name: v124.deployments.apps
     storageVersions:
     - v1
@@ -50,7 +50,7 @@ status:
     resource: pods
     schema:
       UID: ad4c06b1-3d92-46d4-8ca7-78ee41548b40
-      identityHash: <id-hash>
+      identityHash: 1215a6f9c5bad3a00c7af77b1bd715f81357d9238b1f4d2968b0a23cb3412217
       name: v124.pods.core
     storageVersions:
     - v1

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/4-apibinding-kubernetes.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/4-apibinding-kubernetes.yaml
@@ -1,0 +1,42 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIBinding
+metadata:
+  annotations:
+    extra.apis.kcp.io/compute.workload.kcp.io: "true"
+    kcp.io/cluster: br3qimk2t1o3jb70
+  creationTimestamp: "2023-03-21T17:05:37Z"
+  finalizers:
+  - apis.kcp.io/apibinding-finalizer
+  generation: 1
+  labels:
+    claimed.internal.apis.kcp.io/2rwzR3UC0Z0lSFUGD5EuXbE1OSTXPKljY8O67v: LstvmbbzVDDOn90ZbhzSQO5U3DMCf88h1pZ
+    internal.apis.kcp.io/export: 2rwzR3UC0Z0lSFUGD5EuXbE1OSTXPKljY8O67v
+  name: kubernetes
+  resourceVersion: "9101"
+  uid: ba26edd8-fb9c-4b85-a5e1-e662e882a8ca
+spec:
+  reference:
+    export:
+      name: kubernetes
+status:
+  apiExportClusterName: br3qimk2t1o3jb70
+  conditions:
+  - lastTransitionTime: "2023-03-21T17:05:37Z"
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2023-03-21T17:05:37Z"
+    status: "True"
+    type: APIExportValid
+  - lastTransitionTime: "2023-03-21T17:05:37Z"
+    status: "True"
+    type: BindingUpToDate
+  - lastTransitionTime: "2023-03-21T17:05:37Z"
+    status: "True"
+    type: InitialBindingCompleted
+  - lastTransitionTime: "2023-03-21T17:05:37Z"
+    status: "True"
+    type: PermissionClaimsApplied
+  - lastTransitionTime: "2023-03-21T17:05:37Z"
+    status: "True"
+    type: PermissionClaimsValid
+  phase: Bound

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/4-apiexport-kubernetes.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/4-apiexport-kubernetes.yaml
@@ -1,0 +1,29 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIExport
+metadata:
+  annotations:
+    extra.apis.kcp.io/compute.workload.kcp.io: "true"
+    kcp.io/cluster: br3qimk2t1o3jb70
+    kcp.io/path: root:kind
+    workload.kcp.io/skip-default-object-creation: "true"
+  creationTimestamp: "2023-03-21T17:05:37Z"
+  generation: 2
+  name: kubernetes
+  resourceVersion: "9098"
+  uid: 92c4a3e0-c366-466b-8474-b905d81f8fc2
+spec:
+  identity:
+    secretRef:
+      name: kubernetes
+      namespace: kcp-system
+status:
+  conditions:
+  - lastTransitionTime: "2023-03-21T17:05:37Z"
+    status: "True"
+    type: IdentityValid
+  - lastTransitionTime: "2023-03-21T17:05:37Z"
+    status: "True"
+    type: VirtualWorkspaceURLsReady
+  identityHash: 2650446b7496d5eb53a84d078251342a607b3e638c0e1477b3999b02b8fe307d
+  virtualWorkspaces:
+  - url: https://<kcp-url>:6443/services/apiexport/br3qimk2t1o3jb70/kubernetes

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/4-location-default.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/4-location-default.yaml
@@ -1,0 +1,20 @@
+apiVersion: scheduling.kcp.io/v1alpha1
+kind: Location
+metadata:
+  annotations:
+    kcp.io/cluster: br3qimk2t1o3jb70
+    kcp.io/path: root:kind
+  creationTimestamp: "2023-03-21T17:05:37Z"
+  generation: 1
+  name: default
+  resourceVersion: "9136"
+  uid: d5ecd13e-d413-4d87-a62b-c154f9156e73
+spec:
+  instanceSelector: {}
+  resource:
+    group: workload.kcp.io
+    resource: synctargets
+    version: v1alpha1
+status:
+  availableInstances: 1
+  instances: 1

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/4-placement.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/4-placement.yaml
@@ -1,0 +1,32 @@
+apiVersion: scheduling.kcp.io/v1alpha1
+kind: Placement
+metadata:
+  annotations:
+    internal.workload.kcp.io/synctarget: alIviEyJiysDMorx9fWmI2ygTHSTrvxXGyVwSJ
+    kcp.io/cluster: br3qimk2t1o3jb70
+  creationTimestamp: "2023-03-21T17:23:57Z"
+  generation: 1
+  name: placement-2iddvmcj
+  resourceVersion: "9368"
+  uid: acab9d5b-a715-4558-8146-8d570645fca1
+spec:
+  locationResource:
+    group: workload.kcp.io
+    resource: synctargets
+    version: v1alpha1
+  locationSelectors:
+  - {}
+  locationWorkspace: root:kind
+  namespaceSelector: {}
+status:
+  conditions:
+  - lastTransitionTime: "2023-03-21T17:23:57Z"
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2023-03-21T17:23:57Z"
+    status: "True"
+    type: Scheduled
+  phase: Bound
+  selectedLocation:
+    locationName: default
+    path: br3qimk2t1o3jb70

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/4-synctarget-kind.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/4-synctarget-kind.yaml
@@ -1,0 +1,55 @@
+apiVersion: workload.kcp.io/v1alpha1
+kind: SyncTarget
+metadata:
+  annotations:
+    kcp.io/cluster: br3qimk2t1o3jb70
+  creationTimestamp: "2023-03-21T17:05:37Z"
+  generation: 1
+  labels:
+    internal.workload.kcp.io/key: alIviEyJiysDMorx9fWmI2ygTHSTrvxXGyVwSJ
+  name: kind
+  resourceVersion: "9510"
+  uid: 8df305e7-f4f8-439f-9115-51054d519361
+spec:
+  supportedAPIExports:
+  - export: kubernetes
+    path: root:compute
+  unschedulable: false
+status:
+  conditions:
+  - lastTransitionTime: "2023-03-21T17:10:07Z"
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2023-03-21T17:10:07Z"
+    status: "True"
+    type: HeartbeatHealthy
+  - lastTransitionTime: "2023-03-21T17:10:07Z"
+    status: "True"
+    type: SyncerAuthorized
+  lastSyncerHeartbeatTime: "2023-03-21T17:34:48Z"
+  syncedResources:
+  - identityHash: <id-hash>
+    resource: services
+    state: Accepted
+    versions:
+    - v1
+  - identityHash: <id-hash>
+    resource: pods
+    state: Accepted
+    versions:
+    - v1
+  - group: networking.k8s.io
+    identityHash: <id-hash>
+    resource: ingresses
+    state: Accepted
+    versions:
+    - v1
+  - group: apps
+    identityHash: <id-hash>
+    resource: deployments
+    state: Accepted
+    versions:
+    - v1
+  virtualWorkspaces:
+  - syncerURL: https://<kcp-url>:6443/services/syncer/br3qimk2t1o3jb70/kind/8df305e7-f4f8-439f-9115-51054d519361
+    upsyncerURL: https://<kcp-url>:6443/services/upsyncer/br3qimk2t1o3jb70/kind/8df305e7-f4f8-439f-9115-51054d519361

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/4-synctarget-kind.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/4-synctarget-kind.yaml
@@ -28,24 +28,24 @@ status:
     type: SyncerAuthorized
   lastSyncerHeartbeatTime: "2023-03-21T17:34:48Z"
   syncedResources:
-  - identityHash: <id-hash>
+  - identityHash: 1215a6f9c5bad3a00c7af77b1bd715f81357d9238b1f4d2968b0a23cb3412217
     resource: services
     state: Accepted
     versions:
     - v1
-  - identityHash: <id-hash>
+  - identityHash: 1215a6f9c5bad3a00c7af77b1bd715f81357d9238b1f4d2968b0a23cb3412217
     resource: pods
     state: Accepted
     versions:
     - v1
   - group: networking.k8s.io
-    identityHash: <id-hash>
+    identityHash: 1215a6f9c5bad3a00c7af77b1bd715f81357d9238b1f4d2968b0a23cb3412217
     resource: ingresses
     state: Accepted
     versions:
     - v1
   - group: apps
-    identityHash: <id-hash>
+    identityHash: 1215a6f9c5bad3a00c7af77b1bd715f81357d9238b1f4d2968b0a23cb3412217
     resource: deployments
     state: Accepted
     versions:

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/root-compute-apiexport-kubernetes.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/root-compute-apiexport-kubernetes.yaml
@@ -1,0 +1,36 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIExport
+metadata:
+  annotations:
+    bootstrap.kcp.io/battery: root-compute-workspace
+    extra.apis.kcp.io/compute.workload.kcp.io: "true"
+    kcp.io/cluster: 2ei017lw8ljpxp5x
+    kcp.io/path: root:compute
+  creationTimestamp: "2023-03-20T18:15:11Z"
+  generation: 2
+  name: kubernetes
+  resourceVersion: "599"
+  uid: 437f1d1c-2a0a-4592-a22a-1e10e0220df3
+spec:
+  identity:
+    secretRef:
+      name: kubernetes
+      namespace: kcp-system
+  latestResourceSchemas:
+  - v124.ingresses.networking.k8s.io
+  - v124.services.core
+  - v124.deployments.apps
+  - v124.pods.core
+  maximalPermissionPolicy:
+    local: {}
+status:
+  conditions:
+  - lastTransitionTime: "2023-03-20T18:15:11Z"
+    status: "True"
+    type: IdentityValid
+  - lastTransitionTime: "2023-03-20T18:15:11Z"
+    status: "True"
+    type: VirtualWorkspaceURLsReady
+  identityHash: <id-hash>
+  virtualWorkspaces:
+  - url: https://<kcp-url>:6443/services/apiexport/2ei017lw8ljpxp5x/kubernetes

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/root-compute-apiexport-kubernetes.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/root-compute-apiexport-kubernetes.yaml
@@ -31,6 +31,6 @@ status:
   - lastTransitionTime: "2023-03-20T18:15:11Z"
     status: "True"
     type: VirtualWorkspaceURLsReady
-  identityHash: <id-hash>
+  identityHash: 1215a6f9c5bad3a00c7af77b1bd715f81357d9238b1f4d2968b0a23cb3412217
   virtualWorkspaces:
   - url: https://<kcp-url>:6443/services/apiexport/2ei017lw8ljpxp5x/kubernetes

--- a/docs/content/concepts/scenarios/kind-scenario/yamls/syncer-kind.yaml
+++ b/docs/content/concepts/scenarios/kind-scenario/yamls/syncer-kind.yaml
@@ -1,0 +1,239 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kcp-syncer-kind-37zv5s0u
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kcp-syncer-kind-37zv5s0u
+  namespace: kcp-syncer-kind-37zv5s0u
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kcp-syncer-kind-37zv5s0u-token
+  namespace: kcp-syncer-kind-37zv5s0u
+  annotations:
+    kubernetes.io/service-account.name: kcp-syncer-kind-37zv5s0u
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kcp-syncer-kind-37zv5s0u
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - "create"
+  - "get"
+  - "list"
+  - "watch"
+  - "delete"
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - "get"
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - "get"
+  - "watch"
+  - "list"
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - "create"
+  - "list"
+  - "watch"
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - pods/log
+  - pods/exec
+  - pods/attach
+  - pods/binding
+  - pods/portforward
+  - pods/proxy
+  - pods/ephemeralcontainers
+  - secrets
+  - services
+  verbs:
+  - "*"
+- apiGroups:
+  - "apps"
+  resources:
+  - deployments
+  verbs:
+  - "*"
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - ingresses
+  verbs:
+  - "*"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kcp-syncer-kind-37zv5s0u
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kcp-syncer-kind-37zv5s0u
+subjects:
+- kind: ServiceAccount
+  name: kcp-syncer-kind-37zv5s0u
+  namespace: kcp-syncer-kind-37zv5s0u
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kcp-dns-kind-37zv5s0u
+  namespace: kcp-syncer-kind-37zv5s0u
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  - services
+  verbs:
+  - "create"
+  - "get"
+  - "list"
+  - "update"
+  - "delete"
+  - "watch"
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+- apiGroups:
+  - "apps"
+  resources:
+  - deployments
+  verbs:
+  - "create"
+  - "get"
+  - "list"
+  - "update"
+  - "delete"
+  - "watch"
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - "create"
+  - "get"
+  - "list"
+  - "update"
+  - "delete"
+  - "watch"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kcp-dns-kind-37zv5s0u
+  namespace: kcp-syncer-kind-37zv5s0u
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kcp-dns-kind-37zv5s0u
+subjects:
+  - kind: ServiceAccount
+    name: kcp-syncer-kind-37zv5s0u
+    namespace: kcp-syncer-kind-37zv5s0u
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kcp-syncer-kind-37zv5s0u
+  namespace: kcp-syncer-kind-37zv5s0u
+stringData:
+  kubeconfig: |
+    apiVersion: v1
+    kind: Config
+    clusters:
+    - name: default-cluster
+      cluster:
+        certificate-authority-data: <certificate>
+        server: https://<kcp-url>:6443
+    contexts:
+    - name: default-context
+      context:
+        cluster: default-cluster
+        namespace: default
+        user: default-user
+    current-context: default-context
+    users:
+    - name: default-user
+      user:
+        token: <token>
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kcp-syncer-kind-37zv5s0u
+  namespace: kcp-syncer-kind-37zv5s0u
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: kcp-syncer-kind-37zv5s0u
+  template:
+    metadata:
+      labels:
+        app: kcp-syncer-kind-37zv5s0u
+    spec:
+      containers:
+      - name: kcp-syncer
+        command:
+        - /ko-app/syncer
+        args:
+        - --from-kubeconfig=/kcp/kubeconfig
+        - --sync-target-name=kind
+        - --sync-target-uid=8df305e7-f4f8-439f-9115-51054d519361
+        - --from-cluster=br3qimk2t1o3jb70
+        - --api-import-poll-interval=1m0s
+        - --downstream-namespace-clean-delay=30s
+        - --qps=20
+        - --burst=30
+        - --dns-image=ghcr.io/kcp-dev/kcp/syncer:v0.11.0
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: ghcr.io/kcp-dev/kcp/syncer:v0.11.0
+        imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - name: kcp-config
+          mountPath: /kcp/
+          readOnly: true
+      serviceAccountName: kcp-syncer-kind-37zv5s0u
+      volumes:
+        - name: kcp-config
+          secret:
+            secretName: kcp-syncer-kind-37zv5s0u
+            optional: false


### PR DESCRIPTION
## Summary
Document of the key KCP objects, with they Yaml, that are created and modified during the key steps of MC Syncer deployment:

1. Creation of a KCP Workspace (k ws create)
2. Creation of a KCP Syncer (k kcp workload sync)
3. Deployment of the Syncer in the edge pcluster (k apply -f)
4. Binding of the Syncer resources (k kcp bind compute)

Two explanatory scenarios are considered:

1. A pcluster with compatible resource schemas, such as the Kind cluster  example discussed in the [quickstart](https://docs.kcp.io/kcp/main/)
2. A pcluster with incompatible resource schemas, as the MicroShift cluster scenario discussed in https://github.com/kcp-dev/kcp/issues/2885

## Related issue(s)
kcp-dev/contrib-tmc#30 

Fixes #
kcp-dev/contrib-tmc#30 
