### PR TITLE
🌱 compress all build artifacts after e2e tests

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -106,11 +106,10 @@ presubmits:
       containers:
         - image: ghcr.io/kcp-dev/infra/build:1.22.10-1
           command:
+            - ./hack/run-with-prow.sh
             - ./hack/run-with-prometheus.sh
             - make
             - test-e2e
-          args:
-            - ARTIFACT_DIR=$(ARTIFACTS) # propagate prow artifact directory
           env:
             - name: SUITES
               value: control-plane
@@ -136,11 +135,10 @@ presubmits:
       containers:
         - image: ghcr.io/kcp-dev/infra/build:1.22.10-1
           command:
+            - ./hack/run-with-prow.sh
             - ./hack/run-with-prometheus.sh
             - make
             - test-e2e
-          args:
-            - ARTIFACT_DIR=$(ARTIFACTS) # propagate prow artifact directory
           env:
             - name: SUITES
               value: control-plane
@@ -168,11 +166,10 @@ presubmits:
       containers:
         - image: ghcr.io/kcp-dev/infra/build:1.22.10-1
           command:
+            - ./hack/run-with-prow.sh
             - ./hack/run-with-prometheus.sh
             - make
             - test-e2e-shared-minimal
-          args:
-            - ARTIFACT_DIR=$(ARTIFACTS) # propagate prow artifact directory
           env:
             - name: SUITES
               value: control-plane
@@ -196,11 +193,10 @@ presubmits:
       containers:
         - image: ghcr.io/kcp-dev/infra/build:1.22.10-1
           command:
+            - ./hack/run-with-prow.sh
             - ./hack/run-with-prometheus.sh
             - make
             - test-e2e-sharded-minimal
-          args:
-            - ARTIFACT_DIR=$(ARTIFACTS) # propagate prow artifact directory
           env:
             - name: SUITES
               value: control-plane

--- a/hack/run-with-prow.sh
+++ b/hack/run-with-prow.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The KCP Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o nounset
+set -o pipefail
+set -o errexit
+
+apt update
+apt install -y bzip2
+
+# propagate prow artifact directory
+export ARTIFACT_DIR="$ARTIFACTS"
+
+set -o xtrace
+set +o errexit
+"${@}"
+EXIT_CODE=${?}
+set +o xtrace
+set -o errexit
+echo "Command terminated with ${EXIT_CODE}"
+
+echo 'Compressing build artifacts...'
+cd "$ARTIFACTS"
+tar cjf artifacts.tar.bz2 --remove-files *
+echo 'Done compressing files.'
+
+exit "${EXIT_CODE}"


### PR DESCRIPTION
## Summary
This implements another wrapper script, `run-with-prow.sh`, which uses `tar` to pre-compress all build artifacts to save on storage.

I chose to keep the difference between `ARTIFACT_DIR` and `ARTIFACTS`, but to properly inject it into the ProwJob,

* setting them via `env` is not possible because Prow adds `ARTIFACTS` _after_ the env vars declared in the ProwJob, so an `env{name: ARTIFACTS_DIR, value: '$(ARTIFACTS)'}` has no effect.
* setting it the old way did not actually work, evident by the fact that the Prometheus artifacts were also never uploaded to S3. Doing `./run-with-prometheus.sh make e2e FOO=BAR` works well for `make`, but is invisible to the surrounding script.
* I could have replaced the command in the ProwJob with a mini bash script, but that's ugly as well.
* So I chose to add a new wrapper script which exports the env and then also compresses the artifacts.

bzip2 was enough of a win that it makes it worth to install it explicitly. I did not test any other compression methods besides gzip, which was inferior.

## Related issue(s)
Fixes #3285

## Release Notes
```release-note
NONE
```
