### PR TITLE
:bug: reconciler/apibinding: make group resources of APIBindings + CRD race-free

### DIFF
--- a/config/shard/logicalcluster.yaml
+++ b/config/shard/logicalcluster.yaml
@@ -1,0 +1,5 @@
+apiVersion: core.kcp.io/v1alpha1
+kind: LogicalCluster
+metadata:
+  name: cluster
+spec: {}

--- a/pkg/admission/crdnooverlappinggvr/crdnooverlappinggvr_admission.go
+++ b/pkg/admission/crdnooverlappinggvr/crdnooverlappinggvr_admission.go
@@ -20,19 +20,25 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
+	"time"
 
 	"github.com/kcp-dev/logicalcluster/v3"
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
-	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/endpoints/request"
-	"k8s.io/kubernetes/pkg/controlplane/apiserver"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/ptr"
 
 	"github.com/kcp-dev/kcp/pkg/reconciler/apis/apibinding"
-	apisv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/apis/v1alpha1"
+	corev1alpha1 "github.com/kcp-dev/kcp/sdk/apis/core/v1alpha1"
+	kcpclientset "github.com/kcp-dev/kcp/sdk/client/clientset/versioned/cluster"
 	kcpinformers "github.com/kcp-dev/kcp/sdk/client/informers/externalversions"
-	apisv1alpha1listers "github.com/kcp-dev/kcp/sdk/client/listers/apis/v1alpha1"
+	corev1alpha1listers "github.com/kcp-dev/kcp/sdk/client/listers/core/v1alpha1"
 )
 
 const (
@@ -44,6 +50,7 @@ func Register(plugins *admission.Plugins) {
 		func(_ io.Reader) (admission.Interface, error) {
 			return &crdNoOverlappingGVRAdmission{
 				Handler: admission.NewHandler(admission.Create),
+				now:     metav1.Now,
 			}, nil
 		})
 }
@@ -51,7 +58,10 @@ func Register(plugins *admission.Plugins) {
 type crdNoOverlappingGVRAdmission struct {
 	*admission.Handler
 
-	apiBindingClusterLister apisv1alpha1listers.APIBindingClusterLister
+	updateLogicalCluster func(ctx context.Context, logicalCluster *corev1alpha1.LogicalCluster, opts metav1.UpdateOptions) (*corev1alpha1.LogicalCluster, error)
+	logicalclusterLister corev1alpha1listers.LogicalClusterClusterLister
+
+	now func() metav1.Time
 }
 
 // Ensure that the required admission interfaces are implemented.
@@ -60,12 +70,21 @@ var _ = admission.InitializationValidator(&crdNoOverlappingGVRAdmission{})
 
 func (p *crdNoOverlappingGVRAdmission) SetKcpInformers(local, global kcpinformers.SharedInformerFactory) {
 	p.SetReadyFunc(local.Apis().V1alpha1().APIBindings().Informer().HasSynced)
-	p.apiBindingClusterLister = local.Apis().V1alpha1().APIBindings().Lister()
+	p.logicalclusterLister = local.Core().V1alpha1().LogicalClusters().Lister()
+}
+
+func (p *crdNoOverlappingGVRAdmission) SetKcpClusterClient(c kcpclientset.ClusterInterface) {
+	p.updateLogicalCluster = func(ctx context.Context, logicalCluster *corev1alpha1.LogicalCluster, opts metav1.UpdateOptions) (*corev1alpha1.LogicalCluster, error) {
+		return c.CoreV1alpha1().LogicalClusters().Cluster(logicalcluster.From(logicalCluster).Path()).Update(ctx, logicalCluster, opts)
+	}
 }
 
 func (p *crdNoOverlappingGVRAdmission) ValidateInitialization() error {
-	if p.apiBindingClusterLister == nil {
-		return fmt.Errorf(PluginName + " plugin needs an APIBindings lister")
+	if p.logicalclusterLister == nil {
+		return fmt.Errorf(PluginName + " plugin needs an LogicalCluster lister")
+	}
+	if p.updateLogicalCluster == nil {
+		return fmt.Errorf(PluginName + " plugin needs a KCP cluster client")
 	}
 	return nil
 }
@@ -78,13 +97,17 @@ func (p *crdNoOverlappingGVRAdmission) Validate(ctx context.Context, a admission
 	if a.GetKind().GroupKind() != apiextensions.Kind("CustomResourceDefinition") {
 		return nil
 	}
-	cluster, err := request.ClusterNameFrom(ctx)
+	if a.GetOperation() != admission.Create {
+		return nil
+	}
+
+	clusterName, err := request.ClusterNameFrom(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve cluster from context: %w", err)
 	}
-	clusterName := logicalcluster.Name(cluster.String()) // TODO(sttts): remove this cast once ClusterNameFrom returns a tenancy.Name
-	// ignore CRDs targeting system and non-root workspaces
-	if clusterName == apibinding.SystemBoundCRDsClusterName || clusterName == apiserver.LocalAdminCluster {
+
+	if clusterName == apibinding.SystemBoundCRDsClusterName {
+		// bound CRDs will have equal group and resource names.
 		return nil
 	}
 
@@ -92,21 +115,42 @@ func (p *crdNoOverlappingGVRAdmission) Validate(ctx context.Context, a admission
 	if !ok {
 		return fmt.Errorf("unexpected type %T", a.GetObject())
 	}
-	apiBindingsForCurrentClusterName, err := p.listAPIBindingsFor(clusterName)
-	if err != nil {
-		return err
-	}
-	for _, apiBindingForCurrentClusterName := range apiBindingsForCurrentClusterName {
-		for _, boundResource := range apiBindingForCurrentClusterName.Status.BoundResources {
-			if boundResource.Group == crd.Spec.Group && boundResource.Resource == crd.Spec.Names.Plural {
-				return admission.NewForbidden(a, fmt.Errorf("cannot create %q CustomResourceDefinition with %q group and %q resource because it overlaps with a bound CustomResourceDefinition for %q APIBinding in %q logical cluster",
-					crd.Name, crd.Spec.Group, crd.Spec.Names.Plural, apiBindingForCurrentClusterName.Name, clusterName))
-			}
-		}
-	}
-	return nil
-}
 
-func (p *crdNoOverlappingGVRAdmission) listAPIBindingsFor(clusterName logicalcluster.Name) ([]*apisv1alpha1.APIBinding, error) {
-	return p.apiBindingClusterLister.Cluster(clusterName).List(labels.Everything())
+	// (optimistically) lock group resource for LogicalCluster. If this request
+	// eventually fails, the logicalclustercleanup controller will clean them
+	// up eventually.
+	gr := schema.GroupResource{Group: crd.Spec.Group, Resource: crd.Spec.Names.Plural}
+	var skipped map[schema.GroupResource]apibinding.Lock
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		lc, err := p.logicalclusterLister.Cluster(clusterName).Get(corev1alpha1.LogicalClusterName)
+		if errors.IsNotFound(err) && strings.HasPrefix(string(clusterName), "system:") {
+			// in system logical clusters this is not fatal. We usually don't have a LogicalCluster there.
+			return nil
+		} else if err != nil {
+			return fmt.Errorf("failed to get LogicalCluster in logical cluster %q: %w", clusterName, err)
+		}
+
+		var updated *corev1alpha1.LogicalCluster
+		updated, _, skipped, err = apibinding.WithLockedResources(nil, time.Now(), lc, []schema.GroupResource{gr}, apibinding.ExpirableLock{
+			Lock:      apibinding.Lock{CRD: true},
+			CRDExpiry: ptr.To(p.now()),
+		})
+		if err != nil {
+			return fmt.Errorf("failed to lock resources %s in logical cluster %q: %w", gr, logicalcluster.From(crd), err)
+		}
+
+		_, err = p.updateLogicalCluster(ctx, updated, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+		return err
+	})
+	if err != nil {
+		return fmt.Errorf("failed to lock resources %s in logical cluster %q: %w", gr, logicalcluster.From(crd), err)
+	}
+	if len(skipped) > 0 {
+		return admission.NewForbidden(a, fmt.Errorf("cannot create because resource is bound by APIBinding %q", skipped[gr].Name))
+	}
+
+	return nil
 }

--- a/pkg/admission/crdnooverlappinggvr/crdnooverlappinggvr_admission_test.go
+++ b/pkg/admission/crdnooverlappinggvr/crdnooverlappinggvr_admission_test.go
@@ -18,31 +18,45 @@ package crdnooverlappinggvr
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
+	"time"
 
 	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v3"
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/ptr"
 
+	"github.com/kcp-dev/kcp/pkg/reconciler/apis/apibinding"
 	apisv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/apis/v1alpha1"
-	apisv1alpha1listers "github.com/kcp-dev/kcp/sdk/client/listers/apis/v1alpha1"
+	corev1alpha1 "github.com/kcp-dev/kcp/sdk/apis/core/v1alpha1"
+	corev1alpha1listers "github.com/kcp-dev/kcp/sdk/client/listers/core/v1alpha1"
 )
+
+var mockNow = func() metav1.Time {
+	ts, _ := time.Parse(time.RFC3339, "2022-01-01T00:00:00Z")
+	return metav1.Time{Time: ts}
+}
 
 func TestValidate(t *testing.T) {
 	scenarios := []struct {
-		name           string
-		attr           admission.Attributes
-		clusterName    logicalcluster.Name
-		initialObjects []runtime.Object
-		wantErr        bool
+		name                         string
+		attr                         admission.Attributes
+		clusterName                  logicalcluster.Name
+		initialObjects               []runtime.Object
+		logicalClusterUpdateConflict bool
+		wantErr                      bool
+		wantAnnotation               string
 	}{
 		{
 			name: "creating a conflicting CRD is forbidden",
@@ -54,8 +68,33 @@ func TestValidate(t *testing.T) {
 				},
 			}),
 			clusterName:    "root:acme",
-			initialObjects: []runtime.Object{createBinding("foo1", "root:acme", []apisv1alpha1.BoundAPIResource{{Group: "acme.dev", Resource: "foo"}})},
+			initialObjects: []runtime.Object{withBinding(createLogicalCluster("root:acme"), "foo1", []apisv1alpha1.BoundAPIResource{{Group: "acme.dev", Resource: "foo"}})},
 			wantErr:        true,
+			wantAnnotation: `{"foo.acme.dev":{"n":"foo1"}}`,
+		},
+		{
+			name: "updating a CRD is always allowed",
+			attr: updateAttr(&apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: apiextensions.CustomResourceDefinitionSpec{
+					Group: "acme.dev",
+					Names: apiextensions.CustomResourceDefinitionNames{Plural: "foo"},
+				},
+			}),
+			clusterName:    "root:acme",
+			initialObjects: []runtime.Object{withBinding(createLogicalCluster("root:acme"), "foo1", []apisv1alpha1.BoundAPIResource{{Group: "acme.dev", Resource: "foo"}})},
+		},
+		{
+			name: "deleting a CRD is always allowed",
+			attr: deleteAttr(&apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: apiextensions.CustomResourceDefinitionSpec{
+					Group: "acme.dev",
+					Names: apiextensions.CustomResourceDefinitionNames{Plural: "foo"},
+				},
+			}),
+			clusterName:    "root:acme",
+			initialObjects: []runtime.Object{withBinding(createLogicalCluster("root:acme"), "foo1", []apisv1alpha1.BoundAPIResource{{Group: "acme.dev", Resource: "foo"}})},
 		},
 
 		{
@@ -68,7 +107,7 @@ func TestValidate(t *testing.T) {
 				},
 			}),
 			clusterName:    "system:bound-crds",
