### PR TITLE
🌱 update goreleaser config to version 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ goio.yaml
 # Common editor / temporary files
 .DS_Store
 
+# goreleaser snapshots
+/dist/
+
 # Folder where each developer can store temporary files
 tmp
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,4 @@
-
+version: 2
 builds:
 # server builds
 - id: "kcp"
@@ -81,22 +81,22 @@ builds:
 
 archives:
 - id: kcp
-  builds:
+  ids:
   - kcp
 - id: apigen
-  builds:
+  ids:
   - apigen
   name_template: "apigen_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 - id: kubectl-kcp-plugin
-  builds:
+  ids:
   - kubectl-kcp
   name_template: "kubectl-kcp-plugin_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 - id: kubectl-ws-plugin
-  builds:
+  ids:
   - kubectl-ws
   name_template: "kubectl-ws-plugin_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 - id: kubectl-create-workspace-plugin-krew
-  builds:
+  ids:
   - kubectl-create-workspace
   name_template: "kubectl-create-workspace-plugin_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 


### PR DESCRIPTION
## Summary
This fixes the deprecation warnings output by goreleaser 2.8.x, namely:

* only  version: 2  configuration files are supported, yours is  version: 0 , please update your configuration
* DEPRECATED:  archives.builds  should not be used anymore, check https://goreleaser.com/deprecations#archivesbuilds for more info

## Related issue(s)
Fixes #3341

## Release Notes
```release-note
NONE
```
