### PR TITLE
:sparkles: add kubectl-create-workspace command supported with latest kubectl

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,8 +18,8 @@ builds:
     goarch: ppc64le
   env:
   - CGO_ENABLED=0
+
 # plugin builds
-# kubectl-kcp
 - id: "kubectl-kcp"
   main: ./cmd/kubectl-kcp
   dir: cli
@@ -41,7 +41,7 @@ builds:
     goarch: ppc64le
   env:
   - CGO_ENABLED=0
-# kubectl-workspaces
+
 - id: "kubectl-workspaces"
   main: ./cmd/kubectl-workspace
   dir: cli
@@ -63,7 +63,7 @@ builds:
     goarch: ppc64le
   env:
   - CGO_ENABLED=0
-# kubectl-ws
+
 - id: "kubectl-ws"
   main: ./cmd/kubectl-workspace
   dir: cli
@@ -85,6 +85,7 @@ builds:
     goarch: ppc64le
   env:
   - CGO_ENABLED=0
+
 archives:
 - id: kcp
   builds:
@@ -93,43 +94,20 @@ archives:
   builds:
   - kubectl-kcp
   name_template: "kubectl-kcp-plugin_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+- id: kubectl-workspace-plugin
+  builds:
+  - kubectl-workspace
+  name_template: "kubectl-workspace-plugin_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 - id: kubectl-ws-plugin
   builds:
   - kubectl-ws
   name_template: "kubectl-ws-plugin_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-- id: kubectl-workspaces-plugin
-  builds:
-  - kubectl-workspaces
-  name_template: "kubectl-workspaces-plugin_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
 release:
   draft: true
   mode: keep-existing
 
 krews:
-- name: ws
-  ids:
-  - kubectl-ws-plugin
-  repository:
-    owner: kcp-dev
-    name: krew-index
-    token: "{{ .Env.KREW_GITHUB_TOKEN }}"
-  homepage: "https://kcp.io/"
-  description: |
-    KCP workspace cli plugin for kubectl. Enables you to manage your kcp workspaces.
-  short_description: "KCP workspace cli plugin for kubectl."
-  skip_upload: auto
-- name: workspaces
-  ids:
-  - kubectl-workspaces-plugin
-  repository:
-    owner: kcp-dev
-    name: krew-index
-    token: "{{ .Env.KREW_GITHUB_TOKEN }}"
-  homepage: "https://kcp.io/"
-  description: |
-    KCP workspace cli plugin for kubectl. Enables you to manage your kcp workspaces.
-  short_description: "KCP workspace cli plugin for kubectl."
-  skip_upload: auto
 - name: kcp
   ids:
   - kubectl-kcp-plugin
@@ -139,6 +117,30 @@ krews:
     token: "{{ .Env.KREW_GITHUB_TOKEN }}"
   homepage: "https://kcp.io/"
   description: |
-    KCP cli plugin for kubectl. Enables you to manage your kcp.
+    KCP cli plugin for kubectl. Enables you to work with KCP.
   short_description: "KCP cli plugin for kubectl."
+  skip_upload: auto
+- name: workspace
+  ids:
+  - kubectl-workspace-plugin
+  repository:
+    owner: kcp-dev
+    name: krew-index
+    token: "{{ .Env.KREW_GITHUB_TOKEN }}"
+  homepage: "https://kcp.io/"
+  description: |
+    KCP workspace cli plugin for kubectl. Enables you to manage your KCP workspaces.
+  short_description: "KCP workspace cli plugin for kubectl."
+  skip_upload: auto
+- name: ws
+  ids:
+  - kubectl-ws-plugin
+  repository:
+    owner: kcp-dev
+    name: krew-index
+    token: "{{ .Env.KREW_GITHUB_TOKEN }}"
+  homepage: "https://kcp.io/"
+  description: |
+    KCP workspace cli plugin for kubectl. Enables you to manage your KCP workspaces.
+  short_description: "KCP workspace cli plugin for kubectl."
   skip_upload: auto

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -42,30 +42,8 @@ builds:
   env:
   - CGO_ENABLED=0
 
