### PR TITLE
:seedling: Configure prow artifacts correctly

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -109,6 +109,8 @@ presubmits:
             - ./hack/run-with-prometheus.sh
             - make
             - test-e2e
+          args:
+            - ARTIFACT_DIR=$(ARTIFACTS) # propagate prow artifact directory
           env:
             - name: SUITES
               value: control-plane
@@ -137,6 +139,8 @@ presubmits:
             - ./hack/run-with-prometheus.sh
             - make
             - test-e2e
+          args:
+            - ARTIFACT_DIR=$(ARTIFACTS) # propagate prow artifact directory
           env:
             - name: SUITES
               value: control-plane
@@ -167,6 +171,8 @@ presubmits:
             - ./hack/run-with-prometheus.sh
             - make
             - test-e2e-shared-minimal
+          args:
+            - ARTIFACT_DIR=$(ARTIFACTS) # propagate prow artifact directory
           env:
             - name: SUITES
               value: control-plane
@@ -193,6 +199,8 @@ presubmits:
             - ./hack/run-with-prometheus.sh
             - make
             - test-e2e-sharded-minimal
+          args:
+            - ARTIFACT_DIR=$(ARTIFACTS) # propagate prow artifact directory
           env:
             - name: SUITES
               value: control-plane

--- a/Makefile
+++ b/Makefile
@@ -301,7 +301,7 @@ test-e2e-shared-minimal: build-all
 	mkdir -p "$(LOG_DIR)" "$(WORK_DIR)/.kcp"
 	rm -f "$(WORK_DIR)/.kcp/ready-to-test"
 	UNSAFE_E2E_HACK_DISABLE_ETCD_FSYNC=true NO_GORUN=1 \
-		./bin/test-server --quiet --log-file-path="$(LOG_DIR)/kcp.log" $(TEST_SERVER_ARGS) -- --feature-gates=$(TEST_FEATURE_GATES) 2>&1 & PID=$$! && echo "PID $$PID" && \
+		./bin/test-server --quiet --log-dir-path="$(LOG_DIR)" $(TEST_SERVER_ARGS) -- --feature-gates=$(TEST_FEATURE_GATES) 2>&1 & PID=$$! && echo "PID $$PID" && \
 	trap 'kill -TERM $$PID' TERM INT EXIT && \
 	while [ ! -f "$(WORK_DIR)/.kcp/ready-to-test" ]; do sleep 1; done && \
 	echo 'Starting test(s)' && \

--- a/cmd/sharded-test-server/cache.go
+++ b/cmd/sharded-test-server/cache.go
@@ -64,7 +64,10 @@ func startCacheServer(ctx context.Context, logDirPath, workingDir string, synthe
 	fmt.Fprintf(out, "running: %v\n", strings.Join(commandLine, " "))
 	cmd := exec.CommandContext(ctx, commandLine[0], commandLine[1:]...) //nolint:gosec
 
-	logFilePath := filepath.Join(logDirPath, ".kcp-cache", "out.log")
+	logFilePath := filepath.Join(".kcp-cache", "kcp.log")
+	if logDirPath != "" {
+		logFilePath = filepath.Join(logDirPath, "kcp-cache.log")
+	}
 	if err := os.MkdirAll(filepath.Dir(logFilePath), 0755); err != nil {
 		return nil, "", err
 	}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Prow collects artifacts from the directory in `$(ARTIFACTS)`. In kcp we use `ARTIFACT_DIR`. This PR sets it up correctly that `ARTIFACT_DIR` is set to `$(ARTIFACTS)`.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```