### PR TITLE
:bug: change state to pending state in case no corresponding APIResourceImp…

### DIFF
--- a/pkg/reconciler/workload/synctargetexports/synctargetcompatible_reconcile.go
+++ b/pkg/reconciler/workload/synctargetexports/synctargetcompatible_reconcile.go
@@ -115,7 +115,7 @@ func (e *apiCompatibleReconciler) reconcile(ctx context.Context, syncTarget *wor
 
 			downStreamSchema, ok := apiImportMap[gvr]
 			if !ok {
-				syncTarget.Status.SyncedResources[i].State = workloadv1alpha1.ResourceSchemaIncompatibleState
+				syncTarget.Status.SyncedResources[i].State = workloadv1alpha1.ResourceSchemaPendingState
 				continue
 			}
 

--- a/pkg/reconciler/workload/synctargetexports/synctargetcompatible_reconcile_test.go
+++ b/pkg/reconciler/workload/synctargetexports/synctargetcompatible_reconcile_test.go
@@ -84,7 +84,7 @@ func TestSyncTargetCompatibleReconcile(t *testing.T) {
 				}),
 			},
 			wantSyncedResources: []workloadv1alpha1.ResourceToSync{
-				{GroupResource: apisv1alpha1.GroupResource{Group: "apps", Resource: "deployments"}, Versions: []string{"v1"}, State: workloadv1alpha1.ResourceSchemaIncompatibleState},
+				{GroupResource: apisv1alpha1.GroupResource{Group: "apps", Resource: "deployments"}, Versions: []string{"v1"}, State: workloadv1alpha1.ResourceSchemaPendingState},
 			},
 		},
 		{

--- a/test/e2e/reconciler/locationworkspace/synctarget_test.go
+++ b/test/e2e/reconciler/locationworkspace/synctarget_test.go
@@ -116,7 +116,7 @@ func TestSyncTargetExport(t *testing.T) {
 		}
 
 		if syncTarget.Status.SyncedResources[0].Resource != "cowboys" ||
-			syncTarget.Status.SyncedResources[0].State != workloadv1alpha1.ResourceSchemaIncompatibleState {
+			syncTarget.Status.SyncedResources[0].State != workloadv1alpha1.ResourceSchemaPendingState {
 			return false
 		}
 


### PR DESCRIPTION
…ort object is found

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR changes the state of syncedResources to Pending (earllier it was Incompatible) in case no corresponding APIResourceImport object is found!


## Related issue(s)

Fixes kcp-dev/contrib-tmc#28 
