### PR TITLE
🌱 Replicating SyncTarget-related rbac and logicalclusters objects

### DIFF
--- a/pkg/reconciler/workload/replicateclusterrole/replicateclusterrole_controller.go
+++ b/pkg/reconciler/workload/replicateclusterrole/replicateclusterrole_controller.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package replicateclusterrole
+
+import (
+	kcprbacinformers "github.com/kcp-dev/client-go/informers/rbac/v1"
+	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/kube-openapi/pkg/util/sets"
+
+	"github.com/kcp-dev/kcp/pkg/reconciler/cache/labelclusterroles"
+	"github.com/kcp-dev/kcp/sdk/apis/workload"
+)
+
+const (
+	ControllerName = "kcp-workloads-replicate-clusterrole"
+)
+
+// NewController returns a new controller for labelling ClusterRole that should be replicated.
+func NewController(
+	kubeClusterClient kcpkubernetesclientset.ClusterInterface,
+	clusterRoleInformer kcprbacinformers.ClusterRoleClusterInformer,
+	clusterRoleBindingInformer kcprbacinformers.ClusterRoleBindingClusterInformer,
+) labelclusterroles.Controller {
+	return labelclusterroles.NewController(
+		ControllerName,
+		workload.GroupName,
+		HasSyncRule,
+		func(clusterName logicalcluster.Name, crb *rbacv1.ClusterRoleBinding) bool { return false },
+		kubeClusterClient,
+		clusterRoleInformer,
+		clusterRoleBindingInformer,
+	)
+}
+
+func HasSyncRule(clusterName logicalcluster.Name, cr *rbacv1.ClusterRole) bool {
+	for _, rule := range cr.Rules {
+		apiGroups := sets.NewString(rule.APIGroups...)
+		if !apiGroups.Has(workload.GroupName) && !apiGroups.Has("*") {
+			continue
+		}
+		resources := sets.NewString(rule.Resources...)
+		verbs := sets.NewString(rule.Verbs...)
+		if (resources.Has("synctargets") || resources.Has("*")) && (verbs.Has("sync") || verbs.Has("*")) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/reconciler/workload/replicateclusterrolebinding/replicateclusterrolebinding_controller.go
+++ b/pkg/reconciler/workload/replicateclusterrolebinding/replicateclusterrolebinding_controller.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package replicateclusterrolebinding
+
+import (
+	kcprbacinformers "github.com/kcp-dev/client-go/informers/rbac/v1"
+	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+
+	"github.com/kcp-dev/kcp/pkg/reconciler/cache/labelclusterrolebindings"
+	"github.com/kcp-dev/kcp/pkg/reconciler/workload/replicateclusterrole"
+	"github.com/kcp-dev/kcp/sdk/apis/workload"
+)
+
+const (
+	ControllerName = "kcp-workloads-replicate-clusterrolebinding"
+)
+
+// NewController returns a new controller for labelling ClusterRoleBinding that should be replicated.
+func NewController(
+	kubeClusterClient kcpkubernetesclientset.ClusterInterface,
+	clusterRoleBindingInformer kcprbacinformers.ClusterRoleBindingClusterInformer,
+	clusterRoleInformer kcprbacinformers.ClusterRoleClusterInformer,
+) labelclusterrolebindings.Controller {
+	return labelclusterrolebindings.NewController(
+		ControllerName,
+		workload.GroupName,
+		replicateclusterrole.HasSyncRule,
+		func(clusterName logicalcluster.Name, crb *rbacv1.ClusterRoleBinding) bool { return false },
+		kubeClusterClient,
+		clusterRoleBindingInformer,
+		clusterRoleInformer,
+	)
+}

--- a/pkg/reconciler/workload/replicatelogicalcluster/replicatelogicalcluster_controller.go
+++ b/pkg/reconciler/workload/replicatelogicalcluster/replicatelogicalcluster_controller.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package replicatelogicalcluster
+
+import (
+	"fmt"
+
+	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/kcp-dev/kcp/pkg/reconciler/cache/labellogicalcluster"
+	"github.com/kcp-dev/kcp/pkg/reconciler/cache/replication"
+	corev1alpha1 "github.com/kcp-dev/kcp/sdk/apis/core/v1alpha1"
+	"github.com/kcp-dev/kcp/sdk/apis/workload"
+	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
+	kcpclientset "github.com/kcp-dev/kcp/sdk/client/clientset/versioned/cluster"
+	corev1alpha1informers "github.com/kcp-dev/kcp/sdk/client/informers/externalversions/core/v1alpha1"
+	workloadv1alpha1informers "github.com/kcp-dev/kcp/sdk/client/informers/externalversions/workload/v1alpha1"
+)
+
+const (
+	ControllerName = "kcp-workload-replicate-logicalcluster"
+)
+
+// NewController returns a new controller for labelling LogicalClusters that should be replicated.
+
+func NewController(
+	kcpClusterClient kcpclientset.ClusterInterface,
+	logicalClusterInformer corev1alpha1informers.LogicalClusterClusterInformer,
+	syncTargetInformer workloadv1alpha1informers.SyncTargetClusterInformer,
+) labellogicalcluster.Controller {
+	logicalClusterLister := logicalClusterInformer.Lister()
+	syncTargetIndexer := syncTargetInformer.Informer().GetIndexer()
+
+	c := labellogicalcluster.NewController(
+		ControllerName,
+		workload.GroupName,
+		func(cluster *corev1alpha1.LogicalCluster) bool {
+			// If there are any SyncTargets for this logical cluster, then the LogicalCluster object should be replicated.
+			keys, err := syncTargetIndexer.IndexKeys(kcpcache.ClusterIndexName, kcpcache.ClusterIndexKey(logicalcluster.From(cluster)))
+			if err != nil {
+				runtime.HandleError(fmt.Errorf("failed to list SyncTargets: %v", err))
+				return false
+			}
+			return len(keys) > 0
+		},
+		kcpClusterClient,
+		logicalClusterInformer,
+	)
+
+	// enqueue the logical cluster every time the APIExport changes
+	enqueueSyncTarget := func(obj interface{}) {
+		if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+			obj = tombstone.Obj
+		}
+
+		syncTarget, ok := obj.(*workloadv1alpha1.SyncTarget)
+		if !ok {
+			runtime.HandleError(fmt.Errorf("unexpected object type: %T", obj))
+			return
+		}
+
+		cluster, err := logicalClusterLister.Cluster(logicalcluster.From(syncTarget)).Get(corev1alpha1.LogicalClusterName)
+		if err != nil && !apierrors.IsNotFound(err) {
+			runtime.HandleError(fmt.Errorf("failed to get logical cluster: %v", err))
+			return
+		} else if apierrors.IsNotFound(err) {
+			return
+		}
+
+		c.EnqueueLogicalCluster(cluster, "reason", "SyncTarget changed", "synctarget", syncTarget.Name)
+	}
+
+	syncTargetInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: replication.IsNoSystemClusterName,
+		Handler: cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				enqueueSyncTarget(obj)
+			},
+			DeleteFunc: func(obj interface{}) {
+				enqueueSyncTarget(obj)
+			},
+		},
+	})
+
+	return c
+}

