### PR TITLE
:bug: impersonation: add missing privileged groups

### DIFF
--- a/pkg/server/filters/impersonation_test.go
+++ b/pkg/server/filters/impersonation_test.go
@@ -33,14 +33,9 @@ import (
 	authorizationbootstrap "github.com/kcp-dev/kcp/pkg/authorization/bootstrap"
 )
 
-func TestCheckImpersonation(t *testing.T) {
+func TestValidImpersonation(t *testing.T) {
 	var systemUserGroup = "system:user:group"
 	nonExistingGroup := "non-existing-group"
-	specialGroups = map[string]privilege{
-		authorizationbootstrap.SystemMastersGroup:  superPrivileged,
-		authorizationbootstrap.SystemKcpAdminGroup: priviledged,
-		systemUserGroup: unprivileged,
-	}
 
 	tests := []struct {
 		name            string
@@ -79,7 +74,7 @@ func TestCheckImpersonation(t *testing.T) {
 			expectedResult:  false,
 		},
 		{
-			name:            "system:autenticated is beyond unprivileged",
+			name:            "system:authenticated is beyond unprivileged",
 			userGroups:      []string{systemUserGroup},
 			requestedGroups: []string{user.AllAuthenticated},
 			expectedResult:  false,


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

There are some more priviliged groups that this PR is adding to the impersonation guard. Only `system:master` suffices to impersonate as any of them if the incoming user does not have that group already.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```