-			initialObjects: []runtime.Object{createBinding("foo1", "root:acme", []apisv1alpha1.BoundAPIResource{{Group: "acme.dev", Resource: "foo"}})},
+			initialObjects: []runtime.Object{},
 		},
 
 		{
@@ -81,7 +120,90 @@ func TestValidate(t *testing.T) {
 				},
 			}),
 			clusterName:    "root:acme",
-			initialObjects: []runtime.Object{createBinding("foo1", "root:acme", []apisv1alpha1.BoundAPIResource{{Group: "acme.dev", Resource: "bar"}})},
+			initialObjects: []runtime.Object{withBinding(createLogicalCluster("root:acme"), "foo1", []apisv1alpha1.BoundAPIResource{{Group: "acme.dev", Resource: "bar"}})},
+			wantAnnotation: `{"bar.acme.dev":{"n":"foo1"},"foo.acme.dev":{"c":true,"e":"2022-01-01T00:00:00Z"}}`,
+		},
+
+		{
+			name: "permanent logical cluster update conflict fails the request",
+			attr: createAttr(&apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: apiextensions.CustomResourceDefinitionSpec{
+					Group: "acme.dev",
+					Names: apiextensions.CustomResourceDefinitionNames{Plural: "foo"},
+				},
+			}),
+			clusterName:                  "root:acme",
+			initialObjects:               []runtime.Object{withBinding(createLogicalCluster("root:acme"), "foo1", []apisv1alpha1.BoundAPIResource{{Group: "acme.dev", Resource: "bar"}})},
+			logicalClusterUpdateConflict: true,
+			wantErr:                      true,
+		},
+
+		{
+			name: "fails without resource binding annotation on LogicalCluster",
+			attr: createAttr(&apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: apiextensions.CustomResourceDefinitionSpec{
+					Group: "acme.dev",
+					Names: apiextensions.CustomResourceDefinitionNames{Plural: "foo"},
+				},
+			}),
+			clusterName:    "root:acme",
+			initialObjects: []runtime.Object{createLogicalCluster("root:acme")},
+			wantErr:        true,
+		},
+		{
+			name: "fails without LogicalCluster",
+			attr: createAttr(&apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: apiextensions.CustomResourceDefinitionSpec{
+					Group: "acme.dev",
+					Names: apiextensions.CustomResourceDefinitionNames{Plural: "foo"},
+				},
+			}),
+			clusterName:    "root:acme",
+			initialObjects: []runtime.Object{},
+			wantErr:        true,
+		},
+		{
+			name: "passes without LogicalCluster in system logical cluster",
+			attr: createAttr(&apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: apiextensions.CustomResourceDefinitionSpec{
+					Group: "acme.dev",
+					Names: apiextensions.CustomResourceDefinitionNames{Plural: "foo"},
+				},
+			}),
+			clusterName:    "system:shard",
+			initialObjects: []runtime.Object{},
+		},
+
+		{
+			name: "succeeds with other CRD",
+			attr: createAttr(&apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: apiextensions.CustomResourceDefinitionSpec{
+					Group: "acme.dev",
+					Names: apiextensions.CustomResourceDefinitionNames{Plural: "foo"},
+				},
+			}),
+			clusterName:    "root:acme",
+			initialObjects: []runtime.Object{withCRD(createLogicalCluster("root:acme"), schema.GroupResource{Group: "acme.dev", Resource: "bar"}, ptr.To(metav1.Time{Time: mockNow().Add(-time.Minute)}))},
+			wantAnnotation: `{"bar.acme.dev":{"c":true,"e":"2021-12-31T23:59:00Z"},"foo.acme.dev":{"c":true,"e":"2022-01-01T00:00:00Z"}}`,
+		},
+
+		{
+			name: "falls through with same CRD",
+			attr: createAttr(&apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: apiextensions.CustomResourceDefinitionSpec{
+					Group: "acme.dev",
+					Names: apiextensions.CustomResourceDefinitionNames{Plural: "foo"},
+				},
+			}),
+			clusterName:    "root:acme",
+			initialObjects: []runtime.Object{withCRD(createLogicalCluster("root:acme"), schema.GroupResource{Group: "acme.dev", Resource: "foo"}, ptr.To(metav1.Time{Time: mockNow().Add(-time.Minute)}))},
+			wantAnnotation: `{"foo.acme.dev":{"c":true,"e":"2022-01-01T00:00:00Z"}}`,
 		},
 	}
 	for _, scenario := range scenarios {
@@ -93,10 +215,35 @@ func TestValidate(t *testing.T) {
 				}
 			}
 
-			a := &crdNoOverlappingGVRAdmission{Handler: admission.NewHandler(admission.Create, admission.Update), apiBindingClusterLister: apisv1alpha1listers.NewAPIBindingClusterLister(indexer)}
+			var updatedLogicalCluster *corev1alpha1.LogicalCluster
+			a := &crdNoOverlappingGVRAdmission{
+				Handler:              admission.NewHandler(admission.Create, admission.Update),
+				logicalclusterLister: corev1alpha1listers.NewLogicalClusterClusterLister(indexer),
+				updateLogicalCluster: func(ctx context.Context, lc *corev1alpha1.LogicalCluster, opts metav1.UpdateOptions) (*corev1alpha1.LogicalCluster, error) {
+					updatedLogicalCluster = lc
+					return lc, nil
+				},
+				now: mockNow,
+			}
+
+			if scenario.logicalClusterUpdateConflict {
+				a.updateLogicalCluster = func(ctx context.Context, lc *corev1alpha1.LogicalCluster, opts metav1.UpdateOptions) (*corev1alpha1.LogicalCluster, error) {
+					return nil, kerrors.NewConflict(schema.GroupResource{}, "conflict", nil)
+				}
+			}
+
 			ctx := request.WithCluster(context.Background(), request.Cluster{Name: scenario.clusterName})
 			if err := a.Validate(ctx, scenario.attr, nil); (err != nil) != scenario.wantErr {
 				t.Fatalf("Validate() error = %v, wantErr %v", err, scenario.wantErr)
+			}
+
+			if scenario.wantAnnotation != "" {
+				if updatedLogicalCluster == nil {
+					t.Fatal("expected LogicalCluster to be updated, got nil")
+				}
+				if got := updatedLogicalCluster.Annotations[apibinding.ResourceBindingsAnnotationKey]; got != scenario.wantAnnotation {
+					t.Errorf("expected LogicalCluster annotation %q, got %q", scenario.wantAnnotation, got)
+				}
 			}
 		})
 	}
@@ -118,14 +265,88 @@ func createAttr(obj *apiextensions.CustomResourceDefinition) admission.Attribute
 	)
 }
 
