### PR TITLE
:seedling: provide SyncerNetworkPolicies feature flag

### DIFF
--- a/pkg/features/kcp_features.go
+++ b/pkg/features/kcp_features.go
@@ -48,6 +48,12 @@ const (
 	//
 	// Enable reverse tunnels to the downstream clusters through the syncers.
 	SyncerTunnel featuregate.Feature = "KCPSyncerTunnel"
+
+	// owner: @lionelvillard
+	// alpha: v0.12
+	//
+	// Enable network policies managed by the syncer.
+	SyncerNetworkPolicies featuregate.Feature = "KCPSyncerNetworkPolicies"
 )
 
 // DefaultFeatureGate exposes the upstream feature gate, but with our gate setting applied.
@@ -96,8 +102,9 @@ func (f *kcpFeatureGate) Type() string {
 // in the generic control plane code. To add a new feature, define a key for it above and add it
 // here. The features will be available throughout Kubernetes binaries.
 var defaultGenericControlPlaneFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	LocationAPI:  {Default: true, PreRelease: featuregate.Alpha},
-	SyncerTunnel: {Default: true, PreRelease: featuregate.Alpha},
+	LocationAPI:           {Default: true, PreRelease: featuregate.Alpha},
+	SyncerTunnel:          {Default: true, PreRelease: featuregate.Alpha},
+	SyncerNetworkPolicies: {Default: true, PreRelease: featuregate.Alpha},
 
 	// inherited features from generic apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:

--- a/pkg/syncer/spec/dns/dns_process.go
+++ b/pkg/syncer/spec/dns/dns_process.go
@@ -33,6 +33,7 @@ import (
 	listersrbacv1 "k8s.io/client-go/listers/rbac/v1"
 	"k8s.io/klog/v2"
 
+	"github.com/kcp-dev/kcp/pkg/features"
 	"github.com/kcp-dev/kcp/pkg/syncer/shared"
 )
 
@@ -135,8 +136,11 @@ func (d *DNSProcessor) EnsureDNSUpAndReady(ctx context.Context, namespaceLocator
 	if err := d.processService(ctx, dnsID); err != nil {
 		return false, err
 	}
-	if err := d.processNetworkPolicy(ctx, dnsID, namespaceLocator); err != nil {
-		return false, err
+
+	if features.DefaultFeatureGate.Enabled(features.SyncerNetworkPolicies) {
+		if err := d.processNetworkPolicy(ctx, dnsID, namespaceLocator); err != nil {
+			return false, err
+		}
 	}
 
 	// Since the Endpoints resource was not found, the DNS is not yet ready,


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Add SyncerNetworkPolicies feature flags. It's enabled by default. Can be disabled by adding `--feature-gates= SyncerNetworkPolicies=false` to the `kcp workload sync` command.

## Related issue(s)

Fixes #
