### PR TITLE
:bug: apibindings/reconciler/labeller: fix informer error on non-persisted resources

### DIFF
--- a/pkg/reconciler/apis/permissionclaimlabel/permissionclaimlabel_reconcile.go
+++ b/pkg/reconciler/apis/permissionclaimlabel/permissionclaimlabel_reconcile.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/kcp-dev/kcp/pkg/logging"
+	"github.com/kcp-dev/kcp/pkg/permissionclaim"
 	apisv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/apis/v1alpha1"
 	conditionsv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/third_party/conditions/apis/conditions/v1alpha1"
 	"github.com/kcp-dev/kcp/sdk/apis/third_party/conditions/util/conditions"
@@ -106,6 +107,10 @@ func (c *controller) reconcile(ctx context.Context, apiBinding *apisv1alpha1.API
 
 	for _, s := range sets.List[string](allChanges) {
 		claim := claimFromSetKey(s)
+		if _, nonPersisted := permissionclaim.NonPersistedResourcesClaimable[schema.GroupResource{Group: claim.Group, Resource: claim.Resource}]; nonPersisted {
+			continue
+		}
+
 		claimLogger := logger.WithValues("claim", s)
 
 		informer, gvr, err := c.getInformerForGroupResource(claim.Group, claim.Resource)

--- a/test/e2e/apibinding/apibinding_permissionclaims_test.go
+++ b/test/e2e/apibinding/apibinding_permissionclaims_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kcp-dev/logicalcluster/v3"
 	"github.com/stretchr/testify/require"
 
+	authorizationv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery/cached/memory"
@@ -138,6 +139,14 @@ func makePermissionClaims(identityHash string) []apisv1alpha1.PermissionClaim {
 			All:           true,
 			IdentityHash:  identityHash,
 		},
+		{
+			GroupResource: apisv1alpha1.GroupResource{Group: authorizationv1.GroupName, Resource: "subjectaccessreviews"},
+			All:           true,
+		},
+		{
+			GroupResource: apisv1alpha1.GroupResource{Group: authorizationv1.GroupName, Resource: "localsubjectaccessreviews"},
+			All:           true,
+		},
 	}
 }
 
@@ -193,6 +202,20 @@ func getAcceptedPermissionClaims(identityHash string) []apisv1alpha1.AcceptableP
 			PermissionClaim: apisv1alpha1.PermissionClaim{
 				GroupResource: apisv1alpha1.GroupResource{Group: "wild.wild.west", Resource: "sheriffs"},
 				IdentityHash:  identityHash,
+				All:           true,
+			},
+			State: apisv1alpha1.ClaimAccepted,
+		},
+		{
+			PermissionClaim: apisv1alpha1.PermissionClaim{
+				GroupResource: apisv1alpha1.GroupResource{Group: authorizationv1.GroupName, Resource: "localsubjectaccessreviews"},
+				All:           true,
+			},
+			State: apisv1alpha1.ClaimAccepted,
+		},
+		{
+			PermissionClaim: apisv1alpha1.PermissionClaim{
+				GroupResource: apisv1alpha1.GroupResource{Group: authorizationv1.GroupName, Resource: "subjectaccessreviews"},
 				All:           true,
 			},
 			State: apisv1alpha1.ClaimAccepted,


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Since https://github.com/kcp-dev/kcp/pull/3129, both `SubjectAccessReview` and `LocalSubjectAccessReview` can be claimed. But as these are not persisted, there is no need for labelling of objects. It's not even possible to create such an informer. Hence, skip these resources.

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```