### PR TITLE
:bug:  Fixup SA lookups

### DIFF
--- a/pkg/proxy/config.go
+++ b/pkg/proxy/config.go
@@ -89,7 +89,7 @@ func NewConfig(ctx context.Context, opts *proxyoptions.Options) (*Config, error)
 	if err := c.Options.SecureServing.ApplyTo(&c.ServingInfo, &loopbackClientConfig); err != nil {
 		return nil, err
 	}
-	if err := c.Options.Authentication.ApplyTo(ctx, &c.AuthenticationInfo, c.ServingInfo, c.RootShardConfig); err != nil {
+	if err := c.Options.Authentication.ApplyTo(ctx, &c.AuthenticationInfo, c.ServingInfo, loopbackClientConfig); err != nil {
 		return nil, err
 	}
 

--- a/pkg/proxy/options/authentication.go
+++ b/pkg/proxy/options/authentication.go
@@ -86,7 +86,12 @@ func (c *Authentication) serviceAccountAuthEnabled() bool {
 	return c.BuiltInOptions.ServiceAccounts != nil && len(c.BuiltInOptions.ServiceAccounts.KeyFiles) != 0
 }
 
-func (c *Authentication) ApplyTo(ctx context.Context, authenticationInfo *genericapiserver.AuthenticationInfo, servingInfo *genericapiserver.SecureServingInfo, rootShardConfig *rest.Config) error {
+func (c *Authentication) ApplyTo(
+	ctx context.Context,
+	authenticationInfo *genericapiserver.AuthenticationInfo,
+	servingInfo *genericapiserver.SecureServingInfo,
+	loopbackClientConfig *rest.Config,
+) error {
 	// Note BuiltInAuthenticationOptions.ApplyTo is not called, so we
 	// can reduce the dependencies pulled in from auth methods which aren't enabled
 	authenticatorConfig, err := c.BuiltInOptions.ToAuthenticationConfig()
@@ -108,7 +113,7 @@ func (c *Authentication) ApplyTo(ctx context.Context, authenticationInfo *generi
 			authenticationInfo.APIAudiences = c.BuiltInOptions.ServiceAccounts.Issuers
 		}
 
-		config := rest.CopyConfig(rootShardConfig)
+		config := rest.CopyConfig(loopbackClientConfig)
 		tokenGetterClient, err := kcpkubernetesclientset.NewForConfig(config)
 		if err != nil {
 			return fmt.Errorf("failed to create client for ServiceAccountTokenGetter: %w", err)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Service account lookups in claims code is done like this:

```
serviceAccount, err := v.getter.Cluster(clusterName).GetServiceAccount(namespace, saref.Name)
	if err != nil {
		klog.V(4).Infof("Could not retrieve service account %s/%s: %v", namespace, saref.Name, err)
		return nil, err
	}
```

this means if we are evaluating service accounts from different shards, we will not be able to do this. This particular client should be the front proxy loopback client, where we gonna route it to the right shard for lookup.  Now it's set to roots hard, so it works only when SA lands into the root shard. 


## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
