### PR TITLE
:sparkles: Add --cors-allowed-origins flag to kcp-front-proxy

### DIFF
--- a/pkg/proxy/options/options.go
+++ b/pkg/proxy/options/options.go
@@ -27,13 +27,14 @@ import (
 )
 
 type Options struct {
-	SecureServing    apiserveroptions.SecureServingOptionsWithLoopback
-	Authentication   Authentication
-	MappingFile      string
-	RootDirectory    string
-	RootKubeconfig   string
-	ShardsKubeconfig string
-	ProfilerAddress  string
+	SecureServing         apiserveroptions.SecureServingOptionsWithLoopback
+	Authentication        Authentication
+	MappingFile           string
+	RootDirectory         string
+	RootKubeconfig        string
+	ShardsKubeconfig      string
+	ProfilerAddress       string
+	CorsAllowedOriginList []string
 }
 
 func NewOptions() *Options {
@@ -59,6 +60,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.RootKubeconfig, "root-kubeconfig", o.RootKubeconfig, "The path to the kubeconfig of the root shard.")
 	fs.StringVar(&o.ShardsKubeconfig, "shards-kubeconfig", o.ShardsKubeconfig, "The path to the kubeconfig used for communication with all shards. The server name if provided is replaced with a shard's hostname.")
 	fs.StringVar(&o.ProfilerAddress, "profiler-address", "", "[Address]:port to bind the profiler to")
+	fs.StringSliceVar(&o.CorsAllowedOriginList, "cors-allowed-origins", o.CorsAllowedOriginList, "List of allowed origins for CORS, comma separated.  An allowed origin can be a regular expression to support subdomain matching. If this list is empty CORS will not be enabled.")
 }
 
 func (o *Options) Complete() error {

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -88,6 +88,7 @@ func NewServer(ctx context.Context, c CompletedConfig) (*Server, error) {
 	handler = genericfilters.WithHTTPLogging(handler)
 	handler = metrics.WithLatencyTracking(handler)
 	handler = genericfilters.WithPanicRecovery(handler, requestInfoFactory)
+	handler = genericfilters.WithCORS(handler, c.Options.CorsAllowedOriginList, nil, nil, nil, "true")
 
 	mux := http.NewServeMux()
 	// TODO: implement proper readyz handler


### PR DESCRIPTION
## Summary
The APIserver config already has a flag to configure allowed CORS origins, but the front-proxy does not use the APIServer options and so did not get this flag. This PR adds it to the proxy's options to make the flag available.

## Release Notes

```release-note
Add `--cors-allowed-origins` flag to kcp-front-proxy
```
