### PR TITLE
:bug: logicalcluster-deletion: skip bound resources

### DIFF
--- a/pkg/reconciler/core/logicalclusterdeletion/deletion/logicalcluster_resource_deletor_test.go
+++ b/pkg/reconciler/core/logicalclusterdeletion/deletion/logicalcluster_resource_deletor_test.go
@@ -123,7 +123,9 @@ func TestWorkspaceTerminating(t *testing.T) {
 				return resources, tt.gvrError
 			}
 			mockMetadataClient := kcpfakemetadata.NewSimpleMetadataClient(scheme, tt.existingObject...)
-			d := NewWorkspacedResourcesDeleter(mockMetadataClient, fn)
+			d := NewWorkspacedResourcesDeleter(mockMetadataClient, fn, func(clusterName logicalcluster.Name, group, resource string) (bool, error) {
+				return false, nil
+			})
 
 			err := d.Delete(context.TODO(), ws)
 			if !matchErrors(err, tt.expectErrorOnDelete) {

--- a/pkg/reconciler/core/logicalclusterdeletion/logicalcluster_deletion_controller.go
+++ b/pkg/reconciler/core/logicalclusterdeletion/logicalcluster_deletion_controller.go
@@ -31,6 +31,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -47,6 +48,7 @@ import (
 	corev1alpha1 "github.com/kcp-dev/kcp/sdk/apis/core/v1alpha1"
 	kcpclientset "github.com/kcp-dev/kcp/sdk/client/clientset/versioned/cluster"
 	corev1alpha1client "github.com/kcp-dev/kcp/sdk/client/clientset/versioned/typed/core/v1alpha1"
+	apisv1alpha1informers "github.com/kcp-dev/kcp/sdk/client/informers/externalversions/apis/v1alpha1"
 	corev1alpha1informers "github.com/kcp-dev/kcp/sdk/client/informers/externalversions/core/v1alpha1"
 	corev1alpha1listers "github.com/kcp-dev/kcp/sdk/client/listers/core/v1alpha1"
 )
@@ -68,8 +70,24 @@ func NewController(
 	metadataClusterClient kcpmetadata.ClusterInterface,
 	logicalClusterInformer corev1alpha1informers.LogicalClusterClusterInformer,
 	discoverResourcesFn func(clusterName logicalcluster.Path) ([]*metav1.APIResourceList, error),
+	apiBindingInformer apisv1alpha1informers.APIBindingClusterInformer,
 ) *Controller {
 	queue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), ControllerName)
+
+	isBoundResource := func(clusterName logicalcluster.Name, group, resource string) (bool, error) {
+		apiBindings, err := apiBindingInformer.Cluster(clusterName).Lister().List(labels.Everything())
+		if err != nil {
+			return false, err
+		}
+		for _, apiBinding := range apiBindings {
+			for _, boundResource := range apiBinding.Status.BoundResources {
+				if boundResource.Group == group && boundResource.Resource == resource {
+					return true, nil
+				}
+			}
+		}
+		return false, nil
+	}
 
 	c := &Controller{
 		queue:                             queue,
@@ -79,7 +97,7 @@ func NewController(
 		externalLogicalClusterAdminConfig: externalLogicalClusterAdminConfig,
 		metadataClusterClient:             metadataClusterClient,
 		logicalClusterLister:              logicalClusterInformer.Lister(),
-		deleter:                           deletion.NewWorkspacedResourcesDeleter(metadataClusterClient, discoverResourcesFn),
+		deleter:                           deletion.NewWorkspacedResourcesDeleter(metadataClusterClient, discoverResourcesFn, isBoundResource),
 		commit:                            committer.NewCommitter[*LogicalCluster, Patcher, *LogicalClusterSpec, *LogicalClusterStatus](kcpClusterClient.CoreV1alpha1().LogicalClusters()),
 	}
 

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -378,6 +378,7 @@ func (s *Server) installLogicalClusterDeletionController(ctx context.Context, co
 		metadataClusterClient,
 		s.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters(),
 		discoverResourcesFn,
+		s.KcpSharedInformerFactory.Apis().V1alpha1().APIBindings(),
 	)
 
 	return s.registerController(&controllerWrapper{


### PR DESCRIPTION
Skip deleting bound resources in the logicalcluster deletor as this can
race with the apibinding deletion controller. If the apibinding deletion
controller deletes an APIBinding and all its instances and then the
logicalcluster deletor tries to delete the collection of the same
resources (because it saw the resource in discovery), it will get a 404
and go into rate limited backoff, which we don't want.

Taken from @ncdc's rebase PR https://github.com/kcp-dev/kcp/pull/2945.