### PR TITLE
✨ Enable webhook authorization options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,10 @@ GOLANGCI_LINT_VER := v1.62.2
 GOLANGCI_LINT_BIN := golangci-lint
 GOLANGCI_LINT := $(TOOLS_GOBIN_DIR)/$(GOLANGCI_LINT_BIN)-$(GOLANGCI_LINT_VER)
 
+HTTEST_VER := v0.3.2
+HTTEST_BIN := httest
+HTTEST := $(TOOLS_GOBIN_DIR)/$(HTTEST_BIN)-$(HTTEST_VER)
+
 GOTESTSUM_VER := v1.8.1
 GOTESTSUM_BIN := gotestsum
 GOTESTSUM := $(abspath $(TOOLS_DIR))/$(GOTESTSUM_BIN)-$(GOTESTSUM_VER)
@@ -136,6 +140,9 @@ install: require-jq require-go require-git verify-go-versions ## Install the pro
 $(GOLANGCI_LINT):
 	GOBIN=$(TOOLS_GOBIN_DIR) $(GO_INSTALL) github.com/golangci/golangci-lint/cmd/golangci-lint $(GOLANGCI_LINT_BIN) $(GOLANGCI_LINT_VER)
 
+$(HTTEST):
+	GOBIN=$(TOOLS_GOBIN_DIR) $(GO_INSTALL) go.xrstf.de/httest $(HTTEST_BIN) $(HTTEST_VER)
+
 $(LOGCHECK):
 	GOBIN=$(TOOLS_GOBIN_DIR) $(GO_INSTALL) sigs.k8s.io/logtools/logcheck $(LOGCHECK_BIN) $(LOGCHECK_VER)
 
@@ -183,7 +190,7 @@ vendor: ## Vendor the dependencies
 	go mod vendor
 .PHONY: vendor
 
-tools: $(GOLANGCI_LINT) $(CONTROLLER_GEN) $(KCP_APIGEN_GEN) $(YAML_PATCH) $(GOTESTSUM) $(OPENSHIFT_GOIMPORTS) $(CODE_GENERATOR) ## Install tools
+tools: $(GOLANGCI_LINT) $(HTTEST) $(CONTROLLER_GEN) $(KCP_APIGEN_GEN) $(YAML_PATCH) $(GOTESTSUM) $(OPENSHIFT_GOIMPORTS) $(CODE_GENERATOR) ## Install tools
 .PHONY: tools
 
 $(CONTROLLER_GEN):
@@ -269,6 +276,7 @@ endif
 ifdef USE_GOTESTSUM
 test-e2e: $(GOTESTSUM)
 endif
+test-e2e: $(HTTEST)
 test-e2e: TEST_ARGS ?=
 test-e2e: WHAT ?= ./test/e2e...
 test-e2e: build-all ## Run e2e tests
@@ -280,6 +288,7 @@ test-e2e: build-all ## Run e2e tests
 ifdef USE_GOTESTSUM
 test-e2e-shared-minimal: $(GOTESTSUM)
 endif
+test-e2e-shared-minimal: $(HTTEST)
 test-e2e-shared-minimal: TEST_ARGS ?=
 test-e2e-shared-minimal: WHAT ?= ./test/e2e...
 test-e2e-shared-minimal: WORK_DIR ?= .
@@ -305,6 +314,7 @@ test-e2e-shared-minimal: build-all
 ifdef USE_GOTESTSUM
 test-e2e-sharded-minimal: $(GOTESTSUM)
 endif
+test-e2e-sharded-minimal: $(HTTEST)
 test-e2e-sharded-minimal: TEST_ARGS ?=
 test-e2e-sharded-minimal: WHAT ?= ./test/e2e...
 test-e2e-sharded-minimal: WORK_DIR ?= .

--- a/cmd/kcp/kcp.go
+++ b/cmd/kcp/kcp.go
@@ -78,8 +78,8 @@ func main() {
 		}
 	}
 
