### PR TITLE
✨ Add version to kubectl-workspace

### DIFF
--- a/cli/pkg/workspace/cmd/cmd.go
+++ b/cli/pkg/workspace/cmd/cmd.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/component-base/version"
 
 	"github.com/kcp-dev/kcp/cli/pkg/workspace/plugin"
 )
@@ -100,6 +101,12 @@ func New(streams genericclioptions.IOStreams) (*cobra.Command, error) {
 		},
 	}
 	cmdOpts.BindFlags(cmd)
+
+	if v := version.Get().String(); len(v) == 0 {
+		cmd.Version = "<unknown>"
+	} else {
+		cmd.Version = v
+	}
 
 	useWorkspaceOpts := plugin.NewUseWorkspaceOptions(streams)
 	useCmd := &cobra.Command{


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

`kubectl-kcp` already has a `--version` flag, but `kubectl-workspace` does not. This sets the version on the root cmd for `kubectl-workspace`, mirroring what we do in the other kubectl plugin already.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Add `--version` flag to `kubectl-workspace`
```
