### PR TITLE
:bug: authorization/delegated: fix typo leading to zero deny cache ttl

### DIFF
--- a/pkg/authorization/delegated/authorizer.go
+++ b/pkg/authorization/delegated/authorizer.go
@@ -46,7 +46,7 @@ func (d *Options) defaults() {
 		d.AllowCacheTTL = 5 * time.Minute
 	}
 	if d.DenyCacheTTL == 0 {
-		d.AllowCacheTTL = 30 * time.Second
+		d.DenyCacheTTL = 30 * time.Second
 	}
 }
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

A typo led to a zero ttl for the deny cache of delegated authz.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Fix performance problem in virtual workspace authorization.
```