### PR TITLE
:sparkles: authorizer/content: make scoped service account globally valid, but acting as anonymous+authenticated

### DIFF
--- a/pkg/authorization/workspace_content_authorizer.go
+++ b/pkg/authorization/workspace_content_authorizer.go
@@ -27,7 +27,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	controlplaneapiserver "k8s.io/kubernetes/pkg/controlplane/apiserver"
@@ -88,22 +87,9 @@ func (a *workspaceContentAuthorizer) Authorize(ctx context.Context, attr authori
 	}
 
 	isServiceAccount := validation.IsServiceAccount(attr.GetUser())
-	isAuthenticated := sets.New[string](attr.GetUser().GetGroups()...).Has("system:authenticated")
-	isForeign := validation.IsForeign(attr.GetUser(), cluster.Name)
 	isInScope := validation.IsInScope(attr.GetUser(), cluster.Name)
 
 	if IsDeepSubjectAccessReviewFrom(ctx, attr) {
-		attr := deepCopyAttributes(attr)
-		// this is a deep SAR request, we have to skip the checks here and delegate to the subsequent authorizer.
-		if isAuthenticated && isServiceAccount && !isForeign {
-			// service accounts from other workspaces might conflict with local service accounts by name.
-			// This could lead to unwanted side effects of unwanted applied permissions.
-			// Hence, these requests have to be anonymized.
-			attr.User = &user.DefaultInfo{
-				Name:   "system:anonymous",
-				Groups: []string{"system:authenticated"},
-			}
-		}
 		return DelegateAuthorization("deep SAR request", a.delegate).Authorize(ctx, attr)
 	}
 
@@ -126,17 +112,8 @@ func (a *workspaceContentAuthorizer) Authorize(ctx context.Context, attr authori
 	}
 
 	switch {
-	case isServiceAccount && isForeign:
-		// Service accounts from other workspaces might conflict with local service accounts by name.
-		// Use another reason string to make this very common case clearer.
-		return authorizer.DecisionDeny, "foreign service account", nil
-
-	case !isInScope:
-		// No opinion, but there could be a warrant giving access.
-		return authorizer.DecisionNoOpinion, "out of scope", nil
-
-	case isServiceAccount:
-		// A service account declared in the requested workspace is authorized inside that workspace.
+	case isServiceAccount && isInScope:
+		// A service account declared in the requested workspace is always authorized inside that workspace.
 		return DelegateAuthorization("local service account access", a.delegate).Authorize(ctx, attr)
 
 	default:

--- a/pkg/authorization/workspace_content_authorizer_test.go
+++ b/pkg/authorization/workspace_content_authorizer_test.go
@@ -107,12 +107,12 @@ func TestWorkspaceContentAuthorizer(t *testing.T) {
 			wantReason:         "delegating due to user logical cluster access",
 		},
 		{
-			testName: "service account from other cluster is denied",
+			testName: "service account from other cluster is not allowed",
 
 			requestedWorkspace: "root:ready",
 			requestingUser:     newServiceAccountWithCluster("sa", "anotherws"),
-			wantDecision:       authorizer.DecisionDeny, // this must be a deny because otherwise naming conflicts could lead to unwanted permissions
-			wantReason:         "foreign service account",
+			wantDecision:       authorizer.DecisionNoOpinion,
+			wantReason:         "no verb=access permission on /",
 		},
 		{
 			testName: "user with scope to this cluster is allowed",
@@ -132,7 +132,7 @@ func TestWorkspaceContentAuthorizer(t *testing.T) {
 				"authentication.kcp.io/scopes": {"cluster:anotherws"},
 			}},
 			wantDecision: authorizer.DecisionNoOpinion,
-			wantReason:   "out of scope",
+			wantReason:   "no verb=access permission on /",
 		},
 		{
 			testName: "service account from same cluster is granted access",
@@ -151,12 +151,12 @@ func TestWorkspaceContentAuthorizer(t *testing.T) {
 			wantReason:         "delegating due to user logical cluster access",
 		},
 		{
-			testName: "service account from other cluster is denied on root:authenticated",
+			testName: "service account from other cluster is granted access on root:authenticated", // as it act as system:anonymous+system:authenticated there.
 
 			requestedWorkspace: "root:authenticated",
 			requestingUser:     newServiceAccountWithCluster("somebody", "someworkspace", "system:authenticated"),
-			wantDecision:       authorizer.DecisionDeny,
-			wantReason:         "foreign service account",
+			wantDecision:       authorizer.DecisionAllow,
+			wantReason:         "delegating due to user logical cluster access",
 		},
 		{
 			testName: "service account from root:authenticated cluster is granted access on root:authenticated",


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The content authorizer had special logic to forbid foreign service account to access a logical cluster. With our scoping logic deeply injected into the rule resolver of RBAC, this is not necessary anymore. A foreign service account acts as `system:anonymous`+`system:authenticated` outside of its logical cluster, but otherwise there is no naming conflict anymore.

This is not yet https://github.com/kcp-dev/kcp/pull/3258, which adds a warrant you can bind against. The PR here leaves you with `system:anonymous`+`system:authenticated`.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Make scoped service account globally valid, but acting as anonymous+authenticated outside of their home.
```