### PR TITLE
:bug: Fix APIExport SSA apply configuration client

### DIFF
--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -1299,6 +1299,21 @@ func schema_sdk_apis_apis_v1alpha1_AcceptablePermissionClaim(ref common.Referenc
 				Description: "AcceptablePermissionClaim is a PermissionClaim that records if the user accepts or rejects it.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"group": {
+						SchemaProps: spec.SchemaProps{
+							Description: "group is the name of an API group. For core groups this is the empty string '\"\"'.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"resource": {
+						SchemaProps: spec.SchemaProps{
+							Description: "resource is the name of the resource. Note: it is worth noting that you can not ask for permissions for resource provided by a CRD not provided by an api export.",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"all": {
 						SchemaProps: spec.SchemaProps{
 							Description: "all claims all resources for the given group/resource. This is mutually exclusive with resourceSelector.",
@@ -1335,7 +1350,7 @@ func schema_sdk_apis_apis_v1alpha1_AcceptablePermissionClaim(ref common.Referenc
 						},
 					},
 				},
-				Required: []string{"state"},
+				Required: []string{"resource", "state"},
 			},
 		},
 		Dependencies: []string{
@@ -1609,6 +1624,21 @@ func schema_sdk_apis_apis_v1alpha1_PermissionClaim(ref common.ReferenceCallback)
 				Description: "PermissionClaim identifies an object by GR and identity hash. Its purpose is to determine the added permissions that a service provider may request and that a consumer may accept and allow the service provider access to.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"group": {
+						SchemaProps: spec.SchemaProps{
+							Description: "group is the name of an API group. For core groups this is the empty string '\"\"'.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"resource": {
+						SchemaProps: spec.SchemaProps{
+							Description: "resource is the name of the resource. Note: it is worth noting that you can not ask for permissions for resource provided by a CRD not provided by an api export.",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"all": {
 						SchemaProps: spec.SchemaProps{
 							Description: "all claims all resources for the given group/resource. This is mutually exclusive with resourceSelector.",
@@ -1638,6 +1668,7 @@ func schema_sdk_apis_apis_v1alpha1_PermissionClaim(ref common.ReferenceCallback)
 						},
 					},
 				},
+				Required: []string{"resource"},
 			},
 		},
 		Dependencies: []string{

--- a/sdk/apis/apis/v1alpha1/types_apiexport.go
+++ b/sdk/apis/apis/v1alpha1/types_apiexport.go
@@ -199,7 +199,7 @@ const (
 //
 // +kubebuilder:validation:XValidation:rule="(has(self.all) && self.all) != (has(self.resourceSelector) && size(self.resourceSelector) > 0)",message="either \"all\" or \"resourceSelector\" must be set"
 type PermissionClaim struct {
-	GroupResource `json:","`
+	GroupResource `json:",inline"`
 
 	// all claims all resources for the given group/resource.
 	// This is mutually exclusive with resourceSelector.

--- a/sdk/client/applyconfiguration/apis/v1alpha1/acceptablepermissionclaim.go
+++ b/sdk/client/applyconfiguration/apis/v1alpha1/acceptablepermissionclaim.go
@@ -39,7 +39,6 @@ func AcceptablePermissionClaim() *AcceptablePermissionClaimApplyConfiguration {
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Group field is set to the value of the last call.
 func (b *AcceptablePermissionClaimApplyConfiguration) WithGroup(value string) *AcceptablePermissionClaimApplyConfiguration {
-	b.ensureGroupResourceApplyConfigurationExists()
 	b.Group = &value
 	return b
 }
@@ -48,15 +47,8 @@ func (b *AcceptablePermissionClaimApplyConfiguration) WithGroup(value string) *A
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Resource field is set to the value of the last call.
 func (b *AcceptablePermissionClaimApplyConfiguration) WithResource(value string) *AcceptablePermissionClaimApplyConfiguration {
-	b.ensureGroupResourceApplyConfigurationExists()
 	b.Resource = &value
 	return b
-}
-
-func (b *AcceptablePermissionClaimApplyConfiguration) ensureGroupResourceApplyConfigurationExists() {
-	if b.GroupResourceApplyConfiguration == nil {
-		b.GroupResourceApplyConfiguration = &GroupResourceApplyConfiguration{}
-	}
 }
 
 // WithAll sets the All field in the declarative configuration to the given value

--- a/sdk/client/applyconfiguration/apis/v1alpha1/permissionclaim.go
+++ b/sdk/client/applyconfiguration/apis/v1alpha1/permissionclaim.go
@@ -21,10 +21,10 @@ package v1alpha1
 // PermissionClaimApplyConfiguration represents an declarative configuration of the PermissionClaim type for use
 // with apply.
 type PermissionClaimApplyConfiguration struct {
-	*GroupResourceApplyConfiguration `json:"GroupResource,omitempty"`
-	All                              *bool                                `json:"all,omitempty"`
-	ResourceSelector                 []ResourceSelectorApplyConfiguration `json:"resourceSelector,omitempty"`
-	IdentityHash                     *string                              `json:"identityHash,omitempty"`
+	GroupResourceApplyConfiguration `json:",inline"`
+	All                             *bool                                `json:"all,omitempty"`
+	ResourceSelector                []ResourceSelectorApplyConfiguration `json:"resourceSelector,omitempty"`
+	IdentityHash                    *string                              `json:"identityHash,omitempty"`
 }
 
 // PermissionClaimApplyConfiguration constructs an declarative configuration of the PermissionClaim type for use with
@@ -37,7 +37,6 @@ func PermissionClaim() *PermissionClaimApplyConfiguration {
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Group field is set to the value of the last call.
 func (b *PermissionClaimApplyConfiguration) WithGroup(value string) *PermissionClaimApplyConfiguration {
-	b.ensureGroupResourceApplyConfigurationExists()
 	b.Group = &value
 	return b
 }
@@ -46,15 +45,8 @@ func (b *PermissionClaimApplyConfiguration) WithGroup(value string) *PermissionC
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Resource field is set to the value of the last call.
 func (b *PermissionClaimApplyConfiguration) WithResource(value string) *PermissionClaimApplyConfiguration {
-	b.ensureGroupResourceApplyConfigurationExists()
 	b.Resource = &value
 	return b
-}
-
-func (b *PermissionClaimApplyConfiguration) ensureGroupResourceApplyConfigurationExists() {
-	if b.GroupResourceApplyConfiguration == nil {
-		b.GroupResourceApplyConfiguration = &GroupResourceApplyConfiguration{}
-	}
 }
 
 // WithAll sets the All field in the declarative configuration to the given value


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The JSON tag for the permission claim `GroupResource` embedded struct was wrong. The apply configuration resulted in an object like the following:

```json
{
    "apiVersion": "apis.kcp.io/v1alpha1",
    "kind": "APIExport",
    "metadata":
    {
        "name": "fabrics.upbound.io"
    },
    "spec":
    {
        "latestResourceSchemas":
        [
            "v240816-2328.projects.fabrics.upbound.io",
            "v240816-2328.services.fabrics.upbound.io",
            "v240816-2328.servicetiers.fabrics.upbound.io",
            "v240816-2328.spaces.fabrics.upbound.io"
        ],
        "permissionClaims":
        [
            {
                "GroupResource":
                {
                    "group": "tenancy.kcp.io",
                    "resource": "workspaces"
                },
                "all": true,
                "identityHash": "1422105e93411affc2d91b197e07d9168c1e7ca3b01fc6955b393122be112491"
            }
        ]
    }
}
```

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Fix apply configuration client for APIExport.
```