### PR TITLE
:sparkles:  Fix leader election issue with workspace controller and other KCP Controllers

### DIFF
--- a/pkg/permissionclaim/permissionclaim_labeler.go
+++ b/pkg/permissionclaim/permissionclaim_labeler.go
@@ -23,7 +23,6 @@ import (
 	"github.com/kcp-dev/logicalcluster/v3"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
 	"github.com/kcp-dev/kcp/pkg/indexers"
@@ -46,10 +45,6 @@ func NewLabeler(
 	apiBindingInformer apisv1alpha1informers.APIBindingClusterInformer,
 	apiExportInformer, globalAPIExportInformer apisv1alpha1informers.APIExportClusterInformer,
 ) *Labeler {
-	indexers.AddIfNotPresentOrDie(apiExportInformer.Informer().GetIndexer(), cache.Indexers{
-		indexers.ByLogicalClusterPathAndName: indexers.IndexByLogicalClusterPathAndName,
-	})
-
 	return &Labeler{
 		listAPIBindingsAcceptingClaimedGroupResource: func(clusterName logicalcluster.Name, groupResource schema.GroupResource) ([]*apisv1alpha1.APIBinding, error) {
 			indexKey := indexers.ClusterAndGroupResourceValue(clusterName, groupResource)

--- a/pkg/reconciler/apis/apibinding/apibinding_controller.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_controller.go
@@ -164,21 +164,6 @@ func NewController(
 
 	logger := logging.WithReconciler(klog.Background(), ControllerName)
 
-	// APIBinding indexers
-	indexers.AddIfNotPresentOrDie(apiBindingInformer.Informer().GetIndexer(), cache.Indexers{
-		indexers.APIBindingsByAPIExport: indexers.IndexAPIBindingByAPIExport,
-	})
-
-	// APIExport indexers
-	indexers.AddIfNotPresentOrDie(apiExportInformer.Informer().GetIndexer(), cache.Indexers{
-		indexers.ByLogicalClusterPathAndName: indexers.IndexByLogicalClusterPathAndName,
-		indexAPIExportsByAPIResourceSchema:   indexAPIExportsByAPIResourceSchemasFunc,
-	})
-	indexers.AddIfNotPresentOrDie(globalAPIExportInformer.Informer().GetIndexer(), cache.Indexers{
-		indexers.ByLogicalClusterPathAndName: indexers.IndexByLogicalClusterPathAndName,
-		indexAPIExportsByAPIResourceSchema:   indexAPIExportsByAPIResourceSchemasFunc,
-	})
-
 	// APIBinding handlers
 	_, _ = apiBindingInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) { c.enqueueAPIBinding(objOrTombstone[*apisv1alpha1.APIBinding](obj), logger, "") },

--- a/pkg/reconciler/apis/apiexport/apiexport_controller.go
+++ b/pkg/reconciler/apis/apiexport/apiexport_controller.go
@@ -121,14 +121,6 @@ func NewController(
 		commit: committer.NewCommitter[*APIExport, Patcher, *APIExportSpec, *APIExportStatus](kcpClusterClient.ApisV1alpha1().APIExports()),
 	}
 
-	indexers.AddIfNotPresentOrDie(
-		apiExportInformer.Informer().GetIndexer(),
-		cache.Indexers{
-			indexers.APIExportByIdentity: indexers.IndexAPIExportByIdentity,
-			indexers.APIExportBySecret:   indexers.IndexAPIExportBySecret,
-		},
-	)
-
 	_, _ = apiExportInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			c.enqueueAPIExport(obj.(*apisv1alpha1.APIExport))

--- a/pkg/reconciler/apis/apiexportendpointslice/apiexportendpointslice_controller.go
+++ b/pkg/reconciler/apis/apiexportendpointslice/apiexportendpointslice_controller.go
@@ -100,14 +100,6 @@ func NewController(
 		commit:                                committer.NewCommitter[*APIExportEndpointSlice, Patcher, *APIExportEndpointSliceSpec, *APIExportEndpointSliceStatus](kcpClusterClient.ApisV1alpha1().APIExportEndpointSlices()),
 	}
 
-	indexers.AddIfNotPresentOrDie(globalAPIExportClusterInformer.Informer().GetIndexer(), cache.Indexers{
-		indexers.ByLogicalClusterPathAndName: indexers.IndexByLogicalClusterPathAndName,
-	})
-
-	indexers.AddIfNotPresentOrDie(apiExportEndpointSliceClusterInformer.Informer().GetIndexer(), cache.Indexers{
-		indexAPIExportEndpointSliceByAPIExport: indexAPIExportEndpointSliceByAPIExportFunc,
-	})
-
 	_, _ = apiExportEndpointSliceClusterInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			c.enqueueAPIExportEndpointSlice(obj)
@@ -157,10 +149,6 @@ func NewController(
 			},
 		},
 	)
-
-	indexers.AddIfNotPresentOrDie(apiExportEndpointSliceClusterInformer.Informer().GetIndexer(), cache.Indexers{
-		indexAPIExportEndpointSlicesByPartition: indexAPIExportEndpointSlicesByPartitionFunc,
-	})
 
 	return c, nil
 }

--- a/pkg/reconciler/apis/apiexportendpointslice/apiexportendpointslice_indexes.go
+++ b/pkg/reconciler/apis/apiexportendpointslice/apiexportendpointslice_indexes.go
@@ -16,51 +16,7 @@ limitations under the License.
 
 package apiexportendpointslice
 
-import (
-	"fmt"
-
-	"github.com/kcp-dev/logicalcluster/v3"
-
-	apisv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/apis/v1alpha1"
-	"github.com/kcp-dev/kcp/sdk/client"
-)
-
 const (
 	indexAPIExportEndpointSliceByAPIExport  = "indexAPIExportEndpointSliceByAPIExport"
 	indexAPIExportEndpointSlicesByPartition = "indexAPIExportEndpointSlicesByPartition"
 )
-
-// indexAPIExportEndpointSliceByAPIExportFunc indexes the APIExportEndpointSlice by their APIExport's Reference Path and Name.
-func indexAPIExportEndpointSliceByAPIExportFunc(obj interface{}) ([]string, error) {
-	apiExportEndpointSlice, ok := obj.(*apisv1alpha1.APIExportEndpointSlice)
-	if !ok {
-		return []string{}, fmt.Errorf("obj %T is not an APIExportEndpointSlice", obj)
-	}
-
-	path := logicalcluster.NewPath(apiExportEndpointSlice.Spec.APIExport.Path)
-	if path.Empty() {
-		path = logicalcluster.From(apiExportEndpointSlice).Path()
-	}
-	return []string{path.Join(apiExportEndpointSlice.Spec.APIExport.Name).String()}, nil
-}
-
-// indexAPIExportEndpointSlicesByPartitionFunc is an index function that maps a Partition to the key for its
-// spec.partition.
-func indexAPIExportEndpointSlicesByPartitionFunc(obj interface{}) ([]string, error) {
-	slice, ok := obj.(*apisv1alpha1.APIExportEndpointSlice)
-	if !ok {
-		return []string{}, fmt.Errorf("obj is supposed to be an APIExportEndpointSlice, but is %T", obj)
-	}
-
-	if slice.Spec.Partition != "" {
-		clusterName := logicalcluster.From(slice).Path()
-		if !ok {
-			// this will never happen due to validation
-			return []string{}, fmt.Errorf("cluster information missing")
-		}
-		key := client.ToClusterAwareKey(clusterName, slice.Spec.Partition)
-		return []string{key}, nil
-	}
-
-	return []string{}, nil
-}

--- a/pkg/reconciler/apis/crdcleanup/crdcleanup_controller.go
+++ b/pkg/reconciler/apis/crdcleanup/crdcleanup_controller.go
@@ -71,13 +71,6 @@ func NewController(
 		},
 	}
 
