### PR TITLE
:book: remove superflous output from make install command

### DIFF
--- a/docs/content/setup/kubectl-plugin.md
+++ b/docs/content/setup/kubectl-plugin.md
@@ -11,7 +11,6 @@ You can install the plugins from the current repo:
 
 ```sh
 $ make install
-go install ./cmd/...
 ```
 
 or use [krew](https://krew.sigs.k8s.io/):


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The output from `make install` no longer matches the output in the docs. So we just remove that to prevent confusion as to what to execute.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
remove superflous output from make install command
```