-- id: "kubectl-workspaces"
-  main: ./cmd/kubectl-workspace
-  dir: cli
-  binary: bin/kubectl-workspaces
-  ldflags:
-  - "{{ .Env.LDFLAGS }}"
-  goos:
-  - linux
-  - darwin
-  - windows
-  goarch:
-  - amd64
-  - arm64
-  - ppc64le
-  ignore:
-  - goos: darwin
-    goarch: ppc64le
-  - goos: windows
-    goarch: ppc64le
-  env:
-  - CGO_ENABLED=0
-
 - id: "kubectl-ws"
-  main: ./cmd/kubectl-workspace
+  main: ./cmd/kubectl-ws
   dir: cli
   binary: bin/kubectl-ws
   ldflags:
@@ -116,10 +94,6 @@ archives:
   builds:
   - kubectl-kcp
   name_template: "kubectl-kcp-plugin_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-- id: kubectl-workspace-plugin
-  builds:
-  - kubectl-workspace
-  name_template: "kubectl-workspace-plugin_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 - id: kubectl-ws-plugin
   builds:
   - kubectl-ws
@@ -145,18 +119,6 @@ krews:
   description: |
     KCP cli plugin for kubectl. Enables you to work with KCP.
   short_description: "KCP cli plugin for kubectl."
-  skip_upload: auto
-- name: workspace
-  ids:
-  - kubectl-workspace-plugin
-  repository:
-    owner: kcp-dev
-    name: krew-index
-    token: "{{ .Env.KREW_GITHUB_TOKEN }}"
-  homepage: "https://kcp.io/"
-  description: |
-    KCP workspace cli plugin for kubectl. Enables you to manage your KCP workspaces.
-  short_description: "KCP workspace cli plugin for kubectl."
   skip_upload: auto
 - name: ws
   ids:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -86,6 +86,28 @@ builds:
   env:
   - CGO_ENABLED=0
 
+- id: "kubectl-create-workspace"
+  main: ./cmd/kubectl-create-workspace
+  dir: cli
+  binary: bin/kubectl-create-workspace
+  ldflags:
+  - "{{ .Env.LDFLAGS }}"
+  goos:
+  - linux
+  - darwin
+  - windows
+  goarch:
+  - amd64
+  - arm64
+  - ppc64le
+  ignore:
+  - goos: darwin
+    goarch: ppc64le
+  - goos: windows
+    goarch: ppc64le
+  env:
+  - CGO_ENABLED=0
+
 archives:
 - id: kcp
   builds:
@@ -102,6 +124,10 @@ archives:
   builds:
   - kubectl-ws
   name_template: "kubectl-ws-plugin_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+- id: kubectl-create-workspace-plugin-krew
+  builds:
+  - kubectl-create-workspace
+  name_template: "kubectl-create-workspace-plugin_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
 release:
   draft: true
@@ -143,4 +169,16 @@ krews:
   description: |
     KCP workspace cli plugin for kubectl. Enables you to manage your KCP workspaces.
   short_description: "KCP workspace cli plugin for kubectl."
+  skip_upload: auto
+- name: create-workspace
+  ids:
+  - kubectl-create-workspace-plugin-krew
+  repository:
+    owner: kcp-dev
+    name: krew-index
+    token: "{{ .Env.KREW_GITHUB_TOKEN }}"
+  homepage: "https://kcp.io/"
+  description: |
+    KCP create workspace cli plugin for kubectl. Enables you to create KCP workspaces.
+  short_description: "KCP create workspace cli plugin for kubectl."
   skip_upload: auto

--- a/FAQ.md
+++ b/FAQ.md
@@ -65,7 +65,7 @@ In kcp an application should be able to describe the constraints it needs in its
 
 Shards in kcp represent a single apiserver and etcd/db instance.  This is how kcp would like to split workspaces across many kcp instances since etcd will have storage limits.
 
-## Where can I get the kubectl workspace plugin?
+## Where can I get the kubectl ws plugin?
 
 You're in the right place. Clone this repo and run `make install WHAT=./cli/cmd/kubectl-kcp`.
 

