### PR TITLE
:book: Deploy most recent release documentation as 'latest' alias

### DIFF
--- a/.github/workflows/docs-gen-and-push.yaml
+++ b/.github/workflows/docs-gen-and-push.yaml
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - run: git fetch origin gh-pages
+      - run: git fetch origin '+refs/tags/v*:refs/tags/v*' --no-tags
 
       - uses: actions/setup-go@v5
         with:

--- a/docs/scripts/serve-docs.sh
+++ b/docs/scripts/serve-docs.sh
@@ -31,4 +31,5 @@ if [[ -n "${BRANCH:-}" ]]; then
   MIKE_OPTIONS+=(--branch "$BRANCH")
 fi
 
+mike set-default "${MIKE_OPTIONS[@]}" main
 mike serve "${MIKE_OPTIONS[@]}"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

I noticed that on https://docs.kcp.io, the "default" release (the release you get when going to https://docs.kcp.io/kcp/) points to 0.11. The reason for that is that the "default" release was set at _some_ point manually, but it was never automated.

This PR:
- tries to figure out if the pipeline is running for the latest released version series (e.g. v0.23 at the moment)
- if so, updates a version alias "latest" to the version while deploying
- ensures that the default version points to the "latest" alias

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
