### PR TITLE
✨ cli: write diagnostics in `kubectl-workspace` to stderr

### DIFF
--- a/cli/pkg/OWNERS
+++ b/cli/pkg/OWNERS
@@ -1,6 +1,0 @@
-approvers:
-- ncdc
-- sttts
-reviewers:
-- stevekuznetsov
-- davidfestal

--- a/cli/pkg/workspace/plugin/use.go
+++ b/cli/pkg/workspace/plugin/use.go
@@ -128,12 +128,12 @@ func (o *UseWorkspaceOptions) Run(ctx context.Context) (err error) {
 	if name == core.RootCluster.String() || strings.HasPrefix(name, core.RootCluster.String()+":") {
 		// LEGACY(mjudeikis): Remove once everybody gets used to this
 		name = ":" + name
-		fmt.Fprintf(o.Out, "Note: Using 'root:' to define an absolute path is no longer supported. Instead, use ':root' to specify an absolute path.\n")
+		fmt.Fprintf(o.ErrOut, "Note: Using 'root:' to define an absolute path is no longer supported. Instead, use ':root' to specify an absolute path.\n")
 	}
 	if name == "" {
 		defer func() {
 			if err == nil {
-				_, err = fmt.Fprintf(o.Out, "Note: 'kubectl ws' now matches 'cd' semantics: go to home workspace. 'kubectl ws -' to go back. 'kubectl ws .' to print current workspace.\n")
+				_, err = fmt.Fprintf(o.ErrOut, "Note: 'kubectl ws' now matches 'cd' semantics: go to home workspace. 'kubectl ws -' to go back. 'kubectl ws .' to print current workspace.\n")
 			}
 		}()
 		name = "~"
@@ -305,7 +305,7 @@ func (o *UseWorkspaceOptions) swapContexts(ctx context.Context, currentContext *
 		// display the error, but don't stop the current workspace from being reported.
 		fmt.Fprintf(o.ErrOut, "error checking APIBindings: %v\n", err)
 	}
-	if err = findUnresolvedPermissionClaims(o.Out, bindings); err != nil {
+	if err = findUnresolvedPermissionClaims(o.ErrOut, bindings); err != nil {
 		// display the error, but don't stop the current workspace from being reported.
 		fmt.Fprintf(o.ErrOut, "error checking APIBindings: %v\n", err)
 	}
@@ -347,7 +347,7 @@ func (o *UseWorkspaceOptions) commitConfig(ctx context.Context, currentContext *
 		// display the error, but don't stop the current workspace from being reported.
 		fmt.Fprintf(o.ErrOut, "error checking APIBindings: %v\n", err)
 	}
-	if err := findUnresolvedPermissionClaims(o.Out, bindings); err != nil {
+	if err := findUnresolvedPermissionClaims(o.ErrOut, bindings); err != nil {
 		// display the error, but don't stop the current workspace from being reported.
 		fmt.Fprintf(o.ErrOut, "error checking APIBindings: %v\n", err)
 	}

--- a/cli/pkg/workspace/plugin/use_test.go
+++ b/cli/pkg/workspace/plugin/use_test.go
@@ -75,6 +75,7 @@ func TestUse(t *testing.T) {
 
 		expected   *clientcmdapi.Config
 		wantStdout []string
+		wantStderr []string
 		wantErrors []string
 		wantErr    bool
 		noWarn     bool
@@ -451,7 +452,10 @@ func TestUse(t *testing.T) {
 			param:       "",
 			expected:    NewKubeconfig().WithKcpCurrent(homeWorkspace.String()).WithKcpPrevious("root:foo").Build(),
 			destination: homeWorkspace.String(),
-			wantStdout:  []string{fmt.Sprintf("Current workspace is '%s'.\nNote: 'kubectl ws' now matches 'cd' semantics: go to home workspace. 'kubectl ws -' to go back. 'kubectl ws .' to print current workspace.", homeWorkspace.String())},
+			wantStderr: []string{
+				"Note: 'kubectl ws' now matches 'cd' semantics: go to home workspace. 'kubectl ws -' to go back. 'kubectl ws .' to print current workspace.",
+			},
+			wantStdout: []string{fmt.Sprintf("Current workspace is '%s'.", homeWorkspace.String())},
 		},
 		{
 			name:   "workspace name, apibindings have matching permission and export claims",
@@ -488,9 +492,10 @@ func TestUse(t *testing.T) {
 					WithExportClaim("", "configmaps", "").
 					Build(),
 			},
-			wantStdout: []string{
+			wantStderr: []string{
 				"Warning: claim for configmaps exported but not specified on APIBinding a\nAdd this claim to the APIBinding's Spec.\n",
-				"Current workspace is 'root:foo:bar'"},
+			},
+			wantStdout: []string{"Current workspace is 'root:foo:bar'"},
 		},
 		{
 			name:   "~, apibinding claims/exports don't match",
@@ -509,8 +514,10 @@ func TestUse(t *testing.T) {
 					WithExportClaim("", "configmaps", "").
 					Build(),
 			},
+			wantStderr: []string{
+				"Warning: claim for configmaps exported but not specified on APIBinding a\nAdd this claim to the APIBinding's Spec.",
+			},
 			wantStdout: []string{
-				"Warning: claim for configmaps exported but not specified on APIBinding a\nAdd this claim to the APIBinding's Spec.\n",
 				fmt.Sprintf("Current workspace is '%s'", homeWorkspace.String())},
 		},
 		{
@@ -529,8 +536,10 @@ func TestUse(t *testing.T) {
 					WithExportClaim("", "configmaps", "").
 					Build(),
 			},
+			wantStderr: []string{
+				"Warning: claim for configmaps exported but not specified on APIBinding a\nAdd this claim to the APIBinding's Spec.",
+			},
 			wantStdout: []string{
-				"Warning: claim for configmaps exported but not specified on APIBinding a\nAdd this claim to the APIBinding's Spec.\n",
 				"Current workspace is 'root:foo:bar'"},
 		},
 		{
@@ -590,8 +599,10 @@ func TestUse(t *testing.T) {
 					WithExportClaim("", "configmaps", "").
 					Build(),
 			},
+			wantStderr: []string{
+				"Warning: claim for configmaps exported but not specified on APIBinding a\nAdd this claim to the APIBinding's Spec.",
+			},
 			wantStdout: []string{
-				"Warning: claim for configmaps exported but not specified on APIBinding a\nAdd this claim to the APIBinding's Spec.\n",
 				"Current workspace is 'root:foo:bar'"},
 		},
 		{
@@ -610,8 +621,10 @@ func TestUse(t *testing.T) {
 					WithExportClaim("test.kcp.io", "test", "abcdef").
 					Build(),
 			},
+			wantStderr: []string{
+				"Warning: claim for test.test.kcp.io:abcdef specified on APIBinding a but not accepted or rejected.",
+			},
 			wantStdout: []string{
-				"Warning: claim for test.test.kcp.io:abcdef specified on APIBinding a but not accepted or rejected.\n",
 				"Current workspace is 'root:foo:bar'"},
 		},
 		{
@@ -631,9 +644,11 @@ func TestUse(t *testing.T) {
 					WithExportClaim("", "configmaps", "").
 					Build(),
 			},
+			wantStderr: []string{
+				"Warning: claim for configmaps exported but not specified on APIBinding a\nAdd this claim to the APIBinding's Spec.",
+				"Warning: claim for test.test.kcp.io:abcdef specified on APIBinding a but not accepted or rejected.",
+			},
 			wantStdout: []string{
-				"Warning: claim for configmaps exported but not specified on APIBinding a\nAdd this claim to the APIBinding's Spec.\n",
-				"Warning: claim for test.test.kcp.io:abcdef specified on APIBinding a but not accepted or rejected.\n",
 				"Current workspace is 'root:foo:bar'"},
 		},
 		{
@@ -654,10 +669,11 @@ func TestUse(t *testing.T) {
 					WithExportClaim("test2.kcp.io", "test2", "abcdef").
 					Build(),
 			},
-			wantStdout: []string{
-				"Warning: claim for test.test.kcp.io:abcdef specified on APIBinding a but not accepted or rejected.\n",
-				"Warning: claim for test2.test2.kcp.io:abcdef specified on APIBinding a but not accepted or rejected.\n",
-				"Current workspace is 'root:foo:bar'"},
+			wantStderr: []string{
+				"Warning: claim for test.test.kcp.io:abcdef specified on APIBinding a but not accepted or rejected.",
+				"Warning: claim for test2.test2.kcp.io:abcdef specified on APIBinding a but not accepted or rejected.",
+			},
+			wantStdout: []string{"Current workspace is 'root:foo:bar'"},
 		},
 		{
 			name:   "workspace name, multiple APIBindings unspecified",
@@ -675,10 +691,11 @@ func TestUse(t *testing.T) {
 					WithExportClaim("", "configmaps", "").
 					Build(),
 			},
-			wantStdout: []string{
-				"Warning: claim for configmaps exported but not specified on APIBinding a\nAdd this claim to the APIBinding's Spec.\n",
-				"Warning: claim for test.test.kcp.io:abcdef exported but not specified on APIBinding a\nAdd this claim to the APIBinding's Spec.\n",
-				"Current workspace is 'root:foo:bar'"},
+			wantStderr: []string{
+				"Warning: claim for configmaps exported but not specified on APIBinding a\nAdd this claim to the APIBinding's Spec.",
+				"Warning: claim for test.test.kcp.io:abcdef exported but not specified on APIBinding a\nAdd this claim to the APIBinding's Spec.",
+			},
+			wantStdout: []string{"Current workspace is 'root:foo:bar'"},
 		},
 		{
 			name:   "relative change multiple jumps from non root",
@@ -836,7 +853,10 @@ func TestUse(t *testing.T) {
 				require.Contains(t, stdout.String(), s)
 			}
 			if tt.noWarn {
-				require.NotContains(t, stdout.String(), "Warning")
+				require.NotContains(t, stderr.String(), "Warning")
+			}
+			for _, s := range tt.wantStderr {
+				require.Contains(t, stderr.String(), s)
 			}
 			if err != nil {
 				for _, s := range tt.wantErrors {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

While working on https://github.com/embik/kubectl-switch-ws I noticed that `kubectl-workspace use` will always print diagnostic information (deprecation notices and warnings about unfinished API bindings), even when using `--short` for inclusion in scripts / terminal prompts. There is no good way to avoid these warnings for scripts that only expect the workspace name returned as output.

I would like to propose that we start writing this supplementary information to stderr, which is specifically for diagnostic information and errors. This way, scripts can avoid the warnings by using something like `kubectl workspace use --short <workspace> 2>/dev/null` to make sure you only get back the workspace name (or an exit code that isn't zero, which signals that something bad happened).

There's also an old `OWNERS` file left here which I'd propose to remove.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Write diagnostics (deprecation notices and warnings) in `kubectl-workspace` to stderr instead of stdout
```
