### PR TITLE
:sparkles: Simplify index pkg

### DIFF
--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -28,8 +28,17 @@ import (
 
 // Index implements a mapping from logical cluster to (shard) URL.
 type Index interface {
-	Lookup(path logicalcluster.Path) (shard string, cluster, canonicalPath logicalcluster.Path, found bool)
-	LookupURL(logicalCluster logicalcluster.Path) (url string, canonicalPath logicalcluster.Path, found bool)
+	Lookup(path logicalcluster.Path) Result
+	LookupURL(logicalCluster logicalcluster.Path) Result
+}
+
+// Result is the result of a lookup.
+type Result struct {
+	URL   string
+	Found bool
+	Shard string
+	// Cluster canonical path
+	Cluster logicalcluster.Name
 }
 
 // PathRewriter can rewrite a logical cluster path before the actual mapping through
@@ -188,7 +197,7 @@ func (c *State) DeleteShard(shardName string) {
 	delete(c.shardClusterParentCluster, shardName)
 }
 
-func (c *State) Lookup(path logicalcluster.Path) (shard string, cluster logicalcluster.Name, found bool) {
+func (c *State) Lookup(path logicalcluster.Path) Result {
 	segments := strings.Split(path.String(), ":")
 
 	for _, rewriter := range c.rewriters {
@@ -198,13 +207,16 @@ func (c *State) Lookup(path logicalcluster.Path) (shard string, cluster logicalc
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 
+	var shard string
+	var cluster logicalcluster.Name
+
 	// walk through index graph to find the final logical cluster and shard
 	for i, s := range segments {
 		if i == 0 {
 			var found bool
 			shard, found = c.clusterShards[logicalcluster.Name(s)]
 			if !found {
-				return "", "", false
+				return Result{}
 			}
 			cluster = logicalcluster.Name(s)
 			continue
@@ -213,27 +225,30 @@ func (c *State) Lookup(path logicalcluster.Path) (shard string, cluster logicalc
 		var found bool
 		cluster, found = c.shardWorkspaceNameCluster[shard][cluster][s]
 		if !found {
-			return "", "", false
+			return Result{}
 		}
 		shard, found = c.clusterShards[cluster]
 		if !found {
-			return "", "", false
+			return Result{}
 		}
 	}
 
-	return shard, cluster, true
+	return Result{Shard: shard, Cluster: cluster, Found: true}
 }
 
-func (c *State) LookupURL(path logicalcluster.Path) (url string, found bool) {
-	shard, cluster, found := c.Lookup(path)
-	if !found {
-		return "", false
+func (c *State) LookupURL(path logicalcluster.Path) Result {
+	r := c.Lookup(path)
+	if !r.Found {
+		return Result{}
 	}
 
-	baseURL, found := c.shardBaseURLs[shard]
+	baseURL, found := c.shardBaseURLs[r.Shard]
 	if !found {
-		return "", false
+		return Result{}
 	}
 
-	return strings.TrimSuffix(baseURL, "/") + cluster.Path().RequestPath(), true
+	return Result{
+		URL:   strings.TrimSuffix(baseURL, "/") + r.Cluster.Path().RequestPath(),
+		Found: true,
+	}
 }

--- a/pkg/index/index_test.go
+++ b/pkg/index/index_test.go
@@ -244,21 +244,21 @@ func TestLookup(t *testing.T) {
 					target.UpsertLogicalCluster(shardName, lc)
 				}
 			}
-			actualShard, actualCluster, found := target.Lookup(scenario.targetPath)
-			if scenario.expectFound && !found {
+			r := target.Lookup(scenario.targetPath)
+			if scenario.expectFound && !r.Found {
 				t.Fatalf("expected to lookup the path = %v", scenario.targetPath)
 			}
-			if !scenario.expectFound && found {
+			if !scenario.expectFound && r.Found {
 				t.Errorf("didn't expect to lookup the path = %v", scenario.targetPath)
 			}
 			if !scenario.expectFound {
 				return
 			}
-			if actualShard != scenario.expectedShard {
-				t.Errorf("unexpected shard = %v, for path = %v, expected = %v", actualShard, scenario.targetPath, scenario.expectedShard)
+			if r.Shard != scenario.expectedShard {
+				t.Errorf("unexpected shard = %v, for path = %v, expected = %v", r.Shard, scenario.targetPath, scenario.expectedShard)
 			}
-			if actualCluster != scenario.expectedCluster {
-				t.Errorf("unexpected cluster = %v, for path = %v, expected = %v", actualCluster, scenario.targetPath, scenario.expectedCluster)
+			if r.Cluster != scenario.expectedCluster {
+				t.Errorf("unexpected cluster = %v, for path = %v, expected = %v", r.Cluster, scenario.targetPath, scenario.expectedCluster)
 			}
 		})
 	}
@@ -278,16 +278,16 @@ func TestDeleteShard(t *testing.T) {
 	target.UpsertLogicalCluster("root", newLogicalCluster("34"))
 	target.UpsertLogicalCluster("amber", newLogicalCluster("43"))
 
-	shard, cluster, found := target.Lookup(logicalcluster.NewPath("root:org1"))
-	validateLookupOutput(t, logicalcluster.NewPath("root:org"), shard, cluster, found, "amber", "43", true)
+	r := target.Lookup(logicalcluster.NewPath("root:org1"))
+	validateLookupOutput(t, logicalcluster.NewPath("root:org"), r.Shard, r.Cluster, r.Found, "amber", "43", true)
 
 	// delete the shard and ensure we cannot look up a path on it
 	target.DeleteShard("amber")
-	shard, cluster, found = target.Lookup(logicalcluster.NewPath("root:org1"))
-	validateLookupOutput(t, logicalcluster.NewPath("root:org"), shard, cluster, found, "", "", false)
+	r = target.Lookup(logicalcluster.NewPath("root:org1"))
+	validateLookupOutput(t, logicalcluster.NewPath("root:org"), r.Shard, r.Cluster, r.Found, "", "", false)
 
-	shard, cluster, found = target.Lookup(logicalcluster.NewPath("root:org"))
-	validateLookupOutput(t, logicalcluster.NewPath("root:org"), shard, cluster, found, "root", "34", true)
+	r = target.Lookup(logicalcluster.NewPath("root:org"))
+	validateLookupOutput(t, logicalcluster.NewPath("root:org"), r.Shard, r.Cluster, r.Found, "root", "34", true)
 }
 
 func TestDeleteLogicalCluster(t *testing.T) {
@@ -301,17 +301,17 @@ func TestDeleteLogicalCluster(t *testing.T) {
 	target.UpsertLogicalCluster("root", newLogicalCluster("root"))
 	target.UpsertLogicalCluster("root", newLogicalCluster("34"))
 
-	shard, cluster, found := target.Lookup(logicalcluster.NewPath("root:org"))
-	validateLookupOutput(t, logicalcluster.NewPath("root:org"), shard, cluster, found, "root", "34", true)
+	r := target.Lookup(logicalcluster.NewPath("root:org"))
+	validateLookupOutput(t, logicalcluster.NewPath("root:org"), r.Shard, r.Cluster, r.Found, "root", "34", true)
 
 	// ensure that after deleting the logical cluster it cannot be looked up
 	target.DeleteLogicalCluster("root", newLogicalCluster("34"))
 
-	shard, cluster, found = target.Lookup(logicalcluster.NewPath("root:org"))
-	validateLookupOutput(t, logicalcluster.NewPath("root:org"), shard, cluster, found, "", "", false)
+	r = target.Lookup(logicalcluster.NewPath("root:org"))
+	validateLookupOutput(t, logicalcluster.NewPath("root:org"), r.Shard, r.Cluster, r.Found, "", "", false)
 
-	shard, cluster, found = target.Lookup(logicalcluster.NewPath("root"))
-	validateLookupOutput(t, logicalcluster.NewPath("root:org"), shard, cluster, found, "root", "root", true)
+	r = target.Lookup(logicalcluster.NewPath("root"))
+	validateLookupOutput(t, logicalcluster.NewPath("root:org"), r.Shard, r.Cluster, r.Found, "root", "root", true)
 }
 
 func TestDeleteWorkspace(t *testing.T) {
@@ -327,16 +327,16 @@ func TestDeleteWorkspace(t *testing.T) {
 	target.UpsertLogicalCluster("root", newLogicalCluster("34"))
 	target.UpsertLogicalCluster("root", newLogicalCluster("43"))
 
-	shard, cluster, found := target.Lookup(logicalcluster.NewPath("root:org"))
-	validateLookupOutput(t, logicalcluster.NewPath("root:org"), shard, cluster, found, "root", "34", true)
+	r := target.Lookup(logicalcluster.NewPath("root:org"))
+	validateLookupOutput(t, logicalcluster.NewPath("root:org"), r.Shard, r.Cluster, r.Found, "root", "34", true)
 
 	target.DeleteWorkspace("root", newWorkspace("org", "root", "34"))
 
-	shard, cluster, found = target.Lookup(logicalcluster.NewPath("root:org"))
-	validateLookupOutput(t, logicalcluster.NewPath("root:org"), shard, cluster, found, "", "", false)
+	r = target.Lookup(logicalcluster.NewPath("root:org"))
+	validateLookupOutput(t, logicalcluster.NewPath("root:org"), r.Shard, r.Cluster, r.Found, "", "", false)
 
-	shard, cluster, found = target.Lookup(logicalcluster.NewPath("root:org1"))
-	validateLookupOutput(t, logicalcluster.NewPath("root:org"), shard, cluster, found, "root", "43", true)
+	r = target.Lookup(logicalcluster.NewPath("root:org1"))
+	validateLookupOutput(t, logicalcluster.NewPath("root:org"), r.Shard, r.Cluster, r.Found, "root", "43", true)
 }
 
 func TestUpsertLogicalCluster(t *testing.T) {
@@ -348,12 +348,12 @@ func TestUpsertLogicalCluster(t *testing.T) {
 	target.UpsertLogicalCluster("root", newLogicalCluster("root"))
 	target.UpsertLogicalCluster("root", newLogicalCluster("34"))
 
-	shard, cluster, found := target.Lookup(logicalcluster.NewPath("root:org"))
-	validateLookupOutput(t, logicalcluster.NewPath("root:org"), shard, cluster, found, "root", "34", true)
+	r := target.Lookup(logicalcluster.NewPath("root:org"))
+	validateLookupOutput(t, logicalcluster.NewPath("root:org"), r.Shard, r.Cluster, r.Found, "root", "34", true)
 
 	target.UpsertLogicalCluster("amber", newLogicalCluster("34"))
-	shard, cluster, found = target.Lookup(logicalcluster.NewPath("root:org"))
-	validateLookupOutput(t, logicalcluster.NewPath("root:org"), shard, cluster, found, "amber", "34", true)
+	r = target.Lookup(logicalcluster.NewPath("root:org"))
+	validateLookupOutput(t, logicalcluster.NewPath("root:org"), r.Shard, r.Cluster, r.Found, "amber", "34", true)
 }
 
 // Since LookupURL uses Lookup method the following test is just a smoke tests.
@@ -365,20 +365,20 @@ func TestLookupURL(t *testing.T) {
 	target.UpsertLogicalCluster("root", newLogicalCluster("root"))
 	target.UpsertLogicalCluster("root", newLogicalCluster("34"))
 
-	url, found := target.LookupURL(logicalcluster.NewPath("root:org"))
-	if !found {
+	r := target.LookupURL(logicalcluster.NewPath("root:org"))
+	if !r.Found {
 		t.Fatalf("expected to find a URL for %q path", "root:org")
 	}
-	if url != "https://root.io/clusters/34" {
-		t.Fatalf("unexpected url = %v returned, expected = %v for %q path", url, "https://root.io/clusters/34", "root:org")
+	if r.URL != "https://root.io/clusters/34" {
+		t.Fatalf("unexpected url = %v returned, expected = %v for %q path", r.URL, "https://root.io/clusters/34", "root:org")
 	}
 
-	url, found = target.LookupURL(logicalcluster.NewPath("root:org:rh"))
-	if found {
+	r = target.LookupURL(logicalcluster.NewPath("root:org:rh"))
+	if r.Found {
 		t.Fatalf("didn't expected to find a URL for %q path", "root:org:rh")
 	}
-	if len(url) > 0 {
-		t.Fatalf("unexpected url = %v returned for %q path", url, "root:org:rh")
+	if len(r.URL) > 0 {
+		t.Fatalf("unexpected url = %v returned for %q path", r.URL, "root:org:rh")
 	}
 }
 
@@ -390,21 +390,21 @@ func TestUpsertShard(t *testing.T) {
 	target.UpsertLogicalCluster("root", newLogicalCluster("root"))
 	target.UpsertLogicalCluster("root", newLogicalCluster("34"))
 
-	url, found := target.LookupURL(logicalcluster.NewPath("root:org"))
-	if !found {
+	r := target.LookupURL(logicalcluster.NewPath("root:org"))
+	if !r.Found {
 		t.Fatalf("expected to find a URL for %q path", "root:org")
 	}
-	if url != "https://root.io/clusters/34" {
-		t.Fatalf("unexpected url = %v returned, expected = %v for %q path", url, "https://root.io/clusters/34", "root:org")
+	if r.URL != "https://root.io/clusters/34" {
+		t.Fatalf("unexpected url = %v returned, expected = %v for %q path", r.URL, "https://root.io/clusters/34", "root:org")
 	}
 
 	target.UpsertShard("root", "https://new-root.io")
-	url, found = target.LookupURL(logicalcluster.NewPath("root:org"))
-	if !found {
+	r = target.LookupURL(logicalcluster.NewPath("root:org"))
+	if !r.Found {
 		t.Fatalf("expected to find a URL for %q path", "root:org")
 	}
-	if url != "https://new-root.io/clusters/34" {
-		t.Fatalf("unexpected url = %v returned, expected = %v for %q path", url, "https://new-root.io/clusters/34", "root:org")
+	if r.URL != "https://new-root.io/clusters/34" {
+		t.Fatalf("unexpected url = %v returned, expected = %v for %q path", r.URL, "https://new-root.io/clusters/34", "root:org")
 	}
 }
 
@@ -417,12 +417,12 @@ func TestUpsertWorkspace(t *testing.T) {
 	target.UpsertLogicalCluster("root", newLogicalCluster("34"))
 	target.UpsertLogicalCluster("root", newLogicalCluster("44"))
 
-	shard, cluster, found := target.Lookup(logicalcluster.NewPath("root:org"))
-	validateLookupOutput(t, logicalcluster.NewPath("root:org"), shard, cluster, found, "root", "34", true)
+	r := target.Lookup(logicalcluster.NewPath("root:org"))
+	validateLookupOutput(t, logicalcluster.NewPath("root:org"), r.Shard, r.Cluster, r.Found, "root", "34", true)
 
 	target.UpsertWorkspace("root", newWorkspace("org", "root", "44"))
-	shard, cluster, found = target.Lookup(logicalcluster.NewPath("root:org"))
-	validateLookupOutput(t, logicalcluster.NewPath("root:org"), shard, cluster, found, "root", "44", true)
+	r = target.Lookup(logicalcluster.NewPath("root:org"))
+	validateLookupOutput(t, logicalcluster.NewPath("root:org"), r.Shard, r.Cluster, r.Found, "root", "44", true)
 }
 
 func validateLookupOutput(t *testing.T, path logicalcluster.Path, shard string, cluster logicalcluster.Name, found bool, expectedShard string, expectedCluster logicalcluster.Name, expectToFind bool) {

--- a/pkg/proxy/index/index_controller.go
+++ b/pkg/proxy/index/index_controller.go
@@ -287,5 +287,6 @@ func (c *Controller) stopShard(shardName string) {
 }
 
 func (c *Controller) LookupURL(path logicalcluster.Path) (url string, found bool) {
-	return c.state.LookupURL(path)
+	r := c.state.LookupURL(path)
+	return r.URL, r.Found
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Simplify index package and wire in the ability to forward to different URLs. For now only in insecure mode in dev, as we need to wire in certificates deeper into stack. This is preparation for the experimental feature "workspace mounts"

Follow-up PR will follow: https://github.com/kcp-dev/kcp/pull/3057 

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note using the following format:

```release-note
Simplify index package for frontproxy
```
-->

```release-note
Simplify index package for frontproxy
```
