### PR TITLE
:seedling: Pin GitHub Actions workflows to commits

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -2,6 +2,15 @@ version: 2
 updates:
 # Maintain dependencies for GitHub Actions
 - package-ecosystem: "github-actions"
+  # Workflow files stored in the
+  # default location of `.github/workflows`
   directory: "/"
   schedule:
-    interval: "daily"
+    interval: "weekly"
+  groups:
+    all-github-actions:
+      patterns: [ "*" ]
+  commit-message:
+    prefix: ":seedling:"
+  labels:
+  - "ok-to-test"

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: projects
     steps:
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # tag=v1.0.2
         with:
           project-url: https://github.com/orgs/kcp-dev/projects/1
           github-token: ${{ secrets.GHPROJECT_TOKEN }}

--- a/.github/workflows/docs-gen-and-push.yaml
+++ b/.github/workflows/docs-gen-and-push.yaml
@@ -27,17 +27,17 @@ jobs:
     name: Generate and push docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag=v4.2.2
 
       - run: git fetch origin gh-pages
       - run: git fetch origin '+refs/tags/v*:refs/tags/v*' --no-tags
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # tag=v5.4.0
         with:
           go-version: v1.23.7
           cache: true
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 #tag=v5.5.0
         with:
           python-version: '3.10'
           cache: 'pip'

--- a/.github/workflows/gh-image-purge.yaml
+++ b/.github/workflows/gh-image-purge.yaml
@@ -7,7 +7,7 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     steps:
-      - uses: dataaxiom/ghcr-cleanup-action@v1
+      - uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # tag=v1.0.16
         with:
           older-than: 1 month
           owner: kcp-dev

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -17,19 +17,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag=v4.2.2
       with:
         fetch-depth: 0
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # tag=v5.4.0
       with:
-        go-version: v1.22.10
+        go-version: v1.23.7
     - name: Delete non-semver tags
       run: 'git tag -d $(git tag -l | grep -v "^v")'
     - name: Set LDFLAGS
       run: echo LDFLAGS="$(make ldflags)" >> $GITHUB_ENV
     - name: Run GoReleaser on tag
       if: github.event_name != 'pull_request'
-      uses: goreleaser/goreleaser-action@v4
+      uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 # tag=v6.2.1
       with:
         distribution: goreleaser
         version: latest
@@ -39,7 +39,7 @@ jobs:
         KREW_GITHUB_TOKEN: ${{ secrets.KREW_GITHUB_TOKEN }}
     - name: Run GoReleaser on pull request
       if: github.event_name == 'pull_request'
-      uses: goreleaser/goreleaser-action@v4
+      uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 # tag=v6.2.1
       with:
         distribution: goreleaser
         version: latest
@@ -47,7 +47,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         KREW_GITHUB_TOKEN: ${{ secrets.KREW_GITHUB_TOKEN }}
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag=v4.6.2
       if: ${{ always() }}
       with:
         name: binaries

--- a/.github/workflows/pr-verifier.yaml
+++ b/.github/workflows/pr-verifier.yaml
@@ -16,8 +16,28 @@ jobs:
       pull-requests: read
     runs-on: ubuntu-latest
     steps:
-    - name: Verifier action
-      id: verifier
-      uses: kubernetes-sigs/kubebuilder-release-tools@012269a88fa4c034a0acf1ba84c26b195c0dbab4 # tag=v0.4.3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag=v4.2.2
+
+      - name: Validate PR Title Format
+        run: |
+          TITLE="${{ github.event.pull_request.title }}"
+          
+          if [[ -z "$TITLE" ]]; then
+            echo "Error: PR title cannot be empty."
+            exit 1
+          fi
+          
+          if ! [[ "$TITLE" =~ ^($'\u26A0'|$'\u2728'|$'\U0001F41B'|$'\U0001F4D6'|$'\U0001F680'|$'\U0001F331') ]]; then
+            echo "Error: Invalid PR title format."
+            echo "Your PR title must start with one of the following indicators:"
+            echo "- Breaking change: ⚠ (U+26A0)"
+            echo "- Non-breaking feature: ✨ (U+2728)"
+            echo "- Patch fix: 🐛 (U+1F41B)"
+            echo "- Docs: 📖 (U+1F4D6)"
+            echo "- Release: 🚀 (U+1F680)"
+            echo "- Infra/Tests/Other: 🌱 (U+1F331)"
+            exit 1
+          fi
+          
+          echo "PR title is valid: '$TITLE'"

--- a/.github/workflows/pr-verifier.yaml
+++ b/.github/workflows/pr-verifier.yaml
@@ -18,6 +18,6 @@ jobs:
     steps:
     - name: Verifier action
       id: verifier
-      uses: kubernetes-sigs/kubebuilder-release-tools@v0.4.3
+      uses: kubernetes-sigs/kubebuilder-release-tools@012269a88fa4c034a0acf1ba84c26b195c0dbab4 # tag=v0.4.3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

It's a [best practice](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) to pin workflows used in GitHub Actions to specific commits. We should do that.

In addition, I feel like our dependabot configuration doesn't work (is it maybe not enabled?), so I'm copying the one we are using in kubernetes-sigs/multicluster-runtime.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
