### PR TITLE
:bug: Add binding authorizer to APIExport virtual workspace

### DIFF
--- a/pkg/virtual/apiexport/authorizer/binding.go
+++ b/pkg/virtual/apiexport/authorizer/binding.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authorizer
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+
+	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	dynamiccontext "github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/context"
+	apisv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/apis/v1alpha1"
+	apisv1alpha1informers "github.com/kcp-dev/kcp/sdk/client/informers/externalversions/apis/v1alpha1"
+)
+
+type boundAPIAuthorizer struct {
+	getAPIBindingByExport func(clusterName, apiExportName, apiExportCluster string) (*apisv1alpha1.APIBinding, error)
+
+	delegate authorizer.Authorizer
+}
+
+var readOnlyVerbs = []string{"get", "list", "watch"}
+
+func NewBoundAPIAuthorizer(delegate authorizer.Authorizer, apiBindingInformer apisv1alpha1informers.APIBindingClusterInformer, kubeClusterClient kcpkubernetesclientset.ClusterInterface) authorizer.Authorizer {
+	apiBindingLister := apiBindingInformer.Lister()
+
+	return &boundAPIAuthorizer{
+		delegate: delegate,
+		getAPIBindingByExport: func(clusterName, apiExportName, apiExportCluster string) (*apisv1alpha1.APIBinding, error) {
+			bindings, err := apiBindingLister.Cluster(logicalcluster.Name(clusterName)).List(labels.Everything())
+			if err != nil {
+				return nil, err
+			}
+
+			for _, binding := range bindings {
+				if binding == nil {
+					continue
+				}
+
+				if binding.Spec.Reference.Export != nil && binding.Spec.Reference.Export.Name == apiExportName && binding.Status.APIExportClusterName == apiExportCluster {
+					return binding, nil
+				}
+			}
+
+			return nil, fmt.Errorf("no suitable binding found")
+		},
+	}
+}
+
+func (a *boundAPIAuthorizer) Authorize(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+	targetCluster, err := genericapirequest.ValidClusterFrom(ctx)
+	if err != nil {
+		return authorizer.DecisionNoOpinion, "", fmt.Errorf("error getting valid cluster from context: %w", err)
+	}
+
+	if targetCluster.Wildcard || attr.GetResource() == "" {
+		// if the target is the wildcard cluster or it's a non-resurce URL request,
+		// we can skip checking the APIBinding in the target cluster.
+		return a.delegate.Authorize(ctx, attr)
+	}
+
+	apiDomainKey := dynamiccontext.APIDomainKeyFrom(ctx)
+	parts := strings.Split(string(apiDomainKey), "/")
+	if len(parts) < 2 {
+		return authorizer.DecisionNoOpinion, "", fmt.Errorf("invalid API domain key")
+	}
+	apiExportCluster, apiExportName := parts[0], parts[1]
+
+	apiBinding, err := a.getAPIBindingByExport(targetCluster.Name.String(), apiExportName, apiExportCluster)
+	if err != nil {
+		return authorizer.DecisionDeny, "could not find suitable APIBinding in target logical cluster", nil //nolint:nilerr // this is on purpose, we want to deny, not return a server error
+	}
+
+	// check if request is for a bound resource.
+	for _, resource := range apiBinding.Status.BoundResources {
+		if resource.Group == attr.GetAPIGroup() && resource.Resource == attr.GetResource() {
+			return a.delegate.Authorize(ctx, attr)
+		}
+	}
+
+	// check if a resource claim for this resource has been accepted.
+	for _, permissionClaim := range apiBinding.Spec.PermissionClaims {
+		if permissionClaim.State != apisv1alpha1.ClaimAccepted {
+			// if the claim is not accepted it cannot be used.
+			continue
+		}
+
+		if permissionClaim.Group == attr.GetAPIGroup() && permissionClaim.Resource == attr.GetResource() {
+			return a.delegate.Authorize(ctx, attr)
+		}
+	}
+
+	// special case: APIBindings are always available from an APIExport VW,
+	// but the provider should only be allowed to access them read-only to avoid privilege escalation.
+	if attr.GetAPIGroup() == apisv1alpha1.SchemeGroupVersion.Group && attr.GetResource() == "apibindings" {
+		if !slices.Contains(readOnlyVerbs, attr.GetVerb()) {
+			return authorizer.DecisionNoOpinion, "write access to APIBinding is not allowed from virtual workspace", nil
+		}
+
+		return a.delegate.Authorize(ctx, attr)
+	}
+
+	// if we cannot find the API bound to the logical cluster, we deny.
+	// The APIExport owner has not been invited in.
+	return authorizer.DecisionDeny, "failed to find suitable reason to allow access in APIBinding", nil
+}

