### PR TITLE
:sparkles: Add --{accept/reject}-permission-claim flag to bind cli

### DIFF
--- a/cli/pkg/bind/cmd/cmd.go
+++ b/cli/pkg/bind/cmd/cmd.go
@@ -30,6 +30,12 @@ var (
 	bindExampleUses = `
 	# Create an APIBinding named "my-binding" that binds to the APIExport "my-export" in the "root:my-service" workspace.
 	%[1]s bind apiexport root:my-service:my-export --name my-binding
+
+	# Create an APIBinding named "my-binding" that binds to the APIExport "my-export" in the "root:my-service" workspace with accepted permission claims.
+	%[1]s bind apiexport root:my-service:my-export --name my-binding --accept-permission-claims core.secrets,core.configmaps
+
+	# Create an APIBinding named "my-binding" that binds to the APIExport "my-export" in the "root:my-service" workspace with rejected permission claims.
+	%[1]s bind apiexport root:my-service:my-export --name my-binding --reject-permission-claims core.secrets,core.configmaps
 	`
 )
 

--- a/cli/pkg/bind/plugin/bind_test.go
+++ b/cli/pkg/bind/plugin/bind_test.go
@@ -14,49 +14,88 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package plugin_test
+package plugin
 
 import (
 	"testing"
-
-	"github.com/kcp-dev/kcp/cli/pkg/bind/plugin"
 )
 
 func TestBindOptionsValidate(t *testing.T) {
 	testCases := []struct {
 		description string
-		bindOptions plugin.BindOptions
+		bindOptions BindOptions
 		wantValid   bool
 	}{
 		{
 			description: "Fully-qualified APIExport reference with dashes",
-			bindOptions: plugin.BindOptions{APIExportRef: "test-root:test-workspace:test-apiexport-123"},
+			bindOptions: BindOptions{APIExportRef: "test-root:test-workspace:test-apiexport-123"},
 			wantValid:   true,
 		},
 		{
 			description: "Fully-qualified APIExport reference with dots in the name",
-			bindOptions: plugin.BindOptions{APIExportRef: "test-root:test-workspace:test.apiexport.123"},
+			bindOptions: BindOptions{APIExportRef: "test-root:test-workspace:test.apiexport.123"},
 			wantValid:   true,
 		},
 		{
 			description: "Fully-qualified APIExport reference with special characters in the name",
-			bindOptions: plugin.BindOptions{APIExportRef: "test-root:test-workspace:test@apiexport=123"},
+			bindOptions: BindOptions{APIExportRef: "test-root:test-workspace:test@apiexport=123"},
 			wantValid:   true,
 		},
 		{
 			description: "Fully-qualified APIExport reference with upper-case characters in the name",
-			bindOptions: plugin.BindOptions{APIExportRef: "test-root:test-workspace:testAPIExport123"},
+			bindOptions: BindOptions{APIExportRef: "test-root:test-workspace:testAPIExport123"},
 			wantValid:   true,
 		},
 		{
 			description: "Fully-qualified APIExport reference with special characters in the path",
-			bindOptions: plugin.BindOptions{APIExportRef: "test-root:t@st-workspace:test-apiexport"},
+			bindOptions: BindOptions{APIExportRef: "test-root:t@st-workspace:test-apiexport"},
 			wantValid:   false,
 		},
 		{
 			description: "Fully-qualified APIExport reference with upper-case characters in the path",
-			bindOptions: plugin.BindOptions{APIExportRef: "test-root:TestWorkspace:test-apiexport"},
+			bindOptions: BindOptions{APIExportRef: "test-root:TestWorkspace:test-apiexport"},
 			wantValid:   false,
+		},
+		{
+			description: "Valid accepted permission claims",
+			bindOptions: BindOptions{
+				APIExportRef:             "test-root:test-workspace:test-apiexport",
+				AcceptedPermissionClaims: []string{"group.resource"},
+			},
+			wantValid: true,
+		},
+		{
+			description: "Valid rejected permission claims",
+			bindOptions: BindOptions{
+				APIExportRef:             "test-root:test-workspace:test-apiexport",
+				RejectedPermissionClaims: []string{"resource.group"},
+			},
+			wantValid: true,
+		},
+		{
+			description: "Conflicting accepted and rejected permission claims",
+			bindOptions: BindOptions{
+				APIExportRef:             "test-root:test-workspace:test-apiexport",
+				AcceptedPermissionClaims: []string{"resource.group"},
+				RejectedPermissionClaims: []string{"resource.group"},
+			},
+			wantValid: false,
+		},
+		{
+			description: "Invalid accepted permission claim format",
+			bindOptions: BindOptions{
+				APIExportRef:             "test-root:test-workspace:test-apiexport",
+				AcceptedPermissionClaims: []string{"invalidclaim"},
+			},
+			wantValid: false,
+		},
+		{
+			description: "Invalid rejected permission claim format",
+			bindOptions: BindOptions{
+				APIExportRef:             "test-root:test-workspace:test-apiexport",
+				RejectedPermissionClaims: []string{"invalidclaim"},
+			},
+			wantValid: false,
 		},
 	}
 
@@ -70,6 +109,61 @@ func TestBindOptionsValidate(t *testing.T) {
 
 			if (err == nil) && !c.wantValid {
 				t.Errorf("wanted %+v to be invalid, but it's valid", c.bindOptions)
+			}
+		})
+	}
+}
+
+func TestParsePermissionClaim(t *testing.T) {
+	testCases := []struct {
+		description string
+		claim       string
+		accepted    bool
+		wantError   bool
+	}{
+		{
+			description: "Valid accepted permission claim",
+			claim:       "resource.group",
+			accepted:    true,
+			wantError:   false,
+		},
+		{
+			description: "Valid rejected permission claim",
+			claim:       "resource.group",
+			accepted:    false,
+			wantError:   false,
+		},
+		{
+			description: "Invalid permission claim format",
+			claim:       "invalidclaim",
+			accepted:    true,
+			wantError:   true,
+		},
+		{
+			description: "Empty permission claim",
+			claim:       "",
+			accepted:    true,
+			wantError:   true,
+		},
+		{
+			description: "Core group permission claim",
+			claim:       "resource.core",
+			accepted:    true,
+			wantError:   false,
+		},
+	}
+
+	for _, c := range testCases {
+		t.Run(c.description, func(t *testing.T) {
+			b := &BindOptions{}
+			err := b.parsePermissionClaim(c.claim, c.accepted)
+
+			if (err != nil) && !c.wantError {
+				t.Errorf("wanted %q to be parsed without error, but got error: %v", c.claim, err)
+			}
+
+			if (err == nil) && c.wantError {
+				t.Errorf("wanted %q to be parsed with error, but got no error", c.claim)
 			}
 		})
 	}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes https://github.com/kcp-dev/kcp/issues/3189

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Add --accept-permission-claim & --reject-permission-claim flag to `kubectl kcp bind apiexport`
```
