### PR TITLE
[release-0.20] 📖  update release process doc

### DIFF
--- a/docs/content/developers/publishing-a-new-kcp-release.md
+++ b/docs/content/developers/publishing-a-new-kcp-release.md
@@ -35,19 +35,19 @@ kcp has 2 go modules, and a unique tag is needed for each module every time we c
     git tag --sign --message "$TAG" "$TAG" "$REF"
     ```
 
- 3. Tag the `pkg/sdk` module, following the same logic as above for `REF` and `TAG`
+ 3. Tag the `sdk` module, following the same logic as above for `REF` and `TAG`
 
     ```shell
     REF=upstream/main
     TAG=v1.2.3
-    git tag --sign --message "pkg/sdk/$TAG" "pkg/sdk/$TAG" "$REF"
+    git tag --sign --message "sdk/$TAG" "sdk/$TAG" "$REF"
     ```
 ### Push the tags
 
 ```shell
 REMOTE=upstream
 TAG=v1.2.3
-git push "$REMOTE" "$TAG" "pkg/sdk/$TAG"
+git push "$REMOTE" "$TAG" "sdk/$TAG"
 ```
 
 ## If it's a new minor version
@@ -68,53 +68,6 @@ VERSION=1.2
 git checkout -b "release-$VERSION" "$REF"
 git push "$REMOTE" "release-$VERSION"
 ```
-
-### Configure prow for the new release branch
-
-1. Make sure you have [openshift/release](https://github.com/openshift/release/) cloned
-2. Create a new branch
-3. Copy `ci-operator/config/kcp-dev/kcp/kcp-dev-kcp-main.yaml` to `ci-operator/config/kcp-dev/kcp/kcp-dev-kcp-release-<version>.yaml`
-4. Edit the new file
-   1. Change `main` to the name of the release branch, such as `release-0.8`
-
-       ```yaml
-       zz_generated_metadata:
-         branch: main
-       ```
-
-   2. Change `latest` to the name of the release branch
-
-       ```yaml
-       promotion:
-         namespace: kcp
-         tag: latest
-         tag_by_commit: true
-       ```
-
-5. Edit `core-services/prow/02_config/kcp-dev/kcp/_prowconfig.yaml`
-   1. Copy the `main` branch configuration to a new `release-x.y` entry
-6. Run `make update`
-7. Add the new/updated files and commit your changes
-8. Push your branch to your fork
-9. Open a pull request
-10. Wait for it to be reviewed and merged
-
-### Update testgrid
-
-1. Make sure you have a clone of [kubernetes/test-infra](https://github.com/kubernetes/test-infra/)
-2. Edit config/testgrids/kcp/kcp.yaml
-   1. In the `test_groups` section:
-      1. Copy all the entries under `# main` to the bottom of the map
-      2. Rename `-main-` to `-release-<version>-`
-   2. In the `dashboard_groups` section:
-      1. Add a new entry under `dashboard_names` for `kcp-release-<version>`
-   3. In the `dashboards` section:
-      1. Copy the `kcp-main` entry, including `dashboard_tab` and all its entries, to a new entry called `kcp-release-<version>`
-      2. Rename `main` to `release-<version>` in the new entry
-3. Commit your changes
-4. Push your branch to your fork
-5. Open a pull request
-6. Wait for it to be reviewed and merged
 
 ## Review/edit/publish the release in GitHub
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

I would like to cherry-pick #2988 for two reasons:

1. The release process for 0.20 as documented on the release branch is incorrect since 0.20 is the first release under community governance and using Prow for automation. Now we likely will never release a 0.20.1 and instead move to 0.21.0.
2. However, we also never published 0.20 documentation. The reason for that I believe is the GitHub Actions triggers not running when the `release-*` branch is first created. A push event to the branch would be necessary, which we could achieve with a simple cherry-pick PR like this one being merged.

Therefore I would like to merge at least one commit to `release-0.20`, so we get documentation deployed to docs.kcp.io. it might not be strictly necessary and the docs are probably outdated, but I think it would be nice to have the version at least available on docs.kcp.io, now that people are perhaps curious what project is going to join the CNCF here.

## Related issue(s)

Fixes #

## Release Notes

```release-note
NONE
```