-	serverOptions := options.NewOptions(rootDir)
-	serverOptions.Server.GenericControlPlane.Logs.Verbosity = logsapiv1.VerbosityLevel(2)
+	kcpOptions := options.NewOptions(rootDir)
+	kcpOptions.Server.GenericControlPlane.Logs.Verbosity = logsapiv1.VerbosityLevel(2)
 
 	startCmd := &cobra.Command{
 		Use:   "start",
@@ -101,30 +101,30 @@ func main() {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// run as early as possible to avoid races later when some components (e.g. grpc) start early using klog
-			if err := logsapiv1.ValidateAndApply(serverOptions.Server.GenericControlPlane.Logs, kcpfeatures.DefaultFeatureGate); err != nil {
+			if err := logsapiv1.ValidateAndApply(kcpOptions.Server.GenericControlPlane.Logs, kcpfeatures.DefaultFeatureGate); err != nil {
 				return err
 			}
 
-			completed, err := serverOptions.Complete()
+			completedKcpOptions, err := kcpOptions.Complete()
 			if err != nil {
 				return err
 			}
 
-			if errs := completed.Validate(); len(errs) > 0 {
+			if errs := completedKcpOptions.Validate(); len(errs) > 0 {
 				return errors.NewAggregate(errs)
 			}
 
 			logger := klog.FromContext(cmd.Context())
-			logger.Info("running with selected batteries", "batteries", strings.Join(completed.Server.Extra.BatteriesIncluded, ","))
+			logger.Info("running with selected batteries", "batteries", strings.Join(completedKcpOptions.Server.Extra.BatteriesIncluded, ","))
 
 			ctx := genericapiserver.SetupSignalContext()
 
-			serverConfig, err := server.NewConfig(ctx, completed.Server)
+			serverConfig, err := server.NewConfig(ctx, completedKcpOptions.Server)
 			if err != nil {
 				return err
 			}
 
-			completedConfig, err := config.Complete()
+			completedConfig, err := serverConfig.Complete()
 			if err != nil {
 				return err
 			}
@@ -146,7 +146,7 @@ func main() {
 
 	// add start named flag sets to start flags
 	fss := cliflag.NamedFlagSets{}
-	serverOptions.AddFlags(&fss)
+	kcpOptions.AddFlags(&fss)
 	globalflag.AddGlobalFlags(fss.FlagSet("global"), cmd.Name(), logs.SkipLoggingConfigurationFlags())
 	startFlags := startCmd.Flags()
 	for _, f := range fss.FlagSets {

--- a/cmd/kcp/kcp.go
+++ b/cmd/kcp/kcp.go
@@ -117,7 +117,9 @@ func main() {
 			logger := klog.FromContext(cmd.Context())
 			logger.Info("running with selected batteries", "batteries", strings.Join(completed.Server.Extra.BatteriesIncluded, ","))
 
-			config, err := server.NewConfig(completed.Server)
+			ctx := genericapiserver.SetupSignalContext()
+
+			serverConfig, err := server.NewConfig(ctx, completed.Server)
 			if err != nil {
 				return err
 			}
@@ -126,8 +128,6 @@ func main() {
 			if err != nil {
 				return err
 			}
-
-			ctx := genericapiserver.SetupSignalContext()
 
 			// the etcd server must be up before NewServer because storage decorators access it right away
 			if completedConfig.EmbeddedEtcd.Config != nil {

--- a/docs/content/concepts/authorization/authorizers.md
+++ b/docs/content/concepts/authorization/authorizers.md
@@ -5,46 +5,89 @@ description: >
 
 # Authorizers
 
-The following authorizers are configured in kcp:
+In kcp, a request has four different ways of being admitted:
 
-| Authorizer                             | Description                                                                       |
-|----------------------------------------|-----------------------------------------------------------------------------------|
-| Top-Level organization authorizer      | checks that the user is allowed to access the organization                        |
-| Workspace content authorizer           | determines additional groups a user gets inside of a workspace                    |
-| Maximal permission policy authorizer   | validates the maximal permission policy RBAC policy in the API exporter workspace |
-| Local Policy authorizer                | validates the RBAC policy in the workspace that is accessed                       |
-| Kubernetes Bootstrap Policy authorizer | validates the RBAC Kubernetes standard policy                                     |
+* It can be made to one of the preconfigured paths that do not require authorization, like `/healthz`.
+* It can be performed by a user in one of the configured always-allow groups, by default `system:masters`.
+* It can pass through the RBAC chain and match configured Roles and ClusterRoles.
+* It can be permitted by an external HTTPS webhook backend.
 
 They are related in the following way:
 
-1. top-level organization authorizer must allow
-2. workspace content authorizer must allow, and adds additional (virtual per-request) groups to the request user influencing the follow authorizers.
-3. maximal permission policy authorizer must allow
-4. one of the local authorizer or bootstrap policy authorizer must allow.
+``` mermaid
+graph TD
+    start(Request):::state --> main_alt[/one of\]:::or
+    main_alt --> aapa[Always Allow Paths Auth]
+    main_alt --> aaga[Always Allow Groups Auth]
+    main_alt --> wa[Webhook Auth]
+    main_alt --> rga[Required Groups Auth]
 
+    aapa --> decision(Decision):::state
+    aaga --> decision
+    wa --> decision
+
+    subgraph "RBAC"
+    rga --> wca[Workspace Content Auth]
+    wca --> scrda[System CRD Auth]
+    scrda --> mppa[Max. Permission Policy Auth]
+
+    mppa --- mppa_alt[/one of\]:::or
+    mppa_alt --> lpa[Local Policy Auth]
+    mppa_alt --> gpa[Global Policy Auth]
+    mppa_alt --> bpa[Bootstrap Policy Auth]
+    end
+
+    lpa --> decision
+    gpa --> decision
+    bpa --> decision
+
+    classDef state color:#F77
+    classDef or fill:none,stroke:none
 ```
-                                                                                 ┌──────────────┐
-                                                                                 │              │
-                                                                           ┌────►│ Local Policy ├──┐
-          ┌──────────────┐     ┌──────────────┐    ┌───────────────────┐   │     │ authorizer   │  │
- request  │  Workspace   │     │  Required    │    │ Max. Permission   │   │     │              │  │
-─────────►│  Content     ├────►│  Groups      ├────┤ Policy authorizer ├───┤     └──────────────┘  │
-          │  Authorizer  │     │  Authorizer  │    │                   │   │                       ▼
-          └──────────────┘     └──────────────┘    └───────────────────┘   │                       OR───►
-                                                                           │     ┌──────────────┐  ▲
-                                                                           │     │  Bootstrap   │  │
-                                                                           └────►│  Policy      ├──┘
-                                                                                 │  authorizer  │
-                                                                                 │              │
-                                                                                 └──────────────┘
-```
 
-[ASCIIFlow document](https://asciiflow.com/#/share/eJyrVspLzE1VslLydg5QcCwtycgvyqxKLVLSUcpJrATSVkrVMUoVMUpWhgYGBjoxSpVAppGlGZBVklpRAuTEKClQGzya0vNoSgPRaEJMTB4N3NCEIUBde9B9OW0XyE6f%2FOTEHIWA%2FJzM5EqgkjnYPfloyh6SENmaSNWDaQQsIEF0Ijx9wSSgoVqUWliaWlwCtk9BITy%2FKLu4IDE5VQEqAKODgMoyi1JTFBASIMo3sUJPISC1KDezuDgzPw8uiWw1ZuRCrMbnflCMAM1xzs8rSc0rwRqGUCXuRfmlBcW44gYWnUjeB0vAI38JVOMUUpL9DMw0CXaLI1Igo4QeFgmYPJbgwQw1hPy0PUM9NWIC%2FyDkrEjtrA5LiKQVbKCg3kQrpwBpp%2Fz8kuKSosQCBZQ8QVXrUNM0pJCDZQioEnghN4NmJXkiStqnsieR7EEToI09pBUTMUq1SrUA%2FWv8Mg%3D%3D)
+[View graph on Kroki](https://kroki.io/mermaid/svg/eNqFkkFrwzAMhe_7Faa7dLBux0IOg7ZhvWxQusEOWRmKoyambuTZDln__RQnG02bUp-E3mfx9OzcginEe3wj-DgP1o_X-F2h83dRFHHDo5hMnsQeVPkF2iePVKKg7eeGZbLh2p8WQAADyUzXcHBipjXVYgW-4LryxWYIz0_wpaXKXORrSD4wLYh2lwjLA5sVlMWsPyywjb_AZSiVU1SO4674X7jj8j4XuvVJr42tSvMQ42g9ny1GoWe727Vkw2R3zoBEsaDSY-mPrLMeOCdtBsnbwXnci8U6PkKC1D6C4Wxf4edBrNDulWssiBVpJQ_HKzYY85NQXHy0TguDNc99IQm6P-2My5lbakqvgimDcyLvPAdzzmKZtVa1GQg5H2qmZih6qcG5GLei_amSNNno9nk67atkxVZpHZWcwz17oh2G-he4ue-L)
 
+### Always Allow Paths Authorizer
 
-### Workspace Content Authorizer
+Like in vanilla Kubernetes, this authorizer always grants access to the configured URL paths. This is
+used for the health and liveness checks of kcp.
 
-The workspace content authorizer checks whether the user is granted access to the workspace. 
+### Always Allow Groups Authorizer
+
+This authorizer always permits access if the user is in one of the configured groups. By default this
+only includes the `system:masters` group.
+
+### RBAC Chain
+
+The primary authorization flow is handled by a sequence of RBAC-based authorizers that a request must
+satisfy all in order to be granted access.
+
+The following authorizers work together to implement RBAC in kcp:
+
+| Authorizer                             | Description                                                                                |
+|----------------------------------------|--------------------------------------------------------------------------------------------|
+| Workspace content authorizer           | validates that the user has `access` permission to the workspace                           |
+| Required groups authorizer             | validates that the user is in the annotation-based list of groups required for a workspace |
+| System CRD authorizer             | prevents undesired updates to certain core resources, like the status subresource on APIBindings |
+| Maximal permission policy authorizer   | validates the maximal permission policy RBAC policy in the API exporter workspace          |
+| Local Policy authorizer                | validates the RBAC policy in the workspace that is accessed                                |
+| Global Policy authorizer               | validates the RBAC policy in the workspace that is accessed across shards                  |
+| Kubernetes Bootstrap Policy authorizer | validates the RBAC Kubernetes standard policy                                              |
+
+#### Required Groups Authorizer
+
+A `authorization.kcp.io/required-groups` annotation can be added to a LogicalCluster
+to specify additional groups that are required to access a workspace for a user to be member of.
+The syntax is a disjunction (separator `,`) of conjunctions (separator `;`).
+
+For example, `<group1>;<group2>,<group3>` means that a user must be member of `<group1>` AND `<group2>`, OR of `<group3>`.
+
+The annotation is copied onto sub-workspaces during workspace creation, but is then not updated
+automatically if it's changed.
+
+#### Workspace Content Authorizer
+
+The workspace content authorizer checks whether the user is granted access to the workspace.
 Access is granted access through `verb=access` non-resource permission to `/` inside of the workspace.
 
 The ClusterRole `system:kcp:workspace:access` is pre-defined which makes it easy
@@ -86,39 +129,30 @@ A service-account defined in a workspace implicitly is granted access to it.
 
 A service-account defined in a different workspace is NOT given access to it.
 
-### Required Groups Authorizer
+!!! note
+    By default, workspaces are only accessible to a user if they are in `Ready` phase. Workspaces that are initializing
+    can be accessed only by users that are granted `admin` verb on the `workspaces/content` resource in the
+    parent workspace.
 
-A `authorization.kcp.io/required-groups` annotation can be added to a LogicalCluster 
-to specify additional groups that are required to access a workspace for a user to be member of. 
-The syntax is a disjunction (separator `,`) of conjunctions (separator `;`).
+    Service accounts declared within a workspace don't have access to initializing workspaces.
 
-For example, `<group1>;<group2>,<group3>` means that a user must be member of `<group1>` AND `<group2>`, OR of `<group3>`.
+#### System CRD Authorizer
 
-The annotation is copied onto sub-workspaces during scheduling.
+This small authorizer simply prevents updates to the `status` subresource on APIExports or APIBindings. Note that this authorizer does not validate changes to the CustomResourceDefitions themselves, but to objects from those CRDs instead.
 
-#### Initializing Workspaces
-
-By default, workspaces are only accessible to a user if they are in `Ready` phase. Workspaces that are initializing
-can be access only by users that are granted `admin` verb on the `workspaces/content` resource in the
-parent workspace.
-
-Service accounts declared within a workspace don't have access to initializing workspaces.
-
-### Maximal Permission Policy Authorizer
+#### Maximal Permission Policy Authorizer
 
 If the requested resource type is part of an API binding, then this authorizer verifies that
 the request is not exceeding the maximum permission policy of the related API export.
 Currently, the "local policy" maximum permission policy type is supported.
 
-#### Local Policy
+##### Local Policy
 
 The local maximum permission policy delegates the decision to the RBAC of the related API export.
 To distinguish between local RBAC role bindings in that workspace and those for this these maximum permission policy,
 every name and group is prefixed with `apis.kcp.io:binding:`.
 
-Example:
-
-Given an API binding for type `foo` declared in workspace `consumer` that refers to an API export declared in workspace `provider`
+**Example:** Given an APIBinding for type `foo` declared in workspace `consumer` that refers to an APIExport declared in workspace `provider`
 and a user `user-1` having the group `group-1` requesting a `create` of `foo` in the `default` namespace in the `consumer` workspace,
 this authorizer verifies that `user-1` is allowed to execute this request by delegating to `provider`'s RBAC using prefixed attributes.
 
@@ -128,13 +162,13 @@ Using prefixed attributes prevents RBAC collisions i.e. if `user-1` is granted t
 For the given example RBAC request looks as follows:
 
 - Username: `apis.kcp.io:binding:user-1`
-- Group: `apis.kcp.io:binding:group-1`
+- Groups: [`apis.kcp.io:binding:group-1`]
 - Resource: `foo`
 - Namespace: `default`
 - Workspace: `provider`
 - Verb: `create`
 
-The following role and role binding declared within the `provider` workspace will grant access to the request:
+The following Role and RoleBinding declared within the `provider` workspace will grant access to the request:
 
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -166,32 +200,81 @@ roleRef:
 ```
 
 !!! note
-    The same authorization scheme is enforced when executing the request of a claimed resource via the virtual API Export API server,
+    The same authorization scheme is enforced when executing the request of a claimed resource via the virtual APIExport API server,
     i.e. a claimed resource is bound to the same maximal permission policy. Only the actual owner of that resources can go beyond that policy.
 
 TBD: Example
 
-### Kubernetes Bootstrap Policy Authorizer
-
-The bootstrap policy authorizer works just like the local authorizer but references RBAC rules
-defined in the `system:admin` system workspace.
-
-### Local Policy Authorizer
-
-Once the top-level organization authorizer and the workspace content authorizer granted access to a
-workspace, RBAC rules contained in the workspace derived from the request context are evaluated.
+#### Local Policy Authorizer
 
 This authorizer ensures that RBAC rules contained within a workspace are being applied
 and work just like in a regular Kubernetes cluster.
 
+It is possible to bind to Roles and ClusterRoles in the bootstrap policy from a local policy's
+`RoleBinding` or `ClusterRoleBinding`, for example the `system:kcp:workspace:access` ClusterRole exists in the
+`system:admin` logical cluster, but can still be bound from without any other logical cluster.
+
+#### Global Policy Authorizer
+
+This authorizer works identically to the Local Policy Authorizer, just with the difference
+that it uses a global (i.e. across shards) getter for Roles and RoleBindings.
+
+#### Bootstrap Policy Authorizer
+
+The bootstrap policy authorizer works just like the local authorizer but references RBAC rules
+defined in the `system:admin` system workspace. This workspace is where the classic Kubernetes
+RBAC like the `cluster-admin` ClusterRole is being defined and the policy defined in this workspace
+applies to every workspace in a kcp shard.
+
+### Webhook Authorizer
+
+This authorizer can be enabled by providing the `--authorization-webhook-config-file` flag to the kcp process
+and works identically to [how it works in vanilla Kubernetes](https://kubernetes.io/docs/reference/access-authn-authz/webhook/).
+
+The given configuration file must be of the kubeconfg format and point to an HTTPS server, potentially including certificate information as needed:
+
+```yaml
+apiVersion: v1
+kind: Config
+clusters:
+  - name: webhook
+    cluster:
+      server: https://localhost:8080/
+current-context: webhook
+contexts:
+  - name: webhook
+    context:
+      cluster: webhook
+```
+
+The webhook will receive every authorization request made in kcp, including internal ones. This means if the webhook
+is badly configured, it can even prevent kcp from starting up successfully, but on the other hand this allows
+a lot of influence over the authorization in kcp.
+
+The webhook will receive JSON-marshalled `SubjectAccessReview` objects, that (compared to vanilla Kubernetes) include the name of target logical cluster as an `extra` field, like so:
+
+```json
+{
+  "apiVersion": "authorization.k8s.io/v1beta1",
+  "kind": "SubjectAccessReview",
+  "spec": {
+    "resourceAttributes": {
+      "namespace": "kittensandponies",
+      "verb": "get",
+      "group": "unicorn.example.org",
+      "resource": "pods"
+    },
+    "user": "jane",
+    "group": [
+      "group1",
+      "group2"
+    ],
+    "extra": {
+      "authorization.kubernetes.io/cluster-name": ["root"]
+    }
+  }
+}
+```
+
 !!! note
-    Groups added by the workspace content authorizer can be used for role bindings in that workspace.
-
-It is possible to bind to roles and cluster roles in the bootstrap policy from a local policy `RoleBinding` or `ClusterRoleBinding`.
-
-### Service Accounts
-
-Kubernetes service accounts are granted access to the workspaces they are defined in and that are ready.
-
-E.g. a service account "default" in `root:org:ws:ws` is granted access to `root:org:ws:ws`, and through the
-workspace content authorizer it gains the `system:kcp:clusterworkspace:access` group membership.
+    The extra field will contain the logical cluster _name_ (e.g. o43u2gh528rtfg721rg92), not the human-readable path. Webhooks need to resolve the name to a path themselves if necessary.

--- a/docs/content/concepts/authorization/index.md
+++ b/docs/content/concepts/authorization/index.md
@@ -11,13 +11,11 @@ Generally, the same (cluster) role and (cluster) role binding principles apply e
 
 In addition, additional RBAC semantics is implemented cross-workspaces, namely the following:
 
-- **Top-Level Organization** access: the user must have this as pre-requisite to access any other workspace, or is
-  even member and by that can create workspaces inside the organization workspace.
-- **Workspace Content** access: the user needs access to a workspace or is even admin.
-- for some resources, additional permission checks are performed, not represented by local or Kubernetes standard RBAC rules. E.g.
-  - workspace creation checks for organization membership (see above).
-  - workspace creation checks for `use` verb on the `WorkspaceType`.
-  - API binding via APIBinding objects requires verb `bind` access to the corresponding `APIExport`.
+- **Workspace Content** access: the user needs `access` permissions to a workspace or be even admin.
+- for some resources, additional permission checks are performed, not represented by local or Kubernetes standard RBAC rules; for example
+    - workspace creation checks for organization membership (see above).
+    - workspace creation checks for `use` verb on the `WorkspaceType`.
+    - API binding via APIBinding objects requires verb `bind` access to the corresponding `APIExport`.
 - **System Workspaces** access: system workspaces are prefixed with `system:` and are not accessible by users.
 
 The details of the authorizer chain are documented in [Authorizers](./authorizers.md).

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -37,7 +37,7 @@ theme:
 
   # Palette toggle for light mode
   - media: "(prefers-color-scheme: light)"
-    scheme: default 
+    scheme: default
     primary: white
     toggle:
       icon: material/brightness-7
@@ -92,6 +92,11 @@ markdown_extensions:
   - pymdownx.highlight:
       # Allows linking directly to specific lines in code blocks
       anchor_linenums: true
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   # Inline code block highlighting
   - pymdownx.inlinehilite
   # Lets you embed content from another file

--- a/hack/bump-k8s.sh
+++ b/hack/bump-k8s.sh
@@ -29,7 +29,7 @@ set -o xtrace
 # Note: setting GOPROXY=direct allows us to bump very quickly after the fork has been committed to.
 GITHUB_USER=${GITHUB_USER:-kcp-dev}
 GITHUB_REPO=${GITHUB_REPO:-kubernetes}
-BRANCH=${BRANCH:-kcp-feature-logical-clusters-1.24-v3}
+BRANCH=${BRANCH:-kcp-1.31.0}
 
 current_version="$( GOPROXY=direct go mod edit -json | jq '.Replace[] | select(.Old.Path=="k8s.io/kubernetes") | .New.Version' --raw-output )"
 

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -175,7 +175,7 @@ func (c *Config) Complete() (CompletedConfig, error) {
 
 const KcpBootstrapperUserName = "system:kcp:bootstrapper"
 
-func NewConfig(opts kcpserveroptions.CompletedOptions) (*Config, error) {
+func NewConfig(ctx context.Context, opts kcpserveroptions.CompletedOptions) (*Config, error) {
 	c := &Config{
 		Options: opts,
 	}
@@ -324,7 +324,7 @@ func NewConfig(opts kcpserveroptions.CompletedOptions) (*Config, error) {
 		return nil, err
 	}
 
-	if err := opts.Authorization.ApplyTo(c.GenericConfig, c.KubeSharedInformerFactory, c.CacheKubeSharedInformerFactory, c.KcpSharedInformerFactory, c.CacheKcpSharedInformerFactory); err != nil {
+	if err := opts.Authorization.ApplyTo(ctx, c.GenericConfig, c.KubeSharedInformerFactory, c.CacheKubeSharedInformerFactory, c.KcpSharedInformerFactory, c.CacheKcpSharedInformerFactory); err != nil {
 		return nil, err
 	}
 	var userToken string

--- a/pkg/server/options/options.go
+++ b/pkg/server/options/options.go
@@ -29,7 +29,7 @@ import (
 	genericapiserveroptions "k8s.io/apiserver/pkg/server/options"
 	cliflag "k8s.io/component-base/cli/flag"
 	controlplaneapiserver "k8s.io/kubernetes/pkg/controlplane/apiserver/options"
-	kubeoptions "k8s.io/kubernetes/pkg/kubeapiserver/options"
+	authzmodes "k8s.io/kubernetes/pkg/kubeapiserver/authorizer/modes"
 
 	kcpadmission "github.com/kcp-dev/kcp/pkg/admission"
 	etcdoptions "github.com/kcp-dev/kcp/pkg/embeddedetcd/options"
@@ -251,6 +251,10 @@ func (o *Options) Complete(rootDir string) (*CompletedOptions, error) {
 		o.EmbeddedEtcd.Enabled = true
 	}
 
+	if err := o.Authorization.Complete(); err != nil {
+		return nil, err
+	}
+
 	var err error
 	if !filepath.IsAbs(o.EmbeddedEtcd.Directory) {
 		o.EmbeddedEtcd.Directory, err = filepath.Abs(o.EmbeddedEtcd.Directory)
@@ -311,8 +315,6 @@ func (o *Options) Complete(rootDir string) (*CompletedOptions, error) {
 	}
 	if o.GenericControlPlane.ServiceAccountSigningKeyFile == "" {
 		o.GenericControlPlane.ServiceAccountSigningKeyFile = o.Controllers.SAController.ServiceAccountKeyFile
-	}
-
 	completedGenericServerRunOptions, err := o.GenericControlPlane.Complete(nil, nil)
 	if err != nil {
 		return nil, err

--- a/test/e2e/authorizer/webhook.kubeconfig
+++ b/test/e2e/authorizer/webhook.kubeconfig
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Config
+clusters:
+  - name: httest
+    cluster:
+      certificate-authority: .httest/ca.crt
+      server: https://localhost:8080/
+current-context: webhook
+contexts:
+  - name: webhook
+    context:
+      cluster: httest

--- a/test/e2e/authorizer/webhook_test.go
+++ b/test/e2e/authorizer/webhook_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2024 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authorizer
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+	"time"
+
+	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
+	"github.com/kcp-dev/logicalcluster/v3"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+
+	kcpclientset "github.com/kcp-dev/kcp/sdk/client/clientset/versioned/cluster"
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+)
+
+func TestWebhook(t *testing.T) {
+	framework.Suite(t, "control-plane")
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	t.Cleanup(cancelFunc)
+
+	// start a webhook that allows kcp to boot up
+	webhookStop := runWebhook(ctx, t, "kubernetes:authz:allow")
+	t.Cleanup(webhookStop)
+
+	server := framework.PrivateKcpServer(t, framework.WithCustomArguments(
+		"--authorization-webhook-config-file",
+		"webhook.kubeconfig",
+	))
+
+	// create clients
+	kcpConfig := server.BaseConfig(t)
+	kubeClusterClient, err := kcpkubernetesclientset.NewForConfig(kcpConfig)
+	require.NoError(t, err, "failed to construct client for server")
+	kcpClusterClient, err := kcpclientset.NewForConfig(kcpConfig)
+	require.NoError(t, err, "failed to construct client for server")
+
+	t.Log("Admin should be allowed to list Workspaces.")
+	_, err = kcpClusterClient.Cluster(logicalcluster.NewPath("root")).TenancyV1alpha1().Workspaces().List(ctx, metav1.ListOptions{})
+	require.NoError(t, err)
+
+	// stop the webhook and switch to a deny policy
+	webhookStop()
+
+	webhookStop = runWebhook(ctx, t, "kubernetes:authz:deny")
+	t.Cleanup(webhookStop)
+
+	t.Log("Admin should not be allowed to list ConfigMaps.")
+	_, err = kubeClusterClient.Cluster(logicalcluster.NewPath("root")).CoreV1().ConfigMaps("default").List(ctx, metav1.ListOptions{})
+	require.Error(t, err)
+
+	// access to health endpoints should still be granted based on --always-allow-paths,
+	// even if the webhook rejects the request
+	rootShardCfg := server.RootShardSystemMasterBaseConfig(t)
+	if rootShardCfg.NegotiatedSerializer == nil {
+		rootShardCfg.NegotiatedSerializer = kubernetesscheme.Codecs.WithoutConversion()
+	}
+
+	// Ensure the request is unauthenticated, as Kubernetes' webhook authorizer is wrapped
+	// in a reloadable authorizer that also always injects a privilegedGroup authorizer
+	// that lets system:masters users in.
+	rootShardCfg.BearerToken = ""
+
+	restClient, err := rest.UnversionedRESTClientFor(rootShardCfg)
+	require.NoError(t, err)
+
+	for _, endpoint := range []string{"/livez", "/readyz"} {
+		req := rest.NewRequest(restClient).RequestURI(endpoint)
+		t.Logf("%s should still be accessible.", req.URL().String())
+		_, err := req.Do(ctx).Raw()
+		require.NoError(t, err)
+	}
+}
+
+func runWebhook(ctx context.Context, t *testing.T, response string) context.CancelFunc {
+	args := []string{
+		"--tls",
+		"--response", response,
+	}
+
+	t.Logf("Starting webhook with %s policy...", response)
+
+	ctx, cancel := context.WithCancel(ctx)
+
+	cmd := exec.CommandContext(ctx, "httest", args...)
+	if err := cmd.Start(); err != nil {
+		cancel()
+		t.Fatalf("Failed to start webhook: %v", err)
+	}
+
+	// give httest a moment to boot up
+	time.Sleep(2 * time.Second)
+
+	return func() {
+		t.Log("Stopping webhook...")
+		cancel()
+		// give it some time to shutdown
+		time.Sleep(2 * time.Second)
+	}
+}

--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -655,7 +655,7 @@ func (c *kcpServer) Run(opts ...RunOption) error {
 			return apierrors.NewAggregate(errs)
 		}
 
-		config, err := server.NewConfig(completed.Server)
+		config, err := server.NewConfig(ctx, completed.Server)
 		if err != nil {
 			cleanup()
 			return err


### PR DESCRIPTION
## Summary
This PR allows to configure an external webhook for authorization. Previously the relevant flags have been explicitly disabled in kcp, because kcp has its own authorizer. The webhook authorizer will sit next to the existing authorizers (allowPath, allowGroup) and so is an alternative to the built-in authorizers.

In the documentation, it looks like this:

![2024-12-05_18-22-44](https://github.com/user-attachments/assets/bb0239cb-bc78-4d6d-af3e-0c80397c3603)

I chose to let the webhook authorizer run in parallel to the existing RBAC chain so that admins have full freedom to tweak the authorization. This comes with the warning that if your webhook is configured to deny everything, it will block kcp's startup (thankfully, kcp recovers quickly when the webhook stops denying everything and starts to either have no opinion or allow things explicitly).

Since the webhook authorizer is part of a union with the others, and more importantly comes *after* the allowGroups/Paths authorizers, webhooks cannot prevent healthchecks from functioning.

---

Originally I started by simply enabling the authz options in the built-in server options, i.e. remove the `o.GenericControlPlane.Authorization = nil // we have our own` line, to surface the existing webhook options from Kubernetes.

However I did not manage to integrate the webhook well into kcp. When the webhook authorizer is enabled, the code would then _not_ run the RBAC PostStart hook in the server anymore, so RBAC policies like the `cluster-admin` ClusterRole were simply not being created anymore. I fear to break a lot of things if I hack around in the Kubernetes fork and so ultimately decided to not use the authz options in the built-in server options, but instead _add_ them to the kcp authz options (where we also configure --always-allow-paths, for example).

This leads to a bit more code, because some steps like setting up the CLI flags have to be done manually, but allowed much greater control over how the webhook is loaded and was ultimately simpler to do. Now whatever kcp does with the webhook flags, will not affect Kubernetes' internal bootstrapping anymore.

I also renamed a few variables to make things a bit more clear.

---

In addition to the code change, I also revamped the authorizer documentation for kcp. The old one still mentioned non-existing authorizers (like the "top-level org authorizer") or behaviour that simply doesn't exist (like the workspace content authorizer alledgedly injecting data into the auth context for the authorizers downstream, which it doesn't do in reality).

Since the original ASCIIChart looked terrible due to my font settings, I was very glad to see that mkdocs-material comes with a Mermaid integration and so I replaced the oringinal chart with a much easier to maintain Mermaid diagram.

This PR also includes a dependency bump to include https://github.com/kcp-dev/kubernetes/pull/151, which will take care of including the cluster name in the webhook's payload. In that dependency bump is also, slightly hidden, a cleanup for the `bump-k8s` script, which failed at least since the 1.31 bump since the `legacy-cloud-providers` module doesn't exist anymore.

---

Also I vote that we rename the "System CRD Authorizer" to something like "System Resource Authorizer", because the authorizer does not actually handle CustomResourceDefinitions at all. It handles APIBindings and APIExports. Calling it a "CRD Authorizer" is confusing to me.

## Release Notes
```release-note
Add support for external webhook authorization.
```