--- a/pkg/virtual/apiexport/builder/build.go
+++ b/pkg/virtual/apiexport/builder/build.go
@@ -70,7 +70,7 @@ func BuildVirtualWorkspace(
 	cfg *rest.Config,
 	kubeClusterClient, deepSARClient kcpkubernetesclientset.ClusterInterface,
 	kcpClusterClient kcpclientset.ClusterInterface,
-	cachedKcpInformers kcpinformers.SharedInformerFactory,
+	cachedKcpInformers, kcpInformers kcpinformers.SharedInformerFactory,
 ) ([]rootapiserver.NamedVirtualWorkspace, error) {
 	if !strings.HasSuffix(rootPathPrefix, "/") {
 		rootPathPrefix += "/"
@@ -203,6 +203,7 @@ func BuildVirtualWorkspace(
 				for name, informer := range map[string]cache.SharedIndexInformer{
 					"apiresourceschemas": cachedKcpInformers.Apis().V1alpha1().APIResourceSchemas().Informer(),
 					"apiexports":         cachedKcpInformers.Apis().V1alpha1().APIExports().Informer(),
+					"apibindings":        kcpInformers.Apis().V1alpha1().APIBindings().Informer(),
 				} {
 					if !cache.WaitForNamedCacheSync(name, hookContext.Done(), informer.HasSynced) {
 						klog.Background().Error(nil, "informer not synced")
@@ -218,7 +219,7 @@ func BuildVirtualWorkspace(
 
 			return apiReconciler, nil
 		},
-		Authorizer: newAuthorizer(kubeClusterClient, deepSARClient, cachedKcpInformers),
+		Authorizer: newAuthorizer(kubeClusterClient, deepSARClient, cachedKcpInformers, kcpInformers),
 	}
 
 	return []rootapiserver.NamedVirtualWorkspace{
@@ -291,14 +292,17 @@ func digestUrl(urlPath, rootPathPrefix string) (
 	return cluster, dynamiccontext.APIDomainKey(key), strings.TrimSuffix(urlPath, realPath), true
 }
 
-func newAuthorizer(kubeClusterClient, deepSARClient kcpkubernetesclientset.ClusterInterface, cachedKcpInformers kcpinformers.SharedInformerFactory) authorizer.Authorizer {
+func newAuthorizer(kubeClusterClient, deepSARClient kcpkubernetesclientset.ClusterInterface, cachedKcpInformers, kcpInformers kcpinformers.SharedInformerFactory) authorizer.Authorizer {
 	maximalPermissionAuth := virtualapiexportauth.NewMaximalPermissionAuthorizer(deepSARClient, cachedKcpInformers.Apis().V1alpha1().APIExports())
 	maximalPermissionAuth = authorization.NewDecorator("virtual.apiexport.maxpermissionpolicy.authorization.kcp.io", maximalPermissionAuth).AddAuditLogging().AddAnonymization().AddReasonAnnotation()
 
 	apiExportsContentAuth := virtualapiexportauth.NewAPIExportsContentAuthorizer(maximalPermissionAuth, kubeClusterClient)
 	apiExportsContentAuth = authorization.NewDecorator("virtual.apiexport.content.authorization.kcp.io", apiExportsContentAuth).AddAuditLogging().AddAnonymization()
 
-	return apiExportsContentAuth
+	boundApiAuth := virtualapiexportauth.NewBoundAPIAuthorizer(apiExportsContentAuth, kcpInformers.Apis().V1alpha1().APIBindings(), kubeClusterClient)
+	boundApiAuth = authorization.NewDecorator("virtual.apiexport.boundapi.authorization.kcp.io", boundApiAuth).AddAuditLogging().AddAnonymization()
+
+	return boundApiAuth
 }
 
 // apiDefinitionWithCancel calls the cancelFn on tear-down.

--- a/pkg/virtual/apiexport/options/options.go
+++ b/pkg/virtual/apiexport/options/options.go
@@ -56,7 +56,7 @@ func (o *APIExport) Validate(flagPrefix string) []error {
 func (o *APIExport) NewVirtualWorkspaces(
 	rootPathPrefix string,
 	config *rest.Config,
-	cachedKcpInformers kcpinformers.SharedInformerFactory,
+	cachedKcpInformers, wildcardKcpInformers kcpinformers.SharedInformerFactory,
 ) (workspaces []rootapiserver.NamedVirtualWorkspace, err error) {
 	config = rest.AddUserAgent(rest.CopyConfig(config), "apiexport-virtual-workspace")
 	kcpClusterClient, err := kcpclientset.NewForConfig(config)
@@ -72,5 +72,5 @@ func (o *APIExport) NewVirtualWorkspaces(
 		return nil, err
 	}
 
-	return builder.BuildVirtualWorkspace(path.Join(rootPathPrefix, builder.VirtualWorkspaceName), config, kubeClusterClient, deepSARClient, kcpClusterClient, cachedKcpInformers)
+	return builder.BuildVirtualWorkspace(path.Join(rootPathPrefix, builder.VirtualWorkspaceName), config, kubeClusterClient, deepSARClient, kcpClusterClient, cachedKcpInformers, wildcardKcpInformers)
 }

--- a/pkg/virtual/options/options.go
+++ b/pkg/virtual/options/options.go
@@ -65,7 +65,7 @@ func (o *Options) NewVirtualWorkspaces(
 	wildcardKubeInformers kcpkubernetesinformers.SharedInformerFactory,
 	wildcardKcpInformers, cachedKcpInformers kcpinformers.SharedInformerFactory,
 ) ([]rootapiserver.NamedVirtualWorkspace, error) {
-	apiexports, err := o.APIExport.NewVirtualWorkspaces(rootPathPrefix, config, cachedKcpInformers)
+	apiexports, err := o.APIExport.NewVirtualWorkspaces(rootPathPrefix, config, cachedKcpInformers, wildcardKcpInformers)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/virtual/apiexport/authorizer_test.go
+++ b/test/e2e/virtual/apiexport/authorizer_test.go
@@ -465,11 +465,11 @@ metadata:
 		if err == nil {
 			return false, "expected error, got none"
 		}
-		if apierrors.IsNotFound(err) {
+		if apierrors.IsForbidden(err) {
 			return true, ""
 		}
-		return false, fmt.Sprintf("expected a not-found error, but got %v", err)
-	}, wait.ForeverTestTimeout, 100*time.Millisecond, "expected service-provider-2-admin to get a not-found for shadowed cowboy resources")
+		return false, fmt.Sprintf("expected a forbidden error, but got %v", err)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "expected service-provider-2-admin to get a forbidden for shadowed cowboy resources")
 }
 
 var scheme *runtime.Scheme


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This adds an additional authorizer to the authorizer chain for the APIExport VW, incorporating the configuration on the APIBinding present in the target workspace.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Add additional authorizer to APIExport Virtual Workspace that queries APIBinding for authorization decisions
```
