### PR TITLE
🐛 Do not set up local mini-front-proxy without additional mappings file

### DIFF
--- a/pkg/server/localproxy.go
+++ b/pkg/server/localproxy.go
@@ -202,6 +202,11 @@ func WithLocalProxy(
 		handler.ServeHTTP(w, req.WithContext(ctx))
 	})
 
+	// if no additional mappings are provided, do not start local-only mini-front-proxy.
+	if additionalMappingsFile == "" {
+		return defaultHandlerFunc, nil
+	}
+
 	// If additional mappings file is provided, read it and add the mappings to the handler
 	handlers, err := NewLocalProxyHandler(defaultHandlerFunc, indexState, additionalMappingsFile)
 	if err != nil {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

It looks like we missed a conditional in https://github.com/kcp-dev/kcp/commit/d8cbc0a122831367a63fb879f9fdf2d908bf9189 and now every kcp setup that starts sets up the mini-front-proxy handlers. Looking at the PR (#3199), I don't think that was the intention, and it also started exposing an unauthenticated `/metrics` endpoint on the kcp server binary.

My quick read of the code / logic is: Only register the extra handlers if we indeed want to start a mini-front-proxy by passing additional mappings, but I'm not sure if this is the way to go. @mjudeikis please advise if we should do it differently, but we need to make sure this development feature doesn't bleed into kcp-the-server.

## Related issue(s)

Fixes #3360

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Stop exposing mini-front-proxy handlers (including `/metrics`) on kcp server unless `--additional-mappings-file` is passed
```
