### PR TITLE
:sparkles: pkg/indexers: add helers for cache server fallback

### DIFF
--- a/pkg/admission/apibinding/apibinding_admission.go
+++ b/pkg/admission/apibinding/apibinding_admission.go
@@ -57,11 +57,7 @@ func Register(plugins *admission.Plugins) {
 				createAuthorizer: delegated.NewDelegatedAuthorizer,
 			}
 			p.getAPIExport = func(path logicalcluster.Path, name string) (*apisv1alpha1.APIExport, error) {
-				export, err := indexers.ByPathAndName[*apisv1alpha1.APIExport](apisv1alpha1.Resource("apiexports"), p.apiExportIndexer, path, name)
-				if apierrors.IsNotFound(err) {
-					return indexers.ByPathAndName[*apisv1alpha1.APIExport](apisv1alpha1.Resource("apiexports"), p.cacheAPIExportIndexer, path, name)
-				}
-				return export, err
+				return indexers.ByPathAndNameWithFallback[*apisv1alpha1.APIExport](apisv1alpha1.Resource("apiexports"), p.apiExportIndexer, p.cacheAPIExportIndexer, path, name)
 			}
 
 			return p, nil

--- a/pkg/admission/apiexportendpointslice/apiexportendpointslice_admission.go
+++ b/pkg/admission/apiexportendpointslice/apiexportendpointslice_admission.go
@@ -56,11 +56,7 @@ func Register(plugins *admission.Plugins) {
 				createAuthorizer: delegated.NewDelegatedAuthorizer,
 			}
 			p.getAPIExport = func(path logicalcluster.Path, name string) (*apisv1alpha1.APIExport, error) {
-				apiExport, err := indexers.ByPathAndName[*apisv1alpha1.APIExport](apisv1alpha1.Resource("apiexports"), p.localApiExportIndexer, path, name)
-				if apierrors.IsNotFound(err) {
-					apiExport, err = indexers.ByPathAndName[*apisv1alpha1.APIExport](apisv1alpha1.Resource("apiexports"), p.globalApiExportIndexer, path, name)
-				}
-				return apiExport, err
+				return indexers.ByPathAndNameWithFallback[*apisv1alpha1.APIExport](apisv1alpha1.Resource("apiexports"), p.localApiExportIndexer, p.globalApiExportIndexer, path, name)
 			}
 
 			return p, nil

--- a/pkg/admission/workspacetypeexists/admission.go
+++ b/pkg/admission/workspacetypeexists/admission.go
@@ -58,11 +58,7 @@ func Register(plugins *admission.Plugins) {
 				createAuthorizer: delegated.NewDelegatedAuthorizer,
 			}
 			plugin.getType = func(path logicalcluster.Path, name string) (*tenancyv1alpha1.WorkspaceType, error) {
-				obj, err := indexers.ByPathAndName[*tenancyv1alpha1.WorkspaceType](tenancyv1alpha1.Resource("workspacetypes"), plugin.typeIndexer, path, name)
-				if apierrors.IsNotFound(err) {
-					return indexers.ByPathAndName[*tenancyv1alpha1.WorkspaceType](tenancyv1alpha1.Resource("workspacetypes"), plugin.globalTypeIndexer, path, name)
-				}
-				return obj, err
+				return indexers.ByPathAndNameWithFallback[*tenancyv1alpha1.WorkspaceType](tenancyv1alpha1.Resource("workspacetypes"), plugin.typeIndexer, plugin.globalTypeIndexer, path, name)
 			}
 			plugin.transitiveTypeResolver = NewTransitiveTypeResolver(plugin.getType)
 