-	indexers.AddIfNotPresentOrDie(
-		apiBindingInformer.Informer().GetIndexer(),
-		cache.Indexers{
-			indexers.APIBindingByBoundResourceUID: indexers.IndexAPIBindingByBoundResourceUID,
-		},
-	)
-
 	_, _ = crdInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: func(obj interface{}) bool {
 			crd := obj.(*apiextensionsv1.CustomResourceDefinition)

--- a/pkg/reconciler/apis/extraannotationsync/apibindingannotation_controller.go
+++ b/pkg/reconciler/apis/extraannotationsync/apibindingannotation_controller.go
@@ -106,14 +106,6 @@ func NewController(
 
 	logger := logging.WithReconciler(klog.Background(), ControllerName)
 
-	indexers.AddIfNotPresentOrDie(apiExportInformer.Informer().GetIndexer(), cache.Indexers{
-		indexers.ByLogicalClusterPathAndName: indexers.IndexByLogicalClusterPathAndName,
-	})
-
-	indexers.AddIfNotPresentOrDie(apiBindingInformer.Informer().GetIndexer(), cache.Indexers{
-		indexers.APIBindingsByAPIExport: indexers.IndexAPIBindingByAPIExport,
-	})
-
 	_, _ = apiExportInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    func(obj interface{}) { c.enqueueAPIExport(obj, logger) },
 		UpdateFunc: func(_, obj interface{}) { c.enqueueAPIExport(obj, logger) },

--- a/pkg/reconciler/apis/permissionclaimlabel/permissionclaimlabel_controller.go
+++ b/pkg/reconciler/apis/permissionclaimlabel/permissionclaimlabel_controller.go
@@ -78,10 +78,6 @@ func NewController(
 		commit: committer.NewCommitter[*APIBinding, Patcher, *APIBindingSpec, *APIBindingStatus](kcpClusterClient.ApisV1alpha1().APIBindings()),
 	}
 
-	indexers.AddIfNotPresentOrDie(apiExportInformer.Informer().GetIndexer(), cache.Indexers{
-		indexers.ByLogicalClusterPathAndName: indexers.IndexByLogicalClusterPathAndName,
-	})
-
 	_, _ = apiBindingInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) { c.enqueueAPIBinding(obj, logger) },
 		UpdateFunc: func(_, newObj interface{}) {
@@ -125,7 +121,7 @@ func (c *controller) enqueueAPIBinding(obj interface{}, logger logr.Logger) {
 		return
 	}
 
-	logging.WithQueueKey(logger, key).V(4).Info("queueing APIBinding")
+	logging.WithQueueKey(logger, key).V(2).Info("queueing APIBinding")
 	c.queue.Add(key)
 }
 
@@ -161,7 +157,7 @@ func (c *controller) processNextWorkItem(ctx context.Context) bool {
 
 	logger := logging.WithQueueKey(klog.FromContext(ctx), key)
 	ctx = klog.NewContext(ctx, logger)
-	logger.V(4).Info("processing key")
+	logger.V(1).Info("processing key")
 
 	// No matter what, tell the queue we're done with this key, to unblock
 	// other workers.

--- a/pkg/reconciler/apis/permissionclaimlabel/permissionclaimlabel_resource_controller.go
+++ b/pkg/reconciler/apis/permissionclaimlabel/permissionclaimlabel_resource_controller.go
@@ -31,11 +31,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
-	"github.com/kcp-dev/kcp/pkg/indexers"
 	"github.com/kcp-dev/kcp/pkg/informer"
 	"github.com/kcp-dev/kcp/pkg/logging"
 	"github.com/kcp-dev/kcp/pkg/permissionclaim"
@@ -55,14 +53,6 @@ func NewResourceController(
 	apiBindingInformer apisv1alpha1informers.APIBindingClusterInformer,
 	apiExportInformer, globalAPIExportInformer apisv1alpha1informers.APIExportClusterInformer,
 ) (*resourceController, error) {
-	if err := apiBindingInformer.Informer().GetIndexer().AddIndexers(
-		cache.Indexers{
-			indexers.APIBindingByClusterAndAcceptedClaimedGroupResources: indexers.IndexAPIBindingByClusterAndAcceptedClaimedGroupResources,
-		},
-	); err != nil {
-		return nil, err
-	}
-
 	c := &resourceController{
 		queue:                  workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), ResourceControllerName),
 		kcpClusterClient:       kcpClusterClient,
@@ -102,7 +92,7 @@ func (c *resourceController) enqueueForResource(logger logr.Logger, gvr schema.G
 	}
 
 	queueKey += "::" + key
-	logging.WithQueueKey(logger, queueKey).V(4).Info("queuing resource")
+	logging.WithQueueKey(logger, queueKey).V(2).Info("queuing resource")
 	c.queue.Add(queueKey)
 }
 
@@ -138,7 +128,7 @@ func (c *resourceController) processNextWorkItem(ctx context.Context) bool {
 
 	logger := logging.WithQueueKey(klog.FromContext(ctx), key)
 	ctx = klog.NewContext(ctx, logger)
-	logger.V(4).Info("processing key")
+	logger.V(1).Info("processing key")
 
 	// No matter what, tell the queue we're done with this key, to unblock
 	// other workers.

--- a/pkg/reconciler/cache/labelclusterrolebindings/labelclusterrolebinding_controller.go
+++ b/pkg/reconciler/cache/labelclusterrolebindings/labelclusterrolebinding_controller.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
-	"github.com/kcp-dev/kcp/pkg/indexers"
 	"github.com/kcp-dev/kcp/pkg/logging"
 	"github.com/kcp-dev/kcp/pkg/reconciler/cache/labelclusterroles"
 	"github.com/kcp-dev/kcp/pkg/reconciler/cache/replication"
@@ -82,10 +81,6 @@ func NewController(
 
 		commit: committer.NewStatuslessCommitter[*rbacv1.ClusterRoleBinding, rbacclientv1.ClusterRoleBindingInterface](kubeClusterClient.RbacV1().ClusterRoleBindings(), committer.ShallowCopy[rbacv1.ClusterRoleBinding]),
 	}
-
-	indexers.AddIfNotPresentOrDie(clusterRoleBindingInformer.Informer().GetIndexer(), cache.Indexers{
-		labelclusterroles.ClusterRoleBindingByClusterRoleName: labelclusterroles.IndexClusterRoleBindingByClusterRoleName,
-	})
 
 	_, _ = clusterRoleBindingInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: replication.IsNoSystemClusterName,

--- a/pkg/reconciler/cache/labelclusterroles/labelclusterrole_controller.go
+++ b/pkg/reconciler/cache/labelclusterroles/labelclusterrole_controller.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
-	"github.com/kcp-dev/kcp/pkg/indexers"
 	"github.com/kcp-dev/kcp/pkg/logging"
 	"github.com/kcp-dev/kcp/pkg/reconciler/cache/replication"
 	"github.com/kcp-dev/kcp/pkg/reconciler/committer"
@@ -81,10 +80,6 @@ func NewController(
 
 		commit: committer.NewStatuslessCommitter[*rbacv1.ClusterRole, rbacclientv1.ClusterRoleInterface](kubeClusterClient.RbacV1().ClusterRoles(), committer.ShallowCopy[rbacv1.ClusterRole]),
 	}
-
-	indexers.AddIfNotPresentOrDie(clusterRoleBindingInformer.Informer().GetIndexer(), cache.Indexers{
-		ClusterRoleBindingByClusterRoleName: IndexClusterRoleBindingByClusterRoleName,
-	})
 
 	_, _ = clusterRoleInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: replication.IsNoSystemClusterName,

--- a/pkg/reconciler/cache/replication/replication_reconcile.go
+++ b/pkg/reconciler/cache/replication/replication_reconcile.go
@@ -49,7 +49,7 @@ func (c *controller) reconcile(ctx context.Context, gvrKey string) error {
 		shardName: c.shardName,
 		getLocalCopy: func(cluster logicalcluster.Name, namespace, name string) (*unstructured.Unstructured, error) {
 			key := kcpcache.ToClusterAwareKey(cluster.String(), namespace, name)
-			obj, exists, err := info.local.GetIndexer().GetByKey(key)
+			obj, exists, err := info.Local.GetIndexer().GetByKey(key)
 			if !exists {
 				return nil, apierrors.NewNotFound(gvr.GroupResource(), name)
 			} else if err != nil {
@@ -61,19 +61,19 @@ func (c *controller) reconcile(ctx context.Context, gvrKey string) error {
 				return nil, err
 			}
 
-			if info.filter != nil && !info.filter(u) {
+			if info.Filter != nil && !info.Filter(u) {
 				return nil, apierrors.NewNotFound(gvr.GroupResource(), name)
 			}
 
 			if _, ok := obj.(*unstructured.Unstructured); ok {
 				u = u.DeepCopy()
 			}
-			u.SetKind(info.kind)
+			u.SetKind(info.Kind)
 			u.SetAPIVersion(gvr.GroupVersion().String())
 			return u, nil
 		},
 		getGlobalCopy: func(cluster logicalcluster.Name, namespace, name string) (*unstructured.Unstructured, error) {
-			objs, err := info.global.GetIndexer().ByIndex(ByShardAndLogicalClusterAndNamespaceAndName, ShardAndLogicalClusterAndNamespaceKey(c.shardName, cluster, namespace, name))
+			objs, err := info.Global.GetIndexer().ByIndex(ByShardAndLogicalClusterAndNamespaceAndName, ShardAndLogicalClusterAndNamespaceKey(c.shardName, cluster, namespace, name))
 			if err != nil {
 				return nil, err // necessary to avoid non-zero nil interface
 			}
@@ -93,7 +93,7 @@ func (c *controller) reconcile(ctx context.Context, gvrKey string) error {
 				u = u.DeepCopy()
 			}
 
-			u.SetKind(info.kind)
+			u.SetKind(info.Kind)
 			u.SetAPIVersion(gvr.GroupVersion().String())
 			return u, nil
 		},
@@ -197,7 +197,7 @@ func (r *reconciler) reconcile(ctx context.Context, key string) error {
 		return nil
 	}
 
-	logger.V(2).WithValues("kind", globalCopy.GetKind(), "namespace", globalCopy.GetNamespace(), "name", globalCopy.GetName()).Info("Updating object in global cache")
+	logger.V(2).Info("Updating object in global cache")
 	_, err = r.updateObject(ctx, clusterName, globalCopy) // no need for patch because there is only this actor
 	return err
 }

--- a/pkg/reconciler/tenancy/initialization/apibinder_initializer_controller.go
+++ b/pkg/reconciler/tenancy/initialization/apibinder_initializer_controller.go
@@ -96,14 +96,6 @@ func NewAPIBinder(
 
 	logger := logging.WithReconciler(klog.Background(), ControllerName)
 
-	indexers.AddIfNotPresentOrDie(workspaceTypeInformer.Informer().GetIndexer(), cache.Indexers{
-		indexers.ByLogicalClusterPathAndName: indexers.IndexByLogicalClusterPathAndName,
-	})
-
-	indexers.AddIfNotPresentOrDie(globalWorkspaceTypeInformer.Informer().GetIndexer(), cache.Indexers{
-		indexers.ByLogicalClusterPathAndName: indexers.IndexByLogicalClusterPathAndName,
-	})
-
 	_, _ = logicalClusterInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			c.enqueueLogicalCluster(obj, logger)

--- a/pkg/reconciler/tenancy/workspace/workspace_controller.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_controller.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
-	"github.com/kcp-dev/kcp/pkg/indexers"
 	"github.com/kcp-dev/kcp/pkg/logging"
 	"github.com/kcp-dev/kcp/pkg/reconciler/committer"
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/tenancy/v1alpha1"
@@ -86,16 +85,6 @@ func NewController(
 
 		commit: committer.NewCommitter[*tenancyv1alpha1.Workspace, tenancyv1alpha1client.WorkspaceInterface, *tenancyv1alpha1.WorkspaceSpec, *tenancyv1alpha1.WorkspaceStatus](kcpClusterClient.TenancyV1alpha1().Workspaces()),
 	}
-
-	indexers.AddIfNotPresentOrDie(workspaceInformer.Informer().GetIndexer(), cache.Indexers{
-		unschedulable: indexUnschedulable,
-	})
-	indexers.AddIfNotPresentOrDie(globalShardInformer.Informer().GetIndexer(), cache.Indexers{
-		byBase36Sha224Name: indexByBase36Sha224Name,
-	})
-	indexers.AddIfNotPresentOrDie(globalWorkspaceTypeInformer.Informer().GetIndexer(), cache.Indexers{
-		indexers.ByLogicalClusterPathAndName: indexers.IndexByLogicalClusterPathAndName,
-	})
 
 	_, _ = workspaceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    func(obj interface{}) { c.enqueue(obj) },

--- a/pkg/reconciler/tenancy/workspace/workspace_indexes.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_indexes.go
@@ -21,29 +21,12 @@ import (
 	"strings"
 
 	"github.com/martinlindhe/base36"
-
-	corev1alpha1 "github.com/kcp-dev/kcp/sdk/apis/core/v1alpha1"
-	tenancyv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/tenancy/v1alpha1"
-	"github.com/kcp-dev/kcp/sdk/apis/third_party/conditions/util/conditions"
 )
 
 const (
 	byBase36Sha224Name = "byBase36Sha224Name"
 	unschedulable      = "unschedulable"
 )
-
-func indexUnschedulable(obj interface{}) ([]string, error) {
-	workspace := obj.(*tenancyv1alpha1.Workspace)
-	if conditions.IsFalse(workspace, tenancyv1alpha1.WorkspaceScheduled) && conditions.GetReason(workspace, tenancyv1alpha1.WorkspaceScheduled) == tenancyv1alpha1.WorkspaceReasonUnschedulable {
-		return []string{"true"}, nil
-	}
-	return []string{}, nil
-}
-
-func indexByBase36Sha224Name(obj interface{}) ([]string, error) {
-	s := obj.(*corev1alpha1.Shard)
-	return []string{ByBase36Sha224NameValue(s.Name)}, nil
-}
 
 func ByBase36Sha224NameValue(name string) string {
 	hash := sha256.Sum224([]byte(name))

--- a/pkg/reconciler/tenancy/workspacetype/workspacetype_controller.go
+++ b/pkg/reconciler/tenancy/workspacetype/workspacetype_controller.go
@@ -74,10 +74,6 @@ func NewController(
 		commit: committer.NewCommitter[*WorkspaceType, Patcher, *WorkspaceTypeSpec, *WorkspaceTypeStatus](kcpClusterClient.TenancyV1alpha1().WorkspaceTypes()),
 	}
 
-	indexers.AddIfNotPresentOrDie(workspaceTypeInformer.Informer().GetIndexer(), cache.Indexers{
-		indexers.ByLogicalClusterPathAndName: indexers.IndexByLogicalClusterPathAndName,
-	})
-
 	_, _ = workspaceTypeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			c.enqueueWorkspaceTypes(obj)


### PR DESCRIPTION
This PR addresses the following, 

Change the workspace controllers start logic inside runners to fix leader election issue.
The way we register controllers and define the runner is problematic, the runner calls start only. but in case leader election is lost start finishes (as it was waiting on <- ctx.Done()) which leads to the defer on the queue.Shutdown() to run. Once you shutdown a queue, there’s no way to restart it

**Background:**
    At times we faced workspace controller creation stuck at scheduling phase and never recovers. Regarding leader election the requests/events queued to both leader and other pods aswell , this makes the queue depth to grow.


