### PR TITLE
:sparkles: Add wget to final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,10 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:debug
+
+# Copy wget so we can do basic healthchecks in the final image.
+COPY --from=builder /usr/bin/wget /usr/bin/wget
+
 WORKDIR /
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs
 COPY --from=builder workspace/bin/kcp-front-proxy workspace/bin/kcp workspace/bin/virtual-workspaces workspace/bin/cache-server /


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

When running kcp in docker and want to add simple heathchecks, this gets tricky. See the issue below. Dont want to add curl as its way too big, but wget should do just fine to achieve:

```
HEALTHCHECK --interval=30s \
            --timeout=5s \
            CMD ["/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "https://localhost:6443/health"]
```
https://github.com/GoogleContainerTools/distroless/issues/183

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
add wget to final image
```
