### PR TITLE
:bug: reconciler/apibinding: filter by cluster through index, not manually

### DIFF
--- a/pkg/reconciler/apis/apibinding/apibinding_controller.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_controller.go
@@ -82,22 +82,7 @@ func NewController(
 		kcpClusterClient: kcpClusterClient,
 
 		listAPIBindings: func(clusterName logicalcluster.Name) ([]*apisv1alpha1.APIBinding, error) {
-			list, err := apiBindingInformer.Lister().List(labels.Everything())
-			if err != nil {
-				return nil, err
-			}
-
-			var ret []*apisv1alpha1.APIBinding
-
-			for i := range list {
-				if logicalcluster.From(list[i]) != clusterName {
-					continue
-				}
-
-				ret = append(ret, list[i])
-			}
-
-			return ret, nil
+			return apiBindingInformer.Lister().Cluster(clusterName).List(labels.Everything())
 		},
 		listAPIBindingsByAPIExport: func(export *apisv1alpha1.APIExport) ([]*apisv1alpha1.APIBinding, error) {
 			// binding keys by full path


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The apibinding reconciler listed ALL bindings and then filtered by cluster. Obviously, this can be done through the informer indexer.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```