### PR TITLE
✨  Add OpenAPI Schema support to virtual workspace framework

### DIFF
--- a/pkg/virtual/framework/dynamic/apidefinition/types.go
+++ b/pkg/virtual/framework/dynamic/apidefinition/types.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/endpoints/handlers"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/kube-openapi/pkg/spec3"
 
 	dynamiccontext "github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/context"
 	apisv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/apis/v1alpha1"
@@ -33,6 +34,9 @@ import (
 type APIDefinition interface {
 	// GetAPIResourceSchema returns the API schema this definition serves.
 	GetAPIResourceSchema() *apisv1alpha1.APIResourceSchema
+
+	// GetOpenAPIV3Schema fetches OpenAPI V3 Schema
+	GetOpenAPIV3Spec() *spec3.OpenAPI
 
 	// GetClusterName provides the name of the logical cluster where the resource specification comes from.
 	GetClusterName() logicalcluster.Name

--- a/pkg/virtual/framework/dynamic/apiserver/apiserver.go
+++ b/pkg/virtual/framework/dynamic/apiserver/apiserver.go
@@ -177,14 +177,13 @@ func (c completedConfig) New(virtualWorkspaceName string, delegationTarget gener
 
 	s.GenericAPIServer.Handler.GoRestfulContainer.Add(discovery.NewLegacyRootAPIHandler(c.GenericConfig.DiscoveryAddresses, s.GenericAPIServer.Serializer, "/api").WebService())
 
+	openAPIHandler := newOpenAPIHandler(s.APISetRetriever, delegateHandler)
+
 	s.GenericAPIServer.Handler.NonGoRestfulMux.Handle("/apis", crdHandler)
 	s.GenericAPIServer.Handler.NonGoRestfulMux.HandlePrefix("/apis/", crdHandler)
 	s.GenericAPIServer.Handler.NonGoRestfulMux.Handle("/api/v1", crdHandler)
 	s.GenericAPIServer.Handler.NonGoRestfulMux.HandlePrefix("/api/v1/", crdHandler)
-
-	// TODO(david): plug OpenAPI if necessary. For now, according to the various virtual workspace use-cases,
-	// it doesn't seem necessary.
-	// Of course this requires using the --validate=false argument with some kubectl command like kubectl apply.
-
+	s.GenericAPIServer.Handler.NonGoRestfulMux.Handle("/openapi", openAPIHandler)
+	s.GenericAPIServer.Handler.NonGoRestfulMux.HandlePrefix("/openapi/", openAPIHandler)
 	return s, nil
 }

--- a/pkg/virtual/framework/dynamic/apiserver/discovery.go
+++ b/pkg/virtual/framework/dynamic/apiserver/discovery.go
@@ -17,6 +17,7 @@ limitations under the License.
 package apiserver
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"sort"
@@ -33,6 +34,7 @@ import (
 	"k8s.io/apiserver/pkg/endpoints/handlers/negotiation"
 	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/kube-openapi/pkg/handler3"
 	"k8s.io/kubernetes/pkg/controlplane/apiserver/miniaggregator"
 
 	"github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/apidefinition"
@@ -329,4 +331,87 @@ func sortGroupDiscoveryByKubeAwareVersion(gd []metav1.GroupVersionForDiscovery) 
 	sort.Slice(gd, func(i, j int) bool {
 		return version.CompareKubeAwareVersionStrings(gd[i].Version, gd[j].Version) > 0
 	})
+}
+
+type openAPIHandler struct {
+	apiSetRetriever apidefinition.APIDefinitionSetGetter
+	delegate        http.Handler
+
+	openAPIV3Service *handler3.OpenAPIService
+}
+
+func newOpenAPIHandler(apiSetRetriever apidefinition.APIDefinitionSetGetter, delegate http.Handler) *openAPIHandler {
+	openAPIV3Service := handler3.NewOpenAPIService()
+
+	return &openAPIHandler{
+		apiSetRetriever: apiSetRetriever,
+		delegate:        delegate,
+
+		openAPIV3Service: openAPIV3Service,
+	}
+}
+
+func (h *openAPIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// handle /openapi 								-> do nothing
+	// handle /openapi/v2 							-> do nothing for now. TODO: Implement. Actually, let OpenAPIV2 die. Ref: https://github.com/kcp-dev/kcp/pull/3059#discussion_r1424317153
+	// handle /openapi/v3							-> discovery endpoint
+	// handle /openapi/v3/apis/<group>/<version> 	-> serve OpenAPIV3Schema for <group>/<version>
+
+	pathParts := splitPath(r.URL.Path)
+
+	// if request doesn't start with /openapi return
+	// this check is a safety measure
+	if len(pathParts) == 1 && pathParts[0] != "openapi" {
+		h.delegate.ServeHTTP(w, r)
+		return
+	}
+
+	if len(pathParts) == 1 && pathParts[0] == "openapi" {
+		return
+	}
+
+	if len(pathParts) == 2 && pathParts[1] == "v2" { // handle /openapi/v2
+		// TODO: Implement OpenAPI V2 handler. Actually, let OpenAPIV2 die. Ref: https://github.com/kcp-dev/kcp/pull/3059#discussion_r1424317153
+		return
+	} else if len(pathParts) == 2 && pathParts[1] == "v3" { // handle /openapi/v3
+		if err := h.fetchAndUpdate(r.Context(), ""); err != nil {
+			responsewriters.ErrorNegotiated(
+				apierrors.NewInternalError(fmt.Errorf("unable to  set: %w", err)),
+				errorCodecs, schema.GroupVersion{},
+				w, r)
+		}
+
+		h.openAPIV3Service.HandleDiscovery(w, r)
+		return
+	} else if len(pathParts) == 5 && pathParts[1] == "v3" && pathParts[2] == "apis" {
+		requestedGroup := pathParts[3]
+		if err := h.fetchAndUpdate(r.Context(), requestedGroup); err != nil {
+			responsewriters.ErrorNegotiated(
+				apierrors.NewInternalError(fmt.Errorf("unable to  set: %w", err)),
+				errorCodecs, schema.GroupVersion{},
+				w, r)
+		}
+
+		h.openAPIV3Service.HandleGroupVersion(w, r)
+	} else {
+		h.delegate.ServeHTTP(w, r)
+		return
+	}
+}
+
+func (h *openAPIHandler) fetchAndUpdate(ctx context.Context, group string) error {
+	apiDomainKey := dyncamiccontext.APIDomainKeyFrom(ctx)
+	apiSet, _, err := h.apiSetRetriever.GetAPIDefinitionSet(ctx, apiDomainKey)
+	if err != nil {
+		return err
+	}
+
+	for gvr, apiDefinition := range apiSet {
+		if group == "" || (group != "" && group == gvr.Group) {
+			spec := apiDefinition.GetOpenAPIV3Spec()
+			h.openAPIV3Service.UpdateGroupVersion(gvr.Group, spec)
+		}
+	}
+
+	return nil
 }

--- a/pkg/virtual/framework/dynamic/apiserver/handler_test.go
+++ b/pkg/virtual/framework/dynamic/apiserver/handler_test.go
@@ -39,6 +39,7 @@ import (
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 	utilopenapi "k8s.io/apiserver/pkg/util/openapi"
+	"k8s.io/kube-openapi/pkg/spec3"
 	"sigs.k8s.io/yaml"
 
 	"github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/apidefinition"
@@ -58,6 +59,7 @@ type mockedAPIDefinition struct {
 	apiResourceSchema  *apisv1alpha1.APIResourceSchema
 	store              rest.Storage
 	subresourcesStores map[string]rest.Storage
+	openAPIV3Spec      *spec3.OpenAPI
 }
 
 var _ apidefinition.APIDefinition = (*mockedAPIDefinition)(nil)
@@ -70,6 +72,9 @@ func (apiDef *mockedAPIDefinition) GetClusterName() logicalcluster.Name {
 }
 func (apiDef *mockedAPIDefinition) GetStorage() rest.Storage {
 	return apiDef.store
+}
+func (apiDef *mockedAPIDefinition) GetOpenAPIV3Spec() *spec3.OpenAPI {
+	return apiDef.openAPIV3Spec
 }
 func (apiDef *mockedAPIDefinition) GetSubResourceStorage(subresource string) rest.Storage {
 	return apiDef.subresourcesStores[subresource]


### PR DESCRIPTION
## Summary

Add OpenAPI Schema support to virtual workspace framework.

The implementation taps into the `CreateServingInfo` path to generate the spec and adds a handler to VW apiserver for handling the request and updating the OpenAPI v3 service caches.

TODO: OpenAPI v2 support and structuring the code for merge.

## Related issue(s)

None

## Release Notes

```release-note
TODO: Before merge.
```