### PR TITLE
:bug: Remove scope from initializingworkspaces virtual workspace

### DIFF
--- a/pkg/virtual/initializingworkspaces/builder/build.go
+++ b/pkg/virtual/initializingworkspaces/builder/build.go
@@ -252,8 +252,6 @@ func BuildVirtualWorkspace(
 				for k, v := range info.Extra {
 					extra[k] = v
 				}
-				// Scope the user to the cluster they are accessing.
-				extra["authentication.kcp.io/scopes"] = []string{fmt.Sprintf("cluster:%s", cluster)}
 
 				thisCfg := rest.CopyConfig(cfg)
 				thisCfg.Impersonate = rest.ImpersonationConfig{


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

As part of #3235, we added scoping to the impersonation that happens in the `initializingworkspaces` virtual workspace when proxying through content access. This creates a fundamental problem: When creating `APIBindings` through it (a common activity done by kcp itself for the default API bindings in a `WorkspaceType`), the impersonated identity will always be  out-of-scope for the workspace that holds the target `APIExport` for a default binding.

This means default API bindings would always be bound as `system:anonymous` / `system:authenticated` (the identity of out-of-scope entities), which means you cannot properly provide permissions to the owner of a workspace (which is the identity impersonated by the virtual workspace).

So for now we think we should undo the scoping in the virtual workspace.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
