### PR TITLE
:bug: Memory leak fix in mutating & validating webhooks

### DIFF
--- a/pkg/admission/mutatingwebhook/plugin.go
+++ b/pkg/admission/mutatingwebhook/plugin.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
 
 	kcpkubernetesinformers "github.com/kcp-dev/client-go/informers"
 	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
@@ -55,6 +56,7 @@ type Plugin struct {
 
 	getAPIBindings func(clusterName logicalcluster.Name) ([]*apisv1alpha1.APIBinding, error)
 
+	managerLock   sync.Mutex
 	managersCache map[logicalcluster.Name]generic.Source
 }
 
@@ -68,7 +70,9 @@ var (
 
 func NewMutatingAdmissionWebhook(configFile io.Reader) (*Plugin, error) {
 	p := &Plugin{
-		Handler: admission.NewHandler(admission.Connect, admission.Create, admission.Delete, admission.Update),
+		managerLock:   sync.Mutex{},
+		managersCache: make(map[logicalcluster.Name]generic.Source),
+		Handler:       admission.NewHandler(admission.Connect, admission.Create, admission.Delete, admission.Update),
 	}
 	if configFile != nil {
 		config, err := io.ReadAll(configFile)
@@ -127,10 +131,8 @@ func (p *Plugin) getHookSource(clusterName logicalcluster.Name, groupResource sc
 		return nil, err
 	}
 
-	if p.managersCache == nil {
-		p.managersCache = make(map[logicalcluster.Name]generic.Source)
-	}
-
+	p.managerLock.Lock()
+	defer p.managerLock.Unlock()
 	if _, ok := p.managersCache[clusterNameForGroupResource]; !ok {
 		p.managersCache[clusterNameForGroupResource] = configuration.NewMutatingWebhookConfigurationManagerForInformer(
 			p.globalKubeSharedInformerFactory.Admissionregistration().V1().MutatingWebhookConfigurations().Cluster(clusterNameForGroupResource),

--- a/pkg/admission/mutatingwebhook/plugin.go
+++ b/pkg/admission/mutatingwebhook/plugin.go
@@ -54,6 +54,8 @@ type Plugin struct {
 	globalKubeSharedInformerFactory kcpkubernetesinformers.SharedInformerFactory
 
 	getAPIBindings func(clusterName logicalcluster.Name) ([]*apisv1alpha1.APIBinding, error)
+
+	managersCache map[logicalcluster.Name]generic.Source
 }
 
 var (
@@ -125,9 +127,17 @@ func (p *Plugin) getHookSource(clusterName logicalcluster.Name, groupResource sc
 		return nil, err
 	}
 
-	return configuration.NewMutatingWebhookConfigurationManagerForInformer(
-		p.globalKubeSharedInformerFactory.Admissionregistration().V1().MutatingWebhookConfigurations().Cluster(clusterNameForGroupResource),
-	), nil
+	if p.managersCache == nil {
+		p.managersCache = make(map[logicalcluster.Name]generic.Source)
+	}
+
+	if _, ok := p.managersCache[clusterNameForGroupResource]; !ok {
+		p.managersCache[clusterNameForGroupResource] = configuration.NewMutatingWebhookConfigurationManagerForInformer(
+			p.globalKubeSharedInformerFactory.Admissionregistration().V1().MutatingWebhookConfigurations().Cluster(clusterNameForGroupResource),
+		)
+	}
+
+	return p.managersCache[clusterNameForGroupResource], nil
 }
 
 func (p *Plugin) getSourceClusterForGroupResource(clusterName logicalcluster.Name, groupResource schema.GroupResource) (logicalcluster.Name, error) {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Each time `informer.Informer().AddEventHandler` is called go routine is spanned to monitor the event.
`configuration.NewMutatingWebhookConfigurationManagerForInformer` does just that so each time `plugin.Admit` is called we span a go routine. And so it infinity; 
![image](https://github.com/kcp-dev/kcp/assets/3225744/fd100464-426f-4728-82dc-a2b58673f783)



## Related issue(s)

Fixes https://github.com/kcp-dev/kcp/issues/3016

## Release Notes

<!--
Please add a release note using the following format:

```release-note
<description of change>
```
-->

```release-note
NONE
```
