### PR TITLE
:bug: virtual/apiexport: don't keep recreating APIBindings storage

### DIFF
--- a/pkg/virtual/apiexport/controllers/apireconciler/apiexport_apireconciler_reconcile.go
+++ b/pkg/virtual/apiexport/controllers/apireconciler/apiexport_apireconciler_reconcile.go
@@ -242,6 +242,7 @@ func (c *APIReconciler) reconcile(ctx context.Context, apiExport *apisv1alpha1.A
 		}
 	}
 
+	// always serve apibindings, either through a claim, or with this fallback
 	if !claimsAPIBindings {
 		d, err := c.createAPIBindingAPIDefinition(ctx, clusterName, apiExport.Name)
 		if err != nil {
@@ -254,6 +255,9 @@ func (c *APIReconciler) reconcile(ctx context.Context, apiExport *apisv1alpha1.A
 			APIDefinition: d,
 		}
 		newGVRs = append(newGVRs, gvrString(gvr))
+		if _, ok := oldSet[gvr]; ok {
+			preservedGVR = append(preservedGVR, gvrString(gvr))
+		}
 	}
 
 	// cleanup old definitions


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The fallback code to always serve APIBindings in the apiexport virtual workspace lacked logic to preserve the old storage. So on any other change or resync, the APIBinding storage was recretaed.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```