### PR TITLE
:seedling: Add new maintainers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,3 +2,6 @@ approvers:
 - clubanderson
 - scheeles
 - sttts
+- xrstf
+- mjudeikis
+- embik


### PR DESCRIPTION
## Summary

Implementing https://groups.google.com/g/kcp-dev/c/mwUkINOiMjQ after @scheeles's +1 (and mine of course as I proposed them to get added).

## Related issue(s)

```release-note
NONE
```