### PR TITLE
:sparkles: hack/verify-go-modules.sh: compare dependency versions

### DIFF
--- a/hack/verify-go-modules.sh
+++ b/hack/verify-go-modules.sh
@@ -15,6 +15,10 @@
 # limitations under the License.
 
 # This script verifies all go modules in the repository.
+# go.mod and go.sum files are checked that both have been
+# committed. Versions of dependencies they declare are
+# checked to be in line with dependencies in k8s.io/kubernetes,
+# and a warning message is printed if they differ in v<Maj>.<Min>.
 
 set -o errexit
 set -o nounset
@@ -24,14 +28,93 @@ REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 
 mapfile -t DIRS < <(find "${REPO_ROOT}" -name go.mod -print0 | xargs -0 dirname)
 
+# list_deps lists dependencies of the supplied go.mod file (dependencies
+# with version "v0.0.0" are skipped). The output is a json dictionary in the
+# format `{"<Dependency>": "<Version>", ...}`.
+function list_deps {
+  gomod_file="${1}"
+  go mod edit -json "${gomod_file}" \
+    | jq -r '
+        (
+          [ .Require[]
+            | select(.Version != "v0.0.0")
+            | { (.Path): .Version } ]
+          | add
+        )
+      '
+}
+
+# diff_version_deps lists common dependencies of the two supplied go.mod files
+# whose respective versions differ (up to v<Maj>.<Min>). The output is a json
+# dictionary in the format:
+# `{"<Dependency>": {
+#    "has": "<Dependency version of the first file>",
+#    "wants": "<Dependency version of the second file>"
+#  }, ...}`
+function diff_version_deps {
+  has_deps="${1}"
+  wants_deps="${2}"
+  jq -s '
+    # Extracts v<Maj>.<Min> from a semantic version string.
+    def major_minor_semver: capture("v(?<major>\\d+)\\.(?<minor>\\d+)")
+      | "v" + .major + "." + .minor;
+
+    map(to_entries)    # Convert both input dicts into two separate arrays.
+      | add            # Concatenate those two arrays into a single one.
+      | group_by(.key) # Group items by `.key`.
+      | map(           # Map each selected item into { "<Dep>": {"has": "<Version0>", "wants": "<Version1>"} }.
+          select(
+              # If grouping resulted in two items, it means both arrays have this dependency.
+              length == 2
+              # Compare the v<Maj>.<Min> of both items.
+              and (.[0].value | major_minor_semver) != (.[1].value | major_minor_semver)
+            )
+            | { (.[0].key): { "has": .[0].value, "wants": .[1].value } }
+        )
+      | add // empty
+  ' "${has_deps}" "${wants_deps}"
+}
+
+# print_diff_version_deps prints the output of diff_version_deps as a
+# human-readable multi-line text.
+function print_diff_version_deps {
+  jq -r "to_entries | map(\"Warning: version mismatch: has \(.key)@\(.value.has), but \(.value.wants) expected\") | join(\"\\n\")"
+}
+
+# Compares versions of dependencies in the supplied go.mod to
+# makes sure they are in line with the ones declared in
+# k8s.io/kubernetes module and prints the result.
+function compare_mod_versions {
+  gomod_file="${1}"
+  echo "Verifying dependency versions in ${gomod_file} against ${k8s_gomod}"
+  deps="$(list_deps ${gomod_file})"
+
+  diff_version_deps <(echo "${deps}") <(echo "${k8s_deps}") \
+    | print_diff_version_deps "${gomod_file}"
+}
+
+function gomod_filepath_for {
+  mod="${1}"
+  go list -m -json "${mod}" | jq -r .GoMod
+}
+
+k8s_gomod="$(gomod_filepath_for k8s.io/kubernetes)"
+k8s_deps="$(list_deps ${k8s_gomod})"
+
 for dir in "${DIRS[@]}"; do
   (
     cd "$dir"
     echo "Verifying ${dir}"
+
     if ! git diff --quiet HEAD -- go.mod go.sum; then
       echo "go module files are out of date"
       git diff HEAD -- go.mod go.sum
       exit 1
     fi
+
+    compare_mod_versions "${dir}/go.mod"
   )
 done
+
+compare_mod_versions "$(gomod_filepath_for github.com/kcp-dev/client-go)"
+compare_mod_versions "$(gomod_filepath_for github.com/kcp-dev/apimachinery/v2)"


### PR DESCRIPTION
## Summary

This PR adds checks for go.mod dependencies, verifying the versions used in our modules are the same as the ones used declared by k8s.io/kubernetes module. When rebasing or otherwise bringing in dependency updates, they can break our code -- see https://github.com/kcp-dev/kcp/issues/3283#issuecomment-2676780112 for example. Just following the recommendations from this script, the issue I've just linked to was solved in a couple of minutes instead of regrettably spending a day or two debugging different things... :D

The checks only report warnings if our deps are more than a patch version apart with k8s.io/kubernetes, but never return non-zero exit code to not fail CI in cases when we want to use different versions deliberately.

Example output:

