### PR TITLE
:sparkles: Add `admin` battery to kcp server and enable it by default

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -317,12 +317,14 @@ func NewConfig(opts kcpserveroptions.CompletedOptions) (*Config, error) {
 		return nil, err
 	}
 	var userToken string
-	c.kcpAdminToken, c.shardAdminToken, userToken, c.shardAdminTokenHash, err = opts.AdminAuthentication.ApplyTo(c.GenericConfig)
-	if err != nil {
-		return nil, err
-	}
-	if sets.New[string](opts.Extra.BatteriesIncluded...).Has(batteries.User) {
-		c.userToken = userToken
+	if sets.New[string](opts.Extra.BatteriesIncluded...).Has(batteries.Admin) {
+		c.kcpAdminToken, c.shardAdminToken, userToken, c.shardAdminTokenHash, err = opts.AdminAuthentication.ApplyTo(c.GenericConfig)
+		if err != nil {
+			return nil, err
+		}
+		if sets.New[string](opts.Extra.BatteriesIncluded...).Has(batteries.User) {
+			c.userToken = userToken
+		}
 	}
 
 	bootstrapConfig := rest.CopyConfig(c.GenericConfig.LoopbackClientConfig)

--- a/pkg/server/options/batteries/batteries.go
+++ b/pkg/server/options/batteries/batteries.go
@@ -26,7 +26,10 @@ const (
 	// WorkspaceTypes leads to creation of a number of default types beyond the universal type.
 	WorkspaceTypes = "workspace-types"
 
-	// User leads to an additional user named "user" in the admin.kubeconfig that is not admin.
+	// Admin leads to creating a local admin.kubeconfig and a token hash file to access kcp as shard admin.
+	Admin = "admin"
+
+	// User leads to an additional user named "user" in the admin.kubeconfig that is not admin. Requires the "admin" battery to be enabled.
 	User = "user"
 
 	// MetricsViewer leads to an additional service account named "metrics" in the root namespace that can view metrics.
@@ -35,10 +38,12 @@ const (
 
 var All = sets.New[string](
 	WorkspaceTypes,
+	Admin,
 	User,
 	MetricsViewer,
 )
 
 var Defaults = sets.New[string](
 	WorkspaceTypes,
+	Admin,
 )

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -53,6 +53,7 @@ import (
 	bootstrappolicy "github.com/kcp-dev/kcp/pkg/authorization/bootstrap"
 	"github.com/kcp-dev/kcp/pkg/informer"
 	metadataclient "github.com/kcp-dev/kcp/pkg/metadata"
+	"github.com/kcp-dev/kcp/pkg/server/options/batteries"
 	virtualrootapiserver "github.com/kcp-dev/kcp/pkg/virtual/framework/rootapiserver"
 	"github.com/kcp-dev/kcp/sdk/apis/core"
 	corev1alpha1 "github.com/kcp-dev/kcp/sdk/apis/core/v1alpha1"
@@ -535,8 +536,10 @@ func (s *Server) Run(ctx context.Context) error {
 		}
 	}
 
-	if err := s.Options.AdminAuthentication.WriteKubeConfig(s.GenericConfig, s.kcpAdminToken, s.shardAdminToken, s.userToken, s.shardAdminTokenHash); err != nil {
-		return err
+	if sets.New[string](s.Options.Extra.BatteriesIncluded...).Has(batteries.Admin) {
+		if err := s.Options.AdminAuthentication.WriteKubeConfig(s.GenericConfig, s.kcpAdminToken, s.shardAdminToken, s.userToken, s.shardAdminTokenHash); err != nil {
+			return err
+		}
 	}
 
 	// add post start hook that starts all registered controllers.


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This is a follow-up to #3033 and the discussion it created. This new approach adds a new battery called `admin` and enables it by default. Without this battery, `admin.kubeconfig` will not be generated and no admin token will be created to be injected into a new authenticator.

I've also added a check to make sure that the `user` battery is not enabled when `admin` is not.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note using the following format:

```release-note
<description of change>
```
-->

```release-note
Add new `admin` battery which is enabled by default
```
