### PR TITLE
:bug: Terminate kcp process if controller installation fails

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -678,7 +678,7 @@ loop:
 						if len(s.controllers) == 0 {
 							if err = s.installControllers(ctx, controllerConfig, gvrs); err != nil {
 								logger.Error(err, "error in re-registering controllers")
-								return
+								klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 							}
 						}
 						s.startControllers(leaderElectionCtx)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

As per discussions on Slack (https://kubernetes.slack.com/archives/C021U8WSAFK/p1730131234224829), it makes sense to let the kcp process crash when it wins a leader election but then fails to install controllers. If this happens, it might hold onto the leader election lock but no controllers are actually running to reconcile objects. By making it crash, we make a new leader election possible.

The leader election package unfortunately doesn't have a "native" way to handle such failures.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Purposefully crash if leader election was won but controllers failed to install, allowing another instance to take leadership
```
