### PR TITLE
:book: Fix wrong 'labels' key in adopters issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/adopters.yaml
+++ b/.github/ISSUE_TEMPLATE/adopters.yaml
@@ -32,7 +32,7 @@ body:
   - type: dropdown
     id: maturity
     attributes:
-      labels: Maturity Stage
+      label: Maturity Stage
       description: What stage are you at in your adoption of kcp?
       multiple: false
       options:


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

I added an adopters form in #3159 but missed a typo in the GitHub issue template.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
