### PR TITLE
🐛 Fix 'make install' to respect plugin go module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,8 +131,9 @@ build-all:
 install: WHAT ?= ./cmd/... ./cli/cmd/...
 install: require-jq require-go require-git verify-go-versions ## Install the project
 	set -x; for W in $(WHAT); do \
-  		W=$$(echo "$${W}" | sed 's,^\./,github.com/kcp-dev/kcp/,') && \
-  		GOOS=$(OS) GOARCH=$(ARCH) CGO_ENABLED=0 go install -ldflags="$(LDFLAGS)" $${W}; \
+		pushd . && cd $${W%..}; \
+  		GOOS=$(OS) GOARCH=$(ARCH) CGO_ENABLED=0 go install -ldflags="$(LDFLAGS)" ./...; \
+		popd; \
   	done
 .PHONY: install
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Now that plugins have their own go module, the Makefile must change to that module's directory before running go commands on that module.  Currently, `make install` does not do this and therefore plugins don't get installed as expected.

This PR updates `make install` following the pattern of `make build` to fix this.

Before this PR, notice the last line `go: warning: "github.com/kcp-dev/kcp/cli/cmd/..." matched no packages`, and the plugins don't get installed in `$GOPATH/bin`:
```
$ make install
hack/verify-go-versions.sh
set -x; for W in ./cmd/... ./cli/cmd/...; do \
  		W=$(echo "${W}" | sed 's,^\./,github.com/kcp-dev/kcp/,') && \
  		GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go install -ldflags="-X k8s.io/client-go/pkg/version.gitCommit=c1ff50b3 -X k8s.io/client-go/pkg/version.gitTreeState=clean -X k8s.io/client-go/pkg/version.gitVersion=v1.30.3+kcp-v0.20.0-391-gc1ff50b3671d5d -X k8s.io/client-go/pkg/version.gitMajor=1 -X k8s.io/client-go/pkg/version.gitMinor=30 -X k8s.io/client-go/pkg/version.buildDate=2024-09-20T14:42:59Z -X k8s.io/component-base/version.gitCommit=c1ff50b3 -X k8s.io/component-base/version.gitTreeState=clean -X k8s.io/component-base/version.gitVersion=v1.30.3+kcp-v0.20.0-391-gc1ff50b3671d5d -X k8s.io/component-base/version.gitMajor=1 -X k8s.io/component-base/version.gitMinor=30 -X k8s.io/component-base/version.buildDate=2024-09-20T14:42:59Z -extldflags '-static'" ${W}; \
  	done
+ for W in ./cmd/... ./cli/cmd/...
++ echo ./cmd/...
++ sed 's,^\./,github.com/kcp-dev/kcp/,'
+ W=github.com/kcp-dev/kcp/cmd/...
+ GOOS=darwin
+ GOARCH=arm64
+ CGO_ENABLED=0
+ go install '-ldflags=-X k8s.io/client-go/pkg/version.gitCommit=c1ff50b3 -X k8s.io/client-go/pkg/version.gitTreeState=clean -X k8s.io/client-go/pkg/version.gitVersion=v1.30.3+kcp-v0.20.0-391-gc1ff50b3671d5d -X k8s.io/client-go/pkg/version.gitMajor=1 -X k8s.io/client-go/pkg/version.gitMinor=30 -X k8s.io/client-go/pkg/version.buildDate=2024-09-20T14:42:59Z -X k8s.io/component-base/version.gitCommit=c1ff50b3 -X k8s.io/component-base/version.gitTreeState=clean -X k8s.io/component-base/version.gitVersion=v1.30.3+kcp-v0.20.0-391-gc1ff50b3671d5d -X k8s.io/component-base/version.gitMajor=1 -X k8s.io/component-base/version.gitMinor=30 -X k8s.io/component-base/version.buildDate=2024-09-20T14:42:59Z -extldflags '\''-static'\''' github.com/kcp-dev/kcp/cmd/...
+ for W in ./cmd/... ./cli/cmd/...
++ echo ./cli/cmd/...
++ sed 's,^\./,github.com/kcp-dev/kcp/,'
+ W=github.com/kcp-dev/kcp/cli/cmd/...
+ GOOS=darwin
+ GOARCH=arm64
+ CGO_ENABLED=0
+ go install '-ldflags=-X k8s.io/client-go/pkg/version.gitCommit=c1ff50b3 -X k8s.io/client-go/pkg/version.gitTreeState=clean -X k8s.io/client-go/pkg/version.gitVersion=v1.30.3+kcp-v0.20.0-391-gc1ff50b3671d5d -X k8s.io/client-go/pkg/version.gitMajor=1 -X k8s.io/client-go/pkg/version.gitMinor=30 -X k8s.io/client-go/pkg/version.buildDate=2024-09-20T14:42:59Z -X k8s.io/component-base/version.gitCommit=c1ff50b3 -X k8s.io/component-base/version.gitTreeState=clean -X k8s.io/component-base/version.gitVersion=v1.30.3+kcp-v0.20.0-391-gc1ff50b3671d5d -X k8s.io/component-base/version.gitMajor=1 -X k8s.io/component-base/version.gitMinor=30 -X k8s.io/component-base/version.buildDate=2024-09-20T14:42:59Z -extldflags '\''-static'\''' github.com/kcp-dev/kcp/cli/cmd/...
go: warning: "github.com/kcp-dev/kcp/cli/cmd/..." matched no packages
```

With this PR the plugins (as well as the other binaries) get properly installed in `$GOPATH/bin`:
```
$ find $GOPATH/bin -cmin -5
/Users/kmarc/go/bin
/Users/kmarc/go/bin/compat
/Users/kmarc/go/bin/sharded-test-server
/Users/kmarc/go/bin/kubectl-kcp
/Users/kmarc/go/bin/kubectl-create-workspace
/Users/kmarc/go/bin/virtual-workspaces
/Users/kmarc/go/bin/kubectl-ws
/Users/kmarc/go/bin/kcp-front-proxy
/Users/kmarc/go/bin/test-server
/Users/kmarc/go/bin/cache-server
/Users/kmarc/go/bin/kcp
/Users/kmarc/go/bin/crd-puller
```

## Related issue(s)

Fixes # N/A

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
