### PR TITLE
:sparkles:  Add workspace phase update logic

### DIFF
--- a/config/crds/core.kcp.io_logicalclusters.yaml
+++ b/config/crds/core.kcp.io_logicalclusters.yaml
@@ -195,6 +195,7 @@ spec:
                 - Scheduling
                 - Initializing
                 - Ready
+                - Unavailable
                 type: string
             type: object
         type: object

--- a/config/crds/tenancy.kcp.io_workspaces.yaml
+++ b/config/crds/tenancy.kcp.io_workspaces.yaml
@@ -251,6 +251,7 @@ spec:
                 - Scheduling
                 - Initializing
                 - Ready
+                - Unavailable
                 type: string
             type: object
         required:

--- a/config/root-phase0/apiexport-tenancy.kcp.io.yaml
+++ b/config/root-phase0/apiexport-tenancy.kcp.io.yaml
@@ -5,8 +5,8 @@ metadata:
   name: tenancy.kcp.io
 spec:
   latestResourceSchemas:
-  - v240903-d6797056a.workspaces.tenancy.kcp.io
   - v240903-d6797056a.workspacetypes.tenancy.kcp.io
+  - v241020-fce06d31d.workspaces.tenancy.kcp.io
   maximalPermissionPolicy:
     local: {}
 status: {}

--- a/config/root-phase0/apiresourceschema-logicalclusters.core.kcp.io.yaml
+++ b/config/root-phase0/apiresourceschema-logicalclusters.core.kcp.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v240903-d6797056a.logicalclusters.core.kcp.io
+  name: v241020-fce06d31d.logicalclusters.core.kcp.io
 spec:
   group: core.kcp.io
   names:
@@ -193,6 +193,7 @@ spec:
               - Scheduling
               - Initializing
               - Ready
+              - Unavailable
               type: string
           type: object
       type: object

--- a/config/root-phase0/apiresourceschema-workspaces.tenancy.kcp.io.yaml
+++ b/config/root-phase0/apiresourceschema-workspaces.tenancy.kcp.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v240903-d6797056a.workspaces.tenancy.kcp.io
+  name: v241020-fce06d31d.workspaces.tenancy.kcp.io
 spec:
   group: tenancy.kcp.io
   names:
@@ -249,6 +249,7 @@ spec:
               - Scheduling
               - Initializing
               - Ready
+              - Unavailable
               type: string
           type: object
       required:

--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -81,6 +81,12 @@ func (c *State) UpsertWorkspace(shard string, ws *tenancyv1alpha1.Workspace) {
 	if ws.Status.Phase == corev1alpha1.LogicalClusterPhaseScheduling {
 		return
 	}
+	// If the workspace is unavailable, we should delete it from the index,
+	// as it is not usable.
+	if ws.Status.Phase == corev1alpha1.LogicalClusterPhaseUnavailable {
+		c.DeleteWorkspace(shard, ws)
+		return
+	}
 	clusterName := logicalcluster.From(ws)
 
 	c.lock.RLock()

--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -39,6 +39,10 @@ type Result struct {
 	Shard string
 	// Cluster canonical path
 	Cluster logicalcluster.Name
+
+	// ErrorCode is the HTTP error code to return for the request.
+	// If this is set, the URL and Shard fields are ignored.
+	ErrorCode int
 }
 
 // PathRewriter can rewrite a logical cluster path before the actual mapping through
@@ -55,9 +59,13 @@ func New(rewriters []PathRewriter) *State {
 		shardClusterParentCluster: map[string]map[logicalcluster.Name]logicalcluster.Name{},
 		shardBaseURLs:             map[string]string{},
 		// Experimental feature: allow mounts to be used with Workspaces
-		// structure: (clusterName, workspace name) -> string serialized mount objects
+		// structure: (shard, logical cluster, workspace name) -> string serialized mount objects
 		// This should be simplified once we promote this to workspace structure.
-		clusterWorkspaceMountAnnotation: map[logicalcluster.Name]map[string]string{},
+		shardClusterWorkspaceMountAnnotation: map[string]map[logicalcluster.Name]map[string]string{},
+
+		// shardClusterWorkspaceNameErrorCode is a map of shar,logical cluster, workspace to error code when we want to return an error code
+		// instead of a URL.
+		shardClusterWorkspaceNameErrorCode: map[string]map[logicalcluster.Name]map[string]int{},
 	}
 }
 
