### PR TITLE
:bug: index: fix how error codes are stored for unavailable workspaces

### DIFF
--- a/test/e2e/authorizer/serviceaccounts_test.go
+++ b/test/e2e/authorizer/serviceaccounts_test.go
@@ -183,7 +183,7 @@ func TestServiceAccounts(t *testing.T) {
 			})
 
 			t.Run("Access another workspace in the same org", func(t *testing.T) {
-				t.Log("Create namespace with the same name ")
+				t.Log("Create workspace with the same name ")
 				otherPath, _ := framework.NewWorkspaceFixture(t, server, orgPath)
 				_, err := kubeClusterClient.Cluster(otherPath).CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/mounts/mounts_machinery_test.go
+++ b/test/e2e/mounts/mounts_machinery_test.go
@@ -63,7 +63,7 @@ func TestMountsMachinery(t *testing.T) {
 	orgPath, _ := framework.NewOrganizationFixture(t, server)
 
 	mountWorkspaceName := "mounts-machinery"
-	mountPath, _ := framework.NewWorkspaceFixture(t, server, orgPath, framework.WithName(mountWorkspaceName))
+	mountPath, _ := framework.NewWorkspaceFixture(t, server, orgPath, framework.WithName("%s", mountWorkspaceName))
 
 	cfg := server.BaseConfig(t)
 	kcpClusterClient, err := kcpclientset.NewForConfig(cfg)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The old code stored the error code under the logical cluster which was supposed to fail, not the workspace pointing to it. This kind of worked on one shard, but with multiple it failed when workspace and target cluster were not colocated.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```