### PR TITLE
:memo: Mount API POC

### DIFF
--- a/sdk/apis/tenancy/v1alpha1/types_workspace.go
+++ b/sdk/apis/tenancy/v1alpha1/types_workspace.go
@@ -158,8 +158,9 @@ type WorkspaceSpec struct {
 	// MountName is the name of the mount that this workspace is mounted under.
 	//
 	// +optional
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="mountName is immutable"
-	MountName *string `json:"mountName,omitempty"`
+	// +kubebuilder:validation:XValidation:rule="!has(oldSelf.name) || !has(self.name) || self.name == oldSelf.name",message="name is immutable"
+	// +kubebuilder:validation:XValidation:rule="!has(oldSelf.namespace) || !has(self.namespace) || self.namespace == oldSelf.namespace",message="namespace is immutable"
+	Mount *metav1.ObjectMeta `json:"mount,omitempty"`
 
 	// location constraints where this workspace can be scheduled to.
 	//

--- a/sdk/apis/tenancy/v1alpha1/types_workspace.go
+++ b/sdk/apis/tenancy/v1alpha1/types_workspace.go
@@ -155,11 +155,17 @@ type WorkspaceSpec struct {
 	// +kubebuilder:validation:XValidation:rule="!has(oldSelf.path) || !has(self.path) || self.path == oldSelf.path",message="path is immutable"
 	Type WorkspaceTypeReference `json:"type,omitempty"`
 
+	// MountName is the name of the mount that this workspace is mounted under.
+	//
+	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="mountName is immutable"
+	MountName *string `json:"mountName,omitempty"`
+
 	// location constraints where this workspace can be scheduled to.
 	//
 	// If the no location is specified, an arbitrary location is chosen.
 	//
-	// +optional
+	// +optionalz``
 	Location *WorkspaceLocation `json:"location,omitempty"`
 
 	// cluster is the name of the logical cluster this workspace is stored under.

--- a/sdk/apis/tenancy/v1alpha1/types_workspacetype.go
+++ b/sdk/apis/tenancy/v1alpha1/types_workspacetype.go
@@ -116,6 +116,12 @@ type WorkspaceTypeSpec struct {
 	//
 	// +optional
 	DefaultAPIBindings []APIExportReference `json:"defaultAPIBindings,omitempty"`
+
+	// Mount is the mount configuration for the workspace type. Single type can have only one mount kind.
+	// If set, the workspace will be backed by a mount.
+	//
+	// +optional
+	Mount *metav1.TypeMeta `json:"mount,omitempty"`
 }
 
 // APIExportReference provides the fields necessary to resolve an APIExport.


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Thinking how best to promote mounts into more native way of doing things in kcp.
Somehow logical steps in my head currently are:
1. Extend WorkspaceType with `Mount *metav1.TypeMeta `json:"mount,omitempty"`` telling which flavour it is.
Maybe even add "SubType: LogicalCluster,Mount"? But think this is already too much. If Mount is set, we expect everything else to be nil/not set. It would specific Kind for mount object, but not name.

2. Extend Workspace with `Mount *metav1.ObjectMeta `json:"mount,omitempty"`` where we specify what specific object we refer to. It would when be resolved into statuses as we do now. 

3. We would need to relax URL validation for `mount` types and basically use `spec.url` for mount URL if its mountpoint.

This is very much brain-dump to kick-off discussions. @sttts @embik 

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
