### PR TITLE
:sparkles:  Add CRDs to built-in types

### DIFF
--- a/pkg/crdpuller/discovery.go
+++ b/pkg/crdpuller/discovery.go
@@ -495,7 +495,10 @@ func (sc *SchemaConverter) VisitKind(k *proto.Kind) {
 }
 
 func (sc *SchemaConverter) VisitReference(r proto.Reference) {
-	reference := r.Reference()
+	reference := r.Reference() // recursive CRDs are not supported
+	if reference == "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps" {
+		return
+	}
 	if sc.visited.Has(reference) {
 		*sc.errors = append(*sc.errors, fmt.Errorf("recursive schema are not supported: %s", reference))
 		return

--- a/pkg/informer/informer_test.go
+++ b/pkg/informer/informer_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package informer
 
 import (
-	"reflect"
 	"strings"
 	"testing"
 
@@ -84,6 +83,7 @@ func TestBuiltInInformableTypes(t *testing.T) {
 		{Group: "authorization.k8s.io", Version: "v1", Kind: "SelfSubjectAccessReview"}:  {},
 		{Group: "authorization.k8s.io", Version: "v1", Kind: "SelfSubjectRulesReview"}:   {},
 		{Group: "authorization.k8s.io", Version: "v1", Kind: "SubjectAccessReview"}:      {},
+		{Group: "apiextensions.k8s.io", Version: "v1", Kind: "ConversionReview"}:         {},
 	}
 
 	gvsToIgnore := map[schema.GroupVersion]struct{}{
@@ -92,6 +92,7 @@ func TestBuiltInInformableTypes(t *testing.T) {
 
 		// These are alpha/beta versions that are not preferred (they all have v1)
 		{Group: "admissionregistration.k8s.io", Version: "v1beta1"}: {},
+		{Group: "apiextensions.k8s.io", Version: "v1beta1"}:         {},
 		{Group: "authentication.k8s.io", Version: "v1beta1"}:        {},
 		{Group: "authorization.k8s.io", Version: "v1beta1"}:         {},
 		{Group: "certificates.k8s.io", Version: "v1alpha1"}:         {},
@@ -103,11 +104,6 @@ func TestBuiltInInformableTypes(t *testing.T) {
 	}
 
 	allKnownTypes := kcpscheme.Scheme.AllKnownTypes()
-
-	// CRDs are not included in the genericcontrolplane scheme (because they're part of the apiextensions apiserver),
-	// so we have to manually add them
-	allKnownTypes[schema.GroupVersionKind{Group: "apiextensions.k8s.io", Version: "v1", Kind: "CustomResourceDefinition"}] = reflect.TypeOf(struct{}{})
-
 	for gvk := range allKnownTypes {
 		if kindsToIgnore.Has(gvk.Kind) {
 			continue

--- a/pkg/server/scheme/scheme.go
+++ b/pkg/server/scheme/scheme.go
@@ -17,6 +17,7 @@ limitations under the License.
 package scheme
 
 import (
+	apiextensionsinstall "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	admissionregistrationinstall "k8s.io/kubernetes/pkg/apis/admissionregistration/install"
@@ -33,6 +34,7 @@ func init() {
 	install.Install(Scheme)
 	authenticationinstall.Install(Scheme)
 	authorizationinstall.Install(Scheme)
+	apiextensionsinstall.Install(Scheme)
 	certificatesinstall.Install(Scheme)
 	coordinationinstall.Install(Scheme)
 	rbacinstall.Install(Scheme)

--- a/pkg/virtual/apiexport/schemas/builtin/builtin.go
+++ b/pkg/virtual/apiexport/schemas/builtin/builtin.go
@@ -264,5 +264,6 @@ var BuiltInAPIs = []internalapis.InternalAPI{
 		GroupVersion:  schema.GroupVersion{Group: "apiextensions.k8s.io", Version: "v1"},
 		Instance:      &apiextensionsv1.CustomResourceDefinition{},
 		ResourceScope: apiextensionsv1.ClusterScoped,
+		HasStatus:     true,
 	},
 }

--- a/pkg/virtual/apiexport/schemas/builtin/builtin.go
+++ b/pkg/virtual/apiexport/schemas/builtin/builtin.go
@@ -255,4 +255,14 @@ var BuiltInAPIs = []internalapis.InternalAPI{
 		Instance:      &admissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding{},
 		ResourceScope: apiextensionsv1.ClusterScoped,
 	},
+	{
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Plural:   "customresourcedefinitions",
+			Singular: "customresourcedefinition",
+			Kind:     "CustomResourceDefinition",
+		},
+		GroupVersion:  schema.GroupVersion{Group: "apiextensions.k8s.io", Version: "v1"},
+		Instance:      &apiextensionsv1.CustomResourceDefinition{},
+		ResourceScope: apiextensionsv1.ClusterScoped,
+	},
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Attempt to add CRDs to built-in types so they could be claimed

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note using the following format:

```release-note
<description of change>
```
-->

```release-note
CRD resources are now part of Built-in types. 
```
