### PR TITLE
:sparkles: Implement cluster-aware OpenAPI v3

### DIFF
--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -78,6 +78,7 @@ import (
 	"github.com/kcp-dev/kcp/pkg/reconciler/tenancy/workspacemounts"
 	"github.com/kcp-dev/kcp/pkg/reconciler/tenancy/workspacetype"
 	"github.com/kcp-dev/kcp/pkg/reconciler/topology/partitionset"
+	"github.com/kcp-dev/kcp/pkg/server/openapiv3"
 	initializingworkspacesbuilder "github.com/kcp-dev/kcp/pkg/virtual/initializingworkspaces/builder"
 	corev1alpha1 "github.com/kcp-dev/kcp/sdk/apis/core/v1alpha1"
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/tenancy/v1alpha1"
@@ -147,6 +148,17 @@ func (s *Server) installClusterRoleAggregationController(ctx context.Context, co
 		Name: controllerName,
 		Runner: func(ctx context.Context) {
 			c.Run(ctx, 5)
+		},
+	})
+}
+
+func (s *Server) installOpenAPIv3Controller(ctx context.Context, config *rest.Config) error {
+	controllerName := openapiv3.ControllerName
+
+	return s.registerController(&controllerWrapper{
+		Name: controllerName,
+		Runner: func(ctx context.Context) {
+			s.openAPIv3Controller.Run(ctx)
 		},
 	})
 }

