### PR TITLE
🌱 Use cached informers in scheduling controllers

### DIFF
--- a/pkg/reconciler/scheduling/placement/placement_reconcile.go
+++ b/pkg/reconciler/scheduling/placement/placement_reconcile.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	utilserrors "k8s.io/apimachinery/pkg/util/errors"
 
-	"github.com/kcp-dev/kcp/pkg/indexers"
 	schedulingv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/scheduling/v1alpha1"
 )
 
@@ -65,18 +64,6 @@ func (c *controller) reconcile(ctx context.Context, placement *schedulingv1alpha
 	}
 
 	return utilserrors.NewAggregate(errs)
-}
-
-func (c *controller) listLocationsByPath(path logicalcluster.Path) ([]*schedulingv1alpha1.Location, error) {
-	objs, err := c.locationIndexer.ByIndex(indexers.ByLogicalClusterPath, path.String())
-	if err != nil {
-		return nil, err
-	}
-	ret := make([]*schedulingv1alpha1.Location, 0, len(objs))
-	for _, obj := range objs {
-		ret = append(ret, obj.(*schedulingv1alpha1.Location))
-	}
-	return ret, nil
 }
 
 func (c *controller) listNamespacesWithAnnotation(clusterName logicalcluster.Name) ([]*corev1.Namespace, error) {

--- a/pkg/reconciler/workload/placement/placement_controller.go
+++ b/pkg/reconciler/workload/placement/placement_controller.go
@@ -121,6 +121,10 @@ func NewController(
 		indexers.ByLogicalClusterPathAndName: indexers.IndexByLogicalClusterPathAndName,
 	})
 
+	indexers.AddIfNotPresentOrDie(globalLocationInformer.Informer().GetIndexer(), cache.Indexers{
+		indexers.ByLogicalClusterPathAndName: indexers.IndexByLogicalClusterPathAndName,
+	})
+
 	logger := logging.WithReconciler(klog.Background(), ControllerName)
 
 	locationInformer.Informer().AddEventHandler(

--- a/tmc/pkg/server/controllers.go
+++ b/tmc/pkg/server/controllers.go
@@ -263,6 +263,7 @@ func (s *Server) installSchedulingPlacementController(ctx context.Context, confi
 		kcpClusterClient,
 		s.Core.KubeSharedInformerFactory.Core().V1().Namespaces(),
 		s.Core.KcpSharedInformerFactory.Scheduling().V1alpha1().Locations(),
+		s.Core.CacheKcpSharedInformerFactory.Scheduling().V1alpha1().Locations(),
 		s.Core.KcpSharedInformerFactory.Scheduling().V1alpha1().Placements(),
 	)
 	if err != nil {


### PR DESCRIPTION
## Summary

Use cached informers in scheduling controllers.

## Related issue(s)

Fixes #2900 
