### PR TITLE
:sparkles: Add 'metrics-viewer' user to ClusterRoleBinding in `metrics-viewer` battery

### DIFF
--- a/config/root/metrics-3-cluster-role-binding.yaml
+++ b/config/root/metrics-3-cluster-role-binding.yaml
@@ -9,6 +9,9 @@ subjects:
   name: metrics
   namespace: default
   apiGroup: ""
+- kind: User
+  name: metrics-viewer
+  apiGroup: ""
 roleRef:
   kind: ClusterRole
   name: metrics-viewer

--- a/pkg/server/options/options.go
+++ b/pkg/server/options/options.go
@@ -187,7 +187,7 @@ func (o *Options) AddFlags(fss *cliflag.NamedFlagSets) {
 - workspace-types:         creates "organization" and "team" WorkspaceTypes in the root workspace.
 - admin:                   creates an admin.kubeconfig in the path passed to --kubeconfig-path.
 - user:                    creates an additional non-admin user and context named "user" in the admin.kubeconfig. Requires "admin" battery to be enabled.
-- metrics-viewer:          created a service account named "metrics" in the root namespace that can view metrics.
+- metrics-viewer:          creates a service account named "metrics" and a corresponding ClusterRoleBinding (also binds a "metrics-viewer" user) in the root namespace that can view metrics.
 
 Prefixing with - or + means to remove from the default set or add to the default set.`,
 		strings.Join(sets.List[string](batteries.All), ","),


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

I've been thinking about how to get metrics out of kcp for the Helm chart. The `metrics-viewer` battery is a great starting point, but requires you to extract the service account token out of kcp, which seems hard to do.

This PR adds another entity to the `ClusterRoleBinding` subjects: A `metrics-viewer` user. In the Helm chart, we can create a certificate for that user entity and then pass that certificate as credentials to e.g. a `ServiceMonitor` for [prometheus-operator](https://prometheus-operator.dev/). That seems to be the smoothest course of action to me.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note using the following format:

```release-note
<description of change>
```
-->

```release-note
Add a `metrics-viewer` user subject to the ClusterRoleBinding created by the battery `metrics-viewer`, for which credentials can be generated outside of kcp
```
