### PR TITLE
🐛 Generate `admin.kubeconfig` with correct cluster for `system:admin` context

### DIFF
--- a/cmd/sharded-test-server/frontproxy.go
+++ b/cmd/sharded-test-server/frontproxy.go
@@ -105,13 +105,13 @@ func startFrontProxy(
 	// write root shard kubeconfig
 	configLoader := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		&clientcmd.ClientConfigLoadingRules{ExplicitPath: filepath.Join(workDirPath, ".kcp-0/admin.kubeconfig")},
-		&clientcmd.ConfigOverrides{CurrentContext: "system:admin"},
+		&clientcmd.ConfigOverrides{CurrentContext: "shard-base"},
 	)
 	raw, err := configLoader.RawConfig()
 	if err != nil {
 		return err
 	}
-	raw.CurrentContext = "system:admin"
+	raw.CurrentContext = "shard-base"
 	if err := clientcmdapi.MinifyConfig(&raw); err != nil {
 		return err
 	}

--- a/cmd/sharded-test-server/virtual.go
+++ b/cmd/sharded-test-server/virtual.go
@@ -104,7 +104,7 @@ func newVirtualWorkspace(ctx context.Context, index int, servingCA *crypto.CA, h
 	virtualWorkspaceKubeConfig := clientcmdapi.Config{
 		Clusters: map[string]*clientcmdapi.Cluster{
 			"shard": {
-				Server:               fmt.Sprintf("https://localhost:%d/clusters/system:admin", 6444+index),
+				Server:               fmt.Sprintf("https://localhost:%d", 6444+index),
 				CertificateAuthority: servingCAPath,
 			},
 		},

--- a/cmd/test-server/kcp/shard.go
+++ b/cmd/test-server/kcp/shard.go
@@ -196,7 +196,7 @@ func (s *Shard) WaitForReady(ctx context.Context) (<-chan error, error) {
 		// intentionally load again every iteration because it can change
 		kubeconfigPath := filepath.Join(s.runtimeDir, "admin.kubeconfig")
 		configLoader := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfigPath},
-			&clientcmd.ConfigOverrides{CurrentContext: "system:admin"},
+			&clientcmd.ConfigOverrides{CurrentContext: "shard-base"},
 		)
 		config, err := configLoader.ClientConfig()
 		if err != nil {
@@ -243,7 +243,7 @@ func (s *Shard) GatherMetrics(ctx context.Context) {
 
 	kubeconfigPath := filepath.Join(s.runtimeDir, "admin.kubeconfig")
 	configLoader := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfigPath},
-		&clientcmd.ConfigOverrides{CurrentContext: "system:admin"},
+		&clientcmd.ConfigOverrides{CurrentContext: "shard-base"},
 	)
 	config, err := configLoader.ClientConfig()
 	if err != nil {
@@ -283,7 +283,7 @@ func ScrapeMetrics(ctx context.Context, s *Shard, workDir string) error {
 	kubeconfigPath := filepath.Join(s.runtimeDir, "admin.kubeconfig")
 	configLoader := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfigPath},
-		&clientcmd.ConfigOverrides{CurrentContext: "system:admin"},
+		&clientcmd.ConfigOverrides{CurrentContext: "shard-base"},
 	)
 	config, err := configLoader.ClientConfig()
 	if err != nil {

--- a/docs/content/concepts/workspaces.md
+++ b/docs/content/concepts/workspaces.md
@@ -182,5 +182,6 @@ System workspace are only accessible to a shard-local admin user, and there is
 neither a definition via a ClusterWorkspace, nor is there any validation of requests
 that the system workspace exists.
 
-The `system:admin` system workspace is special as it is also accessible through `/`
-of the shard, and at `/cluster/system:admin` at the same time.
+As an example, the `system:admin` workspace exists for administrative objects
+that are scoped to the local shard (e.g. `lease` objects for kcp internal controllers if
+leader election is enabled). It is accessible via `/clusters/system:admin`.

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -235,14 +235,14 @@ func NewConfig(opts kcpserveroptions.CompletedOptions) (*Config, error) {
 	// The informers here are not used before the informers are actually started (i.e. no race).
 	if len(c.Options.Extra.RootShardKubeconfigFile) > 0 {
 		// TODO(p0lyn0mial): use kcp-admin instead of system:admin
-		nonIdentityRootKcpShardSystemAdminConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(&clientcmd.ClientConfigLoadingRules{ExplicitPath: c.Options.Extra.RootShardKubeconfigFile}, &clientcmd.ConfigOverrides{CurrentContext: "system:admin"}).ClientConfig()
+		nonIdentityRootKcpShardBaseConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(&clientcmd.ClientConfigLoadingRules{ExplicitPath: c.Options.Extra.RootShardKubeconfigFile}, &clientcmd.ConfigOverrides{CurrentContext: "shard-base"}).ClientConfig()
 		if err != nil {
 			return nil, fmt.Errorf("failed to load the kubeconfig from: %s, for the root shard, err: %w", c.Options.Extra.RootShardKubeconfigFile, err)
 		}
 
 		var kcpShardIdentityRoundTripper func(rt http.RoundTripper) http.RoundTripper
-		kcpShardIdentityRoundTripper, c.resolveIdentities = bootstrap.NewWildcardIdentitiesWrappingRoundTripper(bootstrap.KcpRootGroupExportNames, bootstrap.KcpRootGroupResourceExportNames, nonIdentityRootKcpShardSystemAdminConfig, c.KubeClusterClient)
-		rootKcpShardIdentityConfig := rest.CopyConfig(nonIdentityRootKcpShardSystemAdminConfig)
+		kcpShardIdentityRoundTripper, c.resolveIdentities = bootstrap.NewWildcardIdentitiesWrappingRoundTripper(bootstrap.KcpRootGroupExportNames, bootstrap.KcpRootGroupResourceExportNames, nonIdentityRootKcpShardBaseConfig, c.KubeClusterClient)
+		rootKcpShardIdentityConfig := rest.CopyConfig(nonIdentityRootKcpShardBaseConfig)
 		rootKcpShardIdentityConfig.Wrap(kcpShardIdentityRoundTripper)
 		c.RootShardKcpClusterClient, err = kcpclientset.NewForConfig(rootKcpShardIdentityConfig)
 		if err != nil {

--- a/pkg/server/options/authentication.go
+++ b/pkg/server/options/authentication.go
@@ -198,11 +198,17 @@ func createKubeConfig(kcpAdminToken, shardAdminToken, userToken, baseHost, tlsSe
 			CertificateAuthorityData: caData,
 			TLSServerName:            tlsServerName,
 		},
+		"system:admin": {
+			Server:                   baseHost + "/clusters/system:admin",
+			CertificateAuthorityData: caData,
+			TLSServerName:            tlsServerName,
+		},
 	}
 	kubeConfig.Contexts = map[string]*clientcmdapi.Context{
 		"root":         {Cluster: "root", AuthInfo: kcpAdminUserName},
 		"base":         {Cluster: "base", AuthInfo: kcpAdminUserName},
-		"system:admin": {Cluster: "base", AuthInfo: shardAdminUserName},
+		"system:admin": {Cluster: "system:admin", AuthInfo: shardAdminUserName},
+		"shard-base":   {Cluster: "base", AuthInfo: shardAdminUserName},
 	}
 	kubeConfig.CurrentContext = "root"
 

--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -831,17 +831,18 @@ func (c *kcpServer) BaseConfig(t *testing.T) *rest.Config {
 	return rest.AddUserAgent(cfg, t.Name())
 }
 
-// RootShardSystemMasterBaseConfig returns a rest.Config for the "system:admin" context. Client-side throttling is disabled (QPS=-1).
+// RootShardSystemMasterBaseConfig returns a rest.Config for the "shard-base" context. Client-side throttling is disabled (QPS=-1).
 func (c *kcpServer) RootShardSystemMasterBaseConfig(t *testing.T) *rest.Config {
 	t.Helper()
 
-	cfg, err := c.config("system:admin")
+	cfg, err := c.config("shard-base")
 	require.NoError(t, err)
 	cfg = rest.CopyConfig(cfg)
+
 	return rest.AddUserAgent(cfg, t.Name())
 }
 
-// ShardSystemMasterBaseConfig returns a rest.Config for the "system:admin" context of a given shard. Client-side throttling is disabled (QPS=-1).
+// ShardSystemMasterBaseConfig returns a rest.Config for the "shard-base" context of a given shard. Client-side throttling is disabled (QPS=-1).
 func (c *kcpServer) ShardSystemMasterBaseConfig(t *testing.T, shard string) *rest.Config {
 	t.Helper()
 
@@ -1089,14 +1090,14 @@ func (s *unmanagedKCPServer) BaseConfig(t *testing.T) *rest.Config {
 	return wrappedCfg
 }
 
-// RootShardSystemMasterBaseConfig returns a rest.Config for the "system:admin" context. Client-side throttling is disabled (QPS=-1).
+// RootShardSystemMasterBaseConfig returns a rest.Config for the "shard-base" context. Client-side throttling is disabled (QPS=-1).
 func (s *unmanagedKCPServer) RootShardSystemMasterBaseConfig(t *testing.T) *rest.Config {
 	t.Helper()
 
 	return s.ShardSystemMasterBaseConfig(t, corev1alpha1.RootShard)
 }
 
-// ShardSystemMasterBaseConfig returns a rest.Config for the "system:admin" context of the given shard. Client-side throttling is disabled (QPS=-1).
+// ShardSystemMasterBaseConfig returns a rest.Config for the "shard-base" context of the given shard. Client-side throttling is disabled (QPS=-1).
 func (s *unmanagedKCPServer) ShardSystemMasterBaseConfig(t *testing.T, shard string) *rest.Config {
 	t.Helper()
 
@@ -1108,7 +1109,7 @@ func (s *unmanagedKCPServer) ShardSystemMasterBaseConfig(t *testing.T, shard str
 	raw, err := cfg.RawConfig()
 	require.NoError(t, err)
 
-	config := clientcmd.NewNonInteractiveClientConfig(raw, "system:admin", nil, nil)
+	config := clientcmd.NewNonInteractiveClientConfig(raw, "shard-base", nil, nil)
 
 	defaultConfig, err := config.ClientConfig()
 	require.NoError(t, err)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

A long while ago, `/` redirected to the `system:admin` workspace. That is no longer the case, and as such the `admin.kubeconfig` generated by kcp should have a separate cluster/server from the `base` one, so that the `system:admin` context in it is functional.

I'm also adding a `shard-base` context because the combination of "base" server and "shard-admin" credentials are required in a lot of testing and sharding.

I also found this outdated information in the docs, so replaced it with some more up-to-date information.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note using the following format:

```release-note
<description of change>
```
-->

```release-note
Fix `system:admin` context and add `system:base` in generated `admin.kubeconfig`
```
