### PR TITLE
📖  Use `--update-aliases` on `mike deploy` correctly

### DIFF
--- a/docs/scripts/deploy-docs.sh
+++ b/docs/scripts/deploy-docs.sh
@@ -42,6 +42,7 @@ fi
 
 MIKE_OPTIONS=()
 MIKE_DEPLOY_OPTIONS=()
+MIKE_ALIASES=()
 
 if [[ -n "${REMOTE:-}" ]]; then
   MIKE_OPTIONS+=(--remote "$REMOTE")
@@ -53,7 +54,8 @@ fi
 
 LATEST=$(git describe --tags --match="v[0-9]*" `git rev-list --tags --max-count=1` | grep -o '^v[0-9]\+\.[0-9]\+')
 if [[ "${LATEST:-}" == "${VERSION:-}" ]]; then
-  MIKE_DEPLOY_OPTIONS+=(--update-aliases "$VERSION" latest)
+  MIKE_DEPLOY_OPTIONS+=(--update-aliases)
+  MIKE_ALIASES+=(latest)
 fi
 
 if [[ -n "${CI:-}" ]]; then
@@ -69,7 +71,7 @@ else
   MIKE_OPTIONS+=(--ignore-remote-status)
 fi
 
-mike deploy "${MIKE_OPTIONS[@]}" "${MIKE_DEPLOY_OPTIONS[@]}" "$VERSION"
+mike deploy "${MIKE_OPTIONS[@]}" "${MIKE_DEPLOY_OPTIONS[@]}" "$VERSION" "${MIKE_ALIASES[@]}"
 
 if [[ -n "${CI:-}" ]]; then
   if [[ "${GITHUB_EVENT_NAME:-}" == "push" ]] || [[ "${GITHUB_EVENT_NAME:-}" == "workflow_dispatch" ]]; then


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

I misunderstood the `--update-aliases` flag on `mike deploy`, which resulted in https://github.com/kcp-dev/kcp/actions/runs/8986885214/job/24684080310:

```
+ mike deploy --push --update-aliases v0.24 latest v0.24
error: duplicated version and alias
```

This PR adjusts the docs deploy script as necessary so it runs the command as intended, something like this:

```sh
mike deploy --push --update-aliases v0.24 latest
```

Also see https://github.com/jimporter/mike?tab=readme-ov-file#building-your-docs.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
