### PR TITLE
🌱  Bump prow jobs to use `ghcr.io/kcp-dev/infra/build:1.20.13-1`

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.20.8-1
+        - image: ghcr.io/kcp-dev/infra/build:1.20.13-1
           command:
             - make
             - verify-boilerplate
@@ -27,7 +27,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.20.8-1
+        - image: ghcr.io/kcp-dev/infra/build:1.20.13-1
           command:
             - make
             - verify-codegen
@@ -44,7 +44,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.20.8-1
+        - image: ghcr.io/kcp-dev/infra/build:1.20.13-1
           command:
             - make
             - lint
@@ -83,7 +83,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.20.8-1
+        - image: ghcr.io/kcp-dev/infra/build:1.20.13-1
           command:
             - make
             - test
@@ -104,7 +104,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.20.8-1
+        - image: ghcr.io/kcp-dev/infra/build:1.20.13-1
           command:
             - ./hack/run-with-prometheus.sh
             - make
@@ -132,7 +132,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.20.8-1
+        - image: ghcr.io/kcp-dev/infra/build:1.20.13-1
           command:
             - ./hack/run-with-prometheus.sh
             - make
@@ -162,7 +162,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.20.8-1
+        - image: ghcr.io/kcp-dev/infra/build:1.20.13-1
           command:
             - ./hack/run-with-prometheus.sh
             - make
@@ -188,7 +188,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.20.8-1
+        - image: ghcr.io/kcp-dev/infra/build:1.20.13-1
           command:
             - ./hack/run-with-prometheus.sh
             - make


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

What it says on the title. The build image got bumped in https://github.com/kcp-dev/infra/pull/64, this updates our prow jobs for this repository.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note using the following format:

```release-note
<description of change>
```
-->

```release-note
NONE
```
