### PR TITLE
:book: Create section navigation that works across any level of nesting

### DIFF
--- a/docs/main.py
+++ b/docs/main.py
@@ -14,9 +14,6 @@
 
 import copy
 
-from mkdocs_macros import fix_url
-
-
 def define_env(env):
     """
     This is the hook for defining variables, macros, and filters. See
@@ -58,11 +55,10 @@ def define_env(env):
 
             # Copy so we don't modify the original
             child = copy.deepcopy(child)
-
-            # Have to fix the URL - see
-            # https://mkdocs-macros-plugin.readthedocs.io/en/latest/tips/#how-do-i-deal-with-relative-links-to-documentsimages
-            child.file.url = fix_url(child.url)
-
+            
+            # Subsection nesting that works across any level of nesting
+            # Replaced mkdocs fix_url function
+            child.file.url = child.url.replace(page.url, "./")
             siblings.append(child)
 
         return siblings

--- a/docs/overrides/partials/section-overview.html
+++ b/docs/overrides/partials/section-overview.html
@@ -1,4 +1,4 @@
 {% for item in section_items(page, navigation, config) %}
-### [{{ item.title }}]({{ item.url }})
+### [{{ item.title }}]({{ item.file.url }})
 {{ item.meta.description or '' }}
 {% endfor %}

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-mike==2.0.0
+mike==2.1.3
 mkdocs==1.5.3
 mkdocs-awesome-pages-plugin==2.9.2
 mkdocs-macros-plugin==1.0.5

--- a/docs/scripts/serve-docs.sh
+++ b/docs/scripts/serve-docs.sh
@@ -34,5 +34,5 @@ fi
 # for local docs testing, we don't care what the remote branch looks like.
 MIKE_OPTIONS+=(--ignore-remote-status)
 
-mike set-default "${MIKE_OPTIONS[@]}" main
+mike set-default "${MIKE_OPTIONS[@]}" --allow-undefined main
 mike serve "${MIKE_OPTIONS[@]}"


### PR DESCRIPTION
Resolves #3218

The fix_url function that we are using doesn't work at a nested level. Given how we are using this partial, using a "current level" value (i.e. `./workspace-types`) vs a "go up levels" (i.e. `../concepts/workspace/workspace-types`) will be portable across any level of nesting.

```release-notes
NONE
```