--- a/Makefile
+++ b/Makefile
@@ -122,8 +122,6 @@ build: require-jq require-go require-git verify-go-versions ## Build the project
     	GOOS=$(OS) GOARCH=$(ARCH) CGO_ENABLED=0 go build $(BUILDFLAGS) -ldflags="$(LDFLAGS)" -o $(ROOT_DIR)/bin ./...; \
 		popd; \
     done
-	ln -sf kubectl-workspace bin/kubectl-workspaces
-	ln -sf kubectl-workspace bin/kubectl-ws
 .PHONY: build
 
 .PHONY: build-all
@@ -136,8 +134,6 @@ install: require-jq require-go require-git verify-go-versions ## Install the pro
   		W=$$(echo "$${W}" | sed 's,^\./,github.com/kcp-dev/kcp/,') && \
   		GOOS=$(OS) GOARCH=$(ARCH) CGO_ENABLED=0 go install -ldflags="$(LDFLAGS)" $${W}; \
   	done
-	ln -sf $(INSTALL_GOBIN)/kubectl-workspace $(INSTALL_GOBIN)/kubectl-ws
-	ln -sf $(INSTALL_GOBIN)/kubectl-workspace $(INSTALL_GOBIN)/kubectl-workspaces
 .PHONY: install
 
 $(GOLANGCI_LINT):

