### PR TITLE
:sparkles: Add inactive annotation to logicalcluster

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -445,6 +445,7 @@ func NewConfig(opts kcpserveroptions.CompletedOptions) (*Config, error) {
 		apiHandler = filters.WithWarningRecorder(apiHandler)
 
 		apiHandler = kcpfilters.WithAuditEventClusterAnnotation(apiHandler)
+		apiHandler = kcpfilters.WithBlockInactiveLogicalClusters(apiHandler, c.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters())
 
 		// Add a mux before the chain, for other handlers with their own handler chain to hook in. For example, when
 		// the virtual workspace server is running as part of kcp, it registers /services with the mux so it can handle


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
In order to do maintenance on a workspace, without controllers reconciling the resources inside the window during the maintenance period, I need a mechanism by which to disable access to the workspace. This feature adds a new optional annotation to `LogicalCluster` which disables API access through to the resource while present:

```
internal.kcp.io/inactive: "true"
```

All requests to the logical cluster while the annotation is set are denied with a 400 error, except for requests to CRUD the logical cluster itself or the OpenAPI spec (so that you can reasonably disable the annotation).

## Related issue(s)

None

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Add support for inactive annotation on logical clusters
```
