### PR TITLE
⚠️ Add `--enable-auth-write` flag and store shard admin token hash as hex-encoded

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -92,6 +92,7 @@ type ExtraConfig struct {
 	IdentityConfig    *rest.Config
 
 	// authentication
+	writeAdminKubeconfig                      bool
 	kcpAdminToken, shardAdminToken, userToken string
 	shardAdminTokenHash                       []byte
 
@@ -317,7 +318,7 @@ func NewConfig(opts kcpserveroptions.CompletedOptions) (*Config, error) {
 		return nil, err
 	}
 	var userToken string
-	c.kcpAdminToken, c.shardAdminToken, userToken, c.shardAdminTokenHash, err = opts.AdminAuthentication.ApplyTo(c.GenericConfig)
+	c.kcpAdminToken, c.shardAdminToken, userToken, c.shardAdminTokenHash, c.writeAdminKubeconfig, err = opts.AdminAuthentication.ApplyTo(c.GenericConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -535,8 +535,11 @@ func (s *Server) Run(ctx context.Context) error {
 		}
 	}
 
-	if err := s.Options.AdminAuthentication.WriteKubeConfig(s.GenericConfig, s.kcpAdminToken, s.shardAdminToken, s.userToken, s.shardAdminTokenHash); err != nil {
-		return err
+	// only write the admin kubeconfig if --enable-auth-write is set.
+	if s.writeAdminKubeconfig {
+		if err := s.Options.AdminAuthentication.WriteKubeConfig(s.GenericConfig, s.kcpAdminToken, s.shardAdminToken, s.userToken, s.shardAdminTokenHash); err != nil {
+			return err
+		}
 	}
 
 	// add post start hook that starts all registered controllers.


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This PR is part of improvements to allow running kcp on Kubernetes. As of now, `kcp start` always tries to write `admin.kubeconfig` and `.admin-token-store` to disk, which means that in the Helm chart we [need to provide a PVC to the kcp server Deployment](https://github.com/kcp-dev/helm-charts/blob/e818463611c3204ebb24ba26ddf7135085d8e55d/charts/kcp/templates/server-deployment.yaml#L1). Eventually, with multiple replicas, we would need a RWX volume and kcp processes would overwrite each other on those files.

Looking at how/where `admin.kubeconfig` is used, it seems to be mainly for admins to access their kcp installation. At least I could not find it being read into kcp itself anywhere. Which means we don't have to provide this in the Kubernetes setup. To have a consistent shard admin token, this PR still requires `--authentication-admin-token-path` to be passed with a pre-configured token hash file (including a sha256 hash). kcp reads that file and accepts the token hash without trying to write the `admin.kubeconfig`. 

Because the token hash file is of greater importance now, I looked at it and saw that it stores sha256 checksums in raw bytes. Which means looking at the file you get some gibberish. It's not clear if that was intentional or not, but IMHO this file should be human-readable and because of that, this PR introduces the **breaking change that the token file is now hex-encoded**. This means you can now pass the output of piping your token to `sha256sum` into a file and pass that to kcp.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note using the following format:

```release-note
<description of change>
```
-->

```release-note
Add `--enable-auth-write` flag with can disable `admin.kubeconfig` and `.admin-token-store` being written to disk. The shard admin token hash is now stored as sha256 hex-encoded string
```
