### PR TITLE
:bug: fix(admission): rename allOf to anyOf for type extension

### DIFF
--- a/pkg/admission/workspacetypeexists/admission.go
+++ b/pkg/admission/workspacetypeexists/admission.go
@@ -478,7 +478,7 @@ func validateAllowedParents(parentAliases, childAliases []*tenancyv1alpha1.Works
 
 		qualifiedChild := canonicalPathFrom(childAlias).Join(string(tenancyv1alpha1.TypeName(childAlias.Name)))
 
-		if !allOfTheFormerExistInTheLater(parentAliases, childAlias.Spec.LimitAllowedParents.Types) {
+		if !anyOfTheFormerExistInTheLater(parentAliases, childAlias.Spec.LimitAllowedParents.Types) {
 			allowedSet := sets.New[string]()
 			for _, allowedParent := range childAlias.Spec.LimitAllowedParents.Types {
 				allowedSet.Insert(logicalcluster.NewPath(allowedParent.Path).Join(string(allowedParent.Name)).String())
@@ -519,7 +519,7 @@ func validateAllowedChildren(parentAliases, childAliases []*tenancyv1alpha1.Work
 
 		qualifiedParent := canonicalPathFrom(parentAlias).Join(string(tenancyv1alpha1.TypeName(parentAlias.Name)))
 
-		if !allOfTheFormerExistInTheLater(childAliases, parentAlias.Spec.LimitAllowedChildren.Types) {
+		if !anyOfTheFormerExistInTheLater(childAliases, parentAlias.Spec.LimitAllowedChildren.Types) {
 			allowedSet := sets.New[string]()
 			for _, allowedChild := range parentAlias.Spec.LimitAllowedChildren.Types {
 				allowedSet.Insert(logicalcluster.NewPath(allowedChild.Path).Join(string(allowedChild.Name)).String())
@@ -544,7 +544,10 @@ func validateAllowedChildren(parentAliases, childAliases []*tenancyv1alpha1.Work
 	return utilerrors.NewAggregate(errs)
 }
 
-func allOfTheFormerExistInTheLater(objectAliases []*tenancyv1alpha1.WorkspaceType, allowedTypes []tenancyv1alpha1.WorkspaceTypeReference) bool {
+// anyOfTheFormerExistInTheLater checks if any of the objectAliases matches any of the allowedTypes.
+// This implements additive workspace type extension, where a type gains the capabilities of types
+// it extends while keeping its own.
+func anyOfTheFormerExistInTheLater(objectAliases []*tenancyv1alpha1.WorkspaceType, allowedTypes []tenancyv1alpha1.WorkspaceTypeReference) bool {
 	allowedAliasSet := sets.New[string]()
 	for _, allowed := range allowedTypes {
 		qualified := logicalcluster.NewPath(allowed.Path).Join(tenancyv1alpha1.ObjectName(allowed.Name)).String()


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The function `allOfTheFormerExistInTheLater` is renamed to `anyOfTheFormerExistInTheLater` to better reflect its behavior. The function implements additive type extension where a type gains capabilities of types it extends.

The implementation was correct, but the name suggested an "all" check when it performs an "any" check. This aligns with documented behavior where a type can be used anywhere its extended type is allowed.

This is a naming-only change with no behavioral modifications.

## Related issue(s)

Fixes `nil`

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
