### PR TITLE
:seedling: Limit several jobs to not run for doc changes

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -37,9 +37,9 @@ presubmits:
               cpu: 1
 
   - name: pull-kcp-lint
-    always_run: true
     decorate: true
     clone_uri: "https://github.com/kcp-dev/kcp"
+    skip_if_only_changed: "(docs)"
     labels:
       preset-goproxy: "true"
     spec:
@@ -54,9 +54,9 @@ presubmits:
               cpu: 2
 
   - name: pull-kcp-build-image
-    always_run: true
     decorate: true
     clone_uri: "https://github.com/kcp-dev/kcp"
+    skip_if_only_changed: "(docs)"
     labels:
       preset-goproxy: "true"
     spec:
@@ -76,9 +76,9 @@ presubmits:
               cpu: 1
 
   - name: pull-kcp-test-unit
-    always_run: true
     decorate: true
     clone_uri: "https://github.com/kcp-dev/kcp"
+    skip_if_only_changed: "(docs)"
     labels:
       preset-goproxy: "true"
     spec:


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

We are running several jobs on changes to `docs/` which are not necessary and just put load on the CI environment. Let's scope down Prow jobs a bit here.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
