### PR TITLE
:seedling: Add Prowjobs

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,0 @@
-build_root_image:
-  namespace: ci
-  name: kcp-dev-build-root
-  tag: "1.19"

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -72,3 +72,109 @@ presubmits:
             requests:
               memory: 4Gi
               cpu: 2
+
+  - name: pull-kcp-test-e2e
+    always_run: true
+    decorate: true
+    clone_uri: "https://github.com/kcp-dev/kcp"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: ghcr.io/kcp-dev/infra/build:1.19.9-2
+          command:
+            - ./hack/run-with-prometheus.sh
+            - make
+            - test-e2e
+          env:
+            - name: SUITES
+              value: control-plane
+            - name: USE_GOTESTSUM
+              value: '1'
+            - name: KUBE_CACHE_MUTATION_DETECTOR
+              value: '1'
+            - name: E2E_PARALLELISM
+              value: '3'
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 3
+
+  - name: pull-kcp-test-e2e-multiple-runs
+    always_run: true
+    decorate: true
+    clone_uri: "https://github.com/kcp-dev/kcp"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: ghcr.io/kcp-dev/infra/build:1.19.9-2
+          command:
+            - ./hack/run-with-prometheus.sh
+            - make
+            - test-e2e
+          env:
+            - name: SUITES
+              value: control-plane
+            - name: USE_GOTESTSUM
+              value: '1'
+            - name: KUBE_CACHE_MUTATION_DETECTOR
+              value: '1'
+            - name: COUNT
+              value: '3'
+            - name: E2E_PARALLELISM
+              value: '3'
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 3
+
+  - name: pull-kcp-test-e2e-shared
+    always_run: true
+    decorate: true
+    clone_uri: "https://github.com/kcp-dev/kcp"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: ghcr.io/kcp-dev/infra/build:1.19.9-2
+          command:
+            - ./hack/run-with-prometheus.sh
+            - make
+            - test-e2e-shared-minimal
+          env:
+            - name: SUITES
+              value: control-plane
+            - name: USE_GOTESTSUM
+              value: '1'
+            - name: KUBE_CACHE_MUTATION_DETECTOR
+              value: '1'
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 3
+
+  - name: pull-kcp-test-e2e-sharded
+    always_run: true
+    decorate: true
+    clone_uri: "https://github.com/kcp-dev/kcp"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: ghcr.io/kcp-dev/infra/build:1.19.9-2
+          command:
+            - ./hack/run-with-prometheus.sh
+            - make
+            - test-e2e-sharded-minimal
+          env:
+            - name: SUITES
+              value: control-plane
+            - name: USE_GOTESTSUM
+              value: '1'
+            - name: KUBE_CACHE_MUTATION_DETECTOR
+              value: '1'
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 3

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1,0 +1,74 @@
+presubmits:
+  - name: pull-kcp-verify
+    always_run: true
+    decorate: true
+    clone_uri: "https://github.com/kcp-dev/kcp"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: ghcr.io/kcp-dev/infra/build:1.19.9-2
+          command:
+            - make
+            - verify-boilerplate
+            - verify-modules
+            - verify-k8s-deps
+            - verify-imports
+          resources:
+            requests:
+              memory: 1Gi
+              cpu: 1
+
+  - name: pull-kcp-verify-codegen
+    always_run: true
+    decorate: true
+    clone_uri: "https://github.com/kcp-dev/kcp"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: ghcr.io/kcp-dev/infra/build:1.19.9-2
+          command:
+            - make
+            - verify-codegen
+          resources:
+            requests:
+              memory: 1Gi
+              cpu: 1
+
+  - name: pull-kcp-lint
+    always_run: true
+    decorate: true
+    clone_uri: "https://github.com/kcp-dev/kcp"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: ghcr.io/kcp-dev/infra/build:1.19.9-2
+          command:
+            - make
+            - lint
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 2
+
+  - name: pull-kcp-test-unit
+    always_run: true
+    decorate: true
+    clone_uri: "https://github.com/kcp-dev/kcp"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: ghcr.io/kcp-dev/infra/build:1.19.9-2
+          command:
+            - make
+            - test
+          env:
+            - name: USE_GOTESTSUM
+              value: '1'
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 2

--- a/hack/verify-go-versions.sh
+++ b/hack/verify-go-versions.sh
@@ -19,7 +19,6 @@ set -o pipefail
 
 VERSION=$(grep "go 1." go.mod | sed 's/go //')
 
-grep "tag: \"" .ci-operator.yaml | { ! grep -v "${VERSION}"; } || { echo "Wrong go version in .ci-operator.yaml, expected ${VERSION}"; exit 1; }
 grep "FROM .* golang:" Dockerfile | { ! grep -v "${VERSION}"; } || { echo "Wrong go version in Dockerfile, expected ${VERSION}"; exit 1; }
 grep -w "go-version:" .github/workflows/*.yaml | { ! grep -v "go-version: v${VERSION}"; } || { echo "Wrong go version in .github/workflows/*.yaml, expected ${VERSION}"; exit 1; }
 


### PR DESCRIPTION
## Summary
This moves the Prowjobs that were previously part of the openshift/release repo into a simple in-repo configuration (i.e. a `.prow.yaml`).

I combined the various verify tasks into a single `pull-kcp-verify` job, but had to pull the codegen task out into its own Prow job, as running it as part of other tasks seems to make it get stuck and I have not further investigated why. `client-gen` seems to just sit forever (I checked the pod, CPU usage was basically idling).

part of kcp-dev/infra#43

## Release Notes
```release-note
NONE
```