### PR TITLE
:seedling:  Add metrics-viewer 'battery'

### DIFF
--- a/config/root-phase0/metrics-cluster-role-binding.yaml
+++ b/config/root-phase0/metrics-cluster-role-binding.yaml
@@ -1,0 +1,16 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: metrics-viewer
+  namespace: default
+  annotations:
+    bootstrap.kcp.io/battery: metrics-viewer
+subjects:
+- kind: ServiceAccount
+  name: metrics
+  namespace: default
+  apiGroup: ""
+roleRef:
+  kind: ClusterRole
+  name: metrics-viewer
+  apiGroup: ""

--- a/config/root-phase0/metrics-cluster-role.yaml
+++ b/config/root-phase0/metrics-cluster-role.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: metrics-viewer
+  annotations:
+    bootstrap.kcp.io/battery: metrics-viewer
+rules:
+- nonResourceURLs:
+  - '/metrics'
+  verbs:
+  - 'GET'

--- a/config/root-phase0/metrics-service-account-secret.yaml
+++ b/config/root-phase0/metrics-service-account-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: metrics
+  annotations:
+    kubernetes.io/service-account.name: metrics
+    bootstrap.kcp.io/battery: metrics-viewer

--- a/config/root-phase0/metrics-service-account.yaml
+++ b/config/root-phase0/metrics-service-account.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metrics
+  namespace: default
+  annotations:
+    bootstrap.kcp.io/battery: metrics-viewer

--- a/pkg/server/options/batteries/batteries.go
+++ b/pkg/server/options/batteries/batteries.go
@@ -28,11 +28,15 @@ const (
 
 	// User leads to an additional user named "user" in the admin.kubeconfig that is not admin.
 	User = "user"
+
+	// MetricsViewer leads to an additional service account named "metrics" in the root namespace that can view metrics.
+	MetricsViewer = "metrics-viewer"
 )
 
 var All = sets.New[string](
 	WorkspaceTypes,
 	User,
+	MetricsViewer,
 )
 
 var Defaults = sets.New[string](


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

While hunting down OOM/go-routine issue found that I needed to setup metrics scrapping. For this I needed service account to access them. Where it is easily done, I found this uslefull for few reasons;
1. I did it multiple times myself so it kinda got to the place - its need to be in the batteries
2. When using TILT, it does not have a clear phases approach. It usually - You deploy everything and wait. So I ended up maintaining a separate job just to deploy this into KCP with dependency created:
`KCP -> Job -> Prometheus`

Having this tilt case becomes - "While deploying Prometheus, read this secret and configure scraping and removing job out of the picture"


## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note using the following format:

```release-note
<description of change>
```
-->

```release-note
NONE
```
