### PR TITLE
🌱 Add images Prowjob

### DIFF
--- a/.github/workflows/kcp-image.yaml
+++ b/.github/workflows/kcp-image.yaml
@@ -10,16 +10,6 @@ on:
       - 'release-*'
     tags:
     - 'v*'
-  pull_request:
-    branches:
-      - main
-      - 'release-*'
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
-      - ".github/ISSUE_TEMPLATE/*"
-      - ".github/workflows/docs-gen-and-push.yaml"
-      - ".goreleaser.yaml"
 
 jobs:
   build:

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -53,6 +53,28 @@ presubmits:
               memory: 4Gi
               cpu: 2
 
+  - name: pull-kcp-build-image
+    always_run: true
+    decorate: true
+    clone_uri: "https://github.com/kcp-dev/kcp"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: quay.io/containers/buildah:v1.30.0
+          command:
+            - hack/build-image.sh
+          env:
+            - name: DRY_RUN
+              value: '1'
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: 1Gi
+              cpu: 1
+
   - name: pull-kcp-test-unit
     always_run: true
     decorate: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Build the binary
-FROM --platform=${BUILDPLATFORM} golang:1.19 AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/golang:1.19 AS builder
 WORKDIR /workspace
 
 # Install dependencies.

--- a/hack/build-image.sh
+++ b/hack/build-image.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The KCP Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+# make git available
+if ! [ -x "$(command -v git)" ]; then
+  echo "Installing git ..."
+  yum install -y git
+fi
+
+# in CI, make use of the registry mirror to avoid getting rate limited
+if [ -n "${DOCKER_REGISTRY_MIRROR_ADDR:-}" ]; then
+  # remove "http://" or "https://" prefix
+  mirror="$(echo "$DOCKER_REGISTRY_MIRROR_ADDR" | awk -F// '{print $NF}')"
+
+  echo "Configuring registry mirror for docker.io ..."
+
+  cat <<EOF > /etc/containers/registries.conf.d/mirror.conf
+[[registry]]
+prefix = "docker.io"
+insecure = true
+location = "$mirror"
+EOF
+fi
+
+repository=ghcr.io/kcp-dev/kcp
+architectures="amd64 arm64 ppc64le"
+
+# when building locally, just tag with the current HEAD hash
+version="$(git rev-parse --short HEAD)"
+
+# deduce the tag from the Prow job metadata
+if [ -n "${PULL_BASE_REF:-}" ]; then
+  version="$(git tag --list "$PULL_BASE_REF")"
+
+  # if the base ref did not point to a tag, it's just a commit hash
+  if [ -z "$version" ]; then
+    version="$(git rev-parse --short "$PULL_BASE_REF")"
+  fi
+fi
+
+image="$repository:$version"
+echo "Building container image $image ..."
+
+# build image for all architectures
+for arch in $architectures; do
+  fullTag="$image-$arch"
+
+  echo "Building $version-$arch ..."
+  buildah build-using-dockerfile \
+    --file Dockerfile \
+    --tag "$fullTag" \
+    --arch "$arch" \
+    --override-arch "$arch" \
+    --build-arg "TARGETOS=linux" \
+    --build-arg "TARGETARCH=$arch" \
+    --format=docker \
+    .
+done
+
+echo "Creating manifest $image ..."
+buildah manifest create "$image"
+for arch in $architectures; do
+  buildah manifest add "$image" "$image-$arch"
+done
+
+# push manifest, except in presubmits
+if [ -z "${DRY_RUN:-}" ]; then
+  echo "Logging into GHCR ..."
+  buildah login --username "$KCP_GHCR_USERNAME" --password "$KCP_GHCR_PASSWORD" ghcr.io
+
+  echo "Pushing manifest and images ..."
+  buildah manifest push --all "$image" "docker://$image"
+else
+  echo "Not pushing images because \$DRY_RUN is set."
+fi
+
+echo "Done."

--- a/hack/verify-go-versions.sh
+++ b/hack/verify-go-versions.sh
@@ -19,7 +19,7 @@ set -o pipefail
 
 VERSION=$(grep "go 1." go.mod | sed 's/go //')
 
-grep "FROM .* golang:" Dockerfile | { ! grep -v "${VERSION}"; } || { echo "Wrong go version in Dockerfile, expected ${VERSION}"; exit 1; }
+grep "FROM .* docker.io/golang:" Dockerfile | { ! grep -v "${VERSION}"; } || { echo "Wrong go version in Dockerfile, expected ${VERSION}"; exit 1; }
 grep -w "go-version:" .github/workflows/*.yaml | { ! grep -v "go-version: v${VERSION}"; } || { echo "Wrong go version in .github/workflows/*.yaml, expected ${VERSION}"; exit 1; }
 
 shopt -s dotglob


### PR DESCRIPTION
## Summary
This PR is part 1 of 2 to convert the Github Workflow for building the kcp container image innto a regular Prowjob. Part 2 will happen in the infra repository, as the postsubmit will need elevated credentials and so has to be maintained there.

I've used buildah to build the image because that's what I'm used to and it seems to work just fine.

part of kcp-dev/infra#43

## Release Note
```release-note
NONE
```