--- a/pkg/server/openapiv3/controller.go
+++ b/pkg/server/openapiv3/controller.go
@@ -1,0 +1,260 @@
+/*
+Copyright 2024 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openapiv3
+
+import (
+	"context"
+	"crypto/sha512"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
+	kcpapiextensionsv1informers "github.com/kcp-dev/client-go/apiextensions/informers/apiextensions/v1"
+	kcpapiextensionsv1listers "github.com/kcp-dev/client-go/apiextensions/listers/apiextensions/v1"
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	apiextensionshelpers "k8s.io/apiextensions-apiserver/pkg/apihelpers"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+	"k8s.io/kube-openapi/pkg/cached"
+	"k8s.io/kube-openapi/pkg/spec3"
+
+	"github.com/kcp-dev/kcp/pkg/logging"
+)
+
+const ControllerName = "kcp-openapiv3"
+
+type CRDSpecGetter interface {
+	GetCRDSpecs(clusterName logicalcluster.Name, name string) (specs map[string]cached.Data[*spec3.OpenAPI], err error)
+}
+
+// Controller watches CustomResourceDefinitions and publishes OpenAPI v3.
+type Controller struct {
+	crdLister  kcpapiextensionsv1listers.CustomResourceDefinitionClusterLister
+	crdsSynced cache.InformerSynced
+
+	queue workqueue.RateLimitingInterface
+
+	// specs per version, logical cluster and per CRD name
+	lock                 sync.Mutex
+	byClusterNameVersion map[logicalcluster.Name]map[string]map[string]cached.Data[*spec3.OpenAPI]
+}
+
+// NewController creates a new Controller with input CustomResourceDefinition informer.
+func NewController(crdInformer kcpapiextensionsv1informers.CustomResourceDefinitionClusterInformer) *Controller {
+	c := &Controller{
+		crdLister:            crdInformer.Lister(),
+		crdsSynced:           crdInformer.Informer().HasSynced,
+		queue:                workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "crd_openapi_v3_controller"),
+		byClusterNameVersion: map[logicalcluster.Name]map[string]map[string]cached.Data[*spec3.OpenAPI]{},
+	}
+
+	crdInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{ //nolint:errcheck
+		AddFunc:    c.addCustomResourceDefinition,
+		UpdateFunc: c.updateCustomResourceDefinition,
+		DeleteFunc: c.deleteCustomResourceDefinition,
+	})
+
+	return c
+}
+
+func (c *Controller) Run(ctx context.Context) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	log := logging.WithReconciler(klog.FromContext(ctx), ControllerName)
+	ctx = klog.NewContext(ctx, log)
+	log.Info("Starting controller")
+	defer log.Info("Shutting down controller")
+
+	if !cache.WaitForCacheSync(ctx.Done(), c.crdsSynced) {
+		utilruntime.HandleError(fmt.Errorf("timed out waiting for caches to sync"))
+		return
+	}
+
+	crds, err := c.crdLister.List(labels.Everything())
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("failed to initially list all CRDs: %v", err))
+		return
+	}
+	for _, crd := range crds {
+		c.processCRD(crd)
+	}
+
+	go wait.Until(func() { c.startWorker(ctx) }, time.Second, ctx.Done())
+
+	<-ctx.Done()
+}
+
+func (c *Controller) startWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *Controller) processNextWorkItem(ctx context.Context) bool {
+	// Wait until there is a new item in the working queue
+	k, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	key := k.(string)
+
+	log := logging.WithQueueKey(klog.FromContext(ctx), key)
+	ctx = klog.NewContext(ctx, log)
+	log.V(4).Info("processing key")
+
+	// No matter what, tell the queue we're done with this key, to unblock
+	// other workers.
+	defer c.queue.Done(key)
+
+	// log slow aggregations
+	start := time.Now()
+	defer func() {
+		elapsed := time.Since(start)
+		if elapsed > time.Second {
+			log.Info("slow openapi v3 aggregation", "duration", elapsed)
+		}
+	}()
+
+	if requeue, err := c.process(ctx, key); err != nil {
+		utilruntime.HandleError(fmt.Errorf("%q controller failed to sync %q, err: %w", ControllerName, key, err))
+		c.queue.AddRateLimited(key)
+		return true
+	} else if requeue {
+		// only requeue if we didn't error, but we still want to requeue
+		c.queue.Add(key)
+		return true
+	}
+	c.queue.Forget(key)
+	return true
+}
+
+func (c *Controller) process(ctx context.Context, key string) (bool, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	clusterName, _, name, err := kcpcache.SplitMetaClusterNamespaceKey(key)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return false, nil
+	}
+	crd, err := c.crdLister.Cluster(clusterName).Get(name)
+	if err != nil && !errors.IsNotFound(err) {
+		return false, err
+	}
+
+	if errors.IsNotFound(err) || !apiextensionshelpers.IsCRDConditionTrue(crd, apiextensionsv1.Established) {
+		delete(c.byClusterNameVersion[clusterName], name)
+		if len(c.byClusterNameVersion[clusterName]) == 0 {
+			delete(c.byClusterNameVersion, clusterName)
+		}
+		return false, nil
+	}
+
+	c.processCRD(crd)
+
+	return false, nil
+}
+
+func (c *Controller) processCRD(crd *apiextensionsv1.CustomResourceDefinition) {
+	clusterName := logicalcluster.From(crd)
+
+	// remove old instance
+	delete(c.byClusterNameVersion[clusterName], crd.Name)
+
+	// add new instance with all versions
+	for _, v := range crd.Spec.Versions {
+		if !v.Served {
+			delete(c.byClusterNameVersion[clusterName][crd.Name], v.Name)
+			continue
+		}
+
+		spec := cached.NewStaticSource[*spec3.OpenAPI](func() cached.Result[*spec3.OpenAPI] {
+			spec, err := builder.BuildOpenAPIV3(crd, v.Name, builder.Options{V2: false})
+			if err != nil {
+				return cached.NewResultErr[*spec3.OpenAPI](err)
+			}
+			bs, err := json.Marshal(spec)
+			if err != nil {
+				return cached.NewResultErr[*spec3.OpenAPI](err)
+			}
+			return cached.NewResultOK[*spec3.OpenAPI](spec, fmt.Sprintf("%X", sha512.Sum512(bs)))
+		})
+		if c.byClusterNameVersion[clusterName] == nil {
+			c.byClusterNameVersion[clusterName] = map[string]map[string]cached.Data[*spec3.OpenAPI]{}
+		}
+		if c.byClusterNameVersion[clusterName][crd.Name] == nil {
+			c.byClusterNameVersion[clusterName][crd.Name] = map[string]cached.Data[*spec3.OpenAPI]{}
+		}
+		c.byClusterNameVersion[clusterName][crd.Name][v.Name] = spec
+	}
+}
+
+func (c *Controller) addCustomResourceDefinition(obj interface{}) {
+	castObj := obj.(*apiextensionsv1.CustomResourceDefinition)
+	c.enqueue(castObj)
+}
+
+func (c *Controller) updateCustomResourceDefinition(oldObj, newObj interface{}) {
+	castNewObj := newObj.(*apiextensionsv1.CustomResourceDefinition)
+	c.enqueue(castNewObj)
+}
+
+func (c *Controller) deleteCustomResourceDefinition(obj interface{}) {
+	castObj, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			return
+		}
+		castObj, ok = tombstone.Obj.(*apiextensionsv1.CustomResourceDefinition)
+		if !ok {
+			return
+		}
+	}
+	c.enqueue(castObj)
+}
+
+func (c *Controller) enqueue(obj *apiextensionsv1.CustomResourceDefinition) {
+	key, err := kcpcache.DeletionHandlingMetaClusterNamespaceKeyFunc(obj)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", obj, err))
+		return
+	}
+	c.queue.Add(key)
+}
+
+func (c *Controller) GetCRDSpecs(clusterName logicalcluster.Name, name string) (specs map[string]cached.Data[*spec3.OpenAPI], err error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	specs, ok := c.byClusterNameVersion[clusterName][name]
+	if !ok {
+		return nil, fmt.Errorf("CRD %s|%s not found", clusterName, name)
+	}
+
+	return specs, nil
+}

--- a/pkg/server/openapiv3/servicecache.go
+++ b/pkg/server/openapiv3/servicecache.go
@@ -1,0 +1,298 @@
+/*
+Copyright 2024 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openapiv3
+
+import (
+	"bytes"
+	"crypto/sha512"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/emicklei/go-restful/v3"
+	"github.com/go-logr/logr"
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	apiextensionshelpers "k8s.io/apiextensions-apiserver/pkg/apihelpers"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder"
+	"k8s.io/apiextensions-apiserver/pkg/kcp"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/server/mux"
+	"k8s.io/klog/v2"
+	"k8s.io/kube-openapi/pkg/builder3"
+	"k8s.io/kube-openapi/pkg/cached"
+	"k8s.io/kube-openapi/pkg/common"
+	"k8s.io/kube-openapi/pkg/common/restfuladapter"
+	"k8s.io/kube-openapi/pkg/handler3"
+	"k8s.io/kube-openapi/pkg/spec3"
+	"k8s.io/utils/lru"
+)
+
+const (
+	// DefaultServiceCacheSize is the default size of the OpenAPI service cache.
+	// Equal API configurations in multiple workspaces are shared.
+	DefaultServiceCacheSize = 100
+
+	// TODO(sttts): move to central place in kube.
+	BoundAnnotationKey = "apis.kcp.io/bound-crd"
+)
+
+// WithOpenAPIv3 returns a handler that serves OpenAPI v3 specs for CRDs, not
+// forwarding /openapi/v3 requests to the delegate handler.
+func WithOpenAPIv3(handler http.Handler, c *ServiceCache) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/openapi/v3" || strings.HasPrefix(r.URL.Path, "/openapi/v3/") {
+			c.ServeHTTP(w, r)
+			return
+		}
+
+		handler.ServeHTTP(w, r)
+	})
+}
+
+// ServiceCache implements a cluster-aware OpenAPI v3 handler, sharing the
+// OpenAPI service for equal API surface configurations.
+type ServiceCache struct {
+	config *common.Config
+
+	specGetter CRDSpecGetter
+	crdLister  kcp.ClusterAwareCRDClusterLister
+
+	services    *lru.Cache
+	staticSpecs map[string]cached.Data[*spec3.OpenAPI]
+}
+
+func NewServiceCache(config *common.Config, crdLister kcp.ClusterAwareCRDClusterLister, specGetter CRDSpecGetter, serviceCacheSize int) *ServiceCache {
+	return &ServiceCache{
+		config:      config,
+		specGetter:  specGetter,
+		crdLister:   crdLister,
+		services:    lru.New(serviceCacheSize),
+		staticSpecs: map[string]cached.Data[*spec3.OpenAPI]{},
+	}
+}
+
+func (c *ServiceCache) RegisterStaticAPIs(cont *restful.Container) error {
+	// create static specs
+	byGVPath := make(map[string][]*restful.WebService)
+	for _, t := range cont.RegisteredWebServices() {
+		// Strip the "/" prefix from the name
+		gvPath := t.RootPath()[1:]
+		byGVPath[gvPath] = []*restful.WebService{t}
+	}
+	for gvPath, ws := range byGVPath {
+		spec, err := builder3.BuildOpenAPISpecFromRoutes(restfuladapter.AdaptWebServices(ws), c.config)
+		if err != nil {
+			return fmt.Errorf("failed to build OpenAPI v3 spec for %s: %w", gvPath, err)
+		}
+		etag, err := computeEtag(spec)
+		if err != nil {
+			return fmt.Errorf("failed to compute OpenAPI v3 spec etag for %s: %w", gvPath, err)
+		}
+		c.staticSpecs[gvPath] = cached.NewResultOK(spec, etag)
+	}
+
+	return nil
+}
+
+func (c *ServiceCache) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	clusterName, err := request.ClusterNameFrom(r.Context())
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	log := klog.FromContext(ctx).WithValues("cluster", clusterName, "path", r.URL.Path)
+
+	// get both real CRDs and bound CRD from APIBindings
+	crds, err := c.crdLister.Cluster(clusterName).List(ctx, labels.Everything())
+	if err != nil {
+		responsewriters.InternalError(w, r, err)
+		return
+	}
+
+	// operate on sorted lists to have deterministic API configuration key
+	orderedCRDs := make([]*apiextensionsv1.CustomResourceDefinition, len(crds))
+	copy(orderedCRDs, crds)
+	sort.Sort(byClusterAndName(orderedCRDs))
+
+	// get the specs for all CRDs
+	specs := make([]map[string]cached.Data[*spec3.OpenAPI], 0, len(orderedCRDs))
+	for _, crd := range orderedCRDs {
+		versionSpecs, err := c.specGetter.GetCRDSpecs(logicalcluster.From(crd), crd.Name)
+		if err != nil {
+			responsewriters.InternalError(w, r, err)
+			return
+		}
+		specs = append(specs, versionSpecs)
+	}
+
+	// get the OpenAPI service from cache or create a new one
+	key := apiConfigurationKey(orderedCRDs, specs)
+	log = log.WithValues("key", key)
+	entry, ok := c.services.Get(key)
+	if !ok {
+		log.V(7).Info("Creating new OpenAPI v3 service")
+
+		// create a new OpenAPI service
+		mux := mux.NewPathRecorderMux("cluster-aware-openapi-v3")
+		service := handler3.NewOpenAPIService()
+		err := service.RegisterOpenAPIV3VersionedService("/openapi/v3", mux)
+		if err != nil {
+			responsewriters.InternalError(w, r, err)
+			return
+		}
+
+		// add static and dynamic APIs
+		if err := addSpecs(service, c.staticSpecs, orderedCRDs, specs, log); err != nil {
+			responsewriters.InternalError(w, r, err)
+			return
+		}
+
+		// remember for next time
+		c.services.Add(key, mux)
+		entry = mux
+	} else {
+		log.V(7).Info("Reusing OpenAPI v3 service from cache")
+	}
+
+	service := entry.(http.Handler)
+	service.ServeHTTP(w, r)
+}
+
+func addSpecs(service *handler3.OpenAPIService, static map[string]cached.Data[*spec3.OpenAPI], crds []*apiextensionsv1.CustomResourceDefinition, specs []map[string]cached.Data[*spec3.OpenAPI], log logr.Logger) error {
+	// start with static specs
+	byGroupVersionSpecs := make(map[string][]cached.Data[*spec3.OpenAPI])
+	for gvPath, spec := range static {
+		byGroupVersionSpecs[gvPath] = []cached.Data[*spec3.OpenAPI]{spec}
+	}
+
+	// add dynamic specs
+	for i, crd := range crds {
+		spec := specs[i]
+		if !apiextensionshelpers.IsCRDConditionTrue(crd, apiextensionsv1.Established) {
+			continue
+		}
+		for _, v := range crd.Spec.Versions {
+			versionSpec, ok := spec[v.Name]
+			if !ok {
+				continue
+			}
+			gv := schema.GroupVersion{Group: crd.Spec.Group, Version: v.Name}
+			gvPath := groupVersionToOpenAPIV3Path(gv)
+			byGroupVersionSpecs[gvPath] = append(byGroupVersionSpecs[gvPath], versionSpec)
+		}
+	}
+
+	// lazily merge spec and add to service
+	for gvPath, specs := range byGroupVersionSpecs {
+		gvSpec := cached.NewListMerger(func(results []cached.Result[*spec3.OpenAPI]) cached.Result[*spec3.OpenAPI] {
+			log.V(6).Info("Merging OpenAPI v3 specs", "gvPath", gvPath)
+			specs := make([]*spec3.OpenAPI, 0, len(results))
+			etags := make([]string, 0, len(results))
+			for _, result := range results {
+				if result.Err != nil {
+					continue
+				}
+				specs = append(specs, result.Data)
+				etags = append(etags, result.Etag)
+			}
+			merged, err := builder.MergeSpecsV3(specs...)
+			if err != nil {
+				return cached.NewResultErr[*spec3.OpenAPI](fmt.Errorf("failed to merge specs: %v", err))
+			}
+			return cached.NewResultOK[*spec3.OpenAPI](merged, fmt.Sprintf("%X", sha512.Sum512([]byte(strings.Join(etags, ",")))))
+		}, specs)
+		service.UpdateGroupVersionLazy(gvPath, gvSpec)
+	}
+
+	return nil
+}
+
+func apiConfigurationKey(orderedCRDs []*apiextensionsv1.CustomResourceDefinition, specs []map[string]cached.Data[*spec3.OpenAPI]) string {
+	var buf bytes.Buffer
+	for i, crd := range orderedCRDs {
+		spec := specs[i]
+		if !apiextensionshelpers.IsCRDConditionTrue(crd, apiextensionsv1.Established) {
+			continue
+		}
+		buf.WriteString(crd.Name)
+		buf.WriteRune(':')
+		firstVersion := true
+		for _, v := range crd.Spec.Versions {
+			versionSpec, ok := spec[v.Name]
+			if !ok {
+				continue
+			}
+			if !firstVersion {
+				buf.WriteRune(',')
+			}
+			buf.WriteString(v.Name)
+			buf.WriteRune(':')
+			buf.WriteString(versionSpec.Get().Etag)
+
+			firstVersion = false
+		}
+
+		buf.WriteRune(';')
+	}
+
+	return buf.String()
+}
+
+func groupVersionToOpenAPIV3Path(gv schema.GroupVersion) string {
+	return "apis/" + gv.Group + "/" + gv.Version
+}
+
+type byClusterAndName []*apiextensionsv1.CustomResourceDefinition
+
+func (a byClusterAndName) Len() int      { return len(a) }
+func (a byClusterAndName) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a byClusterAndName) Less(i, j int) bool {
+	_, aBound := a[i].Annotations[BoundAnnotationKey]
+	_, bBound := a[i].Annotations[BoundAnnotationKey]
+	if aBound && !bBound {
+		return true
+	}
+	if !aBound && bBound {
+		return false
+	}
+
+	aCluster := logicalcluster.From(a[i])
+	bCluster := logicalcluster.From(a[j])
+	if aCluster != bCluster {
+		return aCluster < bCluster
+	}
+
+	return a[i].Name < a[j].Name
+}
+
+func computeEtag(spec *spec3.OpenAPI) (string, error) {
+	bs, err := json.Marshal(spec)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal OpenAPI v3 spec: %w", err)
+	}
+	return fmt.Sprintf("%X", sha512.Sum512(bs)), nil
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -123,6 +123,10 @@ func NewServer(c CompletedConfig) (*Server, error) {
 		return nil, fmt.Errorf("failed to install APIs: %w", err)
 	}
 
+	if err := s.openAPIv3ServiceCache.RegisterStaticAPIs(s.Apis.GenericAPIServer.Handler.GoRestfulContainer); err != nil {
+		return nil, err
+	}
+
 	s.MiniAggregator, err = c.MiniAggregator.New(s.Apis.GenericAPIServer, s.Apis, s.ApiExtensions)
 	if err != nil {
 		return nil, err
@@ -387,6 +391,10 @@ func (s *Server) Run(ctx context.Context) error {
 	// TODO: split apart everything after this line, into their own commands, optional launched in this process
 
 	controllerConfig := rest.CopyConfig(s.IdentityConfig)
+
+	if err := s.installOpenAPIv3Controller(ctx, controllerConfig); err != nil {
+		return err
+	}
 
 	if err := s.installKubeNamespaceController(ctx, controllerConfig); err != nil {
 		return err

--- a/test/e2e/apibinding/apibinding_test.go
+++ b/test/e2e/apibinding/apibinding_test.go
@@ -242,6 +242,12 @@ func TestAPIBinding(t *testing.T) {
 		require.False(t, groupExists(groups, wildwest.GroupName),
 			"should not have seen %s API group in %q group discovery", wildwest.GroupName, providerPath)
 
+		t.Logf("Make sure cowboys API group does NOT show up in workspace %q openapi v3 endpoint", providerPath)
+		providerOpenAPIV3 := providerWorkspaceClient.Cluster(providerPath).Discovery().OpenAPIV3()
+		paths, err := providerOpenAPIV3.Paths()
+		require.NoError(t, err, "error retrieving %q openapi v3 paths", providerPath)
+		require.NotContainsf(t, paths, "apis/"+wildwestv1alpha1.SchemeGroupVersion.String(), "should not have %s API group in %q openapi v3 paths", wildwest.GroupName, providerPath)
+
 		consumerWorkspaceClient, err := kcpclientset.NewForConfig(cfg)
 		require.NoError(t, err)
 
@@ -262,6 +268,12 @@ func TestAPIBinding(t *testing.T) {
 
 		wildwestClusterClient, err := wildwestclientset.NewForConfig(rest.CopyConfig(cfg))
 		require.NoError(t, err)
+
+		t.Logf("Make sure cowboys API group DOES show up in workspace %q openapi v3 endpoint", consumerWorkspace)
+		consumerOpenAPIV3 := consumerWorkspaceClient.Cluster(consumerWorkspace).Discovery().OpenAPIV3()
+		paths, err = consumerOpenAPIV3.Paths()
+		require.NoError(t, err, "error retrieving %q openapi v3 paths", consumerWorkspace)
+		require.Containsf(t, paths, "apis/"+wildwestv1alpha1.SchemeGroupVersion.String(), "should have %s API group in %q openapi v3 paths", wildwest.GroupName, consumerWorkspace)
 
 		t.Logf("Make sure we can perform CRUD operations against consumer workspace %q for the bound API", consumerWorkspace)
 

--- a/test/e2e/openapi/openapi_test.go
+++ b/test/e2e/openapi/openapi_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2024 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package quota
+
+import (
+	"testing"
+
+	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	apisv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/apis/v1alpha1"
+	corev1alpha1 "github.com/kcp-dev/kcp/sdk/apis/core/v1alpha1"
+	tenancyv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/tenancy/v1alpha1"
+	topologyv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/topology/v1alpha1"
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+)
+
+func TestOpenAPIv3(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "control-plane")
+
+	server := framework.SharedKcpServer(t)
+
+	cfg := server.BaseConfig(t)
+
+	kubeClusterClient, err := kcpkubernetesclientset.NewForConfig(cfg)
+	require.NoError(t, err, "error creating kube cluster client")
+
+	wsPath, _ := framework.NewOrganizationFixture(t, server)
+
+	t.Logf("Checking /openapi/v3 paths for %q", wsPath)
+	openAPIV3 := kubeClusterClient.Cluster(wsPath).Discovery().OpenAPIV3()
+	paths, err := openAPIV3.Paths()
+	require.NoError(t, err, "error retrieving %q openapi v3 paths", wsPath)
+	got := sets.NewString()
+	for path := range paths {
+		got.Insert(path)
+	}
+	expected := sets.NewString(
+		"api/v1",
+		"apis/admissionregistration.k8s.io/v1",
+		"apis/authentication.k8s.io/v1",
+		// any many more
+
+		"apis/"+tenancyv1alpha1.SchemeGroupVersion.String(),
+		"apis/"+apisv1alpha1.SchemeGroupVersion.String(),
+		"apis/"+corev1alpha1.SchemeGroupVersion.String(),
+		"apis/"+topologyv1alpha1.SchemeGroupVersion.String(),
+	)
+	if expected.Difference(got).Len() > 0 {
+		t.Errorf("missing paths: %v", expected.Difference(got).List())
+	}
+}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The OpenAPI v3 stack was not yet cluster-aware. This PR adds
1. a controller generating and caching OpenAPI v3 specs for all CRDs, including bound CRD for APIBindings
2. a filter `WithOpenAPIv3` that merges these specs on-demand keeping a cache for different API configurations.

It makes heavy use of the lazy evaluation to avoid computation where possible.

Currently, (2) is implemented with a LRU cache of size 100 holding the (lazily) merged specs for API configurations. This means that with more than a 100 different configurations and constant OpenAPI v3 requests, this will not work well. Either we increase the number of different API configurations in the cache, or we use another kind of cache. But it's probably not common that there are so many different API configurations because some workspace types will be reused a lot.

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Add support for /openapi/v3 endpoints for workspaces with awareness of static resources, CRDs and APIBindings.
```