### PR TITLE
:bug: Be aware of sharding in APIBinding tests for LogicalCluster

### DIFF
--- a/cmd/sharded-test-server/cache.go
+++ b/cmd/sharded-test-server/cache.go
@@ -100,7 +100,7 @@ func startCacheServer(ctx context.Context, logDirPath, workingDir string, synthe
 		case err := <-terminatedCh:
 			var exitErr *exec.ExitError
 			if err == nil {
-				return nil, "", fmt.Errorf("the cahce server terminated unexpectedly with exit code 0")
+				return nil, "", fmt.Errorf("the cache server terminated unexpectedly with exit code 0")
 			} else if errors.As(err, &exitErr) {
 				return nil, "", fmt.Errorf("the cache server terminated with exit code %d", exitErr.ExitCode())
 			}

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -319,7 +319,7 @@ func LogicalClusterRawConfig(rawConfig clientcmdapi.Config, logicalClusterName l
 }
 
 // Eventually asserts that given condition will be met in waitFor time, periodically checking target function
-// each tick. In addition to require.Eventually, this function t.Logs the raason string value returned by the condition
+// each tick. In addition to require.Eventually, this function t.Logs the reason string value returned by the condition
 // function (eventually after 20% of the wait time) to aid in debugging.
 func Eventually(t *testing.T, condition func() (success bool, reason string), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
 	t.Helper()


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

#3035 added some new tests for binding `LogicalClusters`. The test works fine when running "normal" e2e tests, but `test-e2e-sharded-minimal` fails more or less all the time. The reason is that the test was accessing the VirtualWorkspace URL at index 0, but sharded testing makes the situation more complex (with two VW servers). The APIExport and APIBinding workspaces were always added to `shard-1`, and then another virtual workspace is presenting the data we are looking for.

This adjusts the tests to consider multiple VWs and gather objects across VWs for the two new tests.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note using the following format:

```release-note
<description of change>
```
-->

```release-note
NONE
```
