### PR TITLE
🐛 do not create executable YAML files from crd-puller

### DIFF
--- a/cmd/crd-puller/pull-crds.go
+++ b/cmd/crd-puller/pull-crds.go
@@ -85,7 +85,7 @@ func main() {
 				if err != nil {
 					return err
 				}
-				if err := os.WriteFile(name.String()+".yaml", yamlBytes, os.ModePerm); err != nil {
+				if err := os.WriteFile(name.String()+".yaml", yamlBytes, 0644); err != nil {
 					return err
 				}
 			}


### PR DESCRIPTION
## Summary
The crd-puller currently generates YAML files with mode 0777, which is an odd choice for YAML files. This PR changes the mode to 0644, something IMHO more sensible.

## Release Notes
```release-note
crd-puller will generate files with 0644 permissions instead of 0777.
```
