### PR TITLE
:seedling:  hack/verify-go-modules.sh: don't run pager with git diff

### DIFF
--- a/hack/verify-go-modules.sh
+++ b/hack/verify-go-modules.sh
@@ -107,8 +107,8 @@ for dir in "${DIRS[@]}"; do
     echo "Verifying ${dir}"
 
     if ! git diff --quiet HEAD -- go.mod go.sum; then
-      echo "go module files are out of date"
-      git diff HEAD -- go.mod go.sum
+      git --no-pager diff HEAD -- go.mod go.sum
+      echo "Error: go.mod and/or go.sum in ${dir} files have been modified, inspect and commit them before continuing" 1>&2
       exit 1
     fi
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Depending on which pager git is configured to use, it may clear terminal's screen, including the error message from verify-go-modules.sh. This then may be confusing for the user where is this `git diff` coming from.

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