@@ -74,36 +82,38 @@ type State struct {
 	shardClusterParentCluster map[string]map[logicalcluster.Name]logicalcluster.Name            // (shard name, logical cluster) -> parent logical cluster
 	shardBaseURLs             map[string]string                                                 // shard name -> base URL
 	// Experimental feature: allow mounts to be used with Workspaces
-	clusterWorkspaceMountAnnotation map[logicalcluster.Name]map[string]string // (clusterName, workspace name) -> mount object string
+	shardClusterWorkspaceMountAnnotation map[string]map[logicalcluster.Name]map[string]string // (shard name, logical cluster, workspace name) -> mount object string
+
+	shardClusterWorkspaceNameErrorCode map[string]map[logicalcluster.Name]map[string]int // (shard name, logical cluster, workspace name) -> error code
 }
 
 func (c *State) UpsertWorkspace(shard string, ws *tenancyv1alpha1.Workspace) {
 	if ws.Status.Phase == corev1alpha1.LogicalClusterPhaseScheduling {
 		return
 	}
-	// If the workspace is unavailable, we should delete it from the index,
-	// as it is not usable.
-	if ws.Status.Phase == corev1alpha1.LogicalClusterPhaseUnavailable {
-		c.DeleteWorkspace(shard, ws)
-		return
-	}
+
 	clusterName := logicalcluster.From(ws)
-
-	c.lock.RLock()
-	cluster := c.shardWorkspaceNameCluster[shard][clusterName][ws.Name]
-	mountObjString := c.clusterWorkspaceMountAnnotation[clusterName][ws.Name] // experimental feature
-	c.lock.RUnlock()
-
-	// TODO(mjudeikis): we are allowing upsert in 2 cases:
-	// 1. cluster name is different
-	// 2. mount object string is different (updated, added, or removed)
-	// When we promote this to workspace structure, we should make this check smarter and better tested.
-	if (cluster.String() == ws.Spec.Cluster) && (ws.Annotations[tenancyv1alpha1.ExperimentalWorkspaceMountAnnotationKey] != "" && mountObjString == ws.Annotations[tenancyv1alpha1.ExperimentalWorkspaceMountAnnotationKey]) {
-		return
-	}
 
 	c.lock.Lock()
 	defer c.lock.Unlock()
+
+	// If the workspace is unavailable, we set custom error code for it. And add it to the index as normal.
+	// TODO(mjudeikis): Once we have one more case - move to a separate function.
+	if ws.Status.Phase == corev1alpha1.LogicalClusterPhaseUnavailable {
+		if c.shardClusterWorkspaceNameErrorCode[shard] == nil {
+			c.shardClusterWorkspaceNameErrorCode[shard] = map[logicalcluster.Name]map[string]int{}
+		}
+		if c.shardClusterWorkspaceNameErrorCode[shard][logicalcluster.Name(ws.Spec.Cluster)] == nil {
+			c.shardClusterWorkspaceNameErrorCode[shard][logicalcluster.Name(ws.Spec.Cluster)] = map[string]int{}
+		}
+		// Unavailable workspaces should return 503
+		c.shardClusterWorkspaceNameErrorCode[shard][logicalcluster.Name(ws.Spec.Cluster)][ws.Name] = 503
+	} else {
+		delete(c.shardClusterWorkspaceNameErrorCode[shard][logicalcluster.Name(ws.Spec.Cluster)], ws.Name)
+		if len(c.shardClusterWorkspaceNameErrorCode[shard][logicalcluster.Name(ws.Spec.Cluster)]) == 0 {
+			delete(c.shardClusterWorkspaceNameErrorCode[shard], logicalcluster.Name(ws.Spec.Cluster))
+		}
+	}
 
 	if cluster := c.shardWorkspaceNameCluster[shard][clusterName][ws.Name]; cluster.String() != ws.Spec.Cluster {
 		if c.shardWorkspaceNameCluster[shard] == nil {
@@ -119,11 +129,14 @@ func (c *State) UpsertWorkspace(shard string, ws *tenancyv1alpha1.Workspace) {
 		c.shardClusterParentCluster[shard][logicalcluster.Name(ws.Spec.Cluster)] = clusterName
 	}
 
-	if mountObjString := c.clusterWorkspaceMountAnnotation[clusterName][ws.Name]; mountObjString != ws.Annotations[tenancyv1alpha1.ExperimentalWorkspaceMountAnnotationKey] {
-		if c.clusterWorkspaceMountAnnotation[clusterName] == nil {
-			c.clusterWorkspaceMountAnnotation[clusterName] = map[string]string{}
+	if mountObjString := c.shardClusterWorkspaceMountAnnotation[shard][clusterName][ws.Name]; mountObjString != ws.Annotations[tenancyv1alpha1.ExperimentalWorkspaceMountAnnotationKey] {
+		if c.shardClusterWorkspaceMountAnnotation[shard] == nil {
+			c.shardClusterWorkspaceMountAnnotation[shard] = map[logicalcluster.Name]map[string]string{}
 		}
-		c.clusterWorkspaceMountAnnotation[clusterName][ws.Name] = ws.Annotations[tenancyv1alpha1.ExperimentalWorkspaceMountAnnotationKey]
+		if c.shardClusterWorkspaceMountAnnotation[shard][clusterName] == nil {
+			c.shardClusterWorkspaceMountAnnotation[shard][clusterName] = map[string]string{}
+		}
+		c.shardClusterWorkspaceMountAnnotation[shard][clusterName][ws.Name] = ws.Annotations[tenancyv1alpha1.ExperimentalWorkspaceMountAnnotationKey]
 	}
 }
 
@@ -132,7 +145,7 @@ func (c *State) DeleteWorkspace(shard string, ws *tenancyv1alpha1.Workspace) {
 
 	c.lock.RLock()
 	_, foundCluster := c.shardWorkspaceNameCluster[shard][clusterName][ws.Name]
-	_, foundMount := c.clusterWorkspaceMountAnnotation[clusterName][ws.Name]
+	_, foundMount := c.shardClusterWorkspaceMountAnnotation[shard][clusterName][ws.Name]
 	c.lock.RUnlock()
 
 	if !foundCluster && !foundMount {
@@ -162,11 +175,15 @@ func (c *State) DeleteWorkspace(shard string, ws *tenancyv1alpha1.Workspace) {
 		}
 	}
 
-	if _, foundMount = c.clusterWorkspaceMountAnnotation[clusterName][ws.Name]; foundMount {
-		delete(c.clusterWorkspaceMountAnnotation[clusterName], ws.Name)
-		if len(c.clusterWorkspaceMountAnnotation[clusterName]) == 0 {
-			delete(c.clusterWorkspaceMountAnnotation, clusterName)
+	if _, foundMount = c.shardClusterWorkspaceMountAnnotation[shard][clusterName][ws.Name]; foundMount {
+		delete(c.shardClusterWorkspaceMountAnnotation[shard][clusterName], ws.Name)
+		if len(c.shardClusterWorkspaceMountAnnotation[shard][clusterName]) == 0 {
+			delete(c.shardClusterWorkspaceMountAnnotation[shard], clusterName)
 		}
+	}
+	delete(c.shardClusterWorkspaceNameErrorCode[shard][clusterName], ws.Name)
+	if len(c.shardClusterWorkspaceNameErrorCode[shard][clusterName]) == 0 {
+		delete(c.shardClusterWorkspaceNameErrorCode[shard], clusterName)
 	}
 }
 
@@ -225,6 +242,7 @@ func (c *State) DeleteShard(shardName string) {
 	delete(c.shardBaseURLs, shardName)
 	delete(c.shardWorkspaceName, shardName)
 	delete(c.shardClusterParentCluster, shardName)
+	delete(c.shardClusterWorkspaceNameErrorCode, shardName)
 }
 
 func (c *State) Lookup(path logicalcluster.Path) (Result, bool) {
@@ -239,6 +257,7 @@ func (c *State) Lookup(path logicalcluster.Path) (Result, bool) {
 
 	var shard string
 	var cluster logicalcluster.Name
+	var errorCode int
 
 	// walk through index graph to find the final logical cluster and shard
 	for i, s := range segments {
@@ -253,7 +272,7 @@ func (c *State) Lookup(path logicalcluster.Path) (Result, bool) {
 		}
 
 		// check mounts, if found return url and true
-		val, foundMount := c.clusterWorkspaceMountAnnotation[cluster][s] // experimental feature
+		val, foundMount := c.shardClusterWorkspaceMountAnnotation[shard][cluster][s] // experimental feature
 		if foundMount {
 			mount, err := tenancyv1alpha1.ParseTenancyMountAnnotation(val)
 			if !(err != nil || mount == nil || mount.MountStatus.URL == "") {
@@ -275,14 +294,21 @@ func (c *State) Lookup(path logicalcluster.Path) (Result, bool) {
 		if !found {
 			return Result{}, false
 		}
+		ec, found := c.shardClusterWorkspaceNameErrorCode[shard][cluster][s]
+		if found {
+			errorCode = ec
+		}
 	}
-	return Result{Shard: shard, Cluster: cluster}, true
+	return Result{Shard: shard, Cluster: cluster, ErrorCode: errorCode}, true
 }
 
 func (c *State) LookupURL(path logicalcluster.Path) (Result, bool) {
 	result, found := c.Lookup(path)
 	if !found {
 		return Result{}, false
+	}
+	if result.ErrorCode != 0 {
+		return result, true
 	}
 
 	if result.URL != "" && result.Shard == "" && result.Cluster == "" {

--- a/pkg/proxy/handler.go
+++ b/pkg/proxy/handler.go
@@ -56,7 +56,11 @@ func shardHandler(index index.Index, proxy http.Handler) http.HandlerFunc {
 			return
 		}
 
-		shardURLString, found := index.LookupURL(clusterPath)
+		shardURLString, found, errCode := index.LookupURL(clusterPath)
+		if errCode != 0 {
+			http.Error(w, "Not available.", errCode)
+			return
+		}
 		if !found {
 			logger.WithValues("clusterPath", clusterPath).V(4).Info("Unknown cluster path")
 			responsewriters.Forbidden(req.Context(), attributes, w, req, kcpauthorization.WorkspaceAccessNotPermittedReason, kubernetesscheme.Codecs)

--- a/pkg/proxy/index/index_controller.go
+++ b/pkg/proxy/index/index_controller.go
@@ -49,7 +49,7 @@ const (
 )
 
 type Index interface {
-	LookupURL(path logicalcluster.Path) (url string, found bool)
+	LookupURL(path logicalcluster.Path) (url string, found bool, errorCode int)
 }
 
 type ClusterClientGetter func(shard *corev1alpha1.Shard) (kcpclientset.ClusterInterface, error)
@@ -291,7 +291,10 @@ func (c *Controller) stopShard(shardName string) {
 	delete(c.shardLogicalClusterInformers, shardName)
 }
 
-func (c *Controller) LookupURL(path logicalcluster.Path) (url string, found bool) {
+func (c *Controller) LookupURL(path logicalcluster.Path) (url string, found bool, errorCode int) {
 	r, found := c.state.LookupURL(path)
-	return r.URL, found
+	if found && r.ErrorCode != 0 {
+		return r.URL, found, r.ErrorCode
+	}
+	return r.URL, found, 0
 }

--- a/pkg/reconciler/tenancy/workspace/README.md
+++ b/pkg/reconciler/tenancy/workspace/README.md
@@ -1,0 +1,9 @@
+# Workspace Controller
+
+The workspace controller is root controller for the workspace.
+It is responsible for (in calling order):
+
+- `Metadata` - updates workspace metadata in annotations.
+- `Delete` the workspace if it is in the `Deleting` phase and LogicalCluster finalizer is removed.
+- `Scheduling` - picks the shard and schedules the workspace on the shard. Creates logical cluster for it.
+- `Phase` - updates workspace phase based on the conditions of the workspace and LogicalCluster.

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_phase.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_phase.go
@@ -18,10 +18,12 @@ package workspace
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/kcp-dev/logicalcluster/v3"
 
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
 
@@ -74,7 +76,15 @@ func (r *phaseReconciler) reconcile(ctx context.Context, workspace *tenancyv1alp
 		workspace.Status.Phase = corev1alpha1.LogicalClusterPhaseReady
 		conditions.MarkTrue(workspace, tenancyv1alpha1.WorkspaceInitialized)
 
+	case corev1alpha1.LogicalClusterPhaseUnavailable:
+		if checkConditionAndSetPhase(workspace) {
+			return reconcileStatusStopAndRequeue, nil
+		}
+		return reconcileStatusContinue, nil
+
 	case corev1alpha1.LogicalClusterPhaseReady:
+		// On delete we need to wait for the logical cluster to be deleted
+		// before we can mark the workspace as deleted.
 		if !workspace.DeletionTimestamp.IsZero() {
 			logger = logger.WithValues("cluster", workspace.Spec.Cluster)
 
@@ -106,7 +116,33 @@ func (r *phaseReconciler) reconcile(ctx context.Context, workspace *tenancyv1alp
 			logger.Info("workspace content is deleted")
 			return reconcileStatusContinue, nil
 		}
+		logger.Info("workspace is ready, checking conditions", "conditions", workspace.Status.Conditions)
+		// if workspace is ready, we check if it suppose to be ready by checking conditions.
+		if checkConditionAndSetPhase(workspace) {
+			return reconcileStatusStopAndRequeue, nil
+		}
 	}
 
 	return reconcileStatusContinue, nil
+}
+
+// checkConditionAndSetPhase checks if the workspace is ready by checking conditions and sets the phase accordingly.
+// It returns true if the phase was changed, false otherwise.
+func checkConditionAndSetPhase(workspace *tenancyv1alpha1.Workspace) bool {
+	var notReady bool
+	for _, c := range workspace.Status.Conditions {
+		if c.Status == v1.ConditionFalse && strings.HasPrefix(string(c.Type), "Workspace") {
+			notReady = true
+			break
+		}
+	}
+	if notReady && workspace.Status.Phase != corev1alpha1.LogicalClusterPhaseUnavailable {
+		workspace.Status.Phase = corev1alpha1.LogicalClusterPhaseUnavailable
+		return true
+	}
+	if !notReady && workspace.Status.Phase != corev1alpha1.LogicalClusterPhaseReady {
+		workspace.Status.Phase = corev1alpha1.LogicalClusterPhaseReady
+		return true
+	}
+	return false
 }

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_phase.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_phase.go
@@ -77,7 +77,7 @@ func (r *phaseReconciler) reconcile(ctx context.Context, workspace *tenancyv1alp
 		conditions.MarkTrue(workspace, tenancyv1alpha1.WorkspaceInitialized)
 
 	case corev1alpha1.LogicalClusterPhaseUnavailable:
-		if updateTerminalConditionsAndPhase(workspace) {
+		if updateTerminalConditionPhase(workspace) {
 			return reconcileStatusStopAndRequeue, nil
 		}
 		return reconcileStatusContinue, nil
@@ -118,7 +118,7 @@ func (r *phaseReconciler) reconcile(ctx context.Context, workspace *tenancyv1alp
 		}
 
 		// if workspace is ready, we check if it suppose to be ready by checking conditions.
-		if updateTerminalConditionsAndPhase(workspace) {
+		if updateTerminalConditionPhase(workspace) {
 			logger.Info("workspace phase changed", "status", workspace.Status)
 			return reconcileStatusStopAndRequeue, nil
 		}
@@ -127,9 +127,9 @@ func (r *phaseReconciler) reconcile(ctx context.Context, workspace *tenancyv1alp
 	return reconcileStatusContinue, nil
 }
 
-// updateTerminalConditionsAndPhase checks if the workspace is ready by checking conditions and sets the phase accordingly.
+// updateTerminalConditionPhase checks if the workspace is ready by checking conditions and sets the phase accordingly.
 // It returns true if the phase was changed, false otherwise.
-func updateTerminalConditionsAndPhase(workspace *tenancyv1alpha1.Workspace) bool {
+func updateTerminalConditionPhase(workspace *tenancyv1alpha1.Workspace) bool {
 	var notReady bool
 	for _, c := range workspace.Status.Conditions {
 		if c.Status == v1.ConditionFalse && strings.HasPrefix(string(c.Type), "Workspace") {

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_phase_test.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_phase_test.go
@@ -1,0 +1,255 @@
+/*
+Copyright 2024 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workspace
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	corev1alpha1 "github.com/kcp-dev/kcp/sdk/apis/core/v1alpha1"
+	tenancyv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/tenancy/v1alpha1"
+	conditionsv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/third_party/conditions/apis/conditions/v1alpha1"
+)
+
+func TestReconcilePhase(t *testing.T) {
+	for _, testCase := range []struct {
+		name              string
+		input             *tenancyv1alpha1.Workspace
+		getLogicalCluster func(ctx context.Context, cluster logicalcluster.Path) (*corev1alpha1.LogicalCluster, error)
+
+		wantPhase     corev1alpha1.LogicalClusterPhaseType
+		wantStatus    reconcileStatus
+		wantCondition conditionsv1alpha1.Condition
+	}{
+		{
+			name: "workspace is scheduling but not yet initialized",
+			input: &tenancyv1alpha1.Workspace{
+				Status: tenancyv1alpha1.WorkspaceStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseScheduling,
+				},
+			},
+			wantPhase:  corev1alpha1.LogicalClusterPhaseScheduling,
+			wantStatus: reconcileStatusContinue,
+			wantCondition: conditionsv1alpha1.Condition{
+				Type:   tenancyv1alpha1.WorkspaceInitialized,
+				Status: corev1.ConditionFalse,
+			},
+		},
+		{
+			name: "workspace is scheduled and moved to initializing",
+			input: &tenancyv1alpha1.Workspace{
+				Spec: tenancyv1alpha1.WorkspaceSpec{
+					URL:     "http://example.com",
+					Cluster: "cluster-1",
+				},
+				Status: tenancyv1alpha1.WorkspaceStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseScheduling,
+				},
+			},
+			wantPhase:  corev1alpha1.LogicalClusterPhaseInitializing,
+			wantStatus: reconcileStatusContinue,
+		},
+		{
+			name: "workspace is initializing and logical cluster is not found",
+			input: &tenancyv1alpha1.Workspace{
+				Spec: tenancyv1alpha1.WorkspaceSpec{
+					URL:     "http://example.com",
+					Cluster: "cluster-1",
+				},
+				Status: tenancyv1alpha1.WorkspaceStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseInitializing,
+				},
+			},
+			getLogicalCluster: func(ctx context.Context, cluster logicalcluster.Path) (*corev1alpha1.LogicalCluster, error) {
+				return nil, apierrors.NewNotFound(corev1alpha1.Resource("logicalcluster"), "cluster-1")
+			},
+			wantPhase:  corev1alpha1.LogicalClusterPhaseInitializing,
+			wantStatus: reconcileStatusContinue,
+		},
+		{
+			name: "workspace is initializing and logicalCluster not yet initialized",
+			input: &tenancyv1alpha1.Workspace{
+				Spec: tenancyv1alpha1.WorkspaceSpec{
+					URL:     "http://example.com",
+					Cluster: "cluster-1",
+				},
+				Status: tenancyv1alpha1.WorkspaceStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseInitializing,
+				},
+			},
+			getLogicalCluster: func(ctx context.Context, cluster logicalcluster.Path) (*corev1alpha1.LogicalCluster, error) {
+				return &corev1alpha1.LogicalCluster{
+					Status: corev1alpha1.LogicalClusterStatus{
+						Initializers: []corev1alpha1.LogicalClusterInitializer{
+							"initializer-1",
+						},
+					},
+				}, nil
+			},
+			wantPhase:  corev1alpha1.LogicalClusterPhaseInitializing,
+			wantStatus: reconcileStatusContinue,
+		},
+		{
+			name: "workspace is initializing and logicalCluster initialized",
+			input: &tenancyv1alpha1.Workspace{
+				Spec: tenancyv1alpha1.WorkspaceSpec{
+					URL:     "http://example.com",
+					Cluster: "cluster-1",
+				},
+				Status: tenancyv1alpha1.WorkspaceStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseInitializing,
+				},
+			},
+			getLogicalCluster: func(ctx context.Context, cluster logicalcluster.Path) (*corev1alpha1.LogicalCluster, error) {
+				return &corev1alpha1.LogicalCluster{
+					Status: corev1alpha1.LogicalClusterStatus{
+						Initializers: []corev1alpha1.LogicalClusterInitializer{},
+					},
+				}, nil
+			},
+			wantPhase:  corev1alpha1.LogicalClusterPhaseReady,
+			wantStatus: reconcileStatusContinue,
+		},
+		{
+			name: "workspace is ready - no-op",
+			input: &tenancyv1alpha1.Workspace{
+				Spec: tenancyv1alpha1.WorkspaceSpec{
+					URL:     "http://example.com",
+					Cluster: "cluster-1",
+				},
+				Status: tenancyv1alpha1.WorkspaceStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseReady,
+				},
+			},
+			getLogicalCluster: func(ctx context.Context, cluster logicalcluster.Path) (*corev1alpha1.LogicalCluster, error) {
+				return &corev1alpha1.LogicalCluster{
+					Status: corev1alpha1.LogicalClusterStatus{
+						Initializers: []corev1alpha1.LogicalClusterInitializer{},
+					},
+				}, nil
+			},
+			wantPhase:  corev1alpha1.LogicalClusterPhaseReady,
+			wantStatus: reconcileStatusContinue,
+		},
+		{
+			name: "workspace is ready - but condition is not ready",
+			input: &tenancyv1alpha1.Workspace{
+				Spec: tenancyv1alpha1.WorkspaceSpec{
+					URL:     "http://example.com",
+					Cluster: "cluster-1",
+				},
+				Status: tenancyv1alpha1.WorkspaceStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseReady,
+					Conditions: []conditionsv1alpha1.Condition{
+						{
+							Type:   tenancyv1alpha1.MountConditionReady,
+							Status: corev1.ConditionFalse,
+						},
+					},
+				},
+			},
+			getLogicalCluster: func(ctx context.Context, cluster logicalcluster.Path) (*corev1alpha1.LogicalCluster, error) {
+				return &corev1alpha1.LogicalCluster{
+					Status: corev1alpha1.LogicalClusterStatus{
+						Initializers: []corev1alpha1.LogicalClusterInitializer{},
+					},
+				}, nil
+			},
+			wantPhase:  corev1alpha1.LogicalClusterPhaseUnavailable,
+			wantStatus: reconcileStatusStopAndRequeue,
+		},
+		{
+			name: "workspace is no ready - but condition is ready",
+			input: &tenancyv1alpha1.Workspace{
+				Spec: tenancyv1alpha1.WorkspaceSpec{
+					URL:     "http://example.com",
+					Cluster: "cluster-1",
+				},
+				Status: tenancyv1alpha1.WorkspaceStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseUnavailable,
+					Conditions: []conditionsv1alpha1.Condition{
+						{
+							Type:   tenancyv1alpha1.MountConditionReady,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+			getLogicalCluster: func(ctx context.Context, cluster logicalcluster.Path) (*corev1alpha1.LogicalCluster, error) {
+				return &corev1alpha1.LogicalCluster{
+					Status: corev1alpha1.LogicalClusterStatus{
+						Initializers: []corev1alpha1.LogicalClusterInitializer{},
+					},
+				}, nil
+			},
+			wantPhase:  corev1alpha1.LogicalClusterPhaseReady,
+			wantStatus: reconcileStatusStopAndRequeue,
+		},
+		{
+			name: "non blocking condition is not ready",
+			input: &tenancyv1alpha1.Workspace{
+				Spec: tenancyv1alpha1.WorkspaceSpec{
+					URL:     "http://example.com",
+					Cluster: "cluster-1",
+				},
+				Status: tenancyv1alpha1.WorkspaceStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseUnavailable,
+					Conditions: []conditionsv1alpha1.Condition{
+						{
+							Type:   conditionsv1alpha1.ConditionType("UpdateIsNeeded"),
+							Status: corev1.ConditionFalse,
+						},
+					},
+				},
+			},
+			getLogicalCluster: func(ctx context.Context, cluster logicalcluster.Path) (*corev1alpha1.LogicalCluster, error) {
+				return &corev1alpha1.LogicalCluster{
+					Status: corev1alpha1.LogicalClusterStatus{
+						Initializers: []corev1alpha1.LogicalClusterInitializer{},
+					},
+				}, nil
+			},
+			wantPhase:  corev1alpha1.LogicalClusterPhaseReady,
+			wantStatus: reconcileStatusStopAndRequeue,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			reconciler := phaseReconciler{
+				getLogicalCluster: testCase.getLogicalCluster,
+				requeueAfter:      func(workspace *tenancyv1alpha1.Workspace, after time.Duration) {},
+			}
+			status, err := reconciler.reconcile(context.Background(), testCase.input)
+
+			require.NoError(t, err)
+			require.Equal(t, testCase.wantStatus, status)
+			require.Equal(t, testCase.wantPhase, testCase.input.Status.Phase)
+
+			for _, condition := range testCase.input.Status.Conditions {
+				if condition.Type == testCase.wantCondition.Type {
+					require.Equal(t, testCase.wantCondition, condition)
+				}
+			}
+		})
+	}
+}

--- a/pkg/server/localproxy.go
+++ b/pkg/server/localproxy.go
@@ -137,6 +137,12 @@ func WithLocalProxy(
 
 		// lookup in our local, potentially partial index
 		r, found := indexState.Lookup(path)
+		if found && r.ErrorCode != 0 {
+			// return code if set.
+			// TODO(mjudeikis): Would be nice to have a way to return a custom error message.
+			http.Error(w, "Not available.", r.ErrorCode)
+			return
+		}
 		if found && r.Shard != shardName && r.URL == "" {
 			logger.WithValues("cluster", cluster.Name, "requestedShard", r.Shard, "actualShard", shardName).Info("cluster is not on this shard, but on another")
 

--- a/sdk/apis/core/v1alpha1/logicalcluster_types.go
+++ b/sdk/apis/core/v1alpha1/logicalcluster_types.go
@@ -59,13 +59,17 @@ const (
 
 // LogicalClusterPhaseType is the type of the current phase of the logical cluster.
 //
-// +kubebuilder:validation:Enum=Scheduling;Initializing;Ready
+// +kubebuilder:validation:Enum=Scheduling;Initializing;Ready;Unavailable
 type LogicalClusterPhaseType string
 
 const (
 	LogicalClusterPhaseScheduling   LogicalClusterPhaseType = "Scheduling"
 	LogicalClusterPhaseInitializing LogicalClusterPhaseType = "Initializing"
 	LogicalClusterPhaseReady        LogicalClusterPhaseType = "Ready"
+	// LogicalClusterPhaseUnavailable phase is used to indicate that the logical cluster us unavailable to be used.
+	// It will will not be served via front-proxy when in this state.
+	// Possible state transitions are from Ready to Unavailable and from Unavailable to Ready.
+	LogicalClusterPhaseUnavailable LogicalClusterPhaseType = "Unavailable"
 )
 
 // LogicalClusterInitializer is a unique string corresponding to a logical cluster

--- a/sdk/apis/core/v1alpha1/logicalcluster_types.go
+++ b/sdk/apis/core/v1alpha1/logicalcluster_types.go
@@ -66,9 +66,11 @@ const (
 	LogicalClusterPhaseScheduling   LogicalClusterPhaseType = "Scheduling"
 	LogicalClusterPhaseInitializing LogicalClusterPhaseType = "Initializing"
 	LogicalClusterPhaseReady        LogicalClusterPhaseType = "Ready"
-	// LogicalClusterPhaseUnavailable phase is used to indicate that the logical cluster us unavailable to be used.
+	// LogicalClusterPhaseUnavailable phase is used to indicate that the logical cluster is unavailable to be used.
 	// It will will not be served via front-proxy when in this state.
 	// Possible state transitions are from Ready to Unavailable and from Unavailable to Ready.
+	// This should be used when we really can't serve the logical cluster content and not some
+	// temporary flakes, like readiness probe failing.
 	LogicalClusterPhaseUnavailable LogicalClusterPhaseType = "Unavailable"
 )
 

--- a/sdk/apis/tenancy/v1alpha1/types_mounts.go
+++ b/sdk/apis/tenancy/v1alpha1/types_mounts.go
@@ -44,9 +44,6 @@ const (
 const (
 	// MountConditionReady is the condition type for MountReady.
 	MountConditionReady conditionsv1alpha1.ConditionType = "WorkspaceMountReady"
-
-	// MountNotReady is reason when the mount is not ready.
-	MountReasonNotReady = "WorkspaceMountNotReady"
 )
 
 // Mount is a workspace mount that can be used to mount a workspace into another workspace or resource.

--- a/sdk/apis/tenancy/v1alpha1/types_mounts.go
+++ b/sdk/apis/tenancy/v1alpha1/types_mounts.go
@@ -41,6 +41,14 @@ const (
 	MountPhaseUnknown MountPhaseType = "Unknown"
 )
 
+const (
+	// MountConditionReady is the condition type for MountReady.
+	MountConditionReady conditionsv1alpha1.ConditionType = "WorkspaceMountReady"
+
+	// MountNotReady is reason when the mount is not ready.
+	MountReasonNotReady = "WorkspaceMountNotReady"
+)
+
 // Mount is a workspace mount that can be used to mount a workspace into another workspace or resource.
 // Mounting itself is done at front proxy level.
 type Mount struct {

--- a/test/e2e/mounts/apiresourceschema_kubecluster.yaml
+++ b/test/e2e/mounts/apiresourceschema_kubecluster.yaml
@@ -1,0 +1,144 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  name: kubeclusters.contrib.kcp.io
+spec:
+  group: contrib.kcp.io
+  names:
+    kind: KubeCluster
+    listKind: KubeClusterList
+    plural: kubeclusters
+    singular: kubecluster
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="KubeClusterReady")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KubeCluster describes the current KubeCluster proxy object.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KubeClusterSpec is the specification of the Kube cluster
+              proxy resource.
+            properties:
+              workspaceURL:
+                description: workspaceURL is the address under which the workspace
+                  can be found.
+                type: string
+            type: object
+          status:
+            description: KubeClusterStatus communicates the observed state of the
+              Kube cluster proxy.
+            properties:
+              URL:
+                description: |-
+                  url is the address under which the Kubernetes-cluster-like endpoint
+                  can be found. This URL can be used to access the cluster with standard Kubernetes
+                  client libraries and command line tools via proxy.
+                type: string
+              conditions:
+                description: Current processing state of the Cluster proxy.
+                items:
+                  description: Condition defines an observation of a object operational
+                    state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastProxyHeartbeatTime:
+                description: A timestamp indicating when the proxy last reported status.
+                format: date-time
+                type: string
+              phase:
+                default: Initializing
+                description: Phase of the cluster proxy (Initializing, Ready).
+                enum:
+                - Initializing
+                - Connecting
+                - Ready
+                - Unknown
+                type: string
+              tunnelWorkspaces:
+                description: |-
+                  TunnelWorkspaces contains all URLs (one per shard) that is being used
+                  by the proxy to connect to the tunnel for a given shard.
+                items:
+                  properties:
+                    url:
+                      description: |-
+                        url is the URL the Proxy should use to connect
+                        to the Proxy tunnel for a given shard.
+                      minLength: 1
+                      type: string
+                  required:
+                  - url
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/test/e2e/mounts/kubecluster_mounts.yaml
+++ b/test/e2e/mounts/kubecluster_mounts.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: contrib.kcp.io/v1alpha1
+kind: KubeCluster
+metadata:
+  name: proxy-cluster
+spec:

--- a/test/e2e/mounts/mounts_machinery_test.go
+++ b/test/e2e/mounts/mounts_machinery_test.go
@@ -204,6 +204,8 @@ func TestMountsMachinery(t *testing.T) {
 	require.NoError(t, err)
 
 	// Workspace access should not with denied.
-	_, err = kcpClusterClient.Cluster(mountPath).ApisV1alpha1().APIExports().List(ctx, metav1.ListOptions{})
-	require.Error(t, err)
+	err = wait.PollUntilContextCancel(ctx, 100*time.Millisecond, true, func(ctx context.Context) (bool, error) {
+		_, err = kcpClusterClient.Cluster(mountPath).ApisV1alpha1().APIExports().List(ctx, metav1.ListOptions{})
+		return err != nil, nil
+	})
 }

--- a/test/e2e/mounts/mounts_machinery_test.go
+++ b/test/e2e/mounts/mounts_machinery_test.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package homeworkspaces
+
+import (
+	"context"
+	"embed"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	kcpapiextensionsv1client "github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1"
+	kcpdynamic "github.com/kcp-dev/client-go/dynamic"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	crdhelpers "k8s.io/apiextensions-apiserver/pkg/apihelpers"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/restmapper"
+
+	"github.com/kcp-dev/kcp/config/helpers"
+	corev1alpha1 "github.com/kcp-dev/kcp/sdk/apis/core/v1alpha1"
+	tenancyv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/tenancy/v1alpha1"
+	kcpclientset "github.com/kcp-dev/kcp/sdk/client/clientset/versioned/cluster"
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+)
+
+//go:embed *.yaml
+var testFiles embed.FS
+
+func TestMountsMachinery(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "control-plane")
+
+	tokenAuthFile := framework.WriteTokenAuthFile(t)
+	serverArgs := framework.TestServerArgsWithTokenAuthFile(tokenAuthFile)
+	serverArgs = append(serverArgs, "--feature-gates=WorkspaceMounts=true")
+
+	server := framework.PrivateKcpServer(t, framework.WithCustomArguments(serverArgs...))
+
+	fmt.Println(server.KubeconfigPath())
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	t.Cleanup(cancelFunc)
+
+	orgPath, _ := framework.NewOrganizationFixture(t, server)
+
+	workspaceName := "mounts-machinery"
+	mountPath, _ := framework.NewWorkspaceFixture(t, server, orgPath, framework.WithName(workspaceName))
+
+	cfg := server.BaseConfig(t)
+	kcpClusterClient, err := kcpclientset.NewForConfig(cfg)
+	require.NoError(t, err, "error creating kcp cluster client")
+
+	dynamicClusterClient, err := kcpdynamic.NewForConfig(cfg)
+	require.NoError(t, err, "error creating dynamic cluster client")
+
+	extensionsClusterClient, err := kcpapiextensionsv1client.NewForConfig(cfg)
+	require.NoError(t, err, "error creating apiextensions cluster client")
+
+	orgProviderKCPClient, err := kcpclientset.NewForConfig(cfg)
+	require.NoError(t, err, "error creating cowboys provider kcp client")
+
+	t.Logf("Install a mount object APIResourceSchema into workspace %q", orgPath)
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(orgProviderKCPClient.Cluster(orgPath).Discovery()))
+	err = helpers.CreateResourceFromFS(ctx, dynamicClusterClient.Cluster(orgPath), mapper, nil, "apiresourceschema_kubecluster.yaml", testFiles)
+	require.NoError(t, err)
+
+	t.Logf("waiting for CRD to be established")
+	var lastMsg string
+	name := "kubeclusters.contrib.kcp.io"
+	err = wait.PollUntilContextCancel(ctx, 100*time.Millisecond, true, func(ctx context.Context) (bool, error) {
+		crd, err := extensionsClusterClient.Cluster(orgPath).CustomResourceDefinitions().Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, fmt.Errorf("CRD %s was deleted before being established", name)
+			}
+			return false, fmt.Errorf("error fetching CRD %s: %w", name, err)
+		}
+		var reason string
+		condition := crdhelpers.FindCRDCondition(crd, apiextensionsv1.Established)
+		if condition == nil {
+			reason = fmt.Sprintf("CRD has no %s condition", apiextensionsv1.Established)
+		} else {
+			reason = fmt.Sprintf("CRD is not established: %s: %s", condition.Reason, condition.Message)
+		}
+		if reason != lastMsg {
+			lastMsg = reason
+		}
+		t.Log(reason)
+		return crdhelpers.IsCRDConditionTrue(crd, apiextensionsv1.Established), nil
+	})
+	require.NoError(t, err)
+
+	t.Logf("Install a mount object into workspace %q", orgPath)
+	mapper2 := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(orgProviderKCPClient.Cluster(orgPath).Discovery()))
+	err = helpers.CreateResourceFromFS(ctx, dynamicClusterClient.Cluster(orgPath), mapper2, nil, "kubecluster_mounts.yaml", testFiles)
+	require.NoError(t, err)
+
+	// At this point we have object backing the mount object. So lets add mount annotation to the workspace.
+	t.Logf("Install a mount annotation into workspace %q", orgPath)
+	current, err := kcpClusterClient.Cluster(orgPath).TenancyV1alpha1().Workspaces().Get(ctx, workspaceName, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	mount := tenancyv1alpha1.Mount{
+		MountSpec: tenancyv1alpha1.MountSpec{
+			Reference: &corev1.ObjectReference{
+				APIVersion: "contrib.kcp.io/v1alpha1",
+				Kind:       "KubeCluster",
+				Name:       "proxy-cluster", // must match name in kubecluster_mounts.yaml
+			},
+		},
+	}
+	data, err := json.Marshal(mount)
+	require.NoError(t, err)
+
+	current.Annotations[tenancyv1alpha1.ExperimentalWorkspaceMountAnnotationKey] = string(data)
+
+	_, err = kcpClusterClient.Cluster(orgPath).TenancyV1alpha1().Workspaces().Update(ctx, current, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	mountGVR := schema.GroupVersionResource{
+		Group:    "contrib.kcp.io",
+		Version:  "v1alpha1",
+		Resource: "kubeclusters",
+	}
+	currentMount, err := dynamicClusterClient.Cluster(orgPath).Resource(mountGVR).Namespace("").Get(ctx, "proxy-cluster", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	currentMount.Object["status"] = map[string]interface{}{
+		"conditions": []interface{}{
+			map[string]interface{}{
+				"lastTransitionTime": "2024-10-19T12:30:47Z",
+				"message":            "The agent sent a heartbeat",
+				"reason":             "AgentReady",
+				"status":             "True",
+				"type":               "WorkspaceClusterReady",
+			},
+		},
+		"phase": "Ready",
+	}
+
+	_, err = dynamicClusterClient.Cluster(orgPath).Resource(mountGVR).Namespace("").UpdateStatus(ctx, currentMount, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// Workspace should have 2 conditions now, and be in Ready state
+	err = wait.PollUntilContextCancel(ctx, 100*time.Millisecond, true, func(ctx context.Context) (bool, error) {
+		current, err := kcpClusterClient.Cluster(orgPath).TenancyV1alpha1().Workspaces().Get(ctx, workspaceName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		if len(current.Status.Conditions) != 2 {
+			return false, nil
+		}
+		var failed bool
+		for _, condition := range current.Status.Conditions {
+			if condition.Status != corev1.ConditionTrue {
+				failed = true
+			}
+		}
+		return !failed, nil
+	})
+	require.NoError(t, err)
+
+	// Workspace access should work.
+	_, err = kcpClusterClient.Cluster(mountPath).ApisV1alpha1().APIExports().List(ctx, metav1.ListOptions{})
+	require.NoError(t, err)
+
+	// set mount to not ready and verify workspace is not ready
+	currentMount, err = dynamicClusterClient.Cluster(orgPath).Resource(mountGVR).Namespace("").Get(ctx, "proxy-cluster", metav1.GetOptions{})
+	require.NoError(t, err)
+	currentMount.Object["status"].(map[string]interface{})["phase"] = "Connecting"
+	_, err = dynamicClusterClient.Cluster(orgPath).Resource(mountGVR).Namespace("").UpdateStatus(ctx, currentMount, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	err = wait.PollUntilContextCancel(ctx, 100*time.Millisecond, true, func(ctx context.Context) (bool, error) {
+		current, err := kcpClusterClient.Cluster(orgPath).TenancyV1alpha1().Workspaces().Get(ctx, workspaceName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		return current.Status.Phase == corev1alpha1.LogicalClusterPhaseUnavailable, nil
+	})
+	require.NoError(t, err)
+
+	// Workspace access should not with denied.
+	_, err = kcpClusterClient.Cluster(mountPath).ApisV1alpha1().APIExports().List(ctx, metav1.ListOptions{})
+	require.Error(t, err)
+}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Add a reconciler to switch workspaces phase to "Unavailable" if any workspace conditions are not ready.
This way, if some of the auxiliary conditions are `Unavailable`, the phase will change.

Adds mounts controller to propagate status to the workspace when mount is not ready. This way we don't use the workspace at all if the mount is not responding. 

Adds code to index/proxy to not serve workspaces which are in `Unavailable` state, so we avoid using workspaces with errorous backends. 

partially based on https://github.com/kcp-dev/enhancements/pull/6 

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Add workspace phase reporter reconciler 
Add the Unavailable phase to the API
Implement exclusion of Unavailable workspaces from serving via proxy to avoid serving something which is not supposed to be served. 
```
