### PR TITLE
📖  Update deploy-docs.sh script to also deploy on manual runs

### DIFF
--- a/docs/content/developers/publishing-a-new-kcp-release.md
+++ b/docs/content/developers/publishing-a-new-kcp-release.md
@@ -53,7 +53,7 @@ git push "$REMOTE" "$TAG" "sdk/$TAG"
 If this is the first release of a new minor version (e.g. the last release was v0.7.x, and you are releasing the first
 0.8.x version), follow the following steps.
 
-Otherwise, you can skip to [Review/edit/publish the release in GitHub](#revieweditpublish-the-release-in-github)
+Otherwise, you can skip to [Generate release notes](#generate-release-notes)
 
 ### Create a release branch
 
@@ -82,15 +82,15 @@ To use `release-notes` you will need to generate a GitHub API token (Settings ->
 Then, run run the `release-notes` tool (set `PREV_VERSION` to the version released before the one you have just released).
 
 ```shell
-VERSION=1.2
-PREV_VERSION=1.1
+TAG=v1.2.3
+PREV_TAG=v1.2.2
 release-notes \
   --required-author='' \
   --org kcp-dev \
   --repo kcp \
   --branch main \
-  --start-rev v$PREV_VERSION \
-  --end-rev v$VERSION \
+  --start-rev $PREV_TAG \
+  --end-rev $TAG \
   --output CHANGELOG.md 
 ```
 
@@ -104,6 +104,14 @@ The [goreleaser](https://github.com/kcp-dev/kcp/actions/workflows/goreleaser.yml
 2. If the release notes have been pre-populated, delete them.
 3. Copy release notes from the `CHANGELOG.md` file you generated in the previous step.
 4. Publish the release.
+
+## Trigger documentation deployment
+
+Documentation for the respective release branch needs to be triggered manually after the release branch has been pushed.
+
+1. Navigate to the [Generate and push docs](https://github.com/kcp-dev/kcp/actions/workflows/docs-gen-and-push.yaml) GitHub Action.
+2. Hit the "Run forkflow" button, run workflow against `release-$VERSION`.
+3. Make sure the triggered workflow ran and deployed a new version of the documentation to [docs.kcp.io](https://docs.kcp.io).
 
 ## Notify
 

--- a/docs/scripts/deploy-docs.sh
+++ b/docs/scripts/deploy-docs.sh
@@ -51,7 +51,7 @@ if [[ -n "${BRANCH:-}" ]]; then
 fi
 
 if [[ -n "${CI:-}" ]]; then
-  if [[ "${GITHUB_EVENT_NAME:-}" == "push" ]]; then
+  if [[ "${GITHUB_EVENT_NAME:-}" == "push" ]] || [[ "${GITHUB_EVENT_NAME:-}" == "workflow_dispatch" ]]; then
     # Only push to gh-pages if we're in GitHub Actions (CI is set) and we have a non-PR event.
     MIKE_OPTIONS+=(--push)
   fi


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

I was looking at how to get our documentation deployed without a commit pushed to `release-0.22`, and we can trigger the workflow for deploying docs manually. Unfortunately the deploy script doesn't react to manual workflow triggers. I think it should because I cannot think of a situation where you want to trigger a manual run but _not_ see the results deployed.

Also updating the release documentation to include the step.

## Related issue(s)

Fixes #

```release-note
NONE
```
