### PR TITLE
:sparkles:  Add prefix to dev images for gc

### DIFF
--- a/hack/build-image.sh
+++ b/hack/build-image.sh
@@ -40,8 +40,8 @@ fi
 repository=ghcr.io/kcp-dev/kcp
 architectures="amd64 arm64"
 
-# when building locally, just tag with the current HEAD hash with a "dev-" prefix for GC.
-version="dev-$(git rev-parse --short HEAD)"
+# when building locally, just tag with the current HEAD hash.
+version="$(git rev-parse --short HEAD)"
 branchName=""
 
 # deduce the tag from the Prow job metadata
@@ -58,6 +58,11 @@ if [ -n "${PULL_BASE_REF:-}" ]; then
     # branch; because of this we have to deduce the branch name from the tag
     branchName="$(echo "$version" | sed -E 's/^v([0-9]+)\.([0-9]+)\..*/release-\1.\2/')"
   fi
+fi
+
+# Prefix with "dev-" if not on a tag or branch
+if [ -z "$branchName" ]; then
+  version="dev-$version"
 fi
 
 image="$repository:$version"

--- a/hack/build-image.sh
+++ b/hack/build-image.sh
@@ -40,8 +40,8 @@ fi
 repository=ghcr.io/kcp-dev/kcp
 architectures="amd64 arm64"
 
-# when building locally, just tag with the current HEAD hash
-version="$(git rev-parse --short HEAD)"
+# when building locally, just tag with the current HEAD hash with a "dev-" prefix for GC.
+version="dev-$(git rev-parse --short HEAD)"
 branchName=""
 
 # deduce the tag from the Prow job metadata
@@ -67,7 +67,7 @@ echo "Building container image $image ..."
 for arch in $architectures; do
   fullTag="$image-$arch"
 
-  echo "Building $version-$arch ..."
+  echo "Building $fullTag ..."
   buildah build-using-dockerfile \
     --file Dockerfile \
     --tag "$fullTag" \


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This prefixes non-branch or tag images with `dev-` so we can start publishing them (follow-up pr). and later purge them

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
