### PR TITLE
🌱 reduce log verbosity for queueing operations

### DIFF
--- a/config/crds/bootstrap.go
+++ b/config/crds/bootstrap.go
@@ -126,7 +126,7 @@ func CRD(fs embed.FS, gr metav1.GroupResource) (*apiextensionsv1.CustomResourceD
 func CreateSingle(ctx context.Context, client apiextensionsv1client.CustomResourceDefinitionInterface, rawCRD *apiextensionsv1.CustomResourceDefinition) error {
 	logger := klog.FromContext(ctx).WithValues("crd", rawCRD.Name)
 	start := time.Now()
-	logger.V(4).Info("bootstrapping CRD")
+	logger.V(2).Info("bootstrapping CRD")
 
 	updateNeeded := false
 	crd, err := client.Get(ctx, rawCRD.Name, metav1.GetOptions{})

--- a/pkg/proxy/index/index_controller.go
+++ b/pkg/proxy/index/index_controller.go
@@ -176,7 +176,7 @@ func (c *Controller) processNextWorkItem(ctx context.Context) bool {
 
 	logger := logging.WithQueueKey(klog.FromContext(ctx), key)
 	ctx = klog.NewContext(ctx, logger)
-	logger.V(1).Info("processing key")
+	logger.V(4).Info("processing key")
 
 	// No matter what, tell the queue we're done with this key, to unblock
 	// other workers.
@@ -213,7 +213,7 @@ func (c *Controller) process(ctx context.Context, key string) error {
 	defer c.lock.Unlock()
 
 	if _, found := c.shardWorkspaceInformers[shard.Name]; !found {
-		logger.V(1).Info("Starting informers for Shard")
+		logger.V(2).Info("Starting informers for Shard")
 
 		client, err := c.clientGetter(shard)
 		if err != nil {

--- a/pkg/reconciler/apis/apibinding/apibinding_controller.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_controller.go
@@ -324,7 +324,7 @@ func (c *controller) enqueueAPIBinding(apiBinding *apisv1alpha1.APIBinding, logg
 		return
 	}
 
-	logging.WithQueueKey(logger, key).V(2).Info(fmt.Sprintf("queueing APIBinding%s", logSuffix))
+	logging.WithQueueKey(logger, key).V(4).Info(fmt.Sprintf("queueing APIBinding%s", logSuffix))
 	c.queue.Add(key)
 }
 
@@ -427,7 +427,7 @@ func (c *controller) processNextWorkItem(ctx context.Context) bool {
 
 	logger := logging.WithQueueKey(klog.FromContext(ctx), key)
 	ctx = klog.NewContext(ctx, logger)
-	logger.V(1).Info("processing key")
+	logger.V(4).Info("processing key")
 
 	// No matter what, tell the queue we're done with this key, to unblock
 	// other workers.

--- a/pkg/reconciler/apis/apibindingdeletion/apibinding_deletion_controller.go
+++ b/pkg/reconciler/apis/apibindingdeletion/apibinding_deletion_controller.go
@@ -133,7 +133,7 @@ func (c *Controller) enqueue(obj interface{}) {
 		return
 	}
 	logger := logging.WithQueueKey(logging.WithReconciler(klog.Background(), ControllerName), key)
-	logger.V(2).Info("queueing APIBinding")
+	logger.V(4).Info("queueing APIBinding")
 	c.queue.Add(key)
 }
 
@@ -168,7 +168,7 @@ func (c *Controller) processNextWorkItem(ctx context.Context) bool {
 
 	logger := logging.WithQueueKey(klog.FromContext(ctx), key)
 	ctx = klog.NewContext(ctx, logger)
-	logger.V(1).Info("processing key")
+	logger.V(4).Info("processing key")
 
 	// No matter what, tell the queue we're done with this key, to unblock
 	// other workers.
@@ -186,7 +186,7 @@ func (c *Controller) processNextWorkItem(ctx context.Context) bool {
 	if errors.As(err, &estimate) {
 		t := estimate.Estimate/2 + 1
 		duration := time.Duration(t) * time.Second
-		logger.V(2).Info("custom resources remaining for APIBinding, waiting", "duration", duration)
+		logger.V(3).Info("custom resources remaining for APIBinding, waiting", "duration", duration)
 		c.queue.AddAfter(key, duration)
 	} else {
 		// rather than wait for a full resync, re-add the workspace to the queue to be processed

--- a/pkg/reconciler/apis/apiexport/apiexport_controller.go
+++ b/pkg/reconciler/apis/apiexport/apiexport_controller.go
@@ -229,7 +229,7 @@ func (c *controller) enqueueAllAPIExports(shard *corev1alpha1.Shard) {
 			continue
 		}
 
-		logging.WithQueueKey(logger, key).V(2).Info("queuing APIExport because Shard changed")
+		logging.WithQueueKey(logger, key).V(3).Info("queuing APIExport because Shard changed")
 		c.queue.Add(key)
 	}
 }
@@ -248,7 +248,7 @@ func (c *controller) enqueueSecret(secret *corev1.Secret) {
 			runtime.HandleError(err)
 			return
 		}
-		logging.WithQueueKey(logger, key).V(2).Info("queueing APIExport via identity Secret")
+		logging.WithQueueKey(logger, key).V(3).Info("queueing APIExport via identity Secret")
 		c.queue.Add(key)
 	}
 }

--- a/pkg/reconciler/apis/crdcleanup/crdcleanup_controller.go
+++ b/pkg/reconciler/apis/crdcleanup/crdcleanup_controller.go
@@ -153,7 +153,7 @@ func (c *controller) enqueueFromAPIBinding(oldBinding, newBinding *apisv1alpha1.
 
 	for uid := range uidSet {
 		key := kcpcache.ToClusterAwareKey(apibinding.SystemBoundCRDsClusterName.String(), "", uid)
-		logging.WithQueueKey(logger, key).V(2).Info("queueing CRD via APIBinding")
+		logging.WithQueueKey(logger, key).V(3).Info("queueing CRD via APIBinding")
 		c.queue.Add(key)
 	}
 }
@@ -242,7 +242,7 @@ func (c *controller) process(ctx context.Context, key string) error {
 		return nil
 	}
 
-	logger.V(1).Info("Deleting CRD")
+	logger.V(2).Info("Deleting CRD")
 	if err := c.deleteCRD(ctx, obj.Name); err != nil {
 		if errors.IsNotFound(err) {
 			return nil // object deleted before we handled it

--- a/pkg/reconciler/apis/extraannotationsync/apibindingannotation_controller.go
+++ b/pkg/reconciler/apis/extraannotationsync/apibindingannotation_controller.go
@@ -149,7 +149,7 @@ func (c *controller) enqueueAPIBinding(obj interface{}, logger logr.Logger, logS
 		return
 	}
 
-	logging.WithQueueKey(logger, key).V(2).Info(fmt.Sprintf("queueing APIBinding%s", logSuffix))
+	logging.WithQueueKey(logger, key).V(4).Info(fmt.Sprintf("queueing APIBinding%s", logSuffix))
 	c.queue.Add(key)
 }
 
@@ -209,7 +209,7 @@ func (c *controller) processNextWorkItem(ctx context.Context) bool {
 
 	logger := logging.WithQueueKey(klog.FromContext(ctx), key)
 	ctx = klog.NewContext(ctx, logger)
-	logger.V(1).Info("processing key")
+	logger.V(4).Info("processing key")
 
 	// No matter what, tell the queue we're done with this key, to unblock
 	// other workers.
@@ -265,7 +265,7 @@ func (c *controller) process(ctx context.Context, key string) error {
 		return nil
 	}
 
-	logger.V(1).Info("patching APIBinding extra annotations", "patch", string(patchBytes))
+	logger.V(2).Info("patching APIBinding extra annotations", "patch", string(patchBytes))
 	_, err = c.kcpClusterClient.Cluster(clusterName.Path()).ApisV1alpha1().APIBindings().Patch(ctx, name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
 	return err
 }

--- a/pkg/reconciler/apis/permissionclaimlabel/permissionclaimlabel_controller.go
+++ b/pkg/reconciler/apis/permissionclaimlabel/permissionclaimlabel_controller.go
@@ -125,7 +125,7 @@ func (c *controller) enqueueAPIBinding(obj interface{}, logger logr.Logger) {
 		return
 	}
 
-	logging.WithQueueKey(logger, key).V(2).Info("queueing APIBinding")
+	logging.WithQueueKey(logger, key).V(4).Info("queueing APIBinding")
 	c.queue.Add(key)
 }
 
@@ -161,7 +161,7 @@ func (c *controller) processNextWorkItem(ctx context.Context) bool {
 
 	logger := logging.WithQueueKey(klog.FromContext(ctx), key)
 	ctx = klog.NewContext(ctx, logger)
-	logger.V(1).Info("processing key")
+	logger.V(4).Info("processing key")
 
 	// No matter what, tell the queue we're done with this key, to unblock
 	// other workers.

--- a/pkg/reconciler/apis/permissionclaimlabel/permissionclaimlabel_resource_controller.go
+++ b/pkg/reconciler/apis/permissionclaimlabel/permissionclaimlabel_resource_controller.go
@@ -102,7 +102,7 @@ func (c *resourceController) enqueueForResource(logger logr.Logger, gvr schema.G
 	}
 
 	queueKey += "::" + key
-	logging.WithQueueKey(logger, queueKey).V(2).Info("queuing resource")
+	logging.WithQueueKey(logger, queueKey).V(4).Info("queuing resource")
 	c.queue.Add(queueKey)
 }
 
@@ -138,7 +138,7 @@ func (c *resourceController) processNextWorkItem(ctx context.Context) bool {
 
 	logger := logging.WithQueueKey(klog.FromContext(ctx), key)
 	ctx = klog.NewContext(ctx, logger)
-	logger.V(1).Info("processing key")
+	logger.V(4).Info("processing key")
 
 	// No matter what, tell the queue we're done with this key, to unblock
 	// other workers.

--- a/pkg/reconciler/apis/permissionclaimlabel/permissionclaimlabel_resource_reconcile.go
+++ b/pkg/reconciler/apis/permissionclaimlabel/permissionclaimlabel_resource_reconcile.go
@@ -83,7 +83,7 @@ func (c *resourceController) reconcile(ctx context.Context, obj *unstructured.Un
 
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			logger.V(2).Info("got a not found error when trying to patch")
+			logger.V(3).Info("got a not found error when trying to patch")
 			return nil
 		}
 

--- a/pkg/reconciler/cache/labelclusterrolebindings/labelclusterrolebinding_reconcile.go
+++ b/pkg/reconciler/cache/labelclusterrolebindings/labelclusterrolebinding_reconcile.go
@@ -82,7 +82,7 @@ func (r *reconciler) reconcile(ctx context.Context, crb *rbacv1.ClusterRoleBindi
 	} else {
 		var changed bool
 		if crb.Annotations, changed = kcpcorehelper.DontReplicateFor(crb.Annotations, r.groupName); changed {
-			logger.V(2).Info("Not replicating ClusterRoleBinding")
+			logger.V(3).Info("Not replicating ClusterRoleBinding")
 		}
 	}
 

--- a/pkg/reconciler/cache/labelclusterroles/labelclusterrole_reconcile.go
+++ b/pkg/reconciler/cache/labelclusterroles/labelclusterrole_reconcile.go
@@ -79,7 +79,7 @@ func (r *reconciler) reconcile(ctx context.Context, cr *rbacv1.ClusterRole) (boo
 	} else {
 		var changed bool
 		if cr.Annotations, changed = kcpcorehelper.DontReplicateFor(cr.Annotations, r.groupName); changed {
-			logger.V(2).Info("Not replicating ClusterRole")
+			logger.V(3).Info("Not replicating ClusterRole")
 		}
 	}
 

--- a/pkg/reconciler/cache/labellogicalcluster/labellogicalcluster_reconcile.go
+++ b/pkg/reconciler/cache/labellogicalcluster/labellogicalcluster_reconcile.go
@@ -50,7 +50,7 @@ func (r *reconciler) reconcile(ctx context.Context, cluster *corev1alpha1.Logica
 	} else {
 		var changed bool
 		if cluster.Annotations, changed = kcpcorehelper.DontReplicateFor(cluster.Annotations, r.groupName); changed {
-			logger.V(2).Info("Not replicating LogicalCluster")
+			logger.V(3).Info("Not replicating LogicalCluster")
 		}
 	}
 

--- a/pkg/reconciler/core/logicalcluster/logicalcluster_controller.go
+++ b/pkg/reconciler/core/logicalcluster/logicalcluster_controller.go
@@ -93,7 +93,7 @@ func (c *Controller) enqueue(obj interface{}) {
 		return
 	}
 	logger := logging.WithQueueKey(logging.WithReconciler(klog.Background(), ControllerName), key)
-	logger.V(2).Info("queueing LogicalCluster")
+	logger.V(4).Info("queueing LogicalCluster")
 	c.queue.Add(key)
 }
 
@@ -128,7 +128,7 @@ func (c *Controller) processNextWorkItem(ctx context.Context) bool {
 
 	logger := logging.WithQueueKey(klog.FromContext(ctx), key)
 	ctx = klog.NewContext(ctx, logger)
-	logger.V(1).Info("processing key")
+	logger.V(4).Info("processing key")
 
 	// No matter what, tell the queue we're done with this key, to unblock
 	// other workers.

--- a/pkg/reconciler/core/logicalclusterdeletion/logicalcluster_deletion_controller.go
+++ b/pkg/reconciler/core/logicalclusterdeletion/logicalcluster_deletion_controller.go
@@ -237,7 +237,7 @@ func (c *Controller) process(ctx context.Context, key string) error {
 	}
 	logicalCluster, deleteErr := c.logicalClusterLister.Cluster(clusterName).Get(name)
 	if apierrors.IsNotFound(deleteErr) {
-		logger.V(2).Info("Workspace has been deleted")
+		logger.V(3).Info("Workspace has been deleted")
 		return nil
 	}
 	if deleteErr != nil {
@@ -258,7 +258,7 @@ func (c *Controller) process(ctx context.Context, key string) error {
 	startTime := time.Now()
 	deleteErr = c.deleter.Delete(ctx, logicalClusterCopy)
 	if deleteErr == nil {
-		logger.V(2).Info("finished deleting logical cluster content", "duration", time.Since(startTime))
+		logger.V(4).Info("finished deleting logical cluster content", "duration", time.Since(startTime))
 		return c.finalizeWorkspace(ctx, logicalClusterCopy)
 	}
 

--- a/pkg/reconciler/core/shard/shard_controller.go
+++ b/pkg/reconciler/core/shard/shard_controller.go
@@ -92,7 +92,7 @@ func (c *Controller) enqueue(obj interface{}) {
 		return
 	}
 	logger := logging.WithQueueKey(logging.WithReconciler(klog.Background(), ControllerName), key)
-	logger.V(2).Info("queueing Shard")
+	logger.V(4).Info("queueing Shard")
 	c.queue.Add(key)
 }
 
@@ -127,7 +127,7 @@ func (c *Controller) processNextWorkItem(ctx context.Context) bool {
 
 	logger := logging.WithQueueKey(klog.FromContext(ctx), key)
 	ctx = klog.NewContext(ctx, logger)
-	logger.V(1).Info("processing key")
+	logger.V(4).Info("processing key")
 
 	// No matter what, tell the queue we're done with this key, to unblock
 	// other workers.

--- a/pkg/reconciler/garbagecollector/garbagecollector_controller.go
+++ b/pkg/reconciler/garbagecollector/garbagecollector_controller.go
@@ -126,7 +126,7 @@ func (c *Controller) enqueue(obj interface{}) {
 	}
 
 	logger := logging.WithQueueKey(logging.WithReconciler(klog.Background(), ControllerName), key)
-	logger.V(2).Info("queueing LogicalCluster")
+	logger.V(4).Info("queueing LogicalCluster")
 	c.queue.Add(key)
 }
 
@@ -164,7 +164,7 @@ func (c *Controller) processNextWorkItem(ctx context.Context) bool {
 
 	logger := logging.WithQueueKey(klog.FromContext(ctx), key)
 	ctx = klog.NewContext(ctx, logger)
-	logger.V(1).Info("processing key")
+	logger.V(4).Info("processing key")
 
 	// No matter what, tell the queue we're done with this key, to unblock
 	// other workers.

--- a/pkg/reconciler/kubequota/kubequota_controller.go
+++ b/pkg/reconciler/kubequota/kubequota_controller.go
@@ -134,7 +134,7 @@ func (c *Controller) enqueue(obj interface{}) {
 	}
 
 	logger := logging.WithQueueKey(logging.WithReconciler(klog.Background(), ControllerName), key)
-	logger.V(2).Info("queueing Workspace")
+	logger.V(4).Info("queueing Workspace")
 	c.queue.Add(key)
 }
 
@@ -172,7 +172,7 @@ func (c *Controller) processNextWorkItem(ctx context.Context) bool {
 
 	logger := logging.WithQueueKey(klog.FromContext(ctx), key)
 	ctx = klog.NewContext(ctx, logger)
-	logger.V(1).Info("processing key")
+	logger.V(4).Info("processing key")
 
 	// No matter what, tell the queue we're done with this key, to unblock
 	// other workers.

--- a/pkg/reconciler/tenancy/bootstrap/bootstrap_controller.go
+++ b/pkg/reconciler/tenancy/bootstrap/bootstrap_controller.go
@@ -114,7 +114,7 @@ func (c *controller) enqueue(obj interface{}) {
 		return
 	}
 	logger := logging.WithQueueKey(logging.WithReconciler(klog.Background(), c.controllerName), key)
-	logger.V(2).Info("queueing LogicalCluster")
+	logger.V(4).Info("queueing LogicalCluster")
 	c.queue.Add(key)
 }
 
@@ -154,7 +154,7 @@ func (c *controller) processNextWorkItem(ctx context.Context) bool {
 
 	logger := logging.WithQueueKey(klog.FromContext(ctx), key)
 	ctx = klog.NewContext(ctx, logger)
-	logger.V(1).Info("processing key")
+	logger.V(4).Info("processing key")
 
 	if err := c.process(ctx, key); err != nil {
 		runtime.HandleError(fmt.Errorf("%q controller failed to sync %q, err: %w", c.controllerName, key, err))

--- a/pkg/reconciler/tenancy/initialization/apibinder_initializer_controller.go
+++ b/pkg/reconciler/tenancy/initialization/apibinder_initializer_controller.go
@@ -177,7 +177,7 @@ func (b *APIBinder) enqueueLogicalCluster(obj interface{}, logger logr.Logger) {
 		return
 	}
 
-	logging.WithQueueKey(logger, key).V(2).Info("queueing LogicalCluster")
+	logging.WithQueueKey(logger, key).V(4).Info("queueing LogicalCluster")
 	b.queue.Add(key)
 }
 
@@ -265,7 +265,7 @@ func (b *APIBinder) processNextWorkItem(ctx context.Context) bool {
 
 	logger := logging.WithQueueKey(klog.FromContext(ctx), key)
 	ctx = klog.NewContext(ctx, logger)
-	logger.V(1).Info("processing key")
+	logger.V(4).Info("processing key")
 
 	// No matter what, tell the queue we're done with this key, to unblock
 	// other workers.

--- a/pkg/reconciler/tenancy/initialization/apibinder_initializer_reconcile.go
+++ b/pkg/reconciler/tenancy/initialization/apibinder_initializer_reconcile.go
@@ -57,7 +57,7 @@ func (b *APIBinder) reconcile(ctx context.Context, logicalCluster *corev1alpha1.
 
 	var errors []error
 	clusterName := logicalcluster.From(logicalCluster)
-	logger.V(2).Info("initializing APIBindings for workspace")
+	logger.V(3).Info("initializing APIBindings for workspace")
 
 	// Start with the WorkspaceType specified by the Workspace
 	leafWT, err := b.getWorkspaceType(wtCluster, wtName)
@@ -119,7 +119,7 @@ func (b *APIBinder) reconcile(ctx context.Context, logicalCluster *corev1alpha1.
 
 	for _, wt := range wts {
 		logger := logging.WithObject(logger, wt)
-		logger.V(2).Info("attempting to initialize APIBindings")
+		logger.V(3).Info("attempting to initialize APIBindings")
 
 		for i := range wt.Spec.DefaultAPIBindings {
 			exportRef := wt.Spec.DefaultAPIBindings[i]

--- a/pkg/reconciler/tenancy/logicalcluster/logicalcluster_controller.go
+++ b/pkg/reconciler/tenancy/logicalcluster/logicalcluster_controller.go
@@ -109,7 +109,7 @@ func (c *Controller) enqueue(obj interface{}) {
 		return
 	}
 	logger := logging.WithQueueKey(logging.WithReconciler(klog.Background(), ControllerName), key)
-	logger.V(2).Info("queueing LogicalCluster")
+	logger.V(4).Info("queueing LogicalCluster")
 	c.queue.Add(key)
 }
 
@@ -120,7 +120,7 @@ func (c *Controller) enqueueCRB(obj interface{}) {
 		return
 	}
 	logger := logging.WithQueueKey(logging.WithReconciler(klog.Background(), ControllerName), key)
-	logger.V(2).Info("queueing LogicalCluster")
+	logger.V(4).Info("queueing LogicalCluster")
 	c.queue.Add(key)
 }
 
@@ -155,7 +155,7 @@ func (c *Controller) processNextWorkItem(ctx context.Context) bool {
 
 	logger := logging.WithQueueKey(klog.FromContext(ctx), key)
 	ctx = klog.NewContext(ctx, logger)
-	logger.V(1).Info("processing key")
+	logger.V(4).Info("processing key")
 
 	// No matter what, tell the queue we're done with this key, to unblock
 	// other workers.

--- a/pkg/reconciler/tenancy/workspace/workspace_controller.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_controller.go
@@ -149,7 +149,7 @@ func (c *Controller) enqueue(obj interface{}) {
 		return
 	}
 	logger := logging.WithQueueKey(logging.WithReconciler(klog.Background(), ControllerName), key)
-	logger.V(2).Info("queueing Workspace")
+	logger.V(4).Info("queueing Workspace")
 	c.queue.Add(key)
 }
 
@@ -179,7 +179,7 @@ func (c *Controller) enqueueShard(obj interface{}) {
 				runtime.HandleError(err)
 				return
 			}
-			logging.WithQueueKey(logger, key).V(2).Info("queueing unschedulable Workspace because of shard update", "shard", shard)
+			logging.WithQueueKey(logger, key).V(3).Info("queueing unschedulable Workspace because of shard update", "shard", shard)
 			c.queue.Add(key)
 		}
 	}
@@ -225,7 +225,7 @@ func (c *Controller) processNextWorkItem(ctx context.Context) bool {
 
 	logger := logging.WithQueueKey(klog.FromContext(ctx), key)
 	ctx = klog.NewContext(ctx, logger)
-	logger.V(1).Info("processing key")
+	logger.V(4).Info("processing key")
 
 	// No matter what, tell the queue we're done with this key, to unblock
 	// other workers.

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_scheduling.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_scheduling.go
@@ -111,7 +111,7 @@ func (r *schedulingReconciler) reconcile(ctx context.Context, workspace *tenancy
 				conditions.MarkFalse(workspace, tenancyv1alpha1.WorkspaceScheduled, tenancyv1alpha1.WorkspaceReasonUnschedulable, conditionsv1alpha1.ConditionSeverityError, reason)
 				return reconcileStatusContinue, nil // retry is automatic when new shards show up
 			}
-			logger.V(1).Info("Chose shard", "shard", shard.Name)
+			logger.V(2).Info("Chose shard", "shard", shard.Name)
 			shardNameHash = ByBase36Sha224NameValue(shard.Name)
 			if workspace.Annotations == nil {
 				workspace.Annotations = map[string]string{}

--- a/pkg/reconciler/tenancy/workspacetype/workspacetype_controller.go
+++ b/pkg/reconciler/tenancy/workspacetype/workspacetype_controller.go
@@ -134,7 +134,7 @@ func (c *controller) enqueueWorkspaceTypes(obj interface{}) {
 	}
 
 	logger := logging.WithQueueKey(logging.WithReconciler(klog.Background(), ControllerName), key)
-	logger.V(2).Info("queueing WorkspaceType")
+	logger.V(4).Info("queueing WorkspaceType")
 	c.queue.Add(key)
 }
 
@@ -153,7 +153,7 @@ func (c *controller) enqueueAllWorkspaceTypes(shard interface{}) {
 			continue
 		}
 
-		logging.WithQueueKey(logger, key).V(2).Info("queuing WorkspaceType because Shard changed")
+		logging.WithQueueKey(logger, key).V(4).Info("queuing WorkspaceType because Shard changed")
 
 		c.queue.Add(key)
 	}
@@ -195,7 +195,7 @@ func (c *controller) processNextWorkItem(ctx context.Context) bool {
 
 	logger := logging.WithQueueKey(klog.FromContext(ctx), key)
 	ctx = klog.NewContext(ctx, logger)
-	logger.V(1).Info("processing key")
+	logger.V(4).Info("processing key")
 
 	if err := c.process(ctx, key); err != nil {
 		runtime.HandleError(fmt.Errorf("%q controller failed to sync %q, err: %w", ControllerName, key, err))

--- a/pkg/server/bootstrap/identity.go
+++ b/pkg/server/bootstrap/identity.go
@@ -160,7 +160,7 @@ func wildcardIdentitiesResolver(ids *identities,
 			ids.groupIdentities[group] = apiExportIdentity
 			ids.lock.Unlock()
 
-			logger.V(2).Info("APIExport has identity")
+			logger.V(4).Info("APIExport has identity")
 		}
 		for gr, name := range groupResourceExportNames {
 			logger := logging.WithObject(logger, &apisv1alpha1.APIExport{
@@ -192,7 +192,7 @@ func wildcardIdentitiesResolver(ids *identities,
 			ids.groupResourceIdentities[gr] = apiExportIdentity
 			ids.lock.Unlock()
 
-			logger.V(2).Info("APIExport has identity")
+			logger.V(4).Info("APIExport has identity")
 		}
 		return errorsutil.NewAggregate(errs)
 	}

--- a/pkg/virtual/apiexport/controllers/apireconciler/apiexport_apireconciler_controller.go
+++ b/pkg/virtual/apiexport/controllers/apireconciler/apiexport_apireconciler_controller.go
@@ -157,12 +157,12 @@ func (c *APIReconciler) enqueueAPIResourceSchema(apiResourceSchema *apisv1alpha1
 	logger = logging.WithObject(logger, apiResourceSchema)
 
 	if len(exports) == 0 {
-		logger.V(2).Info("No APIExports found")
+		logger.V(3).Info("No APIExports found")
 		return
 	}
 
 	for _, export := range exports {
-		logger.WithValues("apiexport", export.Name).V(2).Info("Queueing APIExport for APIResourceSchema")
+		logger.WithValues("apiexport", export.Name).V(4).Info("Queueing APIExport for APIResourceSchema")
 		c.enqueueAPIExport(export, logger.WithValues("reason", "APIResourceSchema change", "apiResourceSchema", name))
 	}
 }
@@ -173,7 +173,7 @@ func (c *APIReconciler) enqueueAPIExport(apiExport *apisv1alpha1.APIExport, logg
 		runtime.HandleError(err)
 		return
 	}
-	logging.WithQueueKey(logger, key).V(2).Info("queueing APIExport")
+	logging.WithQueueKey(logger, key).V(4).Info("queueing APIExport")
 	c.queue.Add(key)
 
 	if apiExport.Status.IdentityHash != "" {
@@ -190,7 +190,7 @@ func (c *APIReconciler) enqueueAPIExport(apiExport *apisv1alpha1.APIExport, logg
 				logger.Error(err, "error getting key!")
 				continue
 			}
-			logging.WithQueueKey(logger, key).V(2).Info("queueing APIExport for claim")
+			logging.WithQueueKey(logger, key).V(4).Info("queueing APIExport for claim")
 			c.queue.Add(key)
 		}
 	}
@@ -240,7 +240,7 @@ func (c *APIReconciler) processNextWorkItem(ctx context.Context) bool {
 
 	logger := logging.WithQueueKey(klog.FromContext(ctx), key)
 	ctx = klog.NewContext(ctx, logger)
-	logger.V(1).Info("processing key")
+	logger.V(4).Info("processing key")
 
 	// No matter what, tell the queue we're done with this key, to unblock
 	// other workers.


### PR DESCRIPTION
## Summary
This PR reduces the log verbosity of many logging statements in kcp. I tried to debug something recently and the sheer amount of "processing key" and "queueing thing" messages that flew by made it difficult.

https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md defines some guidance for log level usage and most importantly, queueing things should not be on level 1 (what i would consider the "panic" level). So I changed the levels to be

* Level 4 for every basic enqueue/process log lines. Just enqueueing something does not change cluster state and so should not printed every single time.
* Operations that actually change cluster state (creating/deleting/updating objects) have generally been moved to level 2.

My hope is that running kcp with -v=2 should provide a nice log of things that actually change or break, and -v=4 being a nice log level for development.

## Release Notes

```release-note
Reduce log verbosity for processing/queueing messages in controllers.
```
