### PR TITLE
:book: Redirect aliases instead of symlinking to their targets

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -80,6 +80,9 @@ plugins:
           name: English
       reconfigure_material: true
       reconfigure_search: true
+  # Configure multi-version plugin
+  - mike:
+      alias_type: redirect
 
 markdown_extensions:
   # Code block highlighting


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

One last minor follow up to documentation improvements. We now have https://docs.kcp.io/kcp/latest/ and it points to v0.24, but I think it would make more sense if it redirected to https://docs.kcp.io/kcp/v0.24/ over just showing the same content. That way it's clearer what version you are actually looking at and links are more permanent (a link to a page in `/latest/` might no longer work when we update the documentation).

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
