### PR TITLE
[release-0.26] :seedling: Update to Go 1.22.10

### DIFF
--- a/.github/workflows/docs-gen-and-push.yaml
+++ b/.github/workflows/docs-gen-and-push.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: v1.22.7
+          go-version: v1.22.10
           cache: true
 
       - uses: actions/setup-python@v5

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -22,7 +22,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-go@v5
       with:
-        go-version: v1.22.7
+        go-version: v1.22.10
     - name: Delete non-semver tags
       run: 'git tag -d $(git tag -l | grep -v "^v")'
     - name: Set LDFLAGS

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.22.7-1
+        - image: ghcr.io/kcp-dev/infra/build:1.22.10-1
           command:
             - make
             - verify-boilerplate
@@ -27,7 +27,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.22.7-1
+        - image: ghcr.io/kcp-dev/infra/build:1.22.10-1
           command:
             - make
             - verify-codegen
@@ -44,7 +44,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.22.7-1
+        - image: ghcr.io/kcp-dev/infra/build:1.22.10-1
           command:
             - make
             - lint
@@ -83,7 +83,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.22.7-1
+        - image: ghcr.io/kcp-dev/infra/build:1.22.10-1
           command:
             - make
             - test
@@ -104,7 +104,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.22.7-1
+        - image: ghcr.io/kcp-dev/infra/build:1.22.10-1
           command:
             - ./hack/run-with-prometheus.sh
             - make
@@ -132,7 +132,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.22.7-1
+        - image: ghcr.io/kcp-dev/infra/build:1.22.10-1
           command:
             - ./hack/run-with-prometheus.sh
             - make
@@ -162,7 +162,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.22.7-1
+        - image: ghcr.io/kcp-dev/infra/build:1.22.10-1
           command:
             - ./hack/run-with-prometheus.sh
             - make
@@ -188,7 +188,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.22.7-1
+        - image: ghcr.io/kcp-dev/infra/build:1.22.10-1
           command:
             - ./hack/run-with-prometheus.sh
             - make

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Build the binary
-FROM --platform=${BUILDPLATFORM} docker.io/golang:1.22.7 AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/golang:1.22.10 AS builder
 WORKDIR /workspace
 
 # Install dependencies.


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

A manual backport of #3212. Since 0.27 is still out a bit, it would be nice to have some basic maintenance on the active release branch since we should get into the habit of patch releases.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
kcp is built with Go 1.22.10
```
