### PR TITLE
:seedling: stop the bleeding: e2e/sharded: temporarily disable service account lookup

### DIFF
--- a/cmd/sharded-test-server/shard.go
+++ b/cmd/sharded-test-server/shard.go
@@ -89,6 +89,7 @@ func newShard(ctx context.Context, n int, args []string, standaloneVW bool, serv
 		"--requestheader-extra-headers-prefix=X-Remote-Extra-",
 		fmt.Sprintf("--service-account-key-file=%s", filepath.Join(workDirPath, ".kcp/service-account.crt")),
 		fmt.Sprintf("--service-account-private-key-file=%s", filepath.Join(workDirPath, ".kcp/service-account.key")),
+		fmt.Sprintf("--service-account-signing-key-file=%s", filepath.Join(workDirPath, ".kcp/service-account.key")),
 		// TODO(sttts): remove this flag as soon as we have service account token lookup configured.
 		"--service-account-lookup=false",
 		"--audit-log-path", auditFilePath,

--- a/cmd/sharded-test-server/shard.go
+++ b/cmd/sharded-test-server/shard.go
@@ -89,6 +89,8 @@ func newShard(ctx context.Context, n int, args []string, standaloneVW bool, serv
 		"--requestheader-extra-headers-prefix=X-Remote-Extra-",
 		fmt.Sprintf("--service-account-key-file=%s", filepath.Join(workDirPath, ".kcp/service-account.crt")),
 		fmt.Sprintf("--service-account-private-key-file=%s", filepath.Join(workDirPath, ".kcp/service-account.key")),
+		// TODO(sttts): remove this flag as soon as we have service account token lookup configured.
+		"--service-account-lookup=false",
 		"--audit-log-path", auditFilePath,
 		fmt.Sprintf("--shard-external-url=https://%s:%d", hostIP, 6443),
 		fmt.Sprintf("--tls-cert-file=%s", filepath.Join(workDirPath, fmt.Sprintf(".kcp-%d/apiserver.crt", n))),


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The real fix might be https://github.com/kcp-dev/kcp/pull/3274. But to reduce flakes, we need this quick fix in e2e.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```