### PR TITLE
:bug: Partially revert 3105 to not run goreleaser multiple times

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -8,8 +8,6 @@ on:
   push:
     tags:
     - 'v*'
-    - 'cli/v*'
-    - 'sdk/v*'
 
 permissions:
   contents: write


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

In #3105, we added additional triggers to the `goreleaser` action, but it seems to me that had unintended consequences, namely #3121 -- now the action runs three times, and all three of them tried to upload binaries to the release:

- https://github.com/kcp-dev/kcp/actions/runs/8789380794
- https://github.com/kcp-dev/kcp/actions/runs/8789380790
- https://github.com/kcp-dev/kcp/actions/runs/8789380789

Looks like they raced to upload artefacts, and now the checksum file (which came from one of these jobs) doesn't match all uploaded artefacts (since they came from different jobs). I'm not sure if `prerelease: auto` should be removed, so I'm only reverting the triggers since they are the root cause for this behaviour. 

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
