### PR TITLE
🐛 fix check `deleteError != nil` but return an other nil value `err`

### DIFF
--- a/pkg/reconciler/apis/apibindingdeletion/apibinding_deletor.go
+++ b/pkg/reconciler/apis/apibindingdeletion/apibinding_deletor.go
@@ -118,7 +118,7 @@ func (c *Controller) deleteAllCR(ctx context.Context, clusterName logicalcluster
 
 	deleteError := utilerrors.NewAggregate(deleteErrors)
 	if deleteError != nil {
-		return gvrDeletionMetadata{}, err
+		return gvrDeletionMetadata{}, deleteError
 	}
 
 	// resource will not be delete immediately, instead of list again, we just return the


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

it's a harmless bug, but may cause some bug in future.

the code check the `deleteError != nil` but return an other nil `err`
return a other nil `err` , but it was check the 


## Related issue(s)

https://github.com/alingse/sundrylint/issues/4

I have an idea to detect the return nilness error bug, and check the top 1000 github go repos, and found this.


Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
