### PR TITLE
:bug: Send options to stdout instead of stderr

### DIFF
--- a/cmd/kcp/kcp.go
+++ b/cmd/kcp/kcp.go
@@ -168,8 +168,8 @@ func main() {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Fprintf(cmd.OutOrStderr(), usageFmt, startCmd.UseLine())
-			cliflag.PrintSections(cmd.OutOrStderr(), fss, cols)
+			fmt.Fprintf(cmd.OutOrStdout(), usageFmt, startCmd.UseLine())
+			cliflag.PrintSections(cmd.OutOrStdout(), fss, cols)
 			return nil
 		},
 	}


### PR DESCRIPTION
## Summary

Send `kcp start options` to stdout instead of stderr

## Related issue(s)

Fixes #3236 

## Release Notes

```release-note
update kcp start options to print to stdout
```
