### PR TITLE
:sparkles: Index mounting ordering & few debug nits

### DIFF
--- a/cli/pkg/workspace/plugin/kubeconfig.go
+++ b/cli/pkg/workspace/plugin/kubeconfig.go
@@ -215,7 +215,20 @@ func (o *UseWorkspaceOptions) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		newServerHost = homeWorkspace.Spec.URL
+		config, err := o.ClientConfig.ClientConfig()
+		if err != nil {
+			return err
+		}
+		u, _, err := pluginhelpers.ParseClusterURL(config.Host)
+		if err != nil {
+			return fmt.Errorf("current URL %q does not point to a workspace", config.Host)
+		}
+		uh, err := url.Parse(homeWorkspace.Spec.URL)
+		if err != nil {
+			return fmt.Errorf("invalid home workspace URL %q: %w", homeWorkspace.Spec.URL, err)
+		}
+
+		newServerHost = u.Scheme + "://" + path.Join(u.Host, uh.Path)
 
 	case ".":
 		cfg, err := o.ClientConfig.ClientConfig()

--- a/cli/pkg/workspace/plugin/kubeconfig.go
+++ b/cli/pkg/workspace/plugin/kubeconfig.go
@@ -228,6 +228,8 @@ func (o *UseWorkspaceOptions) Run(ctx context.Context) error {
 			return fmt.Errorf("invalid home workspace URL %q: %w", homeWorkspace.Spec.URL, err)
 		}
 
+		// We keep the old host, and append homeworkspace url. This allows users to have front-proxy
+		// host to be different from the workspace host.
 		newServerHost = u.Scheme + "://" + path.Join(u.Host, uh.Path)
 
 	case ".":

