### PR TITLE
:bug: tenancy/workspace-deletion: try harder with the admin client to delete the LogicalCluster

### DIFF
--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile.go
@@ -106,6 +106,8 @@ func (c *Controller) reconcile(ctx context.Context, ws *tenancyv1alpha1.Workspac
 			deleteLogicalCluster: func(ctx context.Context, cluster logicalcluster.Path) error {
 				return c.kcpExternalClient.Cluster(cluster).CoreV1alpha1().LogicalClusters().Delete(ctx, corev1alpha1.LogicalClusterName, metav1.DeleteOptions{})
 			},
+			getShardByHash:                  getShardByName,
+			kcpLogicalClusterAdminClientFor: kcpDirectClientFor,
 		},
 		&schedulingReconciler{
 			generateClusterName: randomClusterName,


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The front-proxy might return errors when looking for the `LogicalCluster` on workspace deletion,
especially when the `LogicalCluster` is already gone, and it returns a 403. This PR adds another attempt through the workspace admin client.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Make workspace deletion more reliable, trying harder to not leak `LogicalClusters`.
```