### PR TITLE
:bug: cache: only enqueue ClusterRoleBindings for the right logical cluster

### DIFF
--- a/pkg/reconciler/cache/labelclusterrolebindings/labelclusterrolebinding_controller.go
+++ b/pkg/reconciler/cache/labelclusterrolebindings/labelclusterrolebinding_controller.go
@@ -48,7 +48,7 @@ import (
 type Controller interface {
 	Start(ctx context.Context, numThreads int)
 
-	EnqueueClusterRoleBindings(values ...interface{})
+	EnqueueClusterRoleBindings(clusterName logicalcluster.Name, values ...interface{})
 }
 
 // NewController returns a new controller for labelling ClusterRoleBinding that should be replicated.
@@ -144,8 +144,8 @@ type controller struct {
 	commit func(ctx context.Context, new, old *rbacv1.ClusterRoleBinding) error
 }
 
-func (c *controller) EnqueueClusterRoleBindings(values ...interface{}) {
-	clusterRoleBindings, err := c.clusterRoleBindingLister.List(labels.Everything())
+func (c *controller) EnqueueClusterRoleBindings(clusterName logicalcluster.Name, values ...interface{}) {
+	clusterRoleBindings, err := c.clusterRoleBindingLister.Cluster(clusterName).List(labels.Everything())
 	if err != nil {
 		runtime.HandleError(err)
 		return

--- a/pkg/reconciler/core/replicateclusterrolebinding/replicateclusterrolebinding_controller.go
+++ b/pkg/reconciler/core/replicateclusterrolebinding/replicateclusterrolebinding_controller.go
@@ -66,7 +66,7 @@ func NewController(
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				cluster := obj.(*corev1alpha1.LogicalCluster)
-				c.EnqueueClusterRoleBindings("reason", "LogicalCluster added", "logicalcluster", logicalcluster.From(cluster).String())
+				c.EnqueueClusterRoleBindings(logicalcluster.From(cluster), "reason", "LogicalCluster added", "logicalcluster", logicalcluster.From(cluster).String())
 			},
 			UpdateFunc: func(old, obj interface{}) {
 				oldCluster, ok := old.(*corev1alpha1.LogicalCluster)
@@ -78,7 +78,7 @@ func NewController(
 					return
 				}
 				if (oldCluster.Annotations[core.ReplicateAnnotationKey] == "") != (newCluster.Annotations[core.ReplicateAnnotationKey] == "") {
-					c.EnqueueClusterRoleBindings("reason", "LogicalCluster changed replication status", "logicalcluster", logicalcluster.From(newCluster).String())
+					c.EnqueueClusterRoleBindings(logicalcluster.From(newCluster), "reason", "LogicalCluster changed replication status", "logicalcluster", logicalcluster.From(newCluster).String())
 				}
 			},
 		},


### PR DESCRIPTION
Taken from @ncdc's rebase PR https://github.com/kcp-dev/kcp/pull/2945.