### PR TITLE
✨  Enhance local-dev for VirtualWorkspaces 

### DIFF
--- a/cmd/kcp/kcp.go
+++ b/cmd/kcp/kcp.go
@@ -68,6 +68,7 @@ func main() {
 
 	// manually extract root directory from flags first as it influence all other flags
 	rootDir := ".kcp"
+	additionalMappingsFile := ""
 	for i, f := range os.Args {
 		if f == "--root-directory" {
 			if i < len(os.Args)-1 {
@@ -75,11 +76,18 @@ func main() {
 			} // else let normal flag processing fail
 		} else if strings.HasPrefix(f, "--root-directory=") {
 			rootDir = strings.TrimPrefix(f, "--root-directory=")
+		} else if f == "--mapping-file" {
+			if i < len(os.Args)-1 {
+				additionalMappingsFile = os.Args[i+1]
+			} // else let normal flag processing fail
+		} else if strings.HasPrefix(f, "--mapping-file") {
+			additionalMappingsFile = strings.TrimPrefix(f, "--mapping-file=")
 		}
 	}
 
 	kcpOptions := options.NewOptions(rootDir)
 	kcpOptions.Server.GenericControlPlane.Logs.Verbosity = logsapiv1.VerbosityLevel(2)
+	kcpOptions.Server.Extra.AdditionalMappingsFile = additionalMappingsFile
 
 	startCmd := &cobra.Command{
 		Use:   "start",

--- a/cmd/kcp/kcp.go
+++ b/cmd/kcp/kcp.go
@@ -76,11 +76,11 @@ func main() {
 			} // else let normal flag processing fail
 		} else if strings.HasPrefix(f, "--root-directory=") {
 			rootDir = strings.TrimPrefix(f, "--root-directory=")
-		} else if f == "--mapping-file" {
+		} else if f == "--miniproxy-mapping-file" {
 			if i < len(os.Args)-1 {
 				additionalMappingsFile = os.Args[i+1]
 			} // else let normal flag processing fail
-		} else if strings.HasPrefix(f, "--mapping-file") {
+		} else if strings.HasPrefix(f, "--miniproxy-mapping-file") {
 			additionalMappingsFile = strings.TrimPrefix(f, "--mapping-file=")
 		}
 	}

--- a/cmd/kcp/options/generic.go
+++ b/cmd/kcp/options/generic.go
@@ -27,17 +27,20 @@ import (
 
 type GenericOptions struct {
 	RootDirectory string
+	MappingFile   string
 }
 
 func NewGeneric(rootDir string) *GenericOptions {
 	return &GenericOptions{
 		RootDirectory: rootDir,
+		MappingFile:   "",
 	}
 }
 
 func (o *GenericOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 	fs := fss.FlagSet("KCP")
 	fs.StringVar(&o.RootDirectory, "root-directory", o.RootDirectory, "Root directory. Set to \"\" to disable file (e.g. certificates) generation in a root directory.")
+	fs.StringVar(&o.MappingFile, "mapping-file", o.MappingFile, "Path to additional mapping file to be used by mini-front-proxy.")
 }
 
 func (o *GenericOptions) Complete() (*GenericOptions, error) {
@@ -53,6 +56,15 @@ func (o *GenericOptions) Complete() (*GenericOptions, error) {
 		// Create the configuration root correctly before other components get a chance.
 		if err := mkdirRoot(o.RootDirectory); err != nil {
 			return nil, err
+		}
+	}
+	if o.MappingFile != "" {
+		if !filepath.IsAbs(o.MappingFile) {
+			pwd, err := os.Getwd()
+			if err != nil {
+				return nil, err
+			}
+			o.MappingFile = filepath.Join(pwd, o.MappingFile)
 		}
 	}
 

--- a/cmd/kcp/options/generic.go
+++ b/cmd/kcp/options/generic.go
@@ -40,7 +40,7 @@ func NewGeneric(rootDir string) *GenericOptions {
 func (o *GenericOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 	fs := fss.FlagSet("KCP")
 	fs.StringVar(&o.RootDirectory, "root-directory", o.RootDirectory, "Root directory. Set to \"\" to disable file (e.g. certificates) generation in a root directory.")
-	fs.StringVar(&o.MappingFile, "mapping-file", o.MappingFile, "Path to additional mapping file to be used by mini-front-proxy.")
+	fs.StringVar(&o.MappingFile, "miniproxy-mapping-file", o.MappingFile, "DEVELOPMENT ONLY. Path to additional mapping file to be used by mini-front-proxy. This should not be used in production. For production usecase use front-proxy component instead.")
 }
 
 func (o *GenericOptions) Complete() (*GenericOptions, error) {

--- a/pkg/proxy/handler.go
+++ b/pkg/proxy/handler.go
@@ -56,9 +56,9 @@ func shardHandler(index index.Index, proxy http.Handler) http.HandlerFunc {
 			return
 		}
 
-		shardURLString, found, errCode := index.LookupURL(clusterPath)
-		if errCode != 0 {
-			http.Error(w, "Not available.", errCode)
+		result, found := index.LookupURL(clusterPath)
+		if result.ErrorCode != 0 {
+			http.Error(w, "Not available.", result.ErrorCode)
 			return
 		}
 		if !found {
@@ -66,7 +66,7 @@ func shardHandler(index index.Index, proxy http.Handler) http.HandlerFunc {
 			responsewriters.Forbidden(req.Context(), attributes, w, req, kcpauthorization.WorkspaceAccessNotPermittedReason, kubernetesscheme.Codecs)
 			return
 		}
-		shardURL, err := url.Parse(shardURLString)
+		shardURL, err := url.Parse(result.URL)
 		if err != nil {
 			responsewriters.InternalError(w, req, err)
 			return

--- a/pkg/proxy/index/index_controller.go
+++ b/pkg/proxy/index/index_controller.go
@@ -49,7 +49,7 @@ const (
 )
 
 type Index interface {
-	LookupURL(path logicalcluster.Path) (url string, found bool, errorCode int)
+	LookupURL(path logicalcluster.Path) (index.Result, bool)
 }
 
 type ClusterClientGetter func(shard *corev1alpha1.Shard) (kcpclientset.ClusterInterface, error)
@@ -291,10 +291,16 @@ func (c *Controller) stopShard(shardName string) {
 	delete(c.shardLogicalClusterInformers, shardName)
 }
 
-func (c *Controller) LookupURL(path logicalcluster.Path) (url string, found bool, errorCode int) {
+func (c *Controller) LookupURL(path logicalcluster.Path) (index.Result, bool) {
 	r, found := c.state.LookupURL(path)
 	if found && r.ErrorCode != 0 {
-		return r.URL, found, r.ErrorCode
+		return index.Result{
+			URL:       r.URL,
+			ErrorCode: r.ErrorCode,
+		}, found
 	}
-	return r.URL, found, 0
+	return index.Result{
+		URL:       r.URL,
+		ErrorCode: 0,
+	}, found
 }

--- a/pkg/proxy/mapping.go
+++ b/pkg/proxy/mapping.go
@@ -23,10 +23,6 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
-	"path"
-	"strings"
-
-	"github.com/kcp-dev/logicalcluster/v3"
 
 	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/klog/v2"
@@ -34,91 +30,8 @@ import (
 
 	"github.com/kcp-dev/kcp/pkg/proxy/index"
 	proxyoptions "github.com/kcp-dev/kcp/pkg/proxy/options"
+	"github.com/kcp-dev/kcp/pkg/server/proxy"
 )
-
-// PathMapping describes how to route traffic from a path to a backend server.
-// Each Path is registered with the DefaultServeMux with a handler that
-// delegates to the specified backend.
-type PathMapping struct {
-	Path              string `json:"path"`
-	Backend           string `json:"backend"`
-	BackendServerCA   string `json:"backend_server_ca"`
-	ProxyClientCert   string `json:"proxy_client_cert"`
-	ProxyClientKey    string `json:"proxy_client_key"`
-	UserHeader        string `json:"user_header,omitempty"`
-	GroupHeader       string `json:"group_header,omitempty"`
-	ExtraHeaderPrefix string `json:"extra_header_prefix"`
-}
-
-type HttpHandler struct {
-	index          index.Index
-	mapping        []httpHandlerMapping
-	defaultHandler http.Handler
-}
-
-// httpHandlerMapping is used to route traffic to the correct backend server.
-// Higher weight means that the mapping is more specific and should be matched first.
-type httpHandlerMapping struct {
-	weight  int
-	path    string
-	handler http.Handler
-}
-
-func (h *HttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// mappings are used to route traffic to the correct backend server.
-	// It should not have `/clusters` as prefix because that is handled by the
-	// shardHandler or mounts. Logic is as follows:
-	// 1. We detect URL for the request and find the correct handler. URL can be
-	// shard based, virtual workspace or mount. First two are covered by r.URL,
-	// where mounts are covered by annotation on the workspace with the mount path.
-	// 2. If mountpoint is found, we rewrite the URL to resolve, else use one in
-	// request to match with mappings.
-	// 3. Iterate over mappings and find the one that matches the URL. If found,
-	// use the handler for that mapping, else use default handler - kcp.
-	// Mappings are done from most specific to least specific:
-	// Example: /clusters/cluster1/ will be matched before /clusters/
-	for _, m := range h.mapping {
-		url, errorCode := h.resolveURL(r)
-		if errorCode != 0 {
-			http.Error(w, http.StatusText(errorCode), errorCode)
-			return
-		}
-		if strings.HasPrefix(url, m.path) {
-			m.handler.ServeHTTP(w, r)
-			return
-		}
-	}
-
-	h.defaultHandler.ServeHTTP(w, r)
-}
-
-func (h *HttpHandler) resolveURL(r *http.Request) (string, int) {
-	// if we don't match any of the paths, use the default behavior - request
-	var cs = strings.SplitN(strings.TrimLeft(r.URL.Path, "/"), "/", 3)
-	if len(cs) < 2 || cs[0] != "clusters" {
-		return r.URL.Path, 0
-	}
-
-	clusterPath := logicalcluster.NewPath(cs[1])
-	if !clusterPath.IsValid() {
-		return r.URL.Path, 0
-	}
-
-	u, found, errCode := h.index.LookupURL(clusterPath)
-	if errCode != 0 {
-		return "", errCode
-	}
-	if found {
-		u, err := url.Parse(u)
-		if err == nil && u != nil {
-			u.Path = strings.TrimSuffix(u.Path, "/")
-			r.URL.Path = path.Join(u.Path, strings.Join(cs[2:], "/")) // override request prefix and keep kube api contextual suffix
-			return u.Path, 0
-		}
-	}
-
-	return r.URL.Path, 0
-}
 
 func NewHandler(ctx context.Context, o *proxyoptions.Options, index index.Index) (http.Handler, error) {
 	mappingData, err := os.ReadFile(o.MappingFile)
@@ -126,18 +39,18 @@ func NewHandler(ctx context.Context, o *proxyoptions.Options, index index.Index)
 		return nil, fmt.Errorf("failed to read mapping file %q: %w", o.MappingFile, err)
 	}
 
-	var mapping []PathMapping
+	var mapping []proxy.PathMapping
 	if err = yaml.Unmarshal(mappingData, &mapping); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal mapping file %q: %w", o.MappingFile, err)
 	}
 
-	handlers := HttpHandler{
-		index: index,
-		mapping: []httpHandlerMapping{
+	handlers := proxy.HttpHandler{
+		Index: index,
+		Mappings: proxy.HttpHandlerMappings{
 			{
-				weight:  0,
-				path:    "/metrics",
-				handler: legacyregistry.Handler(),
+				Weight:  0,
+				Path:    "/metrics",
+				Handler: legacyregistry.Handler(),
 			},
 		},
 	}
@@ -185,31 +98,17 @@ func NewHandler(ctx context.Context, o *proxyoptions.Options, index index.Index)
 
 		logger.V(2).WithValues("path", m.Path).Info("adding handler")
 		if m.Path == "/" {
-			handlers.defaultHandler = handler
+			handlers.DefaultHandler = handler
 		} else {
-			handlers.mapping = append(handlers.mapping, httpHandlerMapping{
-				weight:  len(m.Path),
-				path:    m.Path,
-				handler: handler,
+			handlers.Mappings = append(handlers.Mappings, proxy.HttpHandlerMapping{
+				Weight:  len(m.Path),
+				Path:    m.Path,
+				Handler: handler,
 			})
 		}
 	}
 
-	handlers.mapping = sortMappings(handlers.mapping)
+	handlers.Mappings.Sort()
 
 	return &handlers, nil
-}
-
-func sortMappings(mappings []httpHandlerMapping) []httpHandlerMapping {
-	// sort mappings by weight
-	// higher weight means that the mapping is more specific and should be matched first
-	// Example: /clusters/cluster1/ will be matched before /clusters/
-	for i := range mappings {
-		for j := range mappings {
-			if mappings[i].weight > mappings[j].weight {
-				mappings[i], mappings[j] = mappings[j], mappings[i]
-			}
-		}
-	}
-	return mappings
 }

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -462,7 +462,16 @@ func NewConfig(ctx context.Context, opts kcpserveroptions.CompletedOptions) (*Co
 		apiHandler = mux
 
 		apiHandler = filters.WithAuditInit(apiHandler) // Must run before any audit annotation is made
-		apiHandler = WithLocalProxy(apiHandler, opts.Extra.ShardName, opts.Extra.ShardBaseURL, c.KcpSharedInformerFactory.Tenancy().V1alpha1().Workspaces(), c.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters())
+		apiHandler, err = WithLocalProxy(apiHandler,
+			opts.Extra.ShardName,
+			opts.Extra.ShardBaseURL,
+			opts.Extra.AdditionalMappingsFile,
+			c.KcpSharedInformerFactory.Tenancy().V1alpha1().Workspaces(),
+			c.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters(),
+		)
+		if err != nil {
+			panic(err) // shouldn't happen due to flag validation
+		}
 		apiHandler = WithInClusterServiceAccountRequestRewrite(apiHandler)
 		apiHandler = kcpfilters.WithAcceptHeader(apiHandler)
 		apiHandler = WithUserAgent(apiHandler)

--- a/pkg/server/options/options.go
+++ b/pkg/server/options/options.go
@@ -68,7 +68,7 @@ type ExtraOptions struct {
 	BatteriesIncluded                     []string
 	// DEVELOPMENT ONLY. AdditionalMappingsFile is the path to a file that contains additional mappings
 	// for the mini-front-proxy to use. The file should be in the format of the
-	// --mapping-file flag of the front-proxy. Do NOT expose this flag to users via main server options.
+	// --miniproxy-mapping-file flag of the front-proxy. Do NOT expose this flag to users via main server options.
 	// It is overridden by the kcp start command.
 	AdditionalMappingsFile string
 }

--- a/pkg/server/options/options.go
+++ b/pkg/server/options/options.go
@@ -66,6 +66,11 @@ type ExtraOptions struct {
 	ExternalLogicalClusterAdminKubeconfig string
 	ConversionCELTransformationTimeout    time.Duration
 	BatteriesIncluded                     []string
+	// DEVELOPMENT ONLY. AdditionalMappingsFile is the path to a file that contains additional mappings
+	// for the mini-front-proxy to use. The file should be in the format of the
+	// --mapping-file flag of the front-proxy. Do NOT expose this flag to users via main server options.
+	// It is overridden by the kcp start command.
+	AdditionalMappingsFile string
 }
 
 type completedOptions struct {

--- a/pkg/server/proxy/handler.go
+++ b/pkg/server/proxy/handler.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2024 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	"github.com/kcp-dev/kcp/pkg/proxy/index"
+)
+
+// PathMapping describes how to route traffic from a path to a backend server.
+// Each Path is registered with the DefaultServeMux with a handler that
+// delegates to the specified backend.
+type PathMapping struct {
+	Path              string `json:"path"`
+	Backend           string `json:"backend"`
+	BackendServerCA   string `json:"backend_server_ca"`
+	ProxyClientCert   string `json:"proxy_client_cert"`
+	ProxyClientKey    string `json:"proxy_client_key"`
+	UserHeader        string `json:"user_header,omitempty"`
+	GroupHeader       string `json:"group_header,omitempty"`
+	ExtraHeaderPrefix string `json:"extra_header_prefix"`
+}
+
+type HttpHandler struct {
+	Index          index.Index
+	Mappings       HttpHandlerMappings
+	DefaultHandler http.Handler
+}
+
+// httpHandlerMapping is used to route traffic to the correct backend server.
+// Higher weight means that the mapping is more specific and should be matched first.
+type HttpHandlerMapping struct {
+	Weight  int
+	Path    string
+	Handler http.Handler
+}
+
+type HttpHandlerMappings []HttpHandlerMapping
+
+// Sort mappings by weight
+// higher weight means that the mapping is more specific and should be matched first
+// Example: /clusters/cluster1/ will be matched before /clusters/ .
+func (h HttpHandlerMappings) Sort() {
+	for i := range h {
+		for j := range h {
+			if h[i].Weight > h[j].Weight {
+				h[i], h[j] = h[j], h[i]
+			}
+		}
+	}
+}
+
+func (h *HttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// mappings are used to route traffic to the correct backend server.
+	// It should not have `/clusters` as prefix because that is handled by the
+	// shardHandler or mounts. Logic is as follows:
+	// 1. We detect URL for the request and find the correct handler. URL can be
+	// shard based, virtual workspace or mount. First two are covered by r.URL,
+	// where mounts are covered by annotation on the workspace with the mount path.
+	// 2. If mountpoint is found, we rewrite the URL to resolve, else use one in
+	// request to match with mappings.
+	// 3. Iterate over mappings and find the one that matches the URL. If found,
+	// use the handler for that mapping, else use default handler - kcp.
+	// Mappings are done from most specific to least specific:
+	// Example: /clusters/cluster1/ will be matched before /clusters/ .
+	for _, m := range h.Mappings {
+		url, errorCode := h.resolveURL(r)
+		if errorCode != 0 {
+			http.Error(w, http.StatusText(errorCode), errorCode)
+			return
+		}
+		if strings.HasPrefix(url, m.Path) {
+			m.Handler.ServeHTTP(w, r)
+			return
+		}
+	}
+
+	h.DefaultHandler.ServeHTTP(w, r)
+}
+
+func (h *HttpHandler) resolveURL(r *http.Request) (string, int) {
+	// if we don't match any of the paths, use the default behavior - request
+	var cs = strings.SplitN(strings.TrimLeft(r.URL.Path, "/"), "/", 3)
+	if len(cs) < 2 || cs[0] != "clusters" {
+		return r.URL.Path, 0
+	}
+
+	clusterPath := logicalcluster.NewPath(cs[1])
+	if !clusterPath.IsValid() {
+		return r.URL.Path, 0
+	}
+
+	result, found := h.Index.LookupURL(clusterPath)
+	if result.ErrorCode != 0 {
+		return "", result.ErrorCode
+	}
+	if found {
+		u, err := url.Parse(result.URL)
+		if err == nil && u != nil {
+			u.Path = strings.TrimSuffix(u.Path, "/")
+			r.URL.Path = path.Join(u.Path, strings.Join(cs[2:], "/")) // override request prefix and keep kube api contextual suffix
+			return u.Path, 0
+		}
+	}
+
+	return r.URL.Path, 0
+}

--- a/pkg/server/proxy/mapping_test.go
+++ b/pkg/server/proxy/mapping_test.go
@@ -22,23 +22,23 @@ import (
 )
 
 func TestSortMappings(t *testing.T) {
-	mappings := []httpHandlerMapping{
-		{weight: 3},
-		{weight: 1},
-		{weight: 2},
-		{weight: 10},
+	mappings := HttpHandlerMappings{
+		{Weight: 3},
+		{Weight: 1},
+		{Weight: 2},
+		{Weight: 10},
 	}
 
-	expected := []httpHandlerMapping{
-		{weight: 10},
-		{weight: 3},
-		{weight: 2},
-		{weight: 1},
+	expected := HttpHandlerMappings{
+		{Weight: 10},
+		{Weight: 3},
+		{Weight: 2},
+		{Weight: 1},
 	}
 
-	sortedMappings := sortMappings(mappings)
+	mappings.Sort()
 
-	if !reflect.DeepEqual(sortedMappings, expected) {
-		t.Errorf("Expected %v, but got %v", expected, sortedMappings)
+	if !reflect.DeepEqual(mappings, expected) {
+		t.Errorf("Expected %v, but got %v", expected, mappings)
 	}
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

In this PR:
1. Move some of the proxy handler code from `pkg/proxy` into `pkg/server/proxy` so it could be reused in `miniproxy`. This is to avoid circular imports problem :/ didn't find better place for this.
2. Add flag `--mapping-file` for `kcp start` in dev mode, so once can start kcp locally and iterate on external virtual workspace binary code without having to deal with embedding code. It makes kcp core more standalone and forces people to think "core vs non-core" 
3. Refactors proxy index with error codes to be more consistent (a consequence of reusing same more in miniproxy and front-proxy)

All in all, this makes local development of anything outside kcp (like mounts proxy) exponentially easier. 

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Enhance local development experience for VirtualWorkspaces 
Adding --mappings-file option for local dev
```
