### PR TITLE
:sparkles: apiexports: make SubjectAccessReview and LocalSubjectAccessReview claimable

### DIFF
--- a/pkg/virtual/apiexport/schemas/builtin/builtin.go
+++ b/pkg/virtual/apiexport/schemas/builtin/builtin.go
@@ -21,6 +21,7 @@ import (
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
+	authorizationv1 "k8s.io/api/authorization/v1"
 	certificatesv1 "k8s.io/api/certificates/v1"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -281,5 +282,25 @@ var BuiltInAPIs = []internalapis.InternalAPI{
 		Instance:      &corev1alpha1.LogicalCluster{},
 		ResourceScope: apiextensionsv1.ClusterScoped,
 		HasStatus:     true,
+	},
+	{
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Plural:   "subjectaccessreviews",
+			Singular: "subjectaccessreview",
+			Kind:     "SubjectAccessReview",
+		},
+		GroupVersion:  schema.GroupVersion{Group: "authorization.k8s.io", Version: "v1"},
+		Instance:      &authorizationv1.SubjectAccessReview{},
+		ResourceScope: apiextensionsv1.ClusterScoped,
+	},
+	{
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Plural:   "localsubjectaccessreviews",
+			Singular: "localsubjectaccessreview",
+			Kind:     "LocalSubjectAccessReview",
+		},
+		GroupVersion:  schema.GroupVersion{Group: "authorization.k8s.io", Version: "v1"},
+		Instance:      &authorizationv1.LocalSubjectAccessReview{},
+		ResourceScope: apiextensionsv1.NamespaceScoped,
 	},
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization
-->
## Summary

The list of native resources that are claimable is static and defined at https://github.com/kcp-dev/kcp/blob/main/pkg/virtual/apiexport/schemas/builtin/builtin.go#L88.

This PR adds `SubjectAccessReview` and `LocalSubjectAccessReview` to that list.

## Related issue(s)

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Allow claiming `SubjectAccessReview` and `LocalSubjectAccessReview` in apiexports.
```