### PR TITLE
:bug: Use correct case on verb for metrics-viewer ClusterRole

### DIFF
--- a/config/root/metrics-1-cluster-role.yaml
+++ b/config/root/metrics-1-cluster-role.yaml
@@ -8,4 +8,4 @@ rules:
 - nonResourceURLs:
   - '/metrics'
   verbs:
-  - 'GET'
+  - 'get'


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Some things take you much longer to find than you'd be willing to admit - This is one of them. I was trying to get metrics from `/metrics` with the `metrics-viewer` user we added in #3064, and it just. wasn't. working. I banged my head against that wall for several days.

Until I read the [upstream documentation](https://kubernetes.io/docs/concepts/cluster-administration/system-metrics/#metrics-in-kubernetes) and realised the difference to our `ClusterRole`: The verb was all caps in ours. And - obviously, some might say - verbs in ClusterRoles are case-sensitive! So `GET` != `get`. This confusion is compounded by the fact that the HTTP verb, in fact, is `GET`. Kubernetes still seems to expect `get` here.

Binding to this `ClusterRole` gave me two different outcomes depending on which verb I had in there:

```sh
# this is with the current ClusterRole
$ kubectl http /metrics -v
GET /clusters/root/metrics HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate
Authorization: Bearer <token>
Connection: keep-alive
Host: <host>:6443
User-Agent: HTTPie/3.2.2



HTTP/1.1 403 Forbidden
Audit-Id: ef0fa904-3f29-4465-af42-302d67605742
Cache-Control: no-cache, private
Content-Length: 195
Content-Type: application/json
Date: Tue, 30 Jan 2024 15:32:56 GMT
X-Content-Type-Options: nosniff

{
    "apiVersion": "v1",
    "code": 403,
    "details": {},
    "kind": "Status",
    "message": "forbidden: User \"user\" cannot get path \"/metrics\": access denied",
    "metadata": {},
    "reason": "Forbidden",
    "status": "Failure"
}
```

```sh
# this is with `get` in the ClusterRole
 $ kubectl http /metrics -v
GET /clusters/root/metrics HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate
Authorization: Bearer <token>
Connection: keep-alive
Host: <host>:6443
User-Agent: HTTPie/3.2.2



HTTP/1.1 200 OK
Audit-Id: f9138fb7-7757-474f-a4b3-27b4d6a1c7b9
Cache-Control: no-cache, private
Content-Encoding: gzip
Content-Type: text/plain; version=0.0.4; charset=utf-8
Date: Tue, 30 Jan 2024 15:30:33 GMT
Process-Start-Time-Unix: 1706626255
Transfer-Encoding: chunked

< ... metrics here ...>
```

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Use correct verb in metrics-viewer ClusterRole to give access to `/metrics`
```