--- a/config/crds/bootstrap.go
+++ b/config/crds/bootstrap.go
@@ -168,7 +168,7 @@ func CreateSingle(ctx context.Context, client apiextensionsv1client.CustomResour
 
 	logger.Info("waiting for CRD to be established")
 	var lastMsg string
-	return wait.PollUntilContextCancel(ctx, 100*time.Millisecond, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextCancel(ctx, 100*time.Millisecond, true, func(ctx context.Context) (bool, error) {
 		crd, err := client.Get(ctx, rawCRD.Name, metav1.GetOptions{})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
@@ -189,6 +189,11 @@ func CreateSingle(ctx context.Context, client apiextensionsv1client.CustomResour
 		}
 		return crdhelpers.IsCRDConditionTrue(crd, apiextensionsv1.Established), nil
 	})
+	if err != nil {
+		return err
+	}
+	logger.Info("CRD is established")
+	return nil
 }
 
 func retryRetryableErrors(f func() error) error {

--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -33,6 +33,7 @@ type Index interface {
 	LookupURL(logicalCluster logicalcluster.Path) (Result, bool)
 }
 
+// Result is the result of a lookup.
 type Result struct {
 	URL   string
 	Shard string

--- a/pkg/index/index_test.go
+++ b/pkg/index/index_test.go
@@ -249,7 +249,7 @@ func TestLookup(t *testing.T) {
 			if scenario.expectFound && !found {
 				t.Fatalf("expected to lookup the path = %v", scenario.targetPath)
 			}
-			if !scenario.expectFound && found {
+			if !scenario.expectFound && r.Found {
 				t.Errorf("didn't expect to lookup the path = %v", scenario.targetPath)
 			}
 			if !scenario.expectFound {

--- a/pkg/index/index_test.go
+++ b/pkg/index/index_test.go
@@ -249,7 +249,7 @@ func TestLookup(t *testing.T) {
 			if scenario.expectFound && !found {
 				t.Fatalf("expected to lookup the path = %v", scenario.targetPath)
 			}
-			if !scenario.expectFound && r.Found {
+			if !scenario.expectFound && found {
 				t.Errorf("didn't expect to lookup the path = %v", scenario.targetPath)
 			}
 			if !scenario.expectFound {

--- a/pkg/proxy/mapping.go
+++ b/pkg/proxy/mapping.go
@@ -26,13 +26,14 @@ import (
 	"path"
 	"strings"
 
+	"github.com/kcp-dev/logicalcluster/v3"
+
 	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
 
 	"github.com/kcp-dev/kcp/pkg/proxy/index"
 	proxyoptions "github.com/kcp-dev/kcp/pkg/proxy/options"
-	"github.com/kcp-dev/logicalcluster/v3"
 )
 
 // PathMapping describes how to route traffic from a path to a backend server.

--- a/pkg/proxy/mapping.go
+++ b/pkg/proxy/mapping.go
@@ -23,6 +23,8 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"path"
+	"strings"
 
 	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/klog/v2"
@@ -30,6 +32,7 @@ import (
 
 	"github.com/kcp-dev/kcp/pkg/proxy/index"
 	proxyoptions "github.com/kcp-dev/kcp/pkg/proxy/options"
+	"github.com/kcp-dev/logicalcluster/v3"
 )
 
 // PathMapping describes how to route traffic from a path to a backend server.
@@ -46,6 +49,67 @@ type PathMapping struct {
 	ExtraHeaderPrefix string `json:"extra_header_prefix"`
 }
 
+type HttpHandler struct {
+	index          index.Index
+	mapping        []httpHandlerMapping
+	defaultHandler http.Handler
+}
+
+// httpHandlerMapping is used to route traffic to the correct backend server.
+// Higher weight means that the mapping is more specific and should be matched first
+type httpHandlerMapping struct {
+	weight  int
+	path    string
+	handler http.Handler
+}
+
+func (h *HttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// mappings are used to route traffic to the correct backend server.
+	// It should not have `/clusters` as prefix because that is handled by the
+	// shardHandler or mounts. Logic is as follows:
+	// 1. We detect URL for the request and find the correct handler. URL can be
+	// shard based, virtual workspace or mount. First two are covered by r.URL,
+	// where mounts are covered by annotation on the workspace with the mount path.
+	// 2. If mountpoint is found, we rewrite the URL to resolve, else use one in
+	// request to match with mappings.
+	// 3. Iterate over mappings and find the one that matches the URL. If found,
+	// use the handler for that mapping, else use default handler - kcp.
+	// Mappings are done from most specific to least specific:
+	// Example: /clusters/cluster1/ will be matched before /clusters/
+	for _, m := range h.mapping {
+		if strings.HasPrefix(h.resolveURL(r), m.path) {
+			m.handler.ServeHTTP(w, r)
+			return
+		}
+	}
+
+	h.defaultHandler.ServeHTTP(w, r)
+}
+
+func (h *HttpHandler) resolveURL(r *http.Request) string {
+	// if we don't match any of the paths, use the default behavior - request
+	var cs = strings.SplitN(strings.TrimLeft(r.URL.Path, "/"), "/", 3)
+	if len(cs) < 2 || cs[0] != "clusters" {
+		return r.URL.Path
+	}
+	clusterPath := logicalcluster.NewPath(cs[1])
+	if !clusterPath.IsValid() {
+		return r.URL.Path
+	}
+
+	u, found := h.index.LookupURL(clusterPath)
+	if found {
+		u, err := url.Parse(u)
+		if err == nil && u != nil {
+			u.Path = strings.TrimSuffix(u.Path, "/")
+			r.URL.Path = path.Join(u.Path, strings.Join(cs[2:], "/")) // override request prefix and keep kube api contextual suffix
+			return u.Path
+		}
+	}
+
+	return r.URL.Path
+}
+
 func NewHandler(ctx context.Context, o *proxyoptions.Options, index index.Index) (http.Handler, error) {
 	mappingData, err := os.ReadFile(o.MappingFile)
 	if err != nil {
@@ -57,9 +121,16 @@ func NewHandler(ctx context.Context, o *proxyoptions.Options, index index.Index)
 		return nil, fmt.Errorf("failed to unmarshal mapping file %q: %w", o.MappingFile, err)
 	}
 
-	mux := http.NewServeMux()
-
-	mux.Handle("/metrics", legacyregistry.Handler())
+	handlers := HttpHandler{
+		index: index,
+		mapping: []httpHandlerMapping{
+			{
+				weight:  0,
+				path:    "/metrics",
+				handler: legacyregistry.Handler(),
+			},
+		},
+	}
 
 	logger := klog.FromContext(ctx)
 	for _, m := range mapping {
@@ -102,8 +173,34 @@ func NewHandler(ctx context.Context, o *proxyoptions.Options, index index.Index)
 
 		handler = WithProxyAuthHeaders(handler, userHeader, groupHeader, extraHeaderPrefix)
 
-		mux.Handle(m.Path, handler)
+		logger.V(2).WithValues("path", m.Path).Info("adding handler")
+		if m.Path == "/" {
+			handlers.defaultHandler = handler
+		} else {
+
+			handlers.mapping = append(handlers.mapping, httpHandlerMapping{
+				weight:  len(m.Path),
+				path:    m.Path,
+				handler: handler,
+			})
+		}
 	}
 
-	return mux, nil
+	handlers.mapping = sortMappings(handlers.mapping)
+
+	return &handlers, nil
+}
+
+func sortMappings(mappings []httpHandlerMapping) []httpHandlerMapping {
+	// sort mappings by weight
+	// higher weight means that the mapping is more specific and should be matched first
+	// Example: /clusters/cluster1/ will be matched before /clusters/
+	for i := range mappings {
+		for j := range mappings {
+			if mappings[i].weight > mappings[j].weight {
+				mappings[i], mappings[j] = mappings[j], mappings[i]
+			}
+		}
+	}
+	return mappings
 }

--- a/pkg/proxy/mapping.go
+++ b/pkg/proxy/mapping.go
@@ -57,7 +57,7 @@ type HttpHandler struct {
 }
 
 // httpHandlerMapping is used to route traffic to the correct backend server.
-// Higher weight means that the mapping is more specific and should be matched first
+// Higher weight means that the mapping is more specific and should be matched first.
 type httpHandlerMapping struct {
 	weight  int
 	path    string
@@ -178,7 +178,6 @@ func NewHandler(ctx context.Context, o *proxyoptions.Options, index index.Index)
 		if m.Path == "/" {
 			handlers.defaultHandler = handler
 		} else {
-
 			handlers.mapping = append(handlers.mapping, httpHandlerMapping{
 				weight:  len(m.Path),
 				path:    m.Path,

--- a/pkg/proxy/mapping_test.go
+++ b/pkg/proxy/mapping_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2024 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package proxy
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSortMappings(t *testing.T) {
+	mappings := []httpHandlerMapping{
+		{weight: 3},
+		{weight: 1},
+		{weight: 2},
+		{weight: 10},
+	}
+
+	expected := []httpHandlerMapping{
+		{weight: 10},
+		{weight: 3},
+		{weight: 2},
+		{weight: 1},
+	}
+
+	sortedMappings := sortMappings(mappings)
+
+	if !reflect.DeepEqual(sortedMappings, expected) {
+		t.Errorf("Expected %v, but got %v", expected, sortedMappings)
+	}
+}

--- a/pkg/proxy/mapping_test.go
+++ b/pkg/proxy/mapping_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package proxy
 
 import (

--- a/pkg/reconciler/cache/replication/replication_reconcile.go
+++ b/pkg/reconciler/cache/replication/replication_reconcile.go
@@ -197,7 +197,7 @@ func (r *reconciler) reconcile(ctx context.Context, key string) error {
 		return nil
 	}
 
-	logger.V(2).Info("Updating object in global cache")
+	logger.V(2).WithValues("kind", globalCopy.GetKind(), "namespace", globalCopy.GetNamespace(), "name", globalCopy.GetName()).Info("Updating object in global cache")
 	_, err = r.updateObject(ctx, clusterName, globalCopy) // no need for patch because there is only this actor
 	return err
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This PR does few things:
1. Fixes usage of HOME workspace where it does not honour host fixes: https://github.com/kcp-dev/kcp/issues/3011
2. A few debug logs for cache and CRD creation (way too many hours spend on those...)
3. Add weight into index routes:
```
// 1. We detect URL for the request and find the correct handler. URL can be
// shard based, virtual workspace or mount. First two are covered by r.URL,
// where mounts are covered by annotation on the workspace with the mount path.
// 2. If mountpoint is found, we rewrite the URL to resolve, else use one in
// request to match with mappings.
// 3. Iterate over mappings and find the one that matches the URL. If found,
// use the handler for that mapping, else use default handler - kcp.
// Mappings are done from most specific to least specific:
// Example: /clusters/cluster1/ will be matched before /clusters/
```

In general, it dynamically overrides mounts URLs (this was not done before), and matches them in order of length. Higher the weight (`weight = length of the path`) first it will get matches.

Without this, map is randomly selected and if you have 2 mappings with
```
clusters/foo
clusters/
```
your traffic will be randomized :)


## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Orders index path from longest with weight. 
```