--- a/pkg/authorization/maximal_permission_policy_authorizer.go
+++ b/pkg/authorization/maximal_permission_policy_authorizer.go
@@ -69,11 +69,7 @@ func NewMaximalPermissionPolicyAuthorizer(kubeInformers, globalKubeInformers kcp
 			return kcpInformers.Apis().V1alpha1().APIBindings().Lister().Cluster(clusterName).List(labels.Everything())
 		},
 		getAPIExport: func(path logicalcluster.Path, name string) (*apisv1alpha1.APIExport, error) {
-			export, err := indexers.ByPathAndName[*apisv1alpha1.APIExport](apisv1alpha1.Resource("apiexports"), kcpInformers.Apis().V1alpha1().APIExports().Informer().GetIndexer(), path, name)
-			if apierrors.IsNotFound(err) {
-				return indexers.ByPathAndName[*apisv1alpha1.APIExport](apisv1alpha1.Resource("apiexports"), globalKcpInformers.Apis().V1alpha1().APIExports().Informer().GetIndexer(), path, name)
-			}
-			return export, err
+			return indexers.ByPathAndNameWithFallback[*apisv1alpha1.APIExport](apisv1alpha1.Resource("apiexports"), kcpInformers.Apis().V1alpha1().APIExports().Informer().GetIndexer(), globalKcpInformers.Apis().V1alpha1().APIExports().Informer().GetIndexer(), path, name)
 		},
 		newAuthorizer: func(clusterName logicalcluster.Name) authorizer.Authorizer {
 			return rbac.New(

--- a/pkg/indexers/indexers.go
+++ b/pkg/indexers/indexers.go
@@ -127,6 +127,23 @@ func ByIndex[T runtime.Object](indexer cache.Indexer, indexName, indexValue stri
 	return ret, nil
 }
 
+// ByIndexWithFallback returns all instances of T that match indexValue in indexer, if any. If none match,
+// the same query is done of globalIndexer. Any errors short-circuit this logic.
+func ByIndexWithFallback[T runtime.Object](indexer, globalIndexer cache.Indexer, indexName, indexValue string) ([]T, error) {
+	// Try local informer first
+	results, err := ByIndex[T](indexer, indexName, indexValue)
+	if err != nil {
+		// Unrecoverable error
+		return nil, err
+	}
+	if err == nil && len(results) > 0 {
+		// Quick happy path - found something locally
+		return results, nil
+	}
+	// Didn't find it locally - try remote
+	return ByIndex[T](globalIndexer, indexName, indexValue)
+}
+
 // ByPathAndName returns the instance of T from the indexer with the matching path and name. Path may be a canonical path
 // or a cluster name. Note: this depends on the presence of the optional "kcp.io/path" annotation.
 func ByPathAndName[T runtime.Object](groupResource schema.GroupResource, indexer cache.Indexer, path logicalcluster.Path, name string) (ret T, err error) {
@@ -141,4 +158,22 @@ func ByPathAndName[T runtime.Object](groupResource schema.GroupResource, indexer
 		return ret, fmt.Errorf("multiple %s found for %s", groupResource, path.Join(name).String())
 	}
 	return objs[0].(T), nil
+}
+
+// ByPathAndNameWithFallback returns the instance of T from the indexer with the matching path and name. Path may be a canonical path
+// or a cluster name. Note: this depends on the presence of the optional "kcp.io/path" annotation. If no instance is found, globalIndexer
+// is searched as well. Any errors short-circuit this logic.
+func ByPathAndNameWithFallback[T runtime.Object](groupResource schema.GroupResource, indexer, globalIndexer cache.Indexer, path logicalcluster.Path, name string) (ret T, err error) {
+	// Try local informer first
+	result, err := ByPathAndName[T](groupResource, indexer, path, name)
+	if err != nil && !apierrors.IsNotFound(err) {
+		// Unrecoverable error
+		return ret, err
+	}
+	if err == nil {
+		// Quick happy path - found it locally
+		return result, nil
+	}
+	// Didn't find it locally - try remote
+	return ByPathAndName[T](groupResource, globalIndexer, path, name)
 }

--- a/pkg/permissionclaim/permissionclaim_labeler.go
+++ b/pkg/permissionclaim/permissionclaim_labeler.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -61,11 +60,7 @@ func NewLabeler(
 			return apiBindingInformer.Lister().Cluster(clusterName).Get(name)
 		},
 		getAPIExport: func(path logicalcluster.Path, name string) (*apisv1alpha1.APIExport, error) {
-			obj, err := indexers.ByPathAndName[*apisv1alpha1.APIExport](apisv1alpha1.Resource("apiexports"), apiExportInformer.Informer().GetIndexer(), path, name)
-			if errors.IsNotFound(err) {
-				obj, err = indexers.ByPathAndName[*apisv1alpha1.APIExport](apisv1alpha1.Resource("apiexports"), globalAPIExportInformer.Informer().GetIndexer(), path, name)
-			}
-			return obj, err
+			return indexers.ByPathAndNameWithFallback[*apisv1alpha1.APIExport](apisv1alpha1.Resource("apiexports"), apiExportInformer.Informer().GetIndexer(), globalAPIExportInformer.Informer().GetIndexer(), path, name)
 		},
 	}
 }

