### PR TITLE
:seedling: Bump to Go 1.22.5

### DIFF
--- a/.github/workflows/docs-gen-and-push.yaml
+++ b/.github/workflows/docs-gen-and-push.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: v1.22.2
+          go-version: v1.22.5
           cache: true
 
       - uses: actions/setup-python@v5

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -22,7 +22,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-go@v5
       with:
-        go-version: v1.22.2
+        go-version: v1.22.5
     - name: Delete non-semver tags
       run: 'git tag -d $(git tag -l | grep -v "^v")'
     - name: Set LDFLAGS

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.22.2-1
+        - image: ghcr.io/kcp-dev/infra/build:1.22.5-1
           command:
             - make
             - verify-boilerplate
@@ -27,7 +27,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.22.2-1
+        - image: ghcr.io/kcp-dev/infra/build:1.22.5-1
           command:
             - make
             - verify-codegen
@@ -44,7 +44,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.22.2-1
+        - image: ghcr.io/kcp-dev/infra/build:1.22.5-1
           command:
             - make
             - lint
@@ -83,7 +83,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.22.2-1
+        - image: ghcr.io/kcp-dev/infra/build:1.22.5-1
           command:
             - make
             - test
@@ -104,7 +104,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.22.2-1
+        - image: ghcr.io/kcp-dev/infra/build:1.22.5-1
           command:
             - ./hack/run-with-prometheus.sh
             - make
@@ -132,7 +132,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.22.2-1
+        - image: ghcr.io/kcp-dev/infra/build:1.22.5-1
           command:
             - ./hack/run-with-prometheus.sh
             - make
@@ -162,7 +162,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.22.2-1
+        - image: ghcr.io/kcp-dev/infra/build:1.22.5-1
           command:
             - ./hack/run-with-prometheus.sh
             - make
@@ -188,7 +188,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.22.2-1
+        - image: ghcr.io/kcp-dev/infra/build:1.22.5-1
           command:
             - ./hack/run-with-prometheus.sh
             - make

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Build the binary
-FROM --platform=${BUILDPLATFORM} docker.io/golang:1.22.2 AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/golang:1.22.5 AS builder
 WORKDIR /workspace
 
 # Install dependencies.

--- a/docs/content/contributing/index.md
+++ b/docs/content/contributing/index.md
@@ -17,7 +17,7 @@ contribution. See the [DCO](https://github.com/kcp-dev/kcp/tree/main/DCO) file f
 ### Prerequisites
 
 1. Clone this repository.
-2. [Install Go](https://golang.org/doc/install) (currently 1.22.2).
+2. [Install Go](https://golang.org/doc/install) (currently 1.22).
 3. Install [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl).
 
 Please note that the go language version numbers in these files must exactly agree: go/go.mod file, kcp/.ci-operator.yaml, kcp/Dockerfile, and in all the kcp/.github/workflows yaml files that specify go-version. In kcp/.ci-operator.yaml the go version is indicated by the "tag" attribute. In kcp/Dockerfile it is indicated by the "golang" attribute. In go.mod it is indicated by the "go" directive." In the .github/workflows yaml files it is indicated by "go-version"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This bumps the build image (https://github.com/kcp-dev/infra/pull/72) and Go versions to the latest Go 1.22.5. It's also the first build image that has an arm64 variant, so with this we could execute prowjobs on ARM64 nodes in the future.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
kcp is built with Go 1.22.5 now
```
