### PR TITLE
✨ Allow setting root directory to empty string to disable creation

### DIFF
--- a/pkg/server/options/controllers.go
+++ b/pkg/server/options/controllers.go
@@ -19,6 +19,7 @@ package options
 import (
 	cryptorand "crypto/rand"
 	"crypto/rsa"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -80,6 +81,9 @@ func (c *Controllers) AddFlags(fs *pflag.FlagSet) {
 
 func (c *Controllers) Complete(rootDir string) error {
 	if c.SAController.ServiceAccountKeyFile == "" {
+		if rootDir == "" {
+			return errors.New("no serviceaccount key file loaded and no root directory set")
+		}
 		// use sa.key and auto-generate if not existing
 		c.SAController.ServiceAccountKeyFile = filepath.Join(rootDir, "sa.key")
 		if _, err := os.Stat(c.SAController.ServiceAccountKeyFile); os.IsNotExist(err) {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

`--root-directory` is an extremely handy flag when running `kcp start` locally, and the `.kcp` directory is filled with automatically generated certificates, kubeconfigs, etc.

When running kcp in Kubernetes (e.g. via the Helm chart), this is not needed because certificates are fed from the outside (generated by cert-manager) and kubeconfig generation is disabled. We set this in the Helm chart:

https://github.com/kcp-dev/helm-charts/blob/5e745b2cfbd7ad7cf926fd61b550d9c6c695265e/charts/kcp/templates/server-deployment.yaml#L135

This references an emptyDir volume we mount. The only reason we do that is because kcp fails to start if the root-directory doesn't exist and it cannot create it.

Thus, this PR eliminates the code path that was always trying to create the root directory. It should allow us to set `--root-directory=""` in the Helm chart and eliminate the emptyDir we've been using as a workaround to make the `kcp` binary happy.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Skip attempt to create root directory if `--root-directory=""` is set
```