--- a/pkg/reconciler/apis/permissionclaimlabel/permissionclaimlabel_controller.go
+++ b/pkg/reconciler/apis/permissionclaimlabel/permissionclaimlabel_controller.go
@@ -72,13 +72,7 @@ func NewController(
 		apiBindingsIndexer: apiBindingInformer.Informer().GetIndexer(),
 
 		getAPIExport: func(path logicalcluster.Path, name string) (*apisv1alpha1.APIExport, error) {
-			obj, err := indexers.ByPathAndName[*apisv1alpha1.APIExport](apisv1alpha1.Resource("apiexports"), apiExportInformer.Informer().GetIndexer(), path, name)
-			if err != nil && !apierrors.IsNotFound(err) {
-				return nil, err
-			} else if apierrors.IsNotFound(err) {
-				return indexers.ByPathAndName[*apisv1alpha1.APIExport](apisv1alpha1.Resource("apiexports"), globalAPIExportInformer.Informer().GetIndexer(), path, name)
-			}
-			return obj, nil
+			return indexers.ByPathAndNameWithFallback[*apisv1alpha1.APIExport](apisv1alpha1.Resource("apiexports"), apiExportInformer.Informer().GetIndexer(), globalAPIExportInformer.Informer().GetIndexer(), path, name)
 		},
 
 		commit: committer.NewCommitter[*APIBinding, Patcher, *APIBindingSpec, *APIBindingStatus](kcpClusterClient.ApisV1alpha1().APIBindings()),

--- a/pkg/reconciler/tenancy/initialization/apibinder_initializer_controller.go
+++ b/pkg/reconciler/tenancy/initialization/apibinder_initializer_controller.go
@@ -69,11 +69,7 @@ func NewAPIBinder(
 			return logicalClusterInformer.Lister().Cluster(clusterName).Get(corev1alpha1.LogicalClusterName)
 		},
 		getWorkspaceType: func(path logicalcluster.Path, name string) (*tenancyv1alpha1.WorkspaceType, error) {
-			t, err := indexers.ByPathAndName[*tenancyv1alpha1.WorkspaceType](tenancyv1alpha1.Resource("workspacetypes"), workspaceTypeInformer.Informer().GetIndexer(), path, name)
-			if apierrors.IsNotFound(err) {
-				return indexers.ByPathAndName[*tenancyv1alpha1.WorkspaceType](tenancyv1alpha1.Resource("workspacetypes"), globalWorkspaceTypeInformer.Informer().GetIndexer(), path, name)
-			}
-			return t, err
+			return indexers.ByPathAndNameWithFallback[*tenancyv1alpha1.WorkspaceType](tenancyv1alpha1.Resource("workspacetypes"), workspaceTypeInformer.Informer().GetIndexer(), globalWorkspaceTypeInformer.Informer().GetIndexer(), path, name)
 		},
 		listLogicalClusters: func() ([]*corev1alpha1.LogicalCluster, error) {
 			return logicalClusterInformer.Lister().List(labels.Everything())
@@ -90,11 +86,7 @@ func NewAPIBinder(
 		},
 
 		getAPIExport: func(path logicalcluster.Path, name string) (*apisv1alpha1.APIExport, error) {
-			export, err := indexers.ByPathAndName[*apisv1alpha1.APIExport](apisv1alpha1.Resource("apiexports"), apiExportsInformer.Informer().GetIndexer(), path, name)
-			if apierrors.IsNotFound(err) {
-				return indexers.ByPathAndName[*apisv1alpha1.APIExport](apisv1alpha1.Resource("apiexports"), globalAPIExportsInformer.Informer().GetIndexer(), path, name)
-			}
-			return export, err
+			return indexers.ByPathAndNameWithFallback[*apisv1alpha1.APIExport](apisv1alpha1.Resource("apiexports"), apiExportsInformer.Informer().GetIndexer(), globalAPIExportsInformer.Informer().GetIndexer(), path, name)
 		},
 
 		commit: committer.NewCommitter[*corev1alpha1.LogicalCluster, corev1alpha1client.LogicalClusterInterface, *corev1alpha1.LogicalClusterSpec, *corev1alpha1.LogicalClusterStatus](kcpClusterClient.CoreV1alpha1().LogicalClusters()),

--- a/pkg/reconciler/workload/placement/placement_controller.go
+++ b/pkg/reconciler/workload/placement/placement_controller.go
@@ -100,11 +100,7 @@ func NewController(
 		},
 
 		getLocation: func(path logicalcluster.Path, name string) (*schedulingv1alpha1.Location, error) {
-			location, err := indexers.ByPathAndName[*schedulingv1alpha1.Location](schedulingv1alpha1.Resource("locations"), locationInformer.Informer().GetIndexer(), path, name)
-			if errors.IsNotFound(err) {
-				return indexers.ByPathAndName[*schedulingv1alpha1.Location](schedulingv1alpha1.Resource("locations"), globalLocationInformer.Informer().GetIndexer(), path, name)
-			}
-			return location, nil
+			return indexers.ByPathAndNameWithFallback[*schedulingv1alpha1.Location](schedulingv1alpha1.Resource("locations"), locationInformer.Informer().GetIndexer(), globalLocationInformer.Informer().GetIndexer(), path, name)
 		},
 
 		placementLister:  placementInformer.Lister(),


### PR DESCRIPTION
Every single consumer of these functions operating over replicated data needs to use the same exact pattern to access their data. There's no need to make them all duplicate the logic.

/cc @nrb @sttts 
/assign @p0lyn0mial 