### PR TITLE
:book: Update docs

### DIFF
--- a/docs/content/concepts/quickstart-tenancy-and-apis.md
+++ b/docs/content/concepts/quickstart-tenancy-and-apis.md
@@ -42,16 +42,18 @@ workspaces                        ws           tenancy.kcp.io/v1alpha1          
 
 ## Create and Navigate Some Workspaces
 
-The `ws` plugin for `kubectl` makes it easy to switch your `kubeconfig` between workspaces, and to create new ones:
+The `ws` plugin for `kubectl` makes it easy to switch your `kubeconfig` between workspaces and use `workspace create` plugin for `kubectl` to create new ones:
+> [!NOTE]  
+> Plugins can be found in the [release page](https://github.com/kcp-dev/kcp/releases/latest)
 
 ```shell
 $ kubectl ws .
 Current workspace is "root".
-$ kubectl ws create a --enter
+$ kubectl create workspace a --enter
 Workspace "a" (type root:organization) created. Waiting for it to be ready...
 Workspace "a" (type root:organization) is ready to use.
 Current workspace is "root:a".
-$ kubectl ws create b
+$ kubectl create workspace b
 Workspace "b" (type root:universal) created. Waiting for it to be ready...
 Workspace "b" (type root:universal) is ready to use.
 $ kubectl get workspaces
@@ -156,11 +158,11 @@ capabilities to service consumers in other workspaces.
 First we'll create an organization workspace, and then within that create a service provider workspace.
 
 ```shell
-$ kubectl ws create wildwest --enter
+$ kubectl create workspace wildwest --enter
 Workspace "wildwest" (type root:organization) created. Waiting for it to be ready...
 Workspace "wildwest" (type root:organization) is ready to use.
 Current workspace is "root:wildwest".
-$ kubectl ws create cowboys-service --enter
+$ kubectl create workspace cowboys-service --enter
 Workspace "cowboys-service" (type root:universal) created. Waiting for it to be ready...
 Workspace "cowboys-service" (type root:universal) is ready to use.
 Current workspace is "root:wildwest:cowboys-service".
@@ -196,7 +198,7 @@ Now we can adopt the service consumer persona and create a workspace from which 
 ```shell
 $ kubectl ws
 Current workspace is "root:users:zu:yc:kcp-admin".
-$ kubectl ws create --enter test-consumer
+$ kubectl create workspace --enter test-consumer
 Workspace "test-consumer" (type root:universal) created. Waiting for it to be ready...
 Workspace "test-consumer" (type root:universal) is ready to use.
 Current workspace is "root:users:zu:yc:kcp-admin:test-consumer".

--- a/docs/content/concepts/quickstart-tenancy-and-apis.md
+++ b/docs/content/concepts/quickstart-tenancy-and-apis.md
@@ -171,9 +171,8 @@ Current workspace is "root:wildwest:cowboys-service".
 Then we'll use a CRD to generate an `APIResourceSchema` and `APIExport` and apply these within the service provider
 workspace.
 
-> The `apigen` tool used below can be found
-> [here](https://github.com/kcp-dev/kcp/tree/main/sdk/cmd/apigen). Builds for the
-> tool are not currently published as part of the kcp release process.
+> [!NOTE]
+> The `apigen` tool used below can be found on the [release page](https://github.com/kcp-dev/kcp/releases/latest)
 
 ```shell
 $ mkdir wildwest-schemas/

--- a/docs/content/concepts/quickstart-tenancy-and-apis.md
+++ b/docs/content/concepts/quickstart-tenancy-and-apis.md
@@ -42,9 +42,9 @@ workspaces                        ws           tenancy.kcp.io/v1alpha1          
 
 ## Create and Navigate Some Workspaces
 
-The `ws` plugin for `kubectl` makes it easy to switch your `kubeconfig` between workspaces and use `workspace create` plugin for `kubectl` to create new ones:
+The `ws` plugin for `kubectl` makes it easy to switch your `kubeconfig` between workspaces and use `create-workspace` plugin for `kubectl` to create new ones:
 > [!NOTE]  
-> Plugins can be found in the [release page](https://github.com/kcp-dev/kcp/releases/latest)
+> Refer to the [plugins page](https://docs.kcp.io/kcp/main/setup/kubectl-plugin/) to install them.
 
 ```shell
 $ kubectl ws .


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Hi!

While going through the Tenancy and APIs section, I noticed that the kubectl ws create command is deprecated. I've updated it to kubectl create workspace and added a link to the latest release page.

Additionally, the documentation states that apigen needs to be built, but from what I observed, it is already available on the release page. I’ve adjusted this accordingly.

Hope this helps!

## Related issue(s)

None


## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```