### PR TITLE
:book: Update documentation with CNCF community group

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,16 @@ This community has a [Code of Conduct](./code-of-conduct.md). Please make sure t
 
 There are several ways to communicate with us:
 
-- The [`#kcp-dev` channel](https://app.slack.com/client/T09NY5SBT/C021U8WSAFK) in the [Kubernetes Slack workspace](https://slack.k8s.io)
+- The [`#kcp-dev` channel](https://app.slack.com/client/T09NY5SBT/C021U8WSAFK) in the [Kubernetes Slack workspace](https://slack.k8s.io).
 - Our mailing lists:
-    - [kcp-dev](https://groups.google.com/g/kcp-dev) for development discussions
-    - [kcp-users](https://groups.google.com/g/kcp-users) for discussions among users and potential users
-- See recordings of past community meetings on [YouTube](https://www.youtube.com/channel/UCfP_yS5uYix0ppSbm2ltS5Q)
+    - [kcp-dev](https://groups.google.com/g/kcp-dev) for development discussions.
+    - [kcp-users](https://groups.google.com/g/kcp-users) for discussions among users and potential users.
+- By joining the kcp-dev mailing list, you should receive an invite to our bi-weekly community meetings.
+- See recordings of past community meetings on [YouTube](https://www.youtube.com/channel/UCfP_yS5uYix0ppSbm2ltS5Q).
+- The next community meeting dates are available via our [CNCF community group](https://community.cncf.io/kcp/).
 - Check the [community meeting notes document](https://docs.google.com/document/d/1PrEhbmq1WfxFv1fTikDBZzXEIJkUWVHdqDFxaY1Ply4) for future and past meeting agendas.
 - Browse the [shared Google Drive](https://drive.google.com/drive/folders/1FN7AZ_Q1CQor6eK0gpuKwdGFNwYI517M?usp=sharing) to share design docs, notes, etc.
-    - Members of the kcp-dev mailing list can view this drive
+    - Members of the kcp-dev mailing list can view this drive.
 
 ## Additional references
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -76,15 +76,16 @@ guide.
 
 There are several ways to communicate with us:
 
-- The [`#kcp-dev` channel](https://app.slack.com/client/T09NY5SBT/C021U8WSAFK) in the [Kubernetes Slack workspace](https://slack.k8s.io)
+- The [`#kcp-dev` channel](https://app.slack.com/client/T09NY5SBT/C021U8WSAFK) in the [Kubernetes Slack workspace](https://slack.k8s.io).
 - Our mailing lists:
-    - [kcp-dev](https://groups.google.com/g/kcp-dev) for development discussions
-    - [kcp-users](https://groups.google.com/g/kcp-users) for discussions among users and potential users
-- By joining the kcp-dev mailing list, you should receive an invite to our bi-weekly community meetings
-- See recordings of past community meetings on [YouTube](https://www.youtube.com/channel/UCfP_yS5uYix0ppSbm2ltS5Q)
-- See [upcoming and past](https://docs.google.com/document/d/1PrEhbmq1WfxFv1fTikDBZzXEIJkUWVHdqDFxaY1Ply4) community meeting agendas and notes
+    - [kcp-dev](https://groups.google.com/g/kcp-dev) for development discussions.
+    - [kcp-users](https://groups.google.com/g/kcp-users) for discussions among users and potential users.
+- By joining the kcp-dev mailing list, you should receive an invite to our bi-weekly community meetings.
+- See recordings of past community meetings on [YouTube](https://www.youtube.com/channel/UCfP_yS5uYix0ppSbm2ltS5Q).
+- The next community meeting dates are available via our [CNCF community group](https://community.cncf.io/kcp/).
+- Check the [community meeting notes document](https://docs.google.com/document/d/1PrEhbmq1WfxFv1fTikDBZzXEIJkUWVHdqDFxaY1Ply4) for future and past meeting agendas.
 - Browse the [shared Google Drive](https://drive.google.com/drive/folders/1FN7AZ_Q1CQor6eK0gpuKwdGFNwYI517M?usp=sharing) to share design docs, notes, etc.
-    - Members of the kcp-dev mailing list can view this drive
+    - Members of the kcp-dev mailing list can view this drive.
 
 ## Additional references
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

We were notified on Slack that our docs still refer to the community calendar, which we no longer maintain. This replaces the reference with our CNCF community group instead. I've also made the docs index and repository readme consistent.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
