### PR TITLE
:seedling: Remove redundand imports

### DIFF
--- a/pkg/metadata/dynamic.go
+++ b/pkg/metadata/dynamic.go
@@ -23,7 +23,7 @@ import (
 
 	kcpdynamic "github.com/kcp-dev/client-go/dynamic"
 
-	dynamic "k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 
 	"github.com/kcp-dev/kcp/pkg/server/requestinfo"

--- a/pkg/proxy/config.go
+++ b/pkg/proxy/config.go
@@ -27,7 +27,7 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	proxyoptions "github.com/kcp-dev/kcp/pkg/proxy/options"
-	bootstrap "github.com/kcp-dev/kcp/pkg/server/bootstrap"
+	"github.com/kcp-dev/kcp/pkg/server/bootstrap"
 )
 
 type Config struct {

--- a/pkg/reconciler/tenancy/replicateclusterrolebinding/replicateclusterrolebinding_controller.go
+++ b/pkg/reconciler/tenancy/replicateclusterrolebinding/replicateclusterrolebinding_controller.go
@@ -24,7 +24,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 
 	"github.com/kcp-dev/kcp/pkg/reconciler/cache/labelclusterrolebindings"
-	replicateclusterrole "github.com/kcp-dev/kcp/pkg/reconciler/tenancy/replicateclusterrole"
+	"github.com/kcp-dev/kcp/pkg/reconciler/tenancy/replicateclusterrole"
 	"github.com/kcp-dev/kcp/sdk/apis/tenancy"
 )
 

--- a/pkg/reconciler/tenancy/workspacemounts/workspacemounts_controller.go
+++ b/pkg/reconciler/tenancy/workspacemounts/workspacemounts_controller.go
@@ -41,7 +41,7 @@ import (
 	"github.com/kcp-dev/kcp/pkg/logging"
 	"github.com/kcp-dev/kcp/pkg/reconciler/committer"
 	"github.com/kcp-dev/kcp/pkg/reconciler/events"
-	tenancy "github.com/kcp-dev/kcp/sdk/apis/tenancy"
+	"github.com/kcp-dev/kcp/sdk/apis/tenancy"
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/tenancy/v1alpha1"
 	kcpclientset "github.com/kcp-dev/kcp/sdk/client/clientset/versioned/cluster"
 	tenancyv1alpha1client "github.com/kcp-dev/kcp/sdk/client/clientset/versioned/typed/tenancy/v1alpha1"

--- a/pkg/virtual/apiexport/authorizer/maximal_permission_policy_test.go
+++ b/pkg/virtual/apiexport/authorizer/maximal_permission_policy_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	logicalcluster "github.com/kcp-dev/logicalcluster/v3"
+	"github.com/kcp-dev/logicalcluster/v3"
 	"github.com/stretchr/testify/require"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/sdk/apis/core/install/install.go
+++ b/sdk/apis/core/install/install.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
-	v1alpha1 "github.com/kcp-dev/kcp/sdk/apis/core/v1alpha1"
+	"github.com/kcp-dev/kcp/sdk/apis/core/v1alpha1"
 )
 
 // Install registers the API group and adds types to a scheme


### PR DESCRIPTION
Aliases equal to the names of the imported packages have no effect and the package name can be used directly

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
