### PR TITLE
:seedling: Increase resource requests on Prow jobs but only run if code changed

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -96,8 +96,9 @@ presubmits:
               cpu: 2
 
   - name: pull-kcp-test-e2e
-    always_run: true
     decorate: true
+    # only run e2e tests if code changed.
+    run_if_changed: "(cmd|config|pkg|sdk|test|go.mod|go.sum|Makefile|.prow.yaml)"
     clone_uri: "https://github.com/kcp-dev/kcp"
     labels:
       preset-goproxy: "true"
@@ -119,12 +120,13 @@ presubmits:
               value: '3'
           resources:
             requests:
-              memory: 4Gi
-              cpu: 3
+              memory: 6Gi
+              cpu: 4
 
   - name: pull-kcp-test-e2e-multiple-runs
-    always_run: true
     decorate: true
+    # only run e2e tests if code changed.
+    run_if_changed: "(cmd|config|pkg|sdk|test|go.mod|go.sum|Makefile|.prow.yaml)"
     clone_uri: "https://github.com/kcp-dev/kcp"
     labels:
       preset-goproxy: "true"
@@ -143,17 +145,18 @@ presubmits:
             - name: KUBE_CACHE_MUTATION_DETECTOR
               value: '1'
             - name: COUNT
-              value: '3'
+              value: '2'
             - name: E2E_PARALLELISM
               value: '3'
           resources:
             requests:
-              memory: 4Gi
-              cpu: 3
+              memory: 6Gi
+              cpu: 4
 
   - name: pull-kcp-test-e2e-shared
-    always_run: true
     decorate: true
+    # only run e2e tests if code changed.
+    run_if_changed: "(cmd|config|pkg|sdk|test|go.mod|go.sum|Makefile|.prow.yaml)"
     clone_uri: "https://github.com/kcp-dev/kcp"
     labels:
       preset-goproxy: "true"
@@ -173,12 +176,13 @@ presubmits:
               value: '1'
           resources:
             requests:
-              memory: 4Gi
-              cpu: 3
+              memory: 6Gi
+              cpu: 4
 
   - name: pull-kcp-test-e2e-sharded
-    always_run: true
     decorate: true
+    # only run e2e tests if code changed.
+    run_if_changed: "(cmd|config|pkg|sdk|test|go.mod|go.sum|Makefile|.prow.yaml)"
     clone_uri: "https://github.com/kcp-dev/kcp"
     labels:
       preset-goproxy: "true"
@@ -198,5 +202,5 @@ presubmits:
               value: '1'
           resources:
             requests:
-              memory: 4Gi
-              cpu: 3
+              memory: 6Gi
+              cpu: 4


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This PR increases the memory and cpu requests on Prow jobs for e2e tests to ensure that they get their own nodes with minimal interference. At the same time, it adds `run_if_changed` to ensure that we no longer run e2e tests on non-code changes.

In addition, I'm reducing the number of runs in `pull-kcp-test-e2e-multiple-runs` from 3 to 2. That should be "good enough" while reducing the runtime of the job by one third.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note using the following format:

```release-note
<description of change>
```
-->

```release-note
NONE
```
