### PR TITLE
:sparkles: Protect APIBindings created during workspace initialization

### DIFF
--- a/pkg/reconciler/tenancy/initialization/apibinder_initializer_reconcile.go
+++ b/pkg/reconciler/tenancy/initialization/apibinder_initializer_reconcile.go
@@ -41,6 +41,11 @@ import (
 	"github.com/kcp-dev/kcp/sdk/apis/third_party/conditions/util/conditions"
 )
 
+const (
+	KcpAPIBindingCreationReasonAnnotationKey      = "internal.kcp.io/creation-reason"
+	KcpAPIBindingCreationReasonDefaultAPIBindings = "default-api-bindings"
+)
+
 func (b *APIBinder) reconcile(ctx context.Context, logicalCluster *corev1alpha1.LogicalCluster) error {
 	annotationValue, found := logicalCluster.Annotations[tenancyv1alpha1.LogicalClusterTypeAnnotationKey]
 	if !found {
@@ -152,6 +157,9 @@ func (b *APIBinder) reconcile(ctx context.Context, logicalCluster *corev1alpha1.
 			apiBinding := &apisv1alpha1.APIBinding{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: apiBindingName,
+					Annotations: map[string]string{
+						KcpAPIBindingCreationReasonAnnotationKey: KcpAPIBindingCreationReasonDefaultAPIBindings,
+					},
 				},
 				Spec: apisv1alpha1.APIBindingSpec{
 					Reference: apisv1alpha1.BindingReference{


### PR DESCRIPTION
## Summary

The APIBindings created during workspace initialization should not be updated or deleted by users as no controller reconciles those. Once they are updated or deleted, no lifecycle happens for those APIBindings.

This creates inconsistencies in the system as there is no guarantee that APIBindings listed in `WorkspaceType.spec.defaultAPIBindings` would be honored across the lifecycle of the workspace.

## Release Notes

```release-note
✨ Protect APIBindings created during Workspace Initialization 
```
