### PR TITLE
:bug: virtual/authorization: shallow copy of RBAC objects

### DIFF
--- a/pkg/virtual/framework/wrappers/rbac/merging.go
+++ b/pkg/virtual/framework/wrappers/rbac/merging.go
@@ -45,9 +45,9 @@ func (l mergedClusterRoleBindingLister) List(selector labels.Selector) (ret []*r
 		}
 
 		for i := range list {
-			entry := list[i].DeepCopy()
-			entry.Name = logicalcluster.From(entry).String() + ":" + entry.GetName()
-			result = append(result, entry)
+			cpy := *list[i]
+			cpy.Name = logicalcluster.From(&cpy).String() + ":" + cpy.Name
+			result = append(result, &cpy)
 		}
 	}
 	return result, nil
@@ -194,9 +194,9 @@ func (l *mergedRoleBindingLister) List(selector labels.Selector) (ret []*rbacv1.
 		}
 
 		for i := range list {
-			entry := list[i].DeepCopy()
-			entry.Name = logicalcluster.From(entry).String() + ":" + entry.GetName()
-			result = append(result, entry)
+			cpy := *list[i]
+			cpy.Name = logicalcluster.From(&cpy).String() + ":" + cpy.Name
+			result = append(result, &cpy)
 		}
 	}
 	return result, nil
@@ -229,9 +229,9 @@ func (l mergedRoleBindingNamespaceLister) List(selector labels.Selector) (ret []
 		}
 
 		for i := range list {
-			entry := list[i].DeepCopy()
-			entry.Name = logicalcluster.From(entry).String() + ":" + entry.GetName()
-			result = append(result, entry)
+			cpy := *list[i]
+			cpy.Name = logicalcluster.From(&cpy).String() + ":" + cpy.Name
+			result = append(result, &cpy)
 		}
 	}
 	return result, nil


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

No need to deep-copy for changing the name. This switches to shallow copies in virtual workspace authorization hot path.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Optimize authorization in virtual workspaces.
```