-func createBinding(name string, clusterName string, boundResources []apisv1alpha1.BoundAPIResource) *apisv1alpha1.APIBinding {
-	return &apisv1alpha1.APIBinding{
+func updateAttr(obj *apiextensions.CustomResourceDefinition) admission.Attributes {
+	return admission.NewAttributesRecord(
+		obj,
+		obj,
+		apiextensionsv1.Kind("CustomResourceDefinition").WithVersion("v1"),
+		"",
+		"test",
+		apiextensionsv1.Resource("customresourcedefinitions").WithVersion("v1"),
+		"",
+		admission.Update,
+		&metav1.CreateOptions{},
+		false,
+		&user.DefaultInfo{},
+	)
+}
+
+func deleteAttr(obj *apiextensions.CustomResourceDefinition) admission.Attributes {
+	return admission.NewAttributesRecord(
+		obj,
+		nil,
+		apiextensionsv1.Kind("CustomResourceDefinition").WithVersion("v1"),
+		"",
+		"test",
+		apiextensionsv1.Resource("customresourcedefinitions").WithVersion("v1"),
+		"",
+		admission.Delete,
+		&metav1.CreateOptions{},
+		false,
+		&user.DefaultInfo{},
+	)
+}
+
+func createLogicalCluster(clusterName string) *corev1alpha1.LogicalCluster {
+	return &corev1alpha1.LogicalCluster{
 		ObjectMeta: metav1.ObjectMeta{
+			Name: corev1alpha1.LogicalClusterName,
 			Annotations: map[string]string{
 				logicalcluster.AnnotationKey: clusterName,
 			},
-			Name: name,
 		},
-		Status: apisv1alpha1.APIBindingStatus{BoundResources: boundResources},
 	}
+}
+
+func withCRD(lc *corev1alpha1.LogicalCluster, gr schema.GroupResource, expiry *metav1.Time) *corev1alpha1.LogicalCluster {
+	rbs := make(apibinding.ResourceBindingsAnnotation)
+	if v := lc.Annotations[apibinding.ResourceBindingsAnnotationKey]; v != "" {
+		if err := json.Unmarshal([]byte(v), &rbs); err != nil {
+			panic(err)
+		}
+	}
+
+	rbs[gr.String()] = apibinding.ExpirableLock{
+		Lock:      apibinding.Lock{CRD: true},
+		CRDExpiry: expiry,
+	}
+
+	bs, err := json.Marshal(rbs)
+	if err != nil {
+		panic(err)
+	}
+	lc.Annotations[apibinding.ResourceBindingsAnnotationKey] = string(bs)
+	return lc
+}
+
+func withBinding(lc *corev1alpha1.LogicalCluster, binding string, boundResources []apisv1alpha1.BoundAPIResource) *corev1alpha1.LogicalCluster {
+	rbs := make(apibinding.ResourceBindingsAnnotation)
+	if v := lc.Annotations[apibinding.ResourceBindingsAnnotationKey]; v != "" {
+		if err := json.Unmarshal([]byte(v), &rbs); err != nil {
+			panic(err)
+		}
+	}
+
+	for _, br := range boundResources {
+		rbs[schema.GroupResource{Group: br.Group, Resource: br.Resource}.String()] = apibinding.ExpirableLock{
+			Lock: apibinding.Lock{Name: binding},
+		}
+	}
+
+	bs, err := json.Marshal(rbs)
+	if err != nil {
+		panic(err)
+	}
+	lc.Annotations[apibinding.ResourceBindingsAnnotationKey] = string(bs)
+	return lc
 }

--- a/pkg/reconciler/apis/apibinding/apibinding_reconcile.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_reconcile.go
@@ -211,7 +211,7 @@ func (r *bindingReconciler) reconcile(ctx context.Context, apiBinding *apisv1alp
 
 	var needToWaitForRequeueWhenEstablished []string
 
-	checker, err := newConflictChecker(logicalcluster.From(apiBinding), r.listAPIBindings, r.getAPIExportByPath, r.getAPIResourceSchema, r.getCRD, r.listCRDs)
+	checker, err := newConflictChecker(logicalcluster.From(apiBinding), r.listAPIBindings, r.getAPIResourceSchema, r.getCRD, r.listCRDs)
 	if err != nil {
 		return reconcileStatusContinue, err
 	}

--- a/pkg/reconciler/apis/apibinding/apibinding_reconcile.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_reconcile.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/kcp-dev/logicalcluster/v3"
 
@@ -31,8 +32,10 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/apiserver"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 
 	"github.com/kcp-dev/kcp/pkg/logging"
@@ -140,10 +143,10 @@ type bindingReconciler struct {
 func (r *bindingReconciler) reconcile(ctx context.Context, apiBinding *apisv1alpha1.APIBinding) (reconcileStatus, error) {
 	logger := klog.FromContext(ctx)
 
-	// Check for valid reference
+	// Check for valid APIExport reference
 	workspaceRef := apiBinding.Spec.Reference.Export
 	if workspaceRef == nil {
-		// this should not happen because of OpenAPI
+		// this should not happen because of validation.
 		conditions.MarkFalse(
 			apiBinding,
 			apisv1alpha1.APIExportValid,
@@ -153,8 +156,6 @@ func (r *bindingReconciler) reconcile(ctx context.Context, apiBinding *apisv1alp
 		)
 		return reconcileStatusContinue, nil
 	}
-
-	// Get APIExport
 	apiExportPath := logicalcluster.NewPath(apiBinding.Spec.Reference.Export.Path)
 	if apiExportPath.Empty() {
 		apiExportPath = logicalcluster.From(apiBinding).Path()
@@ -185,7 +186,6 @@ func (r *bindingReconciler) reconcile(ctx context.Context, apiBinding *apisv1alp
 		)
 		return reconcileStatusContinue, err
 	}
-
 	logger = logging.WithObject(logger, apiExport)
 
 	// Record the export's permission claims
@@ -209,19 +209,11 @@ func (r *bindingReconciler) reconcile(ctx context.Context, apiBinding *apisv1alp
 	// The full path is unreliable for this purpose.
 	apiBinding.Status.APIExportClusterName = logicalcluster.From(apiExport).String()
 
-	var needToWaitForRequeueWhenEstablished []string
-
-	checker, err := newConflictChecker(logicalcluster.From(apiBinding), r.listAPIBindings, r.getAPIResourceSchema, r.getCRD, r.listCRDs)
-	if err != nil {
-		return reconcileStatusContinue, err
-	}
-
-	// Process all APIResourceSchemas
+	// Collect the schemas.
+	schemas := make(map[string]*apisv1alpha1.APIResourceSchema)
+	grs := sets.New[schema.GroupResource]()
 	for _, schemaName := range apiExport.Spec.LatestResourceSchemas {
-		bindingClusterName := logicalcluster.From(apiBinding)
-
-		// Get the schema
-		schema, err := r.getAPIResourceSchema(logicalcluster.From(apiExport), schemaName)
+		sch, err := r.getAPIResourceSchema(logicalcluster.From(apiExport), schemaName)
 		if err != nil {
 			logger.Error(err, "error binding")
 
@@ -230,7 +222,7 @@ func (r *bindingReconciler) reconcile(ctx context.Context, apiBinding *apisv1alp
 				apisv1alpha1.APIExportValid,
 				apisv1alpha1.InternalErrorReason,
 				conditionsv1alpha1.ConditionSeverityError,
-				"Invalid APIExport. Please contact the APIExport owner to resolve",
+				"Invalid APIExport. Please contact the APIExport owner to resolve: APIResourceSchema %q not found", schemaName,
 			)
 
 			if apierrors.IsNotFound(err) {
@@ -239,9 +231,57 @@ func (r *bindingReconciler) reconcile(ctx context.Context, apiBinding *apisv1alp
 
 			return reconcileStatusContinue, err
 		}
-		logger := logging.WithObject(logger, schema)
+		schemas[schemaName] = sch
+		grs = grs.Insert(schema.GroupResource{Group: sch.Spec.Group, Resource: sch.Spec.Names.Plural})
+	}
 
-		if err := checker.Check(apiBinding, schema); err != nil {
+	crds, err := r.listCRDs(logicalcluster.From(apiBinding))
+	if err != nil {
+		return reconcileStatusContinue, err
+	}
+
+	var skipped map[schema.GroupResource]Lock
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		// Look up LogicalCluster which acts as our lock to avoid having multiple bindings
+		// and/or CRDs owning the same resource.
+		lc, err := r.getLogicalCluster(logicalcluster.From(apiBinding))
+		if err != nil {
+			conditions.MarkFalse(
+				apiBinding,
+				apisv1alpha1.BindingUpToDate,
+				apisv1alpha1.LogicalClusterNotFoundReason,
+				conditionsv1alpha1.ConditionSeverityError,
+				"Unable to bind APIs: %v",
+				err,
+			)
+
+			// Only change InitialBindingCompleted if it's false.
+			if conditions.IsFalse(apiBinding, apisv1alpha1.InitialBindingCompleted) {
+				conditions.MarkFalse(
+					apiBinding,
+					apisv1alpha1.InitialBindingCompleted,
+					apisv1alpha1.LogicalClusterNotFoundReason,
+					conditionsv1alpha1.ConditionSeverityError,
+					"Unable to bind APIs: %v",
+					err,
+				)
+			}
+
+			// wait until it shows up. Bindings don't work without.
+			return err
+		}
+
+		// Lock resources before going any further. Not being able to lock all resources is NOT an error.
+		// It will be reflected in the BindingUpToDate and InitialBindingCompleted conditions.
+		// TODO(sttts): removed schemas never get unlocked. We need a distinguishable way
+		//              for intentional removal of schemas, versus movement of schemas
+		//              to another APIExport.
+		lc, _, skipped, err = WithLockedResources(crds, time.Now(), lc, grs.UnsortedList(), ExpirableLock{
+			Lock: Lock{Name: apiBinding.Name},
+		})
+		if err != nil {
+			logger.Error(err, "error locking resources", "skipped", skipped)
+
 			conditions.MarkFalse(
 				apiBinding,
 				apisv1alpha1.BindingUpToDate,
@@ -251,7 +291,62 @@ func (r *bindingReconciler) reconcile(ctx context.Context, apiBinding *apisv1alp
 				err,
 			)
 
-			// Only change InitialBindingCompleted if it's false
+			// Only change InitialBindingCompleted if it's false.
+			if conditions.IsFalse(apiBinding, apisv1alpha1.InitialBindingCompleted) {
+				conditions.MarkFalse(
+					apiBinding,
+					apisv1alpha1.InitialBindingCompleted,
+					apisv1alpha1.NamingConflictsReason,
+					conditionsv1alpha1.ConditionSeverityError,
+					"Unable to bind APIs: %v",
+					err,
+				)
+			}
+
+			return err
+		}
+
+		if err := r.updateLogicalCluster(ctx, lc); err != nil {
+			return err
+		}
+
+		if len(skipped) > 0 {
+			logger.V(4).Info("skipped resources", "resources", skipped)
+		}
+
+		return nil
+	}); err != nil {
+		logger.Error(err, "error updating LogicalCluster")
+		return reconcileStatusContinue, err
+	}
+
+	checker, err := newConflictChecker(logicalcluster.From(apiBinding), r.listAPIBindings, r.getAPIResourceSchema, r.getCRD, r.listCRDs)
+	if err != nil {
+		return reconcileStatusContinue, err
+	}
+	var needToWaitForRequeueWhenEstablished []string
+	for _, schemaName := range apiExport.Spec.LatestResourceSchemas {
+		sch := schemas[schemaName]
+		logger := logging.WithObject(logger, sch)
+
+		if _, ok := skipped[schema.GroupResource{Group: sch.Spec.Group, Resource: sch.Spec.Names.Plural}]; ok {
+			// This resource was skipped because it's already locked by another binding.
+			continue
+		}
+
+		// A resource will be served if the group resource is locked by this binding AND there are no
+		// naming conflicts with other bindings or CRDs. The former is critical, the latter is advisory.
+		if err := checker.Check(apiBinding, sch); err != nil {
+			conditions.MarkFalse(
+				apiBinding,
+				apisv1alpha1.BindingUpToDate,
+				apisv1alpha1.NamingConflictsReason,
+				conditionsv1alpha1.ConditionSeverityError,
+				"Unable to bind APIs: %v",
+				err,
+			)
+
+			// Only change InitialBindingCompleted if it's false.
 			if conditions.IsFalse(apiBinding, apisv1alpha1.InitialBindingCompleted) {
 				conditions.MarkFalse(
 					apiBinding,
@@ -266,7 +361,7 @@ func (r *bindingReconciler) reconcile(ctx context.Context, apiBinding *apisv1alp
 		}
 
 		// If there are multiple versions, the conversion strategy must be defined in the APIResourceSchema
-		if len(schema.Spec.Versions) > 1 && schema.Spec.Conversion == nil {
+		if len(sch.Spec.Versions) > 1 && sch.Spec.Conversion == nil {
 			conditions.MarkFalse(
 				apiBinding,
 				apisv1alpha1.APIExportValid,
@@ -278,7 +373,7 @@ func (r *bindingReconciler) reconcile(ctx context.Context, apiBinding *apisv1alp
 			return reconcileStatusContinue, fmt.Errorf(
 				"conversion strategy not specified %s|%s for APIBinding %s|%s, APIExport %s|%s, APIResourceSchema %s|%s: %w",
 				apiExportPath, schemaName,
-				bindingClusterName, apiBinding.Name,
+				logicalcluster.From(apiBinding), apiBinding.Name,
 				apiExportPath, apiExport.Name,
 				apiExportPath, schemaName,
 				err,
@@ -286,7 +381,7 @@ func (r *bindingReconciler) reconcile(ctx context.Context, apiBinding *apisv1alp
 		}
 
 		// Try to get the bound CRD
-		existingCRD, err := r.getCRD(SystemBoundCRDsClusterName, boundCRDName(schema))
+		existingCRD, err := r.getCRD(SystemBoundCRDsClusterName, boundCRDName(sch))
 		if err != nil && !apierrors.IsNotFound(err) {
 			conditions.MarkFalse(
 				apiBinding,
@@ -298,8 +393,8 @@ func (r *bindingReconciler) reconcile(ctx context.Context, apiBinding *apisv1alp
 
 			return reconcileStatusContinue, fmt.Errorf(
 				"error getting CRD %s|%s for APIBinding %s|%s, APIExport %s|%s, APIResourceSchema %s|%s: %w",
-				SystemBoundCRDsClusterName, boundCRDName(schema),
-				bindingClusterName, apiBinding.Name,
+				SystemBoundCRDsClusterName, boundCRDName(sch),
+				logicalcluster.From(apiBinding), apiBinding.Name,
 				apiExportPath, apiExport.Name,
 				apiExportPath, schemaName,
 				err,
@@ -319,7 +414,7 @@ func (r *bindingReconciler) reconcile(ctx context.Context, apiBinding *apisv1alp
 			}
 		} else {
 			// Need to create bound CRD
-			crd, err := generateCRD(schema)
+			crd, err := generateCRD(sch)
 			if err != nil {
 				logger.Error(err, "error generating CRD")
 
@@ -347,7 +442,7 @@ func (r *bindingReconciler) reconcile(ctx context.Context, apiBinding *apisv1alp
 			// Create bound CRD
 			logger.V(2).Info("creating CRD")
 			if _, err := r.createCRD(ctx, SystemBoundCRDsClusterName.Path(), crd); err != nil {
-				schemaClusterName := logicalcluster.From(schema)
+				schemaClusterName := logicalcluster.From(sch)
 				if apierrors.IsInvalid(err) {
 					status := apierrors.APIStatus(nil)
 					// The error is guaranteed to implement APIStatus here
@@ -411,7 +506,7 @@ func (r *bindingReconciler) reconcile(ctx context.Context, apiBinding *apisv1alp
 		}
 
 		for _, b := range apiBinding.Status.BoundResources {
-			if b.Group == schema.Spec.Group && b.Resource == schema.Spec.Names.Plural {
+			if b.Group == sch.Spec.Group && b.Resource == sch.Spec.Names.Plural {
 				storageVersions.Insert(b.StorageVersions...)
 				break
 			}
@@ -422,11 +517,11 @@ func (r *bindingReconciler) reconcile(ctx context.Context, apiBinding *apisv1alp
 
 		// Upsert the BoundAPIResource for this APIResourceSchema
 		newBoundResource := apisv1alpha1.BoundAPIResource{
-			Group:    schema.Spec.Group,
-			Resource: schema.Spec.Names.Plural,
+			Group:    sch.Spec.Group,
+			Resource: sch.Spec.Names.Plural,
 			Schema: apisv1alpha1.BoundAPIResourceSchema{
-				Name:         schema.Name,
-				UID:          string(schema.UID),
+				Name:         sch.Name,
+				UID:          string(sch.UID),
 				IdentityHash: apiExport.Status.IdentityHash,
 			},
 			StorageVersions: sortedStorageVersions,
@@ -434,7 +529,7 @@ func (r *bindingReconciler) reconcile(ctx context.Context, apiBinding *apisv1alp
 
 		found := false
 		for i, r := range apiBinding.Status.BoundResources {
-			if r.Group == schema.Spec.Group && r.Resource == schema.Spec.Names.Plural {
+			if r.Group == sch.Spec.Group && r.Resource == sch.Spec.Names.Plural {
 				apiBinding.Status.BoundResources[i] = newBoundResource
 				found = true
 				break
@@ -468,6 +563,25 @@ func (r *bindingReconciler) reconcile(ctx context.Context, apiBinding *apisv1alp
 				conditionsv1alpha1.ConditionSeverityInfo,
 				"Waiting for API(s) to be established: %s",
 				strings.Join(needToWaitForRequeueWhenEstablished, ", "),
+			)
+		}
+	} else if len(skipped) > 0 {
+		conditions.MarkFalse(
+			apiBinding,
+			apisv1alpha1.BindingUpToDate,
+			apisv1alpha1.NamingConflictsReason,
+			conditionsv1alpha1.ConditionSeverityError,
+			"Unable to bind APIs because they are bound by other APIBindings or CRDs: %v", skipped,
+		)
+
+		// Only change InitialBindingCompleted if it's false
+		if conditions.IsFalse(apiBinding, apisv1alpha1.InitialBindingCompleted) {
+			conditions.MarkFalse(
+				apiBinding,
+				apisv1alpha1.InitialBindingCompleted,
+				apisv1alpha1.NamingConflictsReason,
+				conditionsv1alpha1.ConditionSeverityError,
+				"Unable to bind APIs because they are bound by other APIBindings or CRDs: %v", skipped,
 			)
 		}
 	} else {

--- a/pkg/reconciler/apis/apibinding/apibinding_reconcile_test.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_reconcile_test.go
@@ -163,6 +163,8 @@ func TestReconcileBinding(t *testing.T) {
 
 	todaywidgetsuid := withName(newCRD("kcp.io", "widgets"), "todaywidgetsuid")
 	anotherwidgetsuid := withName(newCRD("kcp.io", "widgets"), "anotherwidgetsuid")
+	uid1 := withName(newCRD("someresources.mygroup", "todays"), "uid1")
+	uid2 := withName(newCRD("someresources.anothergroup", "todays"), "uid2")
 
 	type wantAPIExportValid struct {
 		invalidReference bool
@@ -297,6 +299,9 @@ func TestReconcileBinding(t *testing.T) {
 			apiBinding: binding.Build(),
 			existingAPIBindings: []*apisv1alpha1.APIBinding{
 				bound.Build(),
+			},
+			crds: map[logicalcluster.Name][]*apiextensionsv1.CustomResourceDefinition{
+				SystemBoundCRDsClusterName: {anotherwidgetsuid, uid1, uid2},
 			},
 			wantCreateCRD: true,
 			wantAPIExportValid: wantAPIExportValid{
@@ -514,7 +519,6 @@ func TestReconcileBinding(t *testing.T) {
 							return crd, nil
 						}
 					}
-
 					return nil, apierrors.NewNotFound(schema.GroupResource{}, name)
 				},
 				listCRDs: func(clusterName logicalcluster.Name) ([]*apiextensionsv1.CustomResourceDefinition, error) {

--- a/pkg/reconciler/apis/apibinding/conflict_checker_test.go
+++ b/pkg/reconciler/apis/apibinding/conflict_checker_test.go
@@ -60,24 +60,6 @@ func TestNameConflictCheckerGetBoundCRDs(t *testing.T) {
 		).
 		Build()
 
-	apiExports := map[string]*apisv1alpha1.APIExport{
-		"export0": {
-			Spec: apisv1alpha1.APIExportSpec{
-				LatestResourceSchemas: []string{"export0-schema1"},
-			},
-		},
-		"export1": {
-			Spec: apisv1alpha1.APIExportSpec{
-				LatestResourceSchemas: []string{"export1-schema1", "export1-schema2", "export1-schema3"},
-			},
-		},
-		"export2": {
-			Spec: apisv1alpha1.APIExportSpec{
-				LatestResourceSchemas: []string{"export2-schema1", "export2-schema2", "export2-schema3"},
-			},
-		},
-	}
-
 	apiResourceSchemas := map[string]*apisv1alpha1.APIResourceSchema{
 		"export0-schema1": {ObjectMeta: metav1.ObjectMeta{UID: "e0-s1"}},
 		"export1-schema1": {ObjectMeta: metav1.ObjectMeta{UID: "e1-s1"}},
@@ -95,9 +77,6 @@ func TestNameConflictCheckerGetBoundCRDs(t *testing.T) {
 				existingBinding1,
 				existingBinding2,
 			}, nil
-		},
-		func(path logicalcluster.Path, name string) (*apisv1alpha1.APIExport, error) {
-			return apiExports[name], nil
 		},
 		func(clusterName logicalcluster.Name, name string) (*apisv1alpha1.APIResourceSchema, error) {
 			return apiResourceSchemas[name], nil
@@ -276,7 +255,6 @@ func TestCRDs(t *testing.T) {
 				func(clusterName logicalcluster.Name) ([]*apisv1alpha1.APIBinding, error) {
 					return nil, nil
 				},
-				func(path logicalcluster.Path, name string) (*apisv1alpha1.APIExport, error) { return nil, nil },
 				func(clusterName logicalcluster.Name, name string) (*apisv1alpha1.APIResourceSchema, error) {
 					return nil, nil
 				},

--- a/pkg/reconciler/apis/apibinding/logical_cluster_lock.go
+++ b/pkg/reconciler/apis/apibinding/logical_cluster_lock.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apibinding
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/json"
+
+	corev1alpha1 "github.com/kcp-dev/kcp/sdk/apis/core/v1alpha1"
+	kcpclientset "github.com/kcp-dev/kcp/sdk/client/clientset/versioned/cluster"
+)
+
+const (
+	// ResourceBindingsAnnotationKey is the key for the annotation on the LogicalCluster
+	// to hold ResourceBindings.
+	ResourceBindingsAnnotationKey = "internal.apis.kcp.io/resource-bindings"
+)
+
+// Lock is a lock for a resource, part of the apis.kcp.io/resource-bindings annotation.
+type Lock struct {
+	// Name is the name of the APIBinding, or empty.
+	Name string `json:"n,omitempty"`
+	// CRD is true if the binding is for a CRD.
+	CRD bool `json:"c,omitempty"`
+}
+
+// ExpirableLock is a lock that can expire CRD entries.
+type ExpirableLock struct {
+	Lock `json:",inline"`
+
+	// Expiry is an optional timestamp. After that time, the CRD entry is not
+	// considered valid anymore IF the object cannot be found.
+	CRDExpiry *metav1.Time `json:"e,omitempty"`
+}
+
+// ResourceBindingsAnnotation is a map of "<resource>.<group>" to bindings. It
+// is stored as a JSON string in the LogicalCluster annotation
+// apis.kcp.io/resource-bindings. It serves as a lock for resources
+// to prevent races of multiple bindings or CRDs owning the same resource.
+type ResourceBindingsAnnotation map[string]ExpirableLock
+
+// WithLockedResources tries to lock the resources for the given binding. It
+// returns those resources that got successfully locked. If a resource is already
+// locked by another binding, it is skipped and returned in the second return
+// value.
+//
+// The logical cluster is not mutated.
+func WithLockedResources(crds []*apiextensionsv1.CustomResourceDefinition, now time.Time, lc *corev1alpha1.LogicalCluster, grs []schema.GroupResource, binding ExpirableLock) (*corev1alpha1.LogicalCluster, []schema.GroupResource, map[schema.GroupResource]Lock, error) {
+	v, found := lc.Annotations[ResourceBindingsAnnotationKey]
+	if !found || v == "" {
+		return nil, nil, nil, fmt.Errorf("%s annotation not found, migration has to happen first", ResourceBindingsAnnotationKey)
+	}
+
+	rbs := make(ResourceBindingsAnnotation)
+	if err := json.Unmarshal([]byte(v), &rbs); err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to unmarshal ResourceBindings annotation: %w", err)
+	}
+	if rbs == nil {
+		rbs = make(ResourceBindingsAnnotation)
+	}
+
+	crdNames := make(map[string]bool, len(crds))
+	for _, crd := range crds {
+		crdNames[crd.Name] = true
+	}
+
+	// find what resources need to be newly locked
+	skipped := make(map[schema.GroupResource]Lock)
+	newlyLocked := make([]schema.GroupResource, 0, len(grs))
+	locked := make([]schema.GroupResource, 0, len(grs))
+	for _, gr := range grs {
+		b, found := rbs[gr.String()]
+		if !found || b.Lock == binding.Lock {
+			newlyLocked = append(newlyLocked, gr)
+			locked = append(locked, gr)
+			continue
+		}
+		if b.CRD && !crdNames[gr.String()] && b.CRDExpiry != nil && now.After(b.CRDExpiry.Time) {
+			// CRD binding expired, and CRD is not known
+			newlyLocked = append(newlyLocked, gr)
+			locked = append(locked, gr)
+			continue
+		}
+		skipped[gr] = b.Lock
+	}
+
+	// don't do anything if no resources need to be locked
+	if len(newlyLocked) == 0 {
+		return lc, locked, skipped, nil
+	}
+
+	// update the LogicalCluster with the new binding information
+	for _, gr := range newlyLocked {
+		rbs[gr.String()] = binding
+	}
+	lc = lc.DeepCopy()
+	bs, err := json.Marshal(rbs)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to marshal ResourceBindings annotation: %w", err)
+	}
+	lc.Annotations[ResourceBindingsAnnotationKey] = string(bs)
+
+	return lc, locked, skipped, nil
+}
+
+// unlockResource unlocks the resource for the given binding. It updates the
+// LogicalCluster with the new binding information IFF at least one resource
+// was unlocked.
+func unlockResource(ctx context.Context, kcpClusterCLient kcpclientset.ClusterInterface, lc *corev1alpha1.LogicalCluster, grs []schema.GroupResource, binding Lock) error { //nolint:unused // will be used eventually.
+	v, found := lc.Annotations[ResourceBindingsAnnotationKey]
+	if !found {
+		return fmt.Errorf("%s annotation not found, migration has to happen first", ResourceBindingsAnnotationKey)
+	}
+
+	var rbs ResourceBindingsAnnotation
+	if err := json.Unmarshal([]byte(v), &rbs); err != nil {
+		return fmt.Errorf("failed to unmarshal ResourceBindings annotation: %w", err)
+	}
+
+	unlocked := false
+	for _, gr := range grs {
+		if bound, found := rbs[gr.String()]; found && bound.Lock == binding {
+			delete(rbs, gr.String())
+			unlocked = true
+		}
+	}
+	if !unlocked {
+		return nil
+	}
+
+	lc = lc.DeepCopy()
+	bs, err := json.Marshal(rbs)
+	if err != nil {
+		return fmt.Errorf("failed to marshal ResourceBindings annotation: %w", err)
+	}
+	lc.Annotations[ResourceBindingsAnnotationKey] = string(bs)
+
+	_, err = kcpClusterCLient.CoreV1alpha1().LogicalClusters().Cluster(logicalcluster.From(lc).Path()).Update(ctx, lc, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/reconciler/apis/apibinding/logical_cluster_lock_test.go
+++ b/pkg/reconciler/apis/apibinding/logical_cluster_lock_test.go
@@ -1,0 +1,204 @@
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apibinding
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	corev1alpha1 "github.com/kcp-dev/kcp/sdk/apis/core/v1alpha1"
+)
+
+func TestWithLockedResources(t *testing.T) {
+	now := time.Now().UTC()
+	expired := time.Now().Add(-1).UTC().Format(time.RFC3339)
+	notExpired := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+
+	tests := map[string]struct {
+		lc      *corev1alpha1.LogicalCluster
+		crds    []*apiextensionsv1.CustomResourceDefinition
+		grs     []schema.GroupResource
+		binding ExpirableLock
+
+		want        *corev1alpha1.LogicalCluster
+		wantLocked  []schema.GroupResource
+		wantSkipped map[schema.GroupResource]Lock
+		wantErr     bool
+	}{
+		"no annotation errors": {
+			lc:      &corev1alpha1.LogicalCluster{},
+			grs:     []schema.GroupResource{{Group: "group", Resource: "foos"}},
+			binding: ExpirableLock{Lock: Lock{Name: "binding"}},
+			wantErr: true,
+		},
+		"empty annotation errors": {
+			lc:      newLogicalClusterWithAnnotation(""),
+			grs:     []schema.GroupResource{{Group: "group", Resource: "foos"}},
+			binding: ExpirableLock{Lock: Lock{Name: "binding"}},
+			wantErr: true,
+		},
+		"invalid annotation errors": {
+			lc:      newLogicalClusterWithAnnotation("invalid"),
+			grs:     []schema.GroupResource{{Group: "group", Resource: "foos"}},
+			binding: ExpirableLock{Lock: Lock{Name: "binding"}},
+			wantErr: true,
+		},
+		"empty annotation succeeds": {
+			lc:          newLogicalClusterWithAnnotation("{}"),
+			grs:         []schema.GroupResource{{Group: "group", Resource: "foos"}},
+			binding:     ExpirableLock{Lock: Lock{Name: "binding"}},
+			want:        newLogicalClusterWithAnnotation(`{"foos.group":{"n":"binding"}}`),
+			wantLocked:  []schema.GroupResource{{Group: "group", Resource: "foos"}},
+			wantSkipped: map[schema.GroupResource]Lock{},
+		},
+		"existing annotation without existing bindings succeeds": {
+			lc:          newLogicalClusterWithAnnotation(`{"bars.group":{"n":"another"},"crds.group":{"c":true},"foos.group":{"n":"binding"}}`),
+			grs:         []schema.GroupResource{{Group: "group", Resource: "foos"}},
+			binding:     ExpirableLock{Lock: Lock{Name: "binding"}},
+			want:        newLogicalClusterWithAnnotation(`{"bars.group":{"n":"another"},"crds.group":{"c":true},"foos.group":{"n":"binding"}}`),
+			wantLocked:  []schema.GroupResource{{Group: "group", Resource: "foos"}},
+			wantSkipped: map[schema.GroupResource]Lock{},
+		},
+		"existing annotation with conflicting binding fails": {
+			lc:          newLogicalClusterWithAnnotation(`{"bars.group":{"n":"another"},"crds.group":{"c":true},"foos.group":{"n":"another"}}`),
+			grs:         []schema.GroupResource{{Group: "group", Resource: "foos"}},
+			binding:     ExpirableLock{Lock: Lock{Name: "binding"}},
+			want:        newLogicalClusterWithAnnotation(`{"bars.group":{"n":"another"},"crds.group":{"c":true},"foos.group":{"n":"another"}}`),
+			wantLocked:  []schema.GroupResource{},
+			wantSkipped: map[schema.GroupResource]Lock{{Group: "group", Resource: "foos"}: {Name: "another"}},
+		},
+		"existing annotation with conflicting CRD binding fails": {
+			lc:          newLogicalClusterWithAnnotation(`{"bars.group":{"n":"another"},"crds.group":{"c":true},"foos.group":{"c":true}}`),
+			crds:        []*apiextensionsv1.CustomResourceDefinition{newCRD("group", "foos")},
+			grs:         []schema.GroupResource{{Group: "group", Resource: "foos"}},
+			binding:     ExpirableLock{Lock: Lock{Name: "binding"}},
+			want:        newLogicalClusterWithAnnotation(`{"bars.group":{"n":"another"},"crds.group":{"c":true},"foos.group":{"c":true}}`),
+			wantLocked:  []schema.GroupResource{},
+			wantSkipped: map[schema.GroupResource]Lock{{Group: "group", Resource: "foos"}: {CRD: true}},
+		},
+		"existing annotation with expired conflicting CRD binding and CRD exists": {
+			lc:          newLogicalClusterWithAnnotation(fmt.Sprintf(`{"bars.group":{"n":"another"},"crds.group":{"c":true},"foos.group":{"c":true,"e":%q}}`, expired)),
+			crds:        []*apiextensionsv1.CustomResourceDefinition{newCRD("group", "foos")},
+			grs:         []schema.GroupResource{{Group: "group", Resource: "foos"}},
+			binding:     ExpirableLock{Lock: Lock{Name: "binding"}},
+			want:        newLogicalClusterWithAnnotation(fmt.Sprintf(`{"bars.group":{"n":"another"},"crds.group":{"c":true},"foos.group":{"c":true,"e":%q}}`, expired)),
+			wantLocked:  []schema.GroupResource{},
+			wantSkipped: map[schema.GroupResource]Lock{{Group: "group", Resource: "foos"}: {CRD: true}},
+		},
+		"existing annotation with expired conflicting CRD binding and CRD does not exist": {
+			lc:          newLogicalClusterWithAnnotation(fmt.Sprintf(`{"bars.group":{"n":"another"},"crds.group":{"c":true},"foos.group":{"c":true,"e":%q}}`, expired)),
+			grs:         []schema.GroupResource{{Group: "group", Resource: "foos"}},
+			binding:     ExpirableLock{Lock: Lock{Name: "binding"}},
+			want:        newLogicalClusterWithAnnotation(`{"bars.group":{"n":"another"},"crds.group":{"c":true},"foos.group":{"n":"binding"}}`),
+			wantLocked:  []schema.GroupResource{{Group: "group", Resource: "foos"}},
+			wantSkipped: map[schema.GroupResource]Lock{},
+		},
+		"existing annotation with not expired, but conflicting CRD binding and CRD does not exist": {
+			lc:          newLogicalClusterWithAnnotation(fmt.Sprintf(`{"bars.group":{"n":"another"},"crds.group":{"c":true},"foos.group":{"c":true,"e":%q}}`, notExpired)),
+			crds:        []*apiextensionsv1.CustomResourceDefinition{newCRD("group", "bars")},
+			grs:         []schema.GroupResource{{Group: "group", Resource: "foos"}},
+			binding:     ExpirableLock{Lock: Lock{Name: "binding"}},
+			want:        newLogicalClusterWithAnnotation(fmt.Sprintf(`{"bars.group":{"n":"another"},"crds.group":{"c":true},"foos.group":{"c":true,"e":%q}}`, notExpired)),
+			wantLocked:  []schema.GroupResource{},
+			wantSkipped: map[schema.GroupResource]Lock{{Group: "group", Resource: "foos"}: {CRD: true}},
+		},
+		"multiple resources, all without conflict": {
+			lc:          newLogicalClusterWithAnnotation(`{"crds.group":{"c":true}}`),
+			grs:         []schema.GroupResource{{Group: "group", Resource: "foos"}, {Group: "group", Resource: "bars"}},
+			binding:     ExpirableLock{Lock: Lock{Name: "binding"}},
+			want:        newLogicalClusterWithAnnotation(`{"bars.group":{"n":"binding"},"crds.group":{"c":true},"foos.group":{"n":"binding"}}`),
+			wantLocked:  []schema.GroupResource{{Group: "group", Resource: "foos"}, {Group: "group", Resource: "bars"}},
+			wantSkipped: map[schema.GroupResource]Lock{},
+		},
+		"multiple resources, one with conflict": {
+			lc:          newLogicalClusterWithAnnotation(`{"crds.group":{"c":true},"foos.group":{"n":"another"}}`),
+			grs:         []schema.GroupResource{{Group: "group", Resource: "foos"}, {Group: "group", Resource: "bars"}},
+			binding:     ExpirableLock{Lock: Lock{Name: "binding"}},
+			want:        newLogicalClusterWithAnnotation(`{"bars.group":{"n":"binding"},"crds.group":{"c":true},"foos.group":{"n":"another"}}`),
+			wantLocked:  []schema.GroupResource{{Group: "group", Resource: "bars"}},
+			wantSkipped: map[schema.GroupResource]Lock{{Group: "group", Resource: "foos"}: {Name: "another"}},
+		},
+		"binding a crd": {
+			lc:          newLogicalClusterWithAnnotation(`{"crds.group":{"c":true}}`),
+			grs:         []schema.GroupResource{{Group: "group", Resource: "foos"}},
+			binding:     ExpirableLock{Lock: Lock{CRD: true}},
+			want:        newLogicalClusterWithAnnotation(`{"crds.group":{"c":true},"foos.group":{"c":true}}`),
+			wantLocked:  []schema.GroupResource{{Group: "group", Resource: "foos"}},
+			wantSkipped: map[schema.GroupResource]Lock{},
+		},
+		"binding a crd again": {
+			lc:          newLogicalClusterWithAnnotation(`{"crds.group":{"c":true},"foos.group":{"c":true}}`),
+			grs:         []schema.GroupResource{{Group: "group", Resource: "foos"}},
+			binding:     ExpirableLock{Lock: Lock{CRD: true}},
+			want:        newLogicalClusterWithAnnotation(`{"crds.group":{"c":true},"foos.group":{"c":true}}`),
+			wantLocked:  []schema.GroupResource{{Group: "group", Resource: "foos"}},
+			wantSkipped: map[schema.GroupResource]Lock{},
+		},
+		"binding a crd with expiry again": {
+			lc:          newLogicalClusterWithAnnotation(fmt.Sprintf(`{"crds.group":{"c":true},"foos.group":{"c":true,"e":%q}}`, expired)),
+			grs:         []schema.GroupResource{{Group: "group", Resource: "foos"}},
+			binding:     ExpirableLock{Lock: Lock{CRD: true}, CRDExpiry: &metav1.Time{Time: now}},
+			want:        newLogicalClusterWithAnnotation(fmt.Sprintf(`{"crds.group":{"c":true},"foos.group":{"c":true,"e":%q}}`, now.Format(time.RFC3339))),
+			wantLocked:  []schema.GroupResource{{Group: "group", Resource: "foos"}},
+			wantSkipped: map[schema.GroupResource]Lock{},
+		},
+		"binding a crd with conflicting binding": {
+			lc:          newLogicalClusterWithAnnotation(`{"crds.group":{"c":true},"foos.group":{"n":"another"}}`),
+			grs:         []schema.GroupResource{{Group: "group", Resource: "foos"}},
+			binding:     ExpirableLock{Lock: Lock{CRD: true}},
+			want:        newLogicalClusterWithAnnotation(`{"crds.group":{"c":true},"foos.group":{"n":"another"}}`),
+			wantLocked:  []schema.GroupResource{},
+			wantSkipped: map[schema.GroupResource]Lock{{Group: "group", Resource: "foos"}: {Name: "another"}},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, locked, skipped, err := WithLockedResources(tt.crds, now, tt.lc, tt.grs, tt.binding)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("WithLockedResources() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("WithLockedResources() +got -want\n%s", diff)
+			}
+			if diff := cmp.Diff(locked, tt.wantLocked); diff != "" {
+				t.Errorf("WithLockedResources() +got -want:\n%s", diff)
+			}
+			if diff := cmp.Diff(skipped, tt.wantSkipped); diff != "" {
+				t.Errorf("WithLockedResources() +got -want:\n%s", diff)
+			}
+		})
+	}
+}
+
+func newLogicalClusterWithAnnotation(ann string) *corev1alpha1.LogicalCluster {
+	return &corev1alpha1.LogicalCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				ResourceBindingsAnnotationKey: ann,
+			},
+		},
+	}
+}

--- a/pkg/reconciler/apis/crdcleanup/crdcleanup_controller.go
+++ b/pkg/reconciler/apis/crdcleanup/crdcleanup_controller.go
@@ -45,8 +45,7 @@ import (
 )
 
 const (
-	ControllerName                 = "kcp-crdcleanup"
-	DefaultIdentitySecretNamespace = "kcp-system"
+	ControllerName = "kcp-crdcleanup"
 
 	AgeThreshold time.Duration = time.Minute * 30
 )

--- a/pkg/reconciler/apis/logicalclustercleanup/logicalclustercleanup_controller.go
+++ b/pkg/reconciler/apis/logicalclustercleanup/logicalclustercleanup_controller.go
@@ -1,0 +1,333 @@
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logicalclustercleanup
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
+	kcpapiextensionsv1informers "github.com/kcp-dev/client-go/apiextensions/informers/apiextensions/v1"
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	"k8s.io/apiextensions-apiserver/pkg/apihelpers"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	"github.com/kcp-dev/kcp/pkg/logging"
+	apibindingreconciler "github.com/kcp-dev/kcp/pkg/reconciler/apis/apibinding"
+	"github.com/kcp-dev/kcp/pkg/reconciler/events"
+	apisv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/apis/v1alpha1"
+	corev1alpha1 "github.com/kcp-dev/kcp/sdk/apis/core/v1alpha1"
+	kcpclientset "github.com/kcp-dev/kcp/sdk/client/clientset/versioned/cluster"
+	apisv1alpha1informers "github.com/kcp-dev/kcp/sdk/client/informers/externalversions/apis/v1alpha1"
+	corev1alpha1informers "github.com/kcp-dev/kcp/sdk/client/informers/externalversions/core/v1alpha1"
+)
+
+const (
+	ControllerName = "kcp-logicalclustercleanup"
+)
+
+// NewController returns a new controller for LogicalCluster resource binding annotation cleanup.
+func NewController(
+	kcpClusterClient kcpclientset.ClusterInterface,
+	logicalClusterInformer corev1alpha1informers.LogicalClusterClusterInformer,
+	crdInformer kcpapiextensionsv1informers.CustomResourceDefinitionClusterInformer,
+	apiBindingInformer apisv1alpha1informers.APIBindingClusterInformer,
+) (*controller, error) {
+	c := &controller{
+		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Name: ControllerName,
+			},
+		),
+		getLogicalCluster: func(clusterName logicalcluster.Name) (*corev1alpha1.LogicalCluster, error) {
+			return logicalClusterInformer.Lister().Cluster(clusterName).Get(corev1alpha1.LogicalClusterName)
+		},
+		updateLogicalCluster: func(ctx context.Context, lc *corev1alpha1.LogicalCluster) error {
+			_, err := kcpClusterClient.CoreV1alpha1().Cluster(logicalcluster.From(lc).Path()).LogicalClusters().Update(ctx, lc, metav1.UpdateOptions{})
+			return err
+		},
+		listsCRDs: func(clusterName logicalcluster.Name) ([]*apiextensionsv1.CustomResourceDefinition, error) {
+			return crdInformer.Lister().Cluster(clusterName).List(labels.Everything())
+		},
+		listAPIBindings: func(clusterName logicalcluster.Name) ([]*apisv1alpha1.APIBinding, error) {
+			return apiBindingInformer.Lister().Cluster(clusterName).List(labels.Everything())
+		},
+	}
+
+	_, _ = logicalClusterInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			c.enqueueLogicalCluster(obj.(*corev1alpha1.LogicalCluster))
+		},
+		UpdateFunc: func(_, obj interface{}) {
+			c.enqueueLogicalCluster(obj.(*corev1alpha1.LogicalCluster))
+		},
+	})
+
+	_, _ = crdInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			c.enqueueCRD(obj.(*apiextensionsv1.CustomResourceDefinition), false)
+		},
+		DeleteFunc: func(obj interface{}) {
+			if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+				obj = tombstone.Obj
+			}
+			c.enqueueCRD(obj.(*apiextensionsv1.CustomResourceDefinition), true)
+		},
+	})
+
+	_, _ = apiBindingInformer.Informer().AddEventHandler(events.WithoutSyncs(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			c.enqueueFromAPIBinding(obj.(*apisv1alpha1.APIBinding))
+		},
+		DeleteFunc: func(obj interface{}) {
+			if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+				obj = tombstone.Obj
+			}
+			c.enqueueFromAPIBinding(obj.(*apisv1alpha1.APIBinding))
+		},
+	}))
+
+	return c, nil
+}
+
+// controller deletes bound CRDs when they are no longer in use by any APIBindings.
+type controller struct {
+	queue workqueue.TypedRateLimitingInterface[string]
+
+	getLogicalCluster    func(clusterName logicalcluster.Name) (*corev1alpha1.LogicalCluster, error)
+	updateLogicalCluster func(ctx context.Context, logicalCluster *corev1alpha1.LogicalCluster) error
+	listsCRDs            func(clusterName logicalcluster.Name) ([]*apiextensionsv1.CustomResourceDefinition, error)
+	listAPIBindings      func(clusterName logicalcluster.Name) ([]*apisv1alpha1.APIBinding, error)
+}
+
+// enqueueLogicalCluster enqueues a LogicalCluster.
+func (c *controller) enqueueLogicalCluster(lc *corev1alpha1.LogicalCluster) {
+	if lc.Name != corev1alpha1.LogicalClusterName {
+		// should not happen.
+		return
+	}
+
+	key, err := kcpcache.DeletionHandlingMetaClusterNamespaceKeyFunc(lc)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+
+	logger := logging.WithQueueKey(logging.WithReconciler(klog.Background(), ControllerName), key)
+	logger.V(4).Info("queueing LogicalCluster")
+	c.queue.Add(key)
+}
+
+// enqueueCRD enqueues a CRD.
+func (c *controller) enqueueCRD(crd *apiextensionsv1.CustomResourceDefinition, deleted bool) {
+	key := kcpcache.ToClusterAwareKey(logicalcluster.From(crd).String(), "", corev1alpha1.LogicalClusterName)
+	logger := logging.WithQueueKey(logging.WithReconciler(klog.Background(), ControllerName), key)
+	logger.V(4).Info("queueing LogicalCluster because of CRD", "CRD", crd.Name)
+	c.queue.Add(key)
+}
+
+func (c *controller) enqueueFromAPIBinding(binding *apisv1alpha1.APIBinding) {
+	key := kcpcache.ToClusterAwareKey(logicalcluster.From(binding).String(), "", corev1alpha1.LogicalClusterName)
+	logger := logging.WithQueueKey(logging.WithReconciler(klog.Background(), ControllerName), key)
+	logger.V(4).Info("queueing LogicalCluster because of APIBinding", "APIBinding", binding.Name)
+	c.queue.Add(key)
+}
+
+// Start starts the controller, which stops when ctx.Done() is closed.
+func (c *controller) Start(ctx context.Context, numThreads int) {
+	defer runtime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	logger := logging.WithReconciler(klog.FromContext(ctx), ControllerName)
+	ctx = klog.NewContext(ctx, logger)
+	logger.Info("Starting controller")
+	defer logger.Info("Shutting down controller")
+
+	for i := 0; i < numThreads; i++ {
+		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
+	}
+
+	<-ctx.Done()
+}
+
+func (c *controller) startWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *controller) processNextWorkItem(ctx context.Context) bool {
+	// Wait until there is a new item in the working queue
+	k, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	key := k
+
+	logger := logging.WithQueueKey(klog.FromContext(ctx), key)
+	ctx = klog.NewContext(ctx, logger)
+	logger.V(4).Info("processing key")
+
+	// No matter what, tell the queue we're done with this key, to unblock
+	// other workers.
+	defer c.queue.Done(key)
+
+	if err := c.process(ctx, key); err != nil {
+		runtime.HandleError(fmt.Errorf("%q controller failed to sync %#v, err: %w", ControllerName, key, err))
+		c.queue.AddRateLimited(key)
+		return true
+	}
+	c.queue.Forget(key)
+	return true
+}
+
+func (c *controller) process(ctx context.Context, key string) error {
+	clusterName, _, _, err := kcpcache.SplitMetaClusterNamespaceKey(key)
+	if err != nil {
+		return fmt.Errorf("failed to split key: %w", err)
+	}
+
+	lc, err := c.getLogicalCluster(clusterName)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil // object got deleted before we handled it.
+		}
+		return err
+	}
+
+	logger := logging.WithObject(klog.FromContext(ctx), lc)
+
+	// decode existing annotation.
+	rbs := make(apibindingreconciler.ResourceBindingsAnnotation)
+	annValue, found := lc.Annotations[apibindingreconciler.ResourceBindingsAnnotationKey]
+	if found {
+		if err := json.Unmarshal([]byte(annValue), &rbs); err != nil {
+			logger.Error(err, "failed to unmarshal ResourceBindings annotation, resetting")
+			annValue = ""
+		}
+	}
+	if rbs == nil {
+		rbs = make(apibindingreconciler.ResourceBindingsAnnotation)
+	}
+
+	// get objects
+	bindings, err := c.listAPIBindings(clusterName)
+	if err != nil {
+		return err
+	}
+	crds, err := c.listsCRDs(clusterName)
+	if err != nil {
+		return err
+	}
+
+	// migrate or rebuild APIBinding entries from status.boundResources? This happens only once per logical cluster.
+	// After the initial migration this is done by the apibinding controller.
+	if annValue == "" {
+		for _, b := range bindings {
+			for _, br := range b.Status.BoundResources {
+				gr := schema.GroupResource{Group: br.Group, Resource: br.Resource}
+				if old, found := rbs[gr.String()]; !found {
+					rbs[gr.String()] = apibindingreconciler.ExpirableLock{Lock: apibindingreconciler.Lock{Name: b.Name}}
+				} else {
+					logger.Info("resource is already bound to APIBinding. THIS ININCONSISTENT!", "resource", gr.String(), "apibinding", old.Name, "apibinding", b.Name)
+				}
+			}
+		}
+	} else {
+		// remove bindings that are gone.
+		bindingNames := make(map[string]bool)
+		for _, b := range bindings {
+			bindingNames[b.Name] = true
+		}
+		for gr, b := range rbs {
+			if b.CRD {
+				continue
+			}
+			if _, found := bindingNames[b.Name]; !found {
+				logger.V(4).Info("removing binding", "binding", b.Name, "resource", gr)
+				delete(rbs, gr)
+			}
+		}
+	}
+
+	// always add CRDs.
+	crdNames := make(map[string]bool)
+	for _, crd := range crds {
+		crdNames[crd.Name] = true
+
+		if !apihelpers.IsCRDConditionTrue(crd, apiextensionsv1.Established) {
+			continue
+		}
+
+		gr := schema.GroupResource{Group: crd.Spec.Group, Resource: crd.Spec.Names.Plural}
+		if old, found := rbs[gr.String()]; !found {
+			rbs[gr.String()] = apibindingreconciler.ExpirableLock{Lock: apibindingreconciler.Lock{CRD: true}}
+		} else if !old.CRD {
+			logger.Info("CRD exists and is established, but already bound to APIBinding. THIS IS INCONSISTENT!", "resource", gr.String(), "apibinding", old.Name)
+		}
+	}
+
+	// remove only when expired and gone, remove expiry when CRD exists.
+	for gr, b := range rbs {
+		if !b.CRD {
+			continue
+		}
+		if crdNames[gr] {
+			b.CRDExpiry = nil
+			rbs[gr] = b
+			continue
+		}
+
+		// CRD doesn't exist.
+		if b.CRDExpiry != nil && time.Now().After(b.CRDExpiry.Time) {
+			logger.V(4).Info("removing expired CRD binding of non-existing CRD", "crd", gr)
+			delete(rbs, gr)
+		}
+	}
+
+	// update annotation on LogicalCluster.
+	bs, err := json.Marshal(rbs)
+	if err != nil {
+		return fmt.Errorf("failed to marshal ResourceBindings annotation: %w", err)
+	}
+	if lc.Annotations[apibindingreconciler.ResourceBindingsAnnotationKey] == string(bs) {
+		return nil
+	}
+	logger.V(4).Info("Updating"+apibindingreconciler.ResourceBindingsAnnotationKey, "old", annValue, "new", string(bs))
+	lc = lc.DeepCopy()
+	if lc.Annotations == nil {
+		lc.Annotations = make(map[string]string)
+	}
+	lc.Annotations[apibindingreconciler.ResourceBindingsAnnotationKey] = string(bs)
+	if err := c.updateLogicalCluster(ctx, lc); err != nil {
+		return fmt.Errorf("failed to update LogicalCluster: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/reconciler/apis/logicalclustercleanup/logicalclustercleanup_controller_test.go
+++ b/pkg/reconciler/apis/logicalclustercleanup/logicalclustercleanup_controller_test.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logicalclustercleanup
+
+import (
+	"context"
+	goerrors "errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/kcp-dev/apimachinery/v2/pkg/cache"
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apisv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/apis/v1alpha1"
+	corev1alpha1 "github.com/kcp-dev/kcp/sdk/apis/core/v1alpha1"
+)
+
+func TestReconciler(t *testing.T) {
+	expired := time.Now().Add(-1).UTC().Format(time.RFC3339)
+	notExpired := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+
+	tests := map[string]struct {
+		logicalCluster *corev1alpha1.LogicalCluster
+		crds           []*apiextensionsv1.CustomResourceDefinition
+		apiBindings    []*apisv1alpha1.APIBinding
+		updateError    error
+
+		want    *corev1alpha1.LogicalCluster
+		wantErr bool
+	}{
+		"no LogicalCluster is ignored": {},
+		"no annotations leads to migration – no crds or bindings": {
+			logicalCluster: &corev1alpha1.LogicalCluster{},
+			want: &corev1alpha1.LogicalCluster{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				"internal.apis.kcp.io/resource-bindings": "{}",
+			}}},
+		},
+		"update error": {
+			logicalCluster: &corev1alpha1.LogicalCluster{},
+			updateError:    errors.NewInternalError(goerrors.New("")),
+			wantErr:        true,
+		},
+		"no annotations leads to migration – with crds and bindings": {
+			logicalCluster: &corev1alpha1.LogicalCluster{},
+			crds: []*apiextensionsv1.CustomResourceDefinition{
+				newCRD("group", "unestablisheds"),
+				withEstablished(newCRD("group", "crd1s")),
+				withEstablished(newCRD("group", "crd2s")),
+			},
+			apiBindings: []*apisv1alpha1.APIBinding{
+				&newAPIBinding().WithName("binding1").WithBoundResources("group", "as", "group", "bs").APIBinding,
+				&newAPIBinding().WithName("binding2").WithBoundResources("group", "cs", "group", "ds").APIBinding,
+			},
+			want: &corev1alpha1.LogicalCluster{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				"internal.apis.kcp.io/resource-bindings": `{"as.group":{"n":"binding1"},"bs.group":{"n":"binding1"},"crd1s.group":{"c":true},"crd2s.group":{"c":true},"cs.group":{"n":"binding2"},"ds.group":{"n":"binding2"}}`,
+			}}},
+		},
+		"with annotation, only CRDs are added": {
+			logicalCluster: &corev1alpha1.LogicalCluster{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				"internal.apis.kcp.io/resource-bindings": `{"as.group":{"n":"binding1"},"crd1s.group":{"c":true}}`,
+			}}},
+			crds: []*apiextensionsv1.CustomResourceDefinition{
+				newCRD("group", "unestablisheds"),
+				withEstablished(newCRD("group", "crd1s")),
+				withEstablished(newCRD("group", "crd2s")),
+			},
+			apiBindings: []*apisv1alpha1.APIBinding{
+				&newAPIBinding().WithName("binding1").WithBoundResources("group", "as", "group", "bs").APIBinding,
+				&newAPIBinding().WithName("binding2").WithBoundResources("group", "cs", "group", "ds").APIBinding,
+			},
+			want: &corev1alpha1.LogicalCluster{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				"internal.apis.kcp.io/resource-bindings": `{"as.group":{"n":"binding1"},"crd1s.group":{"c":true},"crd2s.group":{"c":true}}`,
+			}}},
+		},
+		"CRDs are not removed by default, but bindings are": {
+			logicalCluster: &corev1alpha1.LogicalCluster{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				"internal.apis.kcp.io/resource-bindings": `{"as.group":{"n":"binding1"},"bs.group":{"n":"binding1"},"crd1s.group":{"c":true},"crd2s.group":{"c":true},"cs.group":{"n":"binding2"},"ds.group":{"n":"binding2"}}`,
+			}}},
+			apiBindings: []*apisv1alpha1.APIBinding{
+				&newAPIBinding().WithName("binding1").WithBoundResources("group", "as", "group", "bs").APIBinding,
+			},
+			want: &corev1alpha1.LogicalCluster{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				"internal.apis.kcp.io/resource-bindings": `{"as.group":{"n":"binding1"},"bs.group":{"n":"binding1"},"crd1s.group":{"c":true},"crd2s.group":{"c":true}}`,
+			}}},
+		},
+		"Expired CRDs that don't exist are removed": {
+			logicalCluster: &corev1alpha1.LogicalCluster{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				"internal.apis.kcp.io/resource-bindings": fmt.Sprintf(`{"crd1s.group":{"c":true,"e":%q},"crd2s.group":{"c":true,"e":%q},"crd3s.group":{"c":true,"e":%q}}`, expired, expired, notExpired),
+			}}},
+			crds: []*apiextensionsv1.CustomResourceDefinition{
+				newCRD("group", "crd1s"),
+			},
+			want: &corev1alpha1.LogicalCluster{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				"internal.apis.kcp.io/resource-bindings": fmt.Sprintf(`{"crd1s.group":{"c":true},"crd3s.group":{"c":true,"e":%q}}`, notExpired),
+			}}},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			var got *corev1alpha1.LogicalCluster
+			c := &controller{
+				getLogicalCluster: func(clusterName logicalcluster.Name) (*corev1alpha1.LogicalCluster, error) {
+					if tt.logicalCluster == nil {
+						return nil, errors.NewNotFound(corev1alpha1.Resource("logicalclusters"), string(clusterName))
+					}
+					return tt.logicalCluster, nil
+				},
+				updateLogicalCluster: func(ctx context.Context, lc *corev1alpha1.LogicalCluster) error {
+					if tt.updateError != nil {
+						return tt.updateError
+					}
+					got = lc
+					return nil
+				},
+				listsCRDs: func(clusterName logicalcluster.Name) ([]*apiextensionsv1.CustomResourceDefinition, error) {
+					return tt.crds, nil
+				},
+				listAPIBindings: func(clusterName logicalcluster.Name) ([]*apisv1alpha1.APIBinding, error) {
+					return tt.apiBindings, nil
+				},
+			}
+			if err := c.process(context.Background(), cache.ToClusterAwareKey("foo", "", "cluster")); (err != nil) != tt.wantErr {
+				t.Errorf("process() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("process() -want +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+type bindingBuilder struct {
+	apisv1alpha1.APIBinding
+}
+
+func newAPIBinding() *bindingBuilder {
+	b := new(bindingBuilder)
+	return b
+}
+
+func (b *bindingBuilder) WithName(name string) *bindingBuilder {
+	b.Name = name
+	return b
+}
+
+func (b *bindingBuilder) WithBoundResources(boundResources ...string) *bindingBuilder {
+	for i := 0; i < len(boundResources); i += 2 {
+		group, resource := boundResources[i], boundResources[i+1]
+		b.Status.BoundResources = append(b.Status.BoundResources, apisv1alpha1.BoundAPIResource{
+			Group:    group,
+			Resource: resource,
+		})
+	}
+	return b
+}
+
+func newCRD(group, resource string) *apiextensionsv1.CustomResourceDefinition {
+	return &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("%s.%s", resource, group),
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: group,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural: resource,
+			},
+		},
+		Status: apiextensionsv1.CustomResourceDefinitionStatus{
+			AcceptedNames: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural: resource,
+			},
+		},
+	}
+}
+
+func withEstablished(crd *apiextensionsv1.CustomResourceDefinition) *apiextensionsv1.CustomResourceDefinition {
+	crd = crd.DeepCopy()
+	crd.Status.Conditions = append(crd.Status.Conditions, apiextensionsv1.CustomResourceDefinitionCondition{
+		Type:   apiextensionsv1.Established,
+		Status: apiextensionsv1.ConditionTrue,
+	})
+	return crd
+}

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -67,6 +67,7 @@ import (
 	"github.com/kcp-dev/kcp/pkg/reconciler/apis/crdcleanup"
 	"github.com/kcp-dev/kcp/pkg/reconciler/apis/extraannotationsync"
 	"github.com/kcp-dev/kcp/pkg/reconciler/apis/identitycache"
+	"github.com/kcp-dev/kcp/pkg/reconciler/apis/logicalclustercleanup"
 	"github.com/kcp-dev/kcp/pkg/reconciler/apis/permissionclaimlabel"
 	apisreplicateclusterrole "github.com/kcp-dev/kcp/pkg/reconciler/apis/replicateclusterrole"
 	apisreplicateclusterrolebinding "github.com/kcp-dev/kcp/pkg/reconciler/apis/replicateclusterrolebinding"
@@ -749,6 +750,7 @@ func (s *Server) installAPIBindingController(ctx context.Context, config *rest.C
 		s.KcpSharedInformerFactory.Apis().V1alpha1().APIExports(),
 		s.KcpSharedInformerFactory.Apis().V1alpha1().APIResourceSchemas(),
 		s.KcpSharedInformerFactory.Apis().V1alpha1().APIConversions(),
+		s.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters(),
 		s.CacheKcpSharedInformerFactory.Apis().V1alpha1().APIExports(),
 		s.CacheKcpSharedInformerFactory.Apis().V1alpha1().APIResourceSchemas(),
 		s.CacheKcpSharedInformerFactory.Apis().V1alpha1().APIConversions(),
@@ -987,6 +989,40 @@ func (s *Server) installCRDCleanupController(ctx context.Context, config *rest.C
 		Wait: func(ctx context.Context, s *Server) error {
 			return wait.PollUntilContextCancel(ctx, waitPollInterval, true, func(ctx context.Context) (bool, error) {
 				return s.ApiExtensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions().Informer().HasSynced() &&
+					s.KcpSharedInformerFactory.Apis().V1alpha1().APIBindings().Informer().HasSynced(), nil
+			})
+		},
+		Runner: func(ctx context.Context) {
+			c.Start(ctx, 2)
+		},
+	})
+}
+
+func (s *Server) installLogicalClusterCleanupController(ctx context.Context, config *rest.Config) error {
+	config = rest.CopyConfig(config)
+	config = rest.AddUserAgent(config, logicalclustercleanup.ControllerName)
+
+	kcpClusterClient, err := kcpclientset.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+
+	c, err := logicalclustercleanup.NewController(
+		kcpClusterClient,
+		s.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters(),
+		s.ApiExtensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions(),
+		s.KcpSharedInformerFactory.Apis().V1alpha1().APIBindings(),
+	)
+	if err != nil {
+		return err
+	}
+
+	return s.registerController(&controllerWrapper{
+		Name: logicalclustercleanup.ControllerName,
+		Wait: func(ctx context.Context, s *Server) error {
+			return wait.PollUntilContextCancel(ctx, waitPollInterval, true, func(ctx context.Context) (bool, error) {
+				return s.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters().Informer().HasSynced() &&
+					s.ApiExtensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions().Informer().HasSynced() &&
 					s.KcpSharedInformerFactory.Apis().V1alpha1().APIBindings().Informer().HasSynced(), nil
 			})
 		},

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -252,6 +252,9 @@ func (s *Server) installControllers(ctx context.Context, controllerConfig *rest.
 		if err := s.installCRDCleanupController(ctx, controllerConfig); err != nil {
 			return err
 		}
+		if err := s.installLogicalClusterCleanupController(ctx, controllerConfig); err != nil {
+			return err
+		}
 		if err := s.installExtraAnnotationSyncController(ctx, controllerConfig); err != nil {
 			return err
 		}

--- a/sdk/apis/apis/v1alpha1/types_apibinding.go
+++ b/sdk/apis/apis/v1alpha1/types_apibinding.go
@@ -200,6 +200,10 @@ const (
 	// Once true, this can never be reset to false.
 	InitialBindingCompleted conditionsv1alpha1.ConditionType = "InitialBindingCompleted"
 
+	// LogicalClusterNotFoundReason is a reason for the InitialBindingCompleted condition that
+	// the LogicalCluster has not been found.
+	LogicalClusterNotFoundReason = "LogicalClusterNotFound"
+
 	// WaitingForEstablishedReason is a reason for the InitialBindingCompleted condition that the bound CRDs are not ready.
 	WaitingForEstablishedReason = "WaitingForEstablished"
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The conflict checker in the APIBinding reconciler computed a list of CRDs, both real and bound ones. It took the APIExport as reference instead of the bindings directly. This seems wrong. If a schema is removed from an export, or the whole export is deleted, the binding still exists, but it didn't contribute the conflict checker anymore.

This PR does the following:
1. make the conflict checker use the `APIBinding.status.boundResources` as reference.
2. store group resource bindings in an `apis.kcp.io/resource-bindings` annotation on the `LogicalCluster`. It records the APIBinding or whether it is a CRD. This annotation (a JSON map) is updated BEFORE (a) a CRD is created (admission) or (b) an APIBinding bind the group resource:
   ```yaml
   internal.apis.kcp.io/resource-bindings: '{"partitions.topology.kcp.io":{"n":"topology.kcp.io"},"partitionsets.topology.kcp.io":{"n":"topology.kcp.io"},"shards.core.kcp.io":{"n":"shards.core.kcp.io"},"workspaces.tenancy.kcp.io":{"n":"tenancy.kcp.io"},"workspacetypes.tenancy.kcp.io":{"n":"tenancy.kcp.io"}}'
   ```

The tricky case is that we can only update the annotation during CRD creation via admission. And creation can fail. Then we have a dangling group resource reservation. This PR adds an expery timestamp to the group resource entries for CRD which matches the maximum request duration of 30s. For that time an APIBinding of the same group resource would fail (delayed). Don't know a better way to solve that.

**Downside**: CRD creation implies update of the `LogicalCluster`, with potential for conflicts. This might make CRD creation slower. So if you install 1000 CRDs, this PR will have an impact.

## Related issue(s)

Fixes #3252

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Fix critical race condition between APIBindings and CRDs potentially allowing the same resource to be bound by multiple bindings or CRDs, leading to data loss or inconsistent state.
```