### PR TITLE
:seedling: Bump buildah image to v1.38.0

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -61,7 +61,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/containers/buildah:v1.30.0
+        - image: quay.io/containers/buildah:v1.38.0
           command:
             - hack/build-image.sh
           env:


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

We're using an outdated image of `buildah`, this bumps the version up to v1.38.0.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
