### PR TITLE
:bug: Bump WorkspaceType `APIResourceSchema` name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,6 +224,8 @@ verify-codegen: ## Verify codegen
 		exit 1; \
 	fi
 
+	./hack/verify-apiresourceschemas.sh
+
 .PHONY: imports
 imports: WHAT ?=
 imports: $(GOLANGCI_LINT) verify-go-versions

--- a/config/root-phase0/apiexport-tenancy.kcp.io.yaml
+++ b/config/root-phase0/apiexport-tenancy.kcp.io.yaml
@@ -5,8 +5,8 @@ metadata:
   name: tenancy.kcp.io
 spec:
   latestResourceSchemas:
-  - v240903-d6797056a.workspacetypes.tenancy.kcp.io
   - v241020-fce06d31d.workspaces.tenancy.kcp.io
+  - v250325-c1864de17.workspacetypes.tenancy.kcp.io
   maximalPermissionPolicy:
     local: {}
 status: {}

--- a/config/root-phase0/apiresourceschema-workspacetypes.tenancy.kcp.io.yaml
+++ b/config/root-phase0/apiresourceschema-workspacetypes.tenancy.kcp.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v240903-d6797056a.workspacetypes.tenancy.kcp.io
+  name: v250325-c1864de17.workspacetypes.tenancy.kcp.io
 spec:
   group: tenancy.kcp.io
   names:

--- a/hack/verify-apiresourceschemas.sh
+++ b/hack/verify-apiresourceschemas.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The KCP Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script ensures that the generated client code checked into git is up-to-date
+# with the generator. If it is not, re-generate the configuration to update it.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+TARGET_REF=${PULL_BASE_REF:-main}
+
+find config/root-phase0 -name 'apiresourceschema-*.yaml' | while read schema
+do
+    if ! git diff --exit-code ${TARGET_REF} -- ${schema} 2>&1 >/dev/null; then
+        current_name=$(yq '.metadata.name' ${schema})
+        previous_name=$(git show ${TARGET_REF}:${schema} | yq '.metadata.name')
+
+        if [ "${current_name}" == "${previous_name}" ]; then
+            echo "${schema} has changed in comparison to '${TARGET_REF}', but object name is the same (${current_name} == ${previous_name})."
+            echo "This is not valid as APIResourceSchemas are immutable."
+            echo "Please run \`make crds\` without modifying APIResourceSchema files manually."
+            exit 1
+        fi
+    fi  
+done


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This [Slack thread](https://kubernetes.slack.com/archives/C021U8WSAFK/p1742888913738159) mentions that we have a problem with the 0.26 to 0.27 upgrade with the WorkspaceType `APIResourceSchema`. The reason is that we changed the file in #3233 but it looks like changes in that PR were done manually with search and replace, which evaded detection by `apigen` and by any other validation logic we have.

This PR, intended to be backported to `release-0.27`, does two things: It manually resets the `APIResourceSchema` name in question so that upgrades can proceed.

It _also_ adds a small `hack/verify-apiresourceschemas.sh` script that compares the `APIResourceSchemas` against the pull request target branch and if there is a diff in the file, it errors if the object name is the same (a diff is fine, but any changes mean the object name should have been updated). The script is probably not ideal, but it should prevent us from making this mistake again.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Fix `APIResourceSchema` name for the `WorkspaceTypes` resource to unblock upgrade from previous versions
```
