### PR TITLE
📖 Update CONTRIBUTING.md re golang version

### DIFF
--- a/docs/content/CONTRIBUTING.md
+++ b/docs/content/CONTRIBUTING.md
@@ -17,8 +17,15 @@ contribution. See the [DCO](https://github.com/kcp-dev/kcp/tree/main/DCO) file f
 ### Prerequisites
 
 1. Clone this repository.
-2. [Install Go](https://golang.org/doc/install) (1.19+).
+2. [Install Go](https://golang.org/doc/install) (currently 1.19).
 3. Install [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl).
+
+Please note that the go language version numbers in these files must exactly agree:
+    -  Your local go/go.mod file, kcp/.ci-operator.yaml, kcp/Dockerfile, and in all the kcp/.github/workflows yaml files that specify go-version.
+    In kcp/.ci-operator.yaml the go version is indicated by the "tag" attribute.
+    In kcp/Dockerfile it is indicated by the "golang" attribute
+    In go.mod it is indicated by the "go" directive."
+    In the .github/workflows yaml files it is indicated by "go-version"
 
 ### Build & verify
 1. In one terminal, build and start `kcp`:

--- a/docs/content/CONTRIBUTING.md
+++ b/docs/content/CONTRIBUTING.md
@@ -20,12 +20,7 @@ contribution. See the [DCO](https://github.com/kcp-dev/kcp/tree/main/DCO) file f
 2. [Install Go](https://golang.org/doc/install) (currently 1.19).
 3. Install [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl).
 
-Please note that the go language version numbers in these files must exactly agree:
-    -  Your local go/go.mod file, kcp/.ci-operator.yaml, kcp/Dockerfile, and in all the kcp/.github/workflows yaml files that specify go-version.
-    In kcp/.ci-operator.yaml the go version is indicated by the "tag" attribute.
-    In kcp/Dockerfile it is indicated by the "golang" attribute
-    In go.mod it is indicated by the "go" directive."
-    In the .github/workflows yaml files it is indicated by "go-version"
+Please note that the go language version numbers in these files must exactly agree: go/go.mod file, kcp/.ci-operator.yaml, kcp/Dockerfile, and in all the kcp/.github/workflows yaml files that specify go-version. In kcp/.ci-operator.yaml the go version is indicated by the "tag" attribute. In kcp/Dockerfile it is indicated by the "golang" attribute. In go.mod it is indicated by the "go" directive." In the .github/workflows yaml files it is indicated by "go-version"
 
 ### Build & verify
 1. In one terminal, build and start `kcp`:


### PR DESCRIPTION
fixes #2904 

Does not improve the verify-go-versions.sh script which uses a hardcoded high level go version "1".

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #
