### PR TITLE
:bug: Dockerfile: fix constructing URL for kubectl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ COPY cli/go.sum cli/go.sum
 USER 0
 
 # Install kubectl.
-RUN wget "https://dl.k8s.io/release/$(go list -m -json k8s.io/kubernetes | jq -r .Version)/bin/linux/$(uname -m | sed 's/aarch.*/arm64/;s/armv8.*/arm64/;s/x86_64/amd64/')/kubectl" -O bin/kubectl && chmod +x bin/kubectl
+RUN wget "https://dl.k8s.io/release/$(go list -m -json k8s.io/kubernetes | jq -r .Version | sed 's/^v0/v1/')/bin/linux/$(uname -m | sed 's/aarch.*/arm64/;s/armv8.*/arm64/;s/x86_64/amd64/')/kubectl" -O bin/kubectl && chmod +x bin/kubectl
 
 # Cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer


### PR DESCRIPTION
## Summary

`go list -m -json k8s.io/kubernetes | jq -r .Version` outputs a version string in format `v0.<Minor>.<Patch>`, but binaries at dl.k8s.io/release are versioned in line with real K8s versions. This commit replaces the "v0" part with "v1" so that the URL is correct.

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
