### PR TITLE
:seedling: Add cache lookup to TMC controllers

### DIFF
--- a/pkg/informer/fallback_lookup.go
+++ b/pkg/informer/fallback_lookup.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package informer
+
+import (
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// ClusterLister is a cluster-aware Lister API.
+type ClusterLister[R runtime.Object, L Lister[R]] interface {
+	Cluster(name logicalcluster.Name) L
+}
+
+// Lister is a Lister API with generics.
+type Lister[R runtime.Object] interface {
+	List(labels.Selector) ([]R, error)
+}
+
+// FallbackListFunc is a function that returns []R from either local or global informer Listers based on a label selector.
+type FallbackListFunc[R runtime.Object] func(selector labels.Selector) ([]R, error)
+
+// ClusterGetter is a cluster-aware Getter API.
+type ClusterGetter[R runtime.Object, G Getter[R]] interface {
+	Cluster(name logicalcluster.Name) G
+}
+
+// Getter is a GetAPI call with generics.
+type Getter[R runtime.Object] interface {
+	Get(name string) (R, error)
+}
+
+// FallbackGetFunc is a function that returns an instance of R from either local or global informer Listers based on a name.
+type FallbackGetFunc[R runtime.Object] func(name string) (R, error)
+
+// ScopedFallbackGetFunc is a function that returns an instance of R from either local or global cluster-scoped informer Listers based on a name.
+type ScopedFallbackGetFunc[R runtime.Object] func(clusterName logicalcluster.Name, name string) (R, error)
+
+// NewListerWithFallback creates a new FallbackListFunc that looks up an object of type R first in the local lister, then in the global lister if no local results are found.
+func NewListerWithFallback[R runtime.Object](localLister Lister[R], globalLister Lister[R]) FallbackListFunc[R] {
+	return func(selector labels.Selector) ([]R, error) {
+		r, err := localLister.List(selector)
+		if len(r) == 0 {
+			return globalLister.List(selector)
+		}
+		if err != nil {
+			return nil, err
+		}
+		return r, nil
+	}
+}
+
+// NewGetterWithFallback creates a new FallbackGetFunc that gets an object of type R first looking in the local lister, then in the global lister if not found.
+func NewGetterWithFallback[R runtime.Object](localGetter, globalGetter Getter[R]) FallbackGetFunc[R] {
+	return func(name string) (R, error) {
+		var r R
+		r, err := localGetter.Get(name)
+		if errors.IsNotFound(err) {
+			return globalGetter.Get(name)
+		}
+		if err != nil {
+			// r will be nil in this case
+			return r, err
+		}
+		return r, nil
+	}
+}
+
+// NewScopedGetterWithFallback creates a new ScopedFallbackGetFunc that gets an object of type R within a given cluster path. The local lister is
+// checked first, and if nothing is found, the global lister is checked.
+func NewScopedGetterWithFallback[R runtime.Object, G Getter[R]](localGetter, globalGetter ClusterGetter[R, G]) ScopedFallbackGetFunc[R] {
+	return func(clusterName logicalcluster.Name, name string) (R, error) {
+		var r R
+		r, err := localGetter.Cluster(clusterName).Get(name)
+		if errors.IsNotFound(err) {
+			return globalGetter.Cluster(clusterName).Get(name)
+		}
+		if err != nil {
+			return r, err
+		}
+		return r, nil
+	}
+}

--- a/pkg/reconciler/workload/resource/resource_controller.go
+++ b/pkg/reconciler/workload/resource/resource_controller.go
@@ -161,6 +161,12 @@ func NewController(
 		},
 	})
 
+	globalSyncTargetInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		DeleteFunc: func(obj interface{}) {
+			c.enqueueSyncTarget(obj)
+		},
+	})
+
 	return c, nil
 }
 

--- a/tmc/pkg/server/controllers.go
+++ b/tmc/pkg/server/controllers.go
@@ -62,6 +62,7 @@ func (s *Server) installWorkloadResourceScheduler(ctx context.Context, config *r
 		dynamicClusterClient,
 		s.Core.DiscoveringDynamicSharedInformerFactory,
 		s.Core.KcpSharedInformerFactory.Workload().V1alpha1().SyncTargets(),
+		s.Core.CacheKcpSharedInformerFactory.Workload().V1alpha1().SyncTargets(),
 		s.Core.KubeSharedInformerFactory.Core().V1().Namespaces(),
 		s.Core.KcpSharedInformerFactory.Scheduling().V1alpha1().Placements(),
 	)

--- a/tmc/pkg/server/controllers.go
+++ b/tmc/pkg/server/controllers.go
@@ -356,7 +356,9 @@ func (s *Server) installWorkloadSyncTargetExportController(ctx context.Context, 
 		kcpClusterClient,
 		s.Core.KcpSharedInformerFactory.Workload().V1alpha1().SyncTargets(),
 		s.Core.KcpSharedInformerFactory.Apis().V1alpha1().APIExports(),
+		s.Core.CacheKcpSharedInformerFactory.Apis().V1alpha1().APIExports(),
 		s.Core.KcpSharedInformerFactory.Apis().V1alpha1().APIResourceSchemas(),
+		s.Core.CacheKcpSharedInformerFactory.Apis().V1alpha1().APIResourceSchemas(),
 		s.Core.KcpSharedInformerFactory.Apiresource().V1alpha1().APIResourceImports(),
 	)
 	if err != nil {
@@ -387,9 +389,8 @@ func (s *Server) installSyncTargetController(ctx context.Context, config *rest.C
 	c := synctargetcontroller.NewController(
 		kcpClusterClient,
 		s.Core.KcpSharedInformerFactory.Workload().V1alpha1().SyncTargets(),
-		// TODO: change to s.CacheKcpSharedInformerFactory.Core().V1alpha1().Shards(),
-		// once https://github.com/kcp-dev/kcp/issues/2649 is resolved
 		s.Core.KcpSharedInformerFactory.Core().V1alpha1().Shards(),
+		s.Core.CacheKcpSharedInformerFactory.Core().V1alpha1().Shards(),
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

- Use SyncTargets cache in resource controller
- Add cache lookup to SyncTarget(Export) controllers

## Related issue(s)

Fixes #2900
