### PR TITLE
Ensure all PRs into `cli/` are marked with area/cli label

### DIFF
--- a/cli/OWNERS
+++ b/cli/OWNERS
@@ -1,0 +1,7 @@
+options:
+  no_parent_owners: false
+filters:
+  ".*":
+    # make sure that all PRs to this package are marked as CLI (kubectl plugin) changes.
+    labels:
+        - area/cli


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

In #3342, there was a request for better release notes for the kubectl plugins in specific, since they are being picked up by distribution package maintainers. While this PR doesn't give an easily accessible changelog for the kubectl plugins yet, it's a step towards being able to filter for those changes.

All PRs into `cli/` will be marked with the [area/cli](https://github.com/kcp-dev/kcp/pulls?q=is%3Aopen+is%3Apr+label%3Aarea%2Fcli) label.

## What Type of PR Is This?

/kind documentation

## Related Issue(s)

Towards #3342

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
