### PR TITLE
:bug: Fix undo function of cluster annotation setter wiping annotations

### DIFF
--- a/pkg/admission/validatingwebhook/plugin_test.go
+++ b/pkg/admission/validatingwebhook/plugin_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validatingwebhook
+
+import (
+	"testing"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const clusterName = logicalcluster.Name("test-cluster")
+
+func TestSetClusterAnnotation(t *testing.T) {
+	tests := []struct {
+		name string
+		in   *corev1.ConfigMap
+	}{
+		{
+			name: "no annotations",
+			in: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+		},
+		{
+			name: "with annotations",
+			in: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"foo": "bar",
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			origAnnotations := test.in.GetAnnotations()
+
+			undo := SetClusterAnnotation(test.in, clusterName)
+			assert.NotNil(t, undo)
+
+			require.NotNil(t, test.in.GetAnnotations())
+			require.Contains(t, test.in.GetAnnotations(), logicalcluster.AnnotationKey)
+			assert.Equal(t, test.in.GetAnnotations()[logicalcluster.AnnotationKey], clusterName.String())
+
+			// simulate external modification
+			test.in.Annotations["bar"] = "foo"
+			if origAnnotations == nil {
+				origAnnotations = map[string]string{}
+			}
+			origAnnotations["bar"] = "foo"
+
+			undo()
+
+			assert.NotContains(t, test.in.GetAnnotations(), logicalcluster.AnnotationKey)
+			assert.Equal(t, origAnnotations, test.in.GetAnnotations())
+		})
+	}
+}
+
+func TestSetClusterAnnotation_AlreadySet(t *testing.T) {
+	in := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				logicalcluster.AnnotationKey: clusterName.String(),
+			},
+		},
+	}
+	origAnnotations := in.GetAnnotations()
+	assert.Nil(t, SetClusterAnnotation(in, clusterName))
+	assert.Equal(t, origAnnotations, in.GetAnnotations())
+}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The undo function of the admission webhook wiped annotations if the cluster annotation was not present.

## Related issue(s)

Fixes #3182 introduced in #3124 

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Fix external modifications to annotations being reverted by admission webhook
```
