### PR TITLE
✨ Add optional nameValidation field to ApiResourceSchemaSpec

### DIFF
--- a/config/crds/apis.kcp.io_apiresourceschemas.yaml
+++ b/config/crds/apis.kcp.io_apiresourceschemas.yaml
@@ -48,6 +48,21 @@ spec:
                   Empty string means the core API group. \tThe resources are served
                   under `/apis/<group>/...` or `/api` for the core group."
                 type: string
+              nameValidation:
+                default: DNS1123Subdomain
+                description: "nameValidation can be used to configure name validation
+                  for bound APIs. Allowed values are `DNS1123Subdomain` and `PathSegmentName`.
+                  - DNS1123Subdomain: a lowercase RFC 1123 subdomain must consist
+                  of lower case alphanumeric characters, '-' or '.', and must start
+                  and end with an alphanumeric character. Regex used is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'
+                  - PathSegmentName: validates the name can be safely encoded as a
+                  path segment. The name may not be '.' or '..' and the name may not
+                  contain '/' or '%'. \n Defaults to `DNS1123Subdomain`, matching
+                  the behaviour of CRDs."
+                enum:
+                - DNS1123Subdomain
+                - PathSegmentName
+                type: string
               names:
                 description: names specify the resource and kind names for the custom
                   resource.

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -1105,6 +1105,13 @@ func schema_sdk_apis_apis_v1alpha1_APIResourceSchemaSpec(ref common.ReferenceCal
 							},
 						},
 					},
+					"nameValidation": {
+						SchemaProps: spec.SchemaProps{
+							Description: "nameValidation can be used to configure name validation for bound APIs. Allowed values are `DNS1123Subdomain` and `PathSegmentName`. - DNS1123Subdomain: a lowercase RFC 1123 subdomain must consist of lower case\n  alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.\n  Regex used is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'\n- PathSegmentName: validates the name can be safely encoded as a path segment.\n  The name may not be '.' or '..' and the name may not contain '/' or '%'.\n\nDefaults to `DNS1123Subdomain`, matching the behaviour of CRDs.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"group", "names", "scope", "versions"},
 			},

--- a/pkg/reconciler/apis/apibinding/apibinding_reconcile.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_reconcile.go
@@ -28,6 +28,7 @@ import (
 
 	"k8s.io/apiextensions-apiserver/pkg/apihelpers"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apiextensions-apiserver/pkg/apiserver"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilserrors "k8s.io/apimachinery/pkg/util/errors"
@@ -512,6 +513,11 @@ func generateCRD(schema *apisv1alpha1.APIResourceSchema) (*apiextensionsv1.Custo
 	// See https://github.com/kubernetes/enhancements/pull/1111 for more details.
 	if value, found := schema.Annotations[apiextensionsv1.KubeAPIApprovedAnnotation]; found {
 		crd.Annotations[apiextensionsv1.KubeAPIApprovedAnnotation] = value
+	}
+
+	switch schema.Spec.NameValidation {
+	case "PathSegmentName":
+		crd.Annotations[apiserver.KcpValidateNameAnnotationKey] = "path-segment"
 	}
 
 	for _, version := range schema.Spec.Versions {

--- a/sdk/apis/apis/v1alpha1/types_apiresourceschema.go
+++ b/sdk/apis/apis/v1alpha1/types_apiresourceschema.go
@@ -75,6 +75,21 @@ type APIResourceSchemaSpec struct {
 	// +listMapKey=name
 	// +kubebuilder:validation:MinItems=1
 	Versions []APIResourceVersion `json:"versions"`
+
+	// nameValidation can be used to configure name validation for bound APIs.
+	// Allowed values are `DNS1123Subdomain` and `PathSegmentName`.
+	// - DNS1123Subdomain: a lowercase RFC 1123 subdomain must consist of lower case
+	//   alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
+	//   Regex used is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'
+	// - PathSegmentName: validates the name can be safely encoded as a path segment.
+	//   The name may not be '.' or '..' and the name may not contain '/' or '%'.
+	//
+	// Defaults to `DNS1123Subdomain`, matching the behaviour of CRDs.
+	//
+	// +optional
+	// +kubebuilder:validation:Enum=DNS1123Subdomain;PathSegmentName
+	// +kubebuilder:default=DNS1123Subdomain
+	NameValidation string `json:"nameValidation,omitempty"`
 }
 
 // APIResourceVersion describes one API version of a resource.

--- a/sdk/client/applyconfiguration/apis/v1alpha1/apiresourceschemaspec.go
+++ b/sdk/client/applyconfiguration/apis/v1alpha1/apiresourceschemaspec.go
@@ -25,10 +25,11 @@ import (
 // APIResourceSchemaSpecApplyConfiguration represents an declarative configuration of the APIResourceSchemaSpec type for use
 // with apply.
 type APIResourceSchemaSpecApplyConfiguration struct {
-	Group    *string                                `json:"group,omitempty"`
-	Names    *v1.CustomResourceDefinitionNames      `json:"names,omitempty"`
-	Scope    *v1.ResourceScope                      `json:"scope,omitempty"`
-	Versions []APIResourceVersionApplyConfiguration `json:"versions,omitempty"`
+	Group          *string                                `json:"group,omitempty"`
+	Names          *v1.CustomResourceDefinitionNames      `json:"names,omitempty"`
+	Scope          *v1.ResourceScope                      `json:"scope,omitempty"`
+	Versions       []APIResourceVersionApplyConfiguration `json:"versions,omitempty"`
+	NameValidation *string                                `json:"nameValidation,omitempty"`
 }
 
 // APIResourceSchemaSpecApplyConfiguration constructs an declarative configuration of the APIResourceSchemaSpec type for use with
@@ -71,5 +72,13 @@ func (b *APIResourceSchemaSpecApplyConfiguration) WithVersions(values ...*APIRes
 		}
 		b.Versions = append(b.Versions, *values[i])
 	}
+	return b
+}
+
+// WithNameValidation sets the NameValidation field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the NameValidation field is set to the value of the last call.
+func (b *APIResourceSchemaSpecApplyConfiguration) WithNameValidation(value string) *APIResourceSchemaSpecApplyConfiguration {
+	b.NameValidation = &value
 	return b
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Add optional nameValidation field to ApiResourceSchemaSpec.
This field is propagated to the bound crd and the name validation strategy is decided based on the value.
Related [slack thread](https://kubernetes.slack.com/archives/C021U8WSAFK/p1700650436108499).

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Add optional nameValidation field to ApiResourceSchemaSpec. This field is used to add an internal annotation to the bound API and the name validation strategy is decided based on the value.
```