--- a/tmc/pkg/server/controllers.go
+++ b/tmc/pkg/server/controllers.go
@@ -37,6 +37,8 @@ import (
 	"github.com/kcp-dev/kcp/pkg/reconciler/workload/heartbeat"
 	workloadnamespace "github.com/kcp-dev/kcp/pkg/reconciler/workload/namespace"
 	workloadplacement "github.com/kcp-dev/kcp/pkg/reconciler/workload/placement"
+	workloadreplicateclusterrole "github.com/kcp-dev/kcp/pkg/reconciler/workload/replicateclusterrole"
+	workloadreplicateclusterrolebinding "github.com/kcp-dev/kcp/pkg/reconciler/workload/replicateclusterrolebinding"
 	workloadresource "github.com/kcp-dev/kcp/pkg/reconciler/workload/resource"
 	synctargetcontroller "github.com/kcp-dev/kcp/pkg/reconciler/workload/synctarget"
 	"github.com/kcp-dev/kcp/pkg/reconciler/workload/synctargetexports"
@@ -393,6 +395,60 @@ func (s *Server) installSyncTargetController(ctx context.Context, config *rest.C
 
 	return s.Core.AddPostStartHook(postStartHookName(synctargetcontroller.ControllerName), func(hookContext genericapiserver.PostStartHookContext) error {
 		logger := klog.FromContext(ctx).WithValues("postStartHook", postStartHookName(synctargetcontroller.ControllerName))
+		if err := s.Core.WaitForSync(hookContext.StopCh); err != nil {
+			logger.Error(err, "failed to finish post-start-hook")
+			return nil // don't klog.Fatal. This only happens when context is cancelled.
+		}
+
+		go c.Start(goContext(hookContext), 2)
+
+		return nil
+	})
+}
+
+func (s *Server) installWorkloadReplicateClusterRoleControllers(ctx context.Context, config *rest.Config) error {
+	config = rest.CopyConfig(config)
+	config = rest.AddUserAgent(config, workloadreplicateclusterrole.ControllerName)
+	kubeClusterClient, err := kcpkubernetesclientset.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+
+	c := workloadreplicateclusterrole.NewController(
+		kubeClusterClient,
+		s.Core.KubeSharedInformerFactory.Rbac().V1().ClusterRoles(),
+		s.Core.KubeSharedInformerFactory.Rbac().V1().ClusterRoleBindings(),
+	)
+
+	return s.Core.AddPostStartHook(postStartHookName(workloadreplicateclusterrole.ControllerName), func(hookContext genericapiserver.PostStartHookContext) error {
+		logger := klog.FromContext(ctx).WithValues("postStartHook", postStartHookName(workloadreplicateclusterrole.ControllerName))
+		if err := s.Core.WaitForSync(hookContext.StopCh); err != nil {
+			logger.Error(err, "failed to finish post-start-hook")
+			return nil // don't klog.Fatal. This only happens when context is cancelled.
+		}
+
+		go c.Start(goContext(hookContext), 2)
+
+		return nil
+	})
+}
+
+func (s *Server) installWorkloadReplicateClusterRoleBindingControllers(ctx context.Context, config *rest.Config) error {
+	config = rest.CopyConfig(config)
+	config = rest.AddUserAgent(config, workloadreplicateclusterrolebinding.ControllerName)
+	kubeClusterClient, err := kcpkubernetesclientset.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+
+	c := workloadreplicateclusterrolebinding.NewController(
+		kubeClusterClient,
+		s.Core.KubeSharedInformerFactory.Rbac().V1().ClusterRoleBindings(),
+		s.Core.KubeSharedInformerFactory.Rbac().V1().ClusterRoles(),
+	)
+
+	return s.Core.AddPostStartHook(postStartHookName(workloadreplicateclusterrolebinding.ControllerName), func(hookContext genericapiserver.PostStartHookContext) error {
+		logger := klog.FromContext(ctx).WithValues("postStartHook", postStartHookName(workloadreplicateclusterrolebinding.ControllerName))
 		if err := s.Core.WaitForSync(hookContext.StopCh); err != nil {
 			logger.Error(err, "failed to finish post-start-hook")
 			return nil // don't klog.Fatal. This only happens when context is cancelled.

--- a/tmc/pkg/server/server.go
+++ b/tmc/pkg/server/server.go
@@ -102,6 +102,14 @@ func (s *Server) Run(ctx context.Context) error {
 		if err := s.installWorkloadsSyncTargetExportController(ctx, controllerConfig); err != nil {
 			return err
 		}
+
+		if err := s.installWorkloadReplicateClusterRoleControllers(ctx, controllerConfig); err != nil {
+			return err
+		}
+
+		if err := s.installWorkloadReplicateClusterRoleBindingControllers(ctx, controllerConfig); err != nil {
+			return err
+		}
 	}
 
 	if s.Options.Core.Controllers.EnableAll || enabled.Has("resource-scheduler") {

--- a/tmc/pkg/server/server.go
+++ b/tmc/pkg/server/server.go
@@ -110,6 +110,10 @@ func (s *Server) Run(ctx context.Context) error {
 		if err := s.installWorkloadReplicateClusterRoleBindingControllers(ctx, controllerConfig); err != nil {
 			return err
 		}
+
+		if err := s.installWorkloadReplicateLogicalClusterControllers(ctx, controllerConfig); err != nil {
+			return err
+		}
 	}
 
 	if s.Options.Core.Controllers.EnableAll || enabled.Has("resource-scheduler") {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The SyncTarget-related cluster roles and cluster role bindings, as well as logical clusters, should be replicated in order to have the Syncer virtual workspace work correctly.

## Related issue(s)

This is a split of PR https://github.com/kcp-dev/kcp/pull/2675