```
$ make verify-modules
hack/update-go-modules.sh
Tidying /tmp/ws/kcp-rebase/kcp/cli
Tidying /tmp/ws/kcp-rebase/kcp/docs/generators/cli-doc
Tidying /tmp/ws/kcp-rebase/kcp/sdk
Tidying /tmp/ws/kcp-rebase/kcp
hack/verify-go-modules.sh
Verifying /tmp/ws/kcp-rebase/kcp/cli
Verifying dependency versions in /tmp/ws/kcp-rebase/kcp/cli/go.mod against /home/rvasek/go/pkg/mod/cache/download/github.com/kcp-dev/kubernetes/@v/v0.0.0-20250223141144-b901243fc922.mod
Warning: version mismatch: has golang.org/x/net@v0.33.0, but v0.26.0 expected
Warning: version mismatch: has golang.org/x/sync@v0.10.0, but v0.7.0 expected
Warning: version mismatch: has golang.org/x/sys@v0.28.0, but v0.21.0 expected
Warning: version mismatch: has golang.org/x/term@v0.27.0, but v0.21.0 expected
Warning: version mismatch: has golang.org/x/text@v0.21.0, but v0.16.0 expected
Verifying /tmp/ws/kcp-rebase/kcp/docs/generators/cli-doc
Verifying dependency versions in /tmp/ws/kcp-rebase/kcp/docs/generators/cli-doc/go.mod against /home/rvasek/go/pkg/mod/cache/download/github.com/kcp-dev/kubernetes/@v/v0.0.0-20250223141144-b901243fc922.mod
Warning: version mismatch: has github.com/go-openapi/jsonpointer@v0.21.0, but v0.19.6 expected
Warning: version mismatch: has github.com/go-openapi/jsonreference@v0.21.0, but v0.20.2 expected
Warning: version mismatch: has github.com/go-openapi/swag@v0.23.0, but v0.22.4 expected
Warning: version mismatch: has github.com/mailru/easyjson@v0.9.0, but v0.7.7 expected
Warning: version mismatch: has golang.org/x/net@v0.35.0, but v0.26.0 expected
Warning: version mismatch: has golang.org/x/sync@v0.11.0, but v0.7.0 expected
Warning: version mismatch: has golang.org/x/sys@v0.30.0, but v0.21.0 expected
Warning: version mismatch: has golang.org/x/term@v0.29.0, but v0.21.0 expected
Warning: version mismatch: has golang.org/x/text@v0.22.0, but v0.16.0 expected
Warning: version mismatch: has google.golang.org/protobuf@v1.36.5, but v1.34.2 expected
Verifying /tmp/ws/kcp-rebase/kcp/sdk
Verifying dependency versions in /tmp/ws/kcp-rebase/kcp/sdk/go.mod against /home/rvasek/go/pkg/mod/cache/download/github.com/kcp-dev/kubernetes/@v/v0.0.0-20250223141144-b901243fc922.mod
Warning: version mismatch: has golang.org/x/crypto@v0.31.0, but v0.24.0 expected
Warning: version mismatch: has golang.org/x/net@v0.33.0, but v0.26.0 expected
Warning: version mismatch: has golang.org/x/sync@v0.10.0, but v0.7.0 expected
Warning: version mismatch: has golang.org/x/sys@v0.28.0, but v0.21.0 expected
Warning: version mismatch: has golang.org/x/term@v0.27.0, but v0.21.0 expected
Warning: version mismatch: has golang.org/x/text@v0.21.0, but v0.16.0 expected
Verifying /tmp/ws/kcp-rebase/kcp
Verifying dependency versions in /tmp/ws/kcp-rebase/kcp/go.mod against /home/rvasek/go/pkg/mod/cache/download/github.com/kcp-dev/kubernetes/@v/v0.0.0-20250223141144-b901243fc922.mod
Warning: version mismatch: has github.com/go-openapi/jsonpointer@v0.21.0, but v0.19.6 expected
Warning: version mismatch: has github.com/go-openapi/jsonreference@v0.21.0, but v0.20.2 expected
Warning: version mismatch: has github.com/go-openapi/swag@v0.23.0, but v0.22.4 expected
Warning: version mismatch: has github.com/mailru/easyjson@v0.9.0, but v0.7.7 expected
Warning: version mismatch: has github.com/stoewer/go-strcase@v1.3.0, but v1.2.0 expected
Warning: version mismatch: has golang.org/x/crypto@v0.33.0, but v0.24.0 expected
Warning: version mismatch: has golang.org/x/mod@v0.23.0, but v0.17.0 expected
Warning: version mismatch: has golang.org/x/net@v0.35.0, but v0.26.0 expected
Warning: version mismatch: has golang.org/x/sync@v0.11.0, but v0.7.0 expected
Warning: version mismatch: has golang.org/x/sys@v0.30.0, but v0.21.0 expected
Warning: version mismatch: has golang.org/x/term@v0.29.0, but v0.21.0 expected
Warning: version mismatch: has golang.org/x/text@v0.22.0, but v0.16.0 expected
Warning: version mismatch: has golang.org/x/tools@v0.30.0, but v0.21.1-0.20240508182429-e35e4ccd0d2d expected
Warning: version mismatch: has google.golang.org/protobuf@v1.36.5, but v1.34.2 expected
Verifying dependency versions in /home/rvasek/go/pkg/mod/cache/download/github.com/kcp-dev/client-go/@v/v0.0.0-20250223133118-3dea338dc267.mod against /home/rvasek/go/pkg/mod/cache/download/github.com/kcp-dev/kubernetes/@v/v0.0.0-20250223141144-b901243fc922.mod
Verifying dependency versions in /home/rvasek/go/pkg/mod/cache/download/github.com/kcp-dev/apimachinery/v2/@v/v2.0.1-0.20250223115924-431177b024f3.mod against /home/rvasek/go/pkg/mod/cache/download/github.com/kcp-dev/kubernetes/@v/v0.0.0-20250223141144-b901243fc922.mod
```

## Related issue(s)

Fixes https://github.com/kcp-dev/kcp/issues/3306

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
