### PR TITLE
:book: Update release process with release note generation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,11 +23,7 @@ Fixes #
 ## Release Notes
 
 <!--
-Please add a release note using the following format:
-
-```release-note
-<description of change>
-```
+Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
 -->
 
 ```release-note


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This PR is to propose a change in our release process, namely the release note generation. So far, we have relied on the GitHub auto-generated release notes, but we implemented all the tooling via Prow to use Kubernetes release note generation. I've tested this process in anticipation of the upcoming kcp 0.22.0 release and this seems to work fine, so I think we should change this to have a more meaningful changelog.

## Related issue(s)

Fixes #

## Release Notes

```release-note
NONE
```
