### PR TITLE
:seedling: Increase workspace init timeout in e2e tests to 60 seconds

### DIFF
--- a/test/e2e/framework/workspaces.go
+++ b/test/e2e/framework/workspaces.go
@@ -43,6 +43,13 @@ import (
 	kcpclientset "github.com/kcp-dev/kcp/sdk/client/clientset/versioned/cluster"
 )
 
+const (
+	// workspaceInitTimeout is set to 60 seconds. wait.ForeverTestTimeout
+	// is 30 seconds and the optimism on that being forever is great, but workspace
+	// initialisation can take a while in CI.
+	workspaceInitTimeout = 60 * time.Second
+)
+
 type WorkspaceOption interface {
 	PrivilegedWorkspaceOption | UnprivilegedWorkspaceOption
 }
@@ -174,7 +181,7 @@ func newWorkspaceFixture[O WorkspaceOption](t *testing.T, createClusterClient, c
 			return false, fmt.Sprintf("workspace phase is %s, not %s", actual, expected)
 		}
 		return true, ""
-	}, wait.ForeverTestTimeout, time.Millisecond*100, "failed to wait for %s workspace %s to become ready", ws.Spec.Type, parent.Join(ws.Name))
+	}, workspaceInitTimeout, time.Millisecond*100, "failed to wait for %s workspace %s to become ready", ws.Spec.Type, parent.Join(ws.Name))
 
 	Eventually(t, func() (bool, string) {
 		if _, err := clusterClient.Cluster(logicalcluster.NewPath(ws.Spec.Cluster)).CoreV1alpha1().LogicalClusters().Get(ctx, corev1alpha1.LogicalClusterName, metav1.GetOptions{}); err != nil {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Our e2e tests are very unstable and flake a lot. Since they seem to be stable when run locally, we suspect it's related to Prow jobs performing poorly.

This PR will not fix the issue completely, but hopefully improves the situation by waiting longer for workspaces to initialize. The current theory is that tests interfere too much with each other (e.g. by competing for shared resources like disks), and we will need to fix this on the infrastructure level. To be discussed.

## Related issue(s)

xref #2995

## Release Notes

<!--
Please add a release note using the following format:

```release-note
<description of change>
```
-->

```release-note
NONE
```
