### PR TITLE
:seedling: Allow launching components from (sharded-)test-server with delve

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ go.work.*
 go.work.sum
 
 /contrib/tilt/bin/*
+
+# Ignore UNIX sockets and delve binaries
+*.sock
+__debug_*

--- a/cmd/sharded-test-server/cache.go
+++ b/cmd/sharded-test-server/cache.go
@@ -52,7 +52,7 @@ func startCacheServer(ctx context.Context, logDirPath, workingDir string, synthe
 	)
 	cacheWorkingDir := filepath.Join(workingDir, ".kcp-cache")
 	cachePort := 8012
-	commandLine := framework.DirectOrGoRunCommand("cache-server")
+	commandLine := framework.Command("cache-server", "cache")
 	commandLine = append(
 		commandLine,
 		fmt.Sprintf("--root-directory=%s", cacheWorkingDir),

--- a/cmd/sharded-test-server/frontproxy.go
+++ b/cmd/sharded-test-server/frontproxy.go
@@ -131,7 +131,7 @@ func startFrontProxy(
 	}
 
 	// run front-proxy command
-	commandLine := append(framework.DirectOrGoRunCommand("kcp-front-proxy"),
+	commandLine := append(framework.Command("kcp-front-proxy", "front-proxy"),
 		fmt.Sprintf("--mapping-file=%s", filepath.Join(workDirPath, ".kcp-front-proxy/mapping.yaml")),
 		fmt.Sprintf("--root-directory=%s", filepath.Join(workDirPath, ".kcp-front-proxy")),
 		fmt.Sprintf("--root-kubeconfig=%s", filepath.Join(workDirPath, ".kcp/root.kubeconfig")),

--- a/cmd/sharded-test-server/virtual.go
+++ b/cmd/sharded-test-server/virtual.go
@@ -186,7 +186,7 @@ func (v *VirtualWorkspace) start(ctx context.Context) error {
 		auditFilePath = filepath.Join(v.logDirPath, fmt.Sprintf("kcp-virtual-workspaces-%d-audit.log", v.index))
 	}
 
-	commandLine := framework.DirectOrGoRunCommand("virtual-workspaces")
+	commandLine := framework.Command("virtual-workspaces", strings.ToLower(prefix))
 	commandLine = append(commandLine, v.args...)
 	commandLine = append(
 		commandLine,

--- a/cmd/test-server/kcp/shard.go
+++ b/cmd/test-server/kcp/shard.go
@@ -93,7 +93,7 @@ func (s *Shard) Start(ctx context.Context, quiet bool) error {
 	}
 
 	// setup command
-	commandLine := append(framework.StartKcpCommand(), framework.TestServerArgs()...)
+	commandLine := append(framework.StartKcpCommand(s.name), framework.TestServerArgs()...)
 	commandLine = append(commandLine, s.args...)
 	commandLine = append(commandLine,
 		"--audit-log-maxsize", "1024",


### PR DESCRIPTION


<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

When debugging e2e tests for shared and sharded setups, I struggled a bit with figuring out what was going on on the server side of the e2e tests. Tests I could launch via `dlv` to debug them, but for the KCP server/cache/front-proxy side I needed to attach to the running processes or similar.

I added a new environment variable `RUN_DELVE` to the test framework to launch the various processes not from binaries or from `go run`, but from `dlv debug` directly. The workflow is like this:

1. Launch `test-server` or `sharded-test-server`:

    ```sh
    $ RUN_DELVE=1 ./bin/sharded-test-server 2>&1 | tee kcp.log
    ```

2. Wait for `dlv-cache.sock` to appear, connect to it via `dlv connect unix:dlv-cache.sock`, set your breakpoints for the cache server and then hit `c` to start the cache server.
3. Repeat (2) with `dlv-kcp-0.sock` and `dlv-front-proxy.sock`.
4. The setup is running now, proceed with your e2e test or other options and wait for one of the connected delve clients to hit a breakpoint.

Same thing for `test-server`, just with a single socket showing up.

This will 

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
