### PR TITLE
:book: Update README to include link to community meeting agenda doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,8 @@ There are several ways to communicate with us:
 - Our mailing lists:
     - [kcp-dev](https://groups.google.com/g/kcp-dev) for development discussions
     - [kcp-users](https://groups.google.com/g/kcp-users) for discussions among users and potential users
-- Subscribe to the [community calendar](https://calendar.google.com/calendar/embed?src=ujjomvk4fa9fgdaem32afgl7g0%40group.calendar.google.com) for community meetings and events
-    - The kcp-dev mailing list is subscribed to this calendar
 - See recordings of past community meetings on [YouTube](https://www.youtube.com/channel/UCfP_yS5uYix0ppSbm2ltS5Q)
-- See [upcoming](https://github.com/kcp-dev/kcp/issues?q=is%3Aissue+is%3Aopen+label%3Acommunity-meeting) and [past](https://github.com/kcp-dev/kcp/issues?q=is%3Aissue+label%3Acommunity-meeting+is%3Aclosed) community meeting agendas and notes
+- Check the [community meeting notes document](https://docs.google.com/document/d/1PrEhbmq1WfxFv1fTikDBZzXEIJkUWVHdqDFxaY1Ply4) for future and past meeting agendas.
 - Browse the [shared Google Drive](https://drive.google.com/drive/folders/1FN7AZ_Q1CQor6eK0gpuKwdGFNwYI517M?usp=sharing) to share design docs, notes, etc.
     - Members of the kcp-dev mailing list can view this drive
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The readme still references community meeting issues, but we have now moved to a Google doc. This updates it accordingly.

I also believe that the community calendar might be dead, there are no entries on it and we also don't mention it on kcp.io. So maybe it's time to remove that reference as well to avoid confusion. The agenda document has dates, and should therefore help figuring out when the next community meeting happens.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note using the following format:

```release-note
NONE
```
-->

```release-note
NONE
```