--- a/cli/cmd/kubectl-create-workspace/main.go
+++ b/cli/cmd/kubectl-create-workspace/main.go
@@ -33,7 +33,7 @@ func main() {
 	flags := pflag.NewFlagSet("kubectl-create-workspace", pflag.ExitOnError)
 	pflag.CommandLine = flags
 
-	createWorkspaceCmd, err := cmd.NewCreate("kubectl create workspace", genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
+	createWorkspaceCmd, err := cmd.NewCreate("kubectl create workspace", "", genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)

--- a/cli/cmd/kubectl-create-workspace/main.go
+++ b/cli/cmd/kubectl-create-workspace/main.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	goflags "flag"
+	"fmt"
+	"os"
+
+	"github.com/spf13/pflag"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/klog/v2"
+
+	"github.com/kcp-dev/kcp/cli/pkg/workspace/cmd"
+)
+
+func main() {
+	flags := pflag.NewFlagSet("kubectl-create-workspace", pflag.ExitOnError)
+	pflag.CommandLine = flags
+
+	createWorkspaceCmd, err := cmd.NewCreate(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	// setup klog
+	fs := goflags.NewFlagSet("klog", goflags.PanicOnError)
+	klog.InitFlags(fs)
+	createWorkspaceCmd.PersistentFlags().AddGoFlagSet(fs)
+
+	if err := createWorkspaceCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/cli/cmd/kubectl-create-workspace/main.go
+++ b/cli/cmd/kubectl-create-workspace/main.go
@@ -33,7 +33,7 @@ func main() {
 	flags := pflag.NewFlagSet("kubectl-create-workspace", pflag.ExitOnError)
 	pflag.CommandLine = flags
 
-	createWorkspaceCmd, err := cmd.NewCreate(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
+	createWorkspaceCmd, err := cmd.NewCreate("kubectl create workspace", genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)

--- a/cli/cmd/kubectl-ws/main.go
+++ b/cli/cmd/kubectl-ws/main.go
@@ -30,7 +30,7 @@ import (
 )
 
 func main() {
-	flags := pflag.NewFlagSet("kubectl-workspace", pflag.ExitOnError)
+	flags := pflag.NewFlagSet("kubectl-ws", pflag.ExitOnError)
 	pflag.CommandLine = flags
 
 	workspaceCmd, err := cmd.New(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})

--- a/cli/pkg/workspace/cmd/cmd.go
+++ b/cli/pkg/workspace/cmd/cmd.go
@@ -150,7 +150,7 @@ func New(streams genericclioptions.IOStreams) (*cobra.Command, error) {
 	}
 	currentWorkspaceOpts.BindFlags(currentCmd)
 
-	createCmd, err := NewCreate(cliName+" workspace create", streams)
+	createCmd, err := NewCreate(cliName+" workspace create", "install the 'kubectl create workspace' plugin instead, compare https://docs.kcp.io/kcp/latest/setup/kubectl-plugin/.", streams)
 	if err != nil {
 		return nil, err
 	}
@@ -206,12 +206,13 @@ func New(streams genericclioptions.IOStreams) (*cobra.Command, error) {
 }
 
 // NewCreate returns a cobra.Command for workspace create action.
-func NewCreate(prefix string, streams genericclioptions.IOStreams) (*cobra.Command, error) {
+func NewCreate(prefix string, deprecation string, streams genericclioptions.IOStreams) (*cobra.Command, error) {
 	createWorkspaceOpts := plugin.NewCreateWorkspaceOptions(streams)
 	cmd := &cobra.Command{
 		Use:          "create",
 		Short:        "Creates a new workspace",
 		Example:      prefix + " <workspace name> [--type=<type>] [--enter [--ignore-not-ready]] --ignore-existing",
+		Deprecated:   deprecation,
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/pkg/workspace/cmd/cmd.go
+++ b/cli/pkg/workspace/cmd/cmd.go
@@ -150,27 +150,10 @@ func New(streams genericclioptions.IOStreams) (*cobra.Command, error) {
 	}
 	currentWorkspaceOpts.BindFlags(currentCmd)
 
-	createWorkspaceOpts := plugin.NewCreateWorkspaceOptions(streams)
-	createCmd := &cobra.Command{
-		Use:          "create",
-		Short:        "Creates a new workspace",
-		Example:      "kcp workspace create <workspace name> [--type=<type>] [--enter [--ignore-not-ready]] --ignore-existing",
-		SilenceUsage: true,
-		Args:         cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) == 0 {
-				return cmd.Help()
-			}
-			if err := createWorkspaceOpts.Validate(); err != nil {
-				return err
-			}
-			if err := createWorkspaceOpts.Complete(args); err != nil {
-				return err
-			}
-			return createWorkspaceOpts.Run(cmd.Context())
-		},
+	createCmd, err := NewCreate(streams)
+	if err != nil {
+		return nil, err
 	}
-	createWorkspaceOpts.BindFlags(createCmd)
 
 	createContextOpts := plugin.NewCreateContextOptions(streams)
 	createContextCmd := &cobra.Command{
@@ -219,5 +202,32 @@ func New(streams genericclioptions.IOStreams) (*cobra.Command, error) {
 	cmd.AddCommand(currentCmd)
 	cmd.AddCommand(createCmd)
 	cmd.AddCommand(createContextCmd)
+	return cmd, nil
+}
+
+// NewCreate returns a cobra.Command for workspace create action.
+func NewCreate(streams genericclioptions.IOStreams) (*cobra.Command, error) {
+	createWorkspaceOpts := plugin.NewCreateWorkspaceOptions(streams)
+	cmd := &cobra.Command{
+		Use:          "create",
+		Short:        "Creates a new workspace",
+		Example:      "kcp workspace create <workspace name> [--type=<type>] [--enter [--ignore-not-ready]] --ignore-existing",
+		SilenceUsage: true,
+		Args:         cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return cmd.Help()
+			}
+			if err := createWorkspaceOpts.Validate(); err != nil {
+				return err
+			}
+			if err := createWorkspaceOpts.Complete(args); err != nil {
+				return err
+			}
+			return createWorkspaceOpts.Run(cmd.Context())
+		},
+	}
+	createWorkspaceOpts.BindFlags(cmd)
+
 	return cmd, nil
 }

--- a/cli/pkg/workspace/cmd/cmd.go
+++ b/cli/pkg/workspace/cmd/cmd.go
@@ -150,7 +150,7 @@ func New(streams genericclioptions.IOStreams) (*cobra.Command, error) {
 	}
 	currentWorkspaceOpts.BindFlags(currentCmd)
 
-	createCmd, err := NewCreate(streams)
+	createCmd, err := NewCreate(cliName+" workspace create", streams)
 	if err != nil {
 		return nil, err
 	}
@@ -206,12 +206,12 @@ func New(streams genericclioptions.IOStreams) (*cobra.Command, error) {
 }
 
 // NewCreate returns a cobra.Command for workspace create action.
-func NewCreate(streams genericclioptions.IOStreams) (*cobra.Command, error) {
+func NewCreate(prefix string, streams genericclioptions.IOStreams) (*cobra.Command, error) {
 	createWorkspaceOpts := plugin.NewCreateWorkspaceOptions(streams)
 	cmd := &cobra.Command{
 		Use:          "create",
 		Short:        "Creates a new workspace",
-		Example:      "kcp workspace create <workspace name> [--type=<type>] [--enter [--ignore-not-ready]] --ignore-existing",
+		Example:      prefix + " <workspace name> [--type=<type>] [--enter [--ignore-not-ready]] --ignore-existing",
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/contrib/kcp.code-workspace
+++ b/contrib/kcp.code-workspace
@@ -96,7 +96,7 @@
 				],
 			},
 			{
-				"name": "Manage workspaces through the kubectl workspace plugin",
+				"name": "Manage workspaces through the 'kubectl ws' plugin",
 				"type": "go",
 				"request": "launch",
 				"mode": "debug",

--- a/docs/content/setup/kubectl-plugin.md
+++ b/docs/content/setup/kubectl-plugin.md
@@ -3,21 +3,30 @@ description: >
   How to install and use the kubectl kcp plugin.
 ---
 
-# kubectl plugin
+# kubectl plugins
 
-kcp provides a kubectl plugin that simplifies the operations with the kcp server.
+kcp provides kubectl plugins that simplify the operations with the kcp server.
 
-You can install the plugin from the current repo:
+You can install the plugins from the current repo:
 
 ```sh
 $ make install
 go install ./cmd/...
 ```
 
-The plugin will be [automatically discovered by your current `kubectl` binary](https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/):
+or use [krew](https://krew.sigs.k8s.io/):
 
 ```sh
-$ kubectl-kcp
+$ kubectl krew index add kcp-dev https://github.com/kcp-dev/krew-index.git
+$ kubectl krew install kcp-dev/kcp
+$ kubectl krew install kcp-dev/ws
+$ kubectl krew install kcp-dev/create-workspace
+```
+
+The plugins will be [automatically discovered by your current `kubectl` binary](https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/):
+
+```sh
+$ kubectl kcp
 KCP is the easiest way to manage Kubernetes applications against one or more clusters, by giving you a personal control plane that schedules your workloads onto one or many clusters, and making it simple to pick up and move. Advanced use cases including spreading your apps across clusters for resiliency, scheduling batch workloads onto clusters with free capacity, and enabling collaboration for individual teams without having access to the underlying clusters.
 
 This command provides KCP specific sub-command for kubectl.
@@ -26,25 +35,32 @@ Usage:
   kcp [command]
 
 Available Commands:
-  completion  generate the autocompletion script for the specified shell
+  bind        Bind different types into current workspace.
+  claims      Operations related to viewing or updating permission claims
+  completion  Generate the autocompletion script for the specified shell
+  crd         CRD related operations
   help        Help about any command
   workspace   Manages KCP workspaces
 
 Flags:
       --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files
+      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
   -h, --help                             help for kcp
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory
-      --log_file string                  If non-empty, use this log file
-      --log_file_max_size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
+      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
+      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
+      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
       --logtostderr                      log to standard error instead of files (default true)
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level)
+      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
       --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files
-      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
+      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true) (default 2)
   -v, --v Level                          number for the log level verbosity
+      --version                          version for kcp
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
 
 Use "kcp [command] --help" for more information about a command.
+
+$ kubectl ws .                                # a short-cut for kubectl kcp workspace
+$ kubectl create workspace my-workspace       # a short-cut for kubectl kcp workspace create
 ```


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

With https://github.com/kubernetes/kubernetes/pull/124123, kubectl supports create plugins. This PR adds `create workspace`.

## Related issue(s)

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Add `kubectl create workspace` plugin.
```