### PR TITLE
:bug: Implement RoundTripperWrapper everywhere to allow cancellation

### DIFF
--- a/pkg/cache/client/round_tripper.go
+++ b/pkg/cache/client/round_tripper.go
@@ -87,6 +87,10 @@ func (c *ShardRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 	return c.delegate.RoundTrip(req)
 }
 
+func (c *ShardRoundTripper) WrappedRoundTripper() http.RoundTripper {
+	return c.delegate
+}
+
 // generatePath formats the request path to target the specified shard.
 func generatePath(originalPath string, shard clientshard.Name) (string, error) {
 	// if the originalPath already has the shard then the path was already modified and no change needed
@@ -149,6 +153,10 @@ func (c *DefaultShardRoundTripper) RoundTrip(req *http.Request) (*http.Response,
 		req = req.WithContext(WithShardInContext(req.Context(), c.shard))
 	}
 	return c.delegate.RoundTrip(req)
+}
+
+func (c *DefaultShardRoundTripper) WrappedRoundTripper() http.RoundTripper {
+	return c.delegate
 }
 
 // WithShardNameFromObjectRoundTripper wraps an existing config with ShardNameFromObjectRoundTripper.
@@ -221,6 +229,10 @@ func (c *ShardNameFromObjectRoundTripper) RoundTrip(req *http.Request) (*http.Re
 	return c.delegate.RoundTrip(req)
 }
 
+func (c *ShardNameFromObjectRoundTripper) WrappedRoundTripper() http.RoundTripper {
+	return c.delegate
+}
+
 // WithCacheServiceRoundTripper wraps an existing config's with CacheServiceRoundTripper.
 func WithCacheServiceRoundTripper(cfg *rest.Config) *rest.Config {
 	cfg.Wrap(func(rt http.RoundTripper) http.RoundTripper {
@@ -259,4 +271,8 @@ func (c *CacheServiceRoundTripper) RoundTrip(req *http.Request) (*http.Response,
 		req.URL = newURL
 	}
 	return c.delegate.RoundTrip(req)
+}
+
+func (c *CacheServiceRoundTripper) WrappedRoundTripper() http.RoundTripper {
+	return c.delegate
 }

--- a/pkg/metadata/dynamic.go
+++ b/pkg/metadata/dynamic.go
@@ -71,6 +71,10 @@ func (t *metadataTransport) RoundTrip(req *http.Request) (*http.Response, error)
 	return t.RoundTripper.RoundTrip(req)
 }
 
+func (t *metadataTransport) WrappedRoundTripper() http.RoundTripper {
+	return t.RoundTripper
+}
+
 func partialType(req *http.Request) (string, error) {
 	// strip off /clusters/<lcluster>
 	baseReq := *req


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

After https://github.com/kcp-dev/kcp/pull/3112, plenty `Unable to cancel request for` errors appeared after bootstrapping. This PR fixes that by implementing the client-go `RoundTripperWrapper` interface on all of our wrappers.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```