### PR TITLE
🌱 go 1.22.7

### DIFF
--- a/.github/workflows/docs-gen-and-push.yaml
+++ b/.github/workflows/docs-gen-and-push.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: v1.22.5
+          go-version: v1.22.7
           cache: true
 
       - uses: actions/setup-python@v5

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -22,7 +22,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-go@v5
       with:
-        go-version: v1.22.5
+        go-version: v1.22.7
     - name: Delete non-semver tags
       run: 'git tag -d $(git tag -l | grep -v "^v")'
     - name: Set LDFLAGS

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.22.5-1
+        - image: ghcr.io/kcp-dev/infra/build:1.22.7-1
           command:
             - make
             - verify-boilerplate
@@ -27,7 +27,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.22.5-1
+        - image: ghcr.io/kcp-dev/infra/build:1.22.7-1
           command:
             - make
             - verify-codegen
@@ -44,7 +44,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.22.5-1
+        - image: ghcr.io/kcp-dev/infra/build:1.22.7-1
           command:
             - make
             - lint
@@ -83,7 +83,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.22.5-1
+        - image: ghcr.io/kcp-dev/infra/build:1.22.7-1
           command:
             - make
             - test
@@ -104,7 +104,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.22.5-1
+        - image: ghcr.io/kcp-dev/infra/build:1.22.7-1
           command:
             - ./hack/run-with-prometheus.sh
             - make
@@ -132,7 +132,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.22.5-1
+        - image: ghcr.io/kcp-dev/infra/build:1.22.7-1
           command:
             - ./hack/run-with-prometheus.sh
             - make
@@ -162,7 +162,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.22.5-1
+        - image: ghcr.io/kcp-dev/infra/build:1.22.7-1
           command:
             - ./hack/run-with-prometheus.sh
             - make
@@ -188,7 +188,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.22.5-1
+        - image: ghcr.io/kcp-dev/infra/build:1.22.7-1
           command:
             - ./hack/run-with-prometheus.sh
             - make

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Build the binary
-FROM --platform=${BUILDPLATFORM} docker.io/golang:1.22.5 AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/golang:1.22.7 AS builder
 WORKDIR /workspace
 
 # Install dependencies.


### PR DESCRIPTION
## Summary

Update to go 1.22.7. This is needed to get rid of vulnerability scan results for CVE-2024-34156.

## Related issue(s)

Depends on kcp-dev/infra#73

## Release Notes

```release-note
NONE
```
