### PR TITLE
feat(workspacetype): Add defaultAPIBinding lifecylce

### DIFF
--- a/config/crds/tenancy.kcp.io_workspacetypes.yaml
+++ b/config/crds/tenancy.kcp.io_workspacetypes.yaml
@@ -56,6 +56,12 @@ spec:
                   additionalWorkspaceLabels are a set of labels that will be added to a
                   Workspace on creation.
                 type: object
+              defaultAPIBindingLifecycle:
+                description: Configure the lifecycle behaviour of defaultAPIBindings.
+                enum:
+                - InitializeOnly
+                - Maintain
+                type: string
               defaultAPIBindings:
                 description: |-
                   defaultAPIBindings are the APIs to bind during initialization of workspaces created from this type.

--- a/config/root-phase0/apiexport-tenancy.kcp.io.yaml
+++ b/config/root-phase0/apiexport-tenancy.kcp.io.yaml
@@ -14,7 +14,7 @@ spec:
       crd: {}
   - group: tenancy.kcp.io
     name: workspacetypes
-    schema: v250325-c1864de17.workspacetypes.tenancy.kcp.io
+    schema: v250603-d4d365c8e.workspacetypes.tenancy.kcp.io
     storage:
       crd: {}
 status: {}

--- a/config/root-phase0/apiresourceschema-workspacetypes.tenancy.kcp.io.yaml
+++ b/config/root-phase0/apiresourceschema-workspacetypes.tenancy.kcp.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v250325-c1864de17.workspacetypes.tenancy.kcp.io
+  name: v250603-d4d365c8e.workspacetypes.tenancy.kcp.io
 spec:
   group: tenancy.kcp.io
   names:
@@ -54,6 +54,12 @@ spec:
                 additionalWorkspaceLabels are a set of labels that will be added to a
                 Workspace on creation.
               type: object
+            defaultAPIBindingLifecycle:
+              description: Configure the lifecycle behaviour of defaultAPIBindings.
+              enum:
+              - InitializeOnly
+              - Maintain
+              type: string
             defaultAPIBindings:
               description: |-
                 defaultAPIBindings are the APIs to bind during initialization of workspaces created from this type.

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -4249,6 +4249,13 @@ func schema_sdk_apis_tenancy_v1alpha1_WorkspaceTypeSpec(ref common.ReferenceCall
 							},
 						},
 					},
+					"defaultAPIBindingLifecycle": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Configure the lifecycle behaviour of defaultAPIBindings.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/reconciler/tenancy/defaultapibindinglifecycle/default_apibinding_lifecycle_controller.go
+++ b/pkg/reconciler/tenancy/defaultapibindinglifecycle/default_apibinding_lifecycle_controller.go
@@ -1,0 +1,312 @@
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaultapibindinglifecycle
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	admission "github.com/kcp-dev/kcp/pkg/admission/workspacetypeexists"
+	"github.com/kcp-dev/kcp/pkg/indexers"
+	"github.com/kcp-dev/kcp/pkg/logging"
+	"github.com/kcp-dev/kcp/pkg/reconciler/committer"
+	apisv1alpha2 "github.com/kcp-dev/kcp/sdk/apis/apis/v1alpha2"
+	corev1alpha1 "github.com/kcp-dev/kcp/sdk/apis/core/v1alpha1"
+	tenancyv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/tenancy/v1alpha1"
+	kcpclientset "github.com/kcp-dev/kcp/sdk/client/clientset/versioned/cluster"
+	apisv1alpha2client "github.com/kcp-dev/kcp/sdk/client/clientset/versioned/typed/apis/v1alpha2"
+	corev1alpha1client "github.com/kcp-dev/kcp/sdk/client/clientset/versioned/typed/core/v1alpha1"
+	apisv1alpha2informers "github.com/kcp-dev/kcp/sdk/client/informers/externalversions/apis/v1alpha2"
+	corev1alpha1informers "github.com/kcp-dev/kcp/sdk/client/informers/externalversions/core/v1alpha1"
+	tenancyv1alpha1informers "github.com/kcp-dev/kcp/sdk/client/informers/externalversions/tenancy/v1alpha1"
+)
+
+const (
+	ControllerName = "kcp-default-apibinding-controller"
+)
+
+// NewDefaultAPIBindingController returns a new controller which instantiates APIBindings and waits for them to be fully bound
+// in new Workspaces.
+func NewDefaultAPIBindingController(
+	kcpClusterClient kcpclientset.ClusterInterface,
+	logicalClusterInformer corev1alpha1informers.LogicalClusterClusterInformer,
+	workspaceTypeInformer, globalWorkspaceTypeInformer tenancyv1alpha1informers.WorkspaceTypeClusterInformer,
+	apiBindingsInformer apisv1alpha2informers.APIBindingClusterInformer,
+	apiExportsInformer, globalAPIExportsInformer apisv1alpha2informers.APIExportClusterInformer,
+) (*DefaultAPIBindingController, error) {
+	c := &DefaultAPIBindingController{
+		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Name: ControllerName,
+			},
+		),
+
+		getLogicalCluster: func(clusterName logicalcluster.Name) (*corev1alpha1.LogicalCluster, error) {
+			return logicalClusterInformer.Lister().Cluster(clusterName).Get(corev1alpha1.LogicalClusterName)
+		},
+
+		listLogicalClusters: func() ([]*corev1alpha1.LogicalCluster, error) {
+			return logicalClusterInformer.Lister().List(labels.Everything())
+		},
+
+		getWorkspaceType: func(path logicalcluster.Path, name string) (*tenancyv1alpha1.WorkspaceType, error) {
+			return indexers.ByPathAndNameWithFallback[*tenancyv1alpha1.WorkspaceType](tenancyv1alpha1.Resource("workspacetypes"), workspaceTypeInformer.Informer().GetIndexer(), globalWorkspaceTypeInformer.Informer().GetIndexer(), path, name)
+		},
+
+		listAPIBindings: func(clusterName logicalcluster.Name) ([]*apisv1alpha2.APIBinding, error) {
+			return apiBindingsInformer.Lister().Cluster(clusterName).List(labels.Everything())
+		},
+		getAPIBinding: func(clusterName logicalcluster.Name, name string) (*apisv1alpha2.APIBinding, error) {
+			return apiBindingsInformer.Lister().Cluster(clusterName).Get(name)
+		},
+		createAPIBinding: func(ctx context.Context, clusterName logicalcluster.Path, binding *apisv1alpha2.APIBinding) (*apisv1alpha2.APIBinding, error) {
+			return kcpClusterClient.Cluster(clusterName).ApisV1alpha2().APIBindings().Create(ctx, binding, metav1.CreateOptions{})
+		},
+
+		getAPIExport: func(path logicalcluster.Path, name string) (*apisv1alpha2.APIExport, error) {
+			return indexers.ByPathAndNameWithFallback[*apisv1alpha2.APIExport](apisv1alpha2.Resource("apiexports"), apiExportsInformer.Informer().GetIndexer(), globalAPIExportsInformer.Informer().GetIndexer(), path, name)
+		},
+
+		commitApiBinding:     committer.NewCommitter[*apisv1alpha2.APIBinding, apisv1alpha2client.APIBindingInterface, *apisv1alpha2.APIBindingSpec, *apisv1alpha2.APIBindingStatus](kcpClusterClient.ApisV1alpha2().APIBindings()),
+		commitLogicalCluster: committer.NewCommitter[*corev1alpha1.LogicalCluster, corev1alpha1client.LogicalClusterInterface, *corev1alpha1.LogicalClusterSpec, *corev1alpha1.LogicalClusterStatus](kcpClusterClient.CoreV1alpha1().LogicalClusters()),
+	}
+
+	c.transitiveTypeResolver = admission.NewTransitiveTypeResolver(c.getWorkspaceType)
+
+	logger := logging.WithReconciler(klog.Background(), ControllerName)
+
+	// needed to reconcile if providers change defaultAPIBindings on their WorkspaceTypes
+	_, _ = workspaceTypeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(_, obj interface{}) { c.enqueueWorkspaceTypes(obj, logger) },
+	})
+	_, _ = globalWorkspaceTypeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(_, obj interface{}) { c.enqueueWorkspaceTypes(obj, logger) },
+	})
+
+	// needed to reconcile when new published resources or claims are added to api exports
+	_, _ = apiExportsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(_, obj interface{}) { c.enqueueAPIExport(obj, logger) },
+	})
+	_, _ = globalAPIExportsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { c.enqueueAPIExport(obj, logger) },
+		UpdateFunc: func(_, obj interface{}) { c.enqueueAPIExport(obj, logger) },
+	})
+
+	return c, nil
+}
+
+type apiBindingResource = committer.Resource[*apisv1alpha2.APIBindingSpec, *apisv1alpha2.APIBindingStatus]
+type logicalClusterResource = committer.Resource[*corev1alpha1.LogicalClusterSpec, *corev1alpha1.LogicalClusterStatus]
+
+// DefaultAPIBindingController is a controller which instantiates APIBindings and waits for them to be fully bound
+// in new Workspaces.
+type DefaultAPIBindingController struct {
+	queue workqueue.TypedRateLimitingInterface[string]
+
+	getLogicalCluster   func(clusterName logicalcluster.Name) (*corev1alpha1.LogicalCluster, error)
+	getWorkspaceType    func(clusterName logicalcluster.Path, name string) (*tenancyv1alpha1.WorkspaceType, error)
+	listLogicalClusters func() ([]*corev1alpha1.LogicalCluster, error)
+
+	listAPIBindings  func(clusterName logicalcluster.Name) ([]*apisv1alpha2.APIBinding, error)
+	getAPIBinding    func(clusterName logicalcluster.Name, name string) (*apisv1alpha2.APIBinding, error)
+	createAPIBinding func(ctx context.Context, clusterName logicalcluster.Path, binding *apisv1alpha2.APIBinding) (*apisv1alpha2.APIBinding, error)
+	getAPIExport     func(clusterName logicalcluster.Path, name string) (*apisv1alpha2.APIExport, error)
+
+	commitApiBinding     func(ctx context.Context, old, new *apiBindingResource) error
+	commitLogicalCluster func(ctx context.Context, old, new *logicalClusterResource) error
+
+	transitiveTypeResolver transitiveTypeResolver
+}
+
+type transitiveTypeResolver interface {
+	Resolve(t *tenancyv1alpha1.WorkspaceType) ([]*tenancyv1alpha1.WorkspaceType, error)
+}
+
+func (c *DefaultAPIBindingController) enqueueLogicalCluster(obj interface{}, logger logr.Logger, logSuffix string) {
+	key, err := kcpcache.DeletionHandlingMetaClusterNamespaceKeyFunc(obj)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+
+	logging.WithQueueKey(logger, key).V(4).Info(fmt.Sprintf("queueing LogicalCluster%s", logSuffix))
+	c.queue.Add(key)
+}
+
+func (c *DefaultAPIBindingController) enqueueWorkspaceTypes(obj interface{}, logger logr.Logger) {
+	wt, ok := obj.(*tenancyv1alpha1.WorkspaceType)
+	if !ok {
+		runtime.HandleError(fmt.Errorf("obj is supposed to be a WorkspaceType, but is %T", obj))
+		return
+	}
+
+	if len(wt.Spec.DefaultAPIBindings) == 0 {
+		return
+	}
+
+	list, err := c.listLogicalClusters()
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("error listing workspaces: %w", err))
+	}
+
+	for _, ws := range list {
+		logger := logging.WithObject(logger, ws)
+		c.enqueueLogicalCluster(ws, logger, " because of WorkspaceType")
+	}
+}
+
+func (c *DefaultAPIBindingController) enqueueAPIExport(obj interface{}, logger logr.Logger) {
+	apiExport, ok := obj.(*apisv1alpha2.APIExport)
+	if !ok {
+		runtime.HandleError(fmt.Errorf("obj is supposed to be an APIExport, but is %T", obj))
+		return
+	}
+
+	if len(apiExport.Spec.Resources) == 0 && len(apiExport.Spec.PermissionClaims) == 0 {
+		return
+	}
+
+	list, err := c.listLogicalClusters()
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("error listing logical clusters: %w", err))
+	}
+
+	// NOTE: Changing an APIExport will trigger an update for every cluster
+	// regardless if it binds to it or not.
+	for _, ws := range list {
+		logger := logging.WithObject(logger, ws)
+		c.enqueueLogicalCluster(ws, logger, " because of referenced APIExport")
+	}
+}
+
+func (c *DefaultAPIBindingController) startWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *DefaultAPIBindingController) Start(ctx context.Context, numThreads int) {
+	defer runtime.HandleCrash()
+	defer c.queue.ShutDown()
+	logger := logging.WithReconciler(klog.FromContext(ctx), ControllerName)
+	ctx = klog.NewContext(ctx, logger)
+
+	logger.Info("Starting controller")
+	defer logger.Info("Shutting down controller")
+
+	for i := 0; i < numThreads; i++ {
+		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
+	}
+	<-ctx.Done()
+}
+
+func (c *DefaultAPIBindingController) ShutDown() {
+	c.queue.ShutDown()
+}
+
+func (c *DefaultAPIBindingController) processNextWorkItem(ctx context.Context) bool {
+	// Wait until there is a new item in the working queue
+	k, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	key := k
+
+	logger := logging.WithQueueKey(klog.FromContext(ctx), key)
+	ctx = klog.NewContext(ctx, logger)
+	logger.V(4).Info("processing key")
+
+	// No matter what, tell the queue we're done with this key, to unblock
+	// other workers.
+	defer c.queue.Done(key)
+
+	if err := c.process(ctx, key); err != nil {
+		runtime.HandleError(fmt.Errorf("%s: failed to sync %q, err: %w", ControllerName, key, err))
+		c.queue.AddRateLimited(key)
+		return true
+	}
+
+	c.queue.Forget(key)
+	return true
+}
+
+func (c *DefaultAPIBindingController) process(ctx context.Context, key string) error {
+	logger := klog.FromContext(ctx)
+	logger.V(3).Info("processing item", "key", key)
+
+	clusterName, _, _, err := kcpcache.SplitMetaClusterNamespaceKey(key)
+	if err != nil {
+		logger.Error(err, "unable to decode key")
+		return nil
+	}
+
+	logicalCluster, err := c.getLogicalCluster(clusterName)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			logger.Error(err, "failed to get LogicalCluster from lister", "cluster", clusterName)
+		}
+
+		return nil // nothing we can do here
+	}
+
+	old := logicalCluster
+	logicalCluster = logicalCluster.DeepCopy()
+
+	logger = logging.WithObject(logger, logicalCluster)
+	ctx = klog.NewContext(ctx, logger)
+
+	var errs []error
+	err = c.reconcile(ctx, logicalCluster)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	// If the object being reconciled changed as a result, update it.
+	oldResource := &logicalClusterResource{ObjectMeta: old.ObjectMeta, Spec: &old.Spec, Status: &old.Status}
+	newResource := &logicalClusterResource{ObjectMeta: logicalCluster.ObjectMeta, Spec: &logicalCluster.Spec, Status: &logicalCluster.Status}
+	if err := c.commitLogicalCluster(ctx, oldResource, newResource); err != nil {
+		errs = append(errs, err)
+	}
+
+	return utilerrors.NewAggregate(errs)
+}
+
+// InstallIndexers adds the additional indexers that this controller requires to the informers.
+func InstallIndexers(apiExportInformer, globalApiExportInformer apisv1alpha2informers.APIExportClusterInformer) {
+	indexers.AddIfNotPresentOrDie(apiExportInformer.Informer().GetIndexer(), cache.Indexers{
+		indexers.ByLogicalClusterPathAndName: indexers.IndexByLogicalClusterPathAndName,
+	})
+	indexers.AddIfNotPresentOrDie(globalApiExportInformer.Informer().GetIndexer(), cache.Indexers{
+		indexers.ByLogicalClusterPathAndName: indexers.IndexByLogicalClusterPathAndName,
+	})
+}

--- a/pkg/reconciler/tenancy/defaultapibindinglifecycle/default_apibinding_lifecycle_reconcile.go
+++ b/pkg/reconciler/tenancy/defaultapibindinglifecycle/default_apibinding_lifecycle_reconcile.go
@@ -14,34 +14,34 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package initialization
+package defaultapibindinglifecycle
 
 import (
 	"context"
-	"crypto/sha256"
 	"fmt"
-	"math/big"
 	"sort"
 	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 
 	"github.com/kcp-dev/logicalcluster/v3"
 
 	"github.com/kcp-dev/kcp/pkg/logging"
+	"github.com/kcp-dev/kcp/pkg/reconciler/tenancy/initialization"
 	apisv1alpha2 "github.com/kcp-dev/kcp/sdk/apis/apis/v1alpha2"
 	corev1alpha1 "github.com/kcp-dev/kcp/sdk/apis/core/v1alpha1"
-	"github.com/kcp-dev/kcp/sdk/apis/tenancy/initialization"
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/tenancy/v1alpha1"
 	conditionsv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/third_party/conditions/apis/conditions/v1alpha1"
 	"github.com/kcp-dev/kcp/sdk/apis/third_party/conditions/util/conditions"
 )
 
-func (b *APIBinder) reconcile(ctx context.Context, logicalCluster *corev1alpha1.LogicalCluster) error {
+func (c *DefaultAPIBindingController) reconcile(ctx context.Context, logicalCluster *corev1alpha1.LogicalCluster) error {
+	logger := klog.FromContext(ctx)
+
 	annotationValue, found := logicalCluster.Annotations[tenancyv1alpha1.LogicalClusterTypeAnnotationKey]
 	if !found {
 		return nil
@@ -50,51 +50,26 @@ func (b *APIBinder) reconcile(ctx context.Context, logicalCluster *corev1alpha1.
 	if wtCluster.Empty() {
 		return nil
 	}
-	logger := klog.FromContext(ctx).WithValues(
-		"workspacetype.path", wtCluster.String(),
-		"workspacetype.name", wtName,
-	)
-
 	var errors []error
 	clusterName := logicalcluster.From(logicalCluster)
-	logger.V(3).Info("initializing APIBindings for workspace")
+	logger.V(4).Info("reconciling default APIBindings")
 
 	// Start with the WorkspaceType specified by the Workspace
-	leafWT, err := b.getWorkspaceType(wtCluster, wtName)
+	leafWT, err := c.getWorkspaceType(wtCluster, wtName)
 	if err != nil {
 		logger.Error(err, "error getting WorkspaceType")
-
-		conditions.MarkFalse(
-			logicalCluster,
-			tenancyv1alpha1.WorkspaceAPIBindingsInitialized,
-			tenancyv1alpha1.WorkspaceInitializedWorkspaceTypeInvalid,
-			conditionsv1alpha1.ConditionSeverityError,
-			"error getting WorkspaceType %s|%s: %v",
-			wtCluster.String(), wtName, err,
-		)
-
 		return nil
 	}
 
 	// Get all the transitive WorkspaceTypes
-	wts, err := b.transitiveTypeResolver.Resolve(leafWT)
+	wts, err := c.transitiveTypeResolver.Resolve(leafWT)
 	if err != nil {
 		logger.Error(err, "error resolving transitive types")
-
-		conditions.MarkFalse(
-			logicalCluster,
-			tenancyv1alpha1.WorkspaceAPIBindingsInitialized,
-			tenancyv1alpha1.WorkspaceInitializedWorkspaceTypeInvalid,
-			conditionsv1alpha1.ConditionSeverityError,
-			"error resolving transitive set of workspace types: %v",
-			err,
-		)
-
 		return nil
 	}
 
 	// Get current bindings
-	bindings, err := b.listAPIBindings(clusterName)
+	bindings, err := c.listAPIBindings(clusterName)
 	if err != nil {
 		errors = append(errors, err)
 	}
@@ -117,18 +92,22 @@ func (b *APIBinder) reconcile(ctx context.Context, logicalCluster *corev1alpha1.
 	someExportsMissing := false
 
 	for _, wt := range wts {
+		if ptr.Deref(wt.Spec.DefaultAPIBindingLifecycle, tenancyv1alpha1.APIBindingLifecycleModeInitializeOnly) != tenancyv1alpha1.APIBindingLifecycleModeMaintain {
+			continue
+		}
+
 		logger := logging.WithObject(logger, wt)
-		logger.V(3).Info("attempting to initialize APIBindings")
+		logger.V(3).Info("attempting to reconcile APIBindings")
 
 		for i := range wt.Spec.DefaultAPIBindings {
 			exportRef := wt.Spec.DefaultAPIBindings[i]
 			if exportRef.Path == "" {
 				exportRef.Path = logicalcluster.From(wt).String()
 			}
-			apiExport, err := b.getAPIExport(logicalcluster.NewPath(exportRef.Path), exportRef.Export)
+			apiExport, err := c.getAPIExport(logicalcluster.NewPath(exportRef.Path), exportRef.Export)
 			if err != nil {
 				if !someExportsMissing {
-					errors = append(errors, fmt.Errorf("unable to complete initialization: unable to find at least 1 APIExport"))
+					errors = append(errors, fmt.Errorf("unable to complete reconciliation: unable to find at least 1 APIExport"))
 				}
 				someExportsMissing = true
 				continue
@@ -140,65 +119,60 @@ func (b *APIBinder) reconcile(ctx context.Context, logicalCluster *corev1alpha1.
 			logger := logger.WithValues("apiExport.path", exportRef.Path, "apiExport.name", exportRef.Export)
 			ctx := klog.NewContext(ctx, logger)
 
-			apiBindingName := generateAPIBindingName(clusterName, exportRef.Path, exportRef.Export)
+			apiBindingName := initialization.GenerateAPIBindingName(clusterName, exportRef.Path, exportRef.Export)
 			logger = logger.WithValues("apiBindingName", apiBindingName)
 
-			if _, err = b.getAPIBinding(clusterName, apiBindingName); err == nil {
-				logger.V(4).Info("APIBinding already exists - skipping creation")
-				continue
-			}
-
-			apiBinding := &apisv1alpha2.APIBinding{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: apiBindingName,
-				},
-				Spec: apisv1alpha2.APIBindingSpec{
-					Reference: apisv1alpha2.BindingReference{
-						Export: &apisv1alpha2.ExportBindingReference{
-							Path: exportRef.Path,
-							Name: apiExport.Name,
-						},
+			apiBindingSpec := apisv1alpha2.APIBindingSpec{
+				Reference: apisv1alpha2.BindingReference{
+					Export: &apisv1alpha2.ExportBindingReference{
+						Path: exportRef.Path,
+						Name: apiExport.Name,
 					},
 				},
 			}
 
 			for _, exportClaim := range apiExport.Spec.PermissionClaims {
+				// For now we automatically accept DefaultAPIBindings
 				acceptedClaim := apisv1alpha2.AcceptablePermissionClaim{
 					PermissionClaim: exportClaim,
 					State:           apisv1alpha2.ClaimAccepted,
 				}
 
-				apiBinding.Spec.PermissionClaims = append(apiBinding.Spec.PermissionClaims, acceptedClaim)
+				apiBindingSpec.PermissionClaims = append(apiBindingSpec.PermissionClaims, acceptedClaim)
 			}
 
-			logger = logging.WithObject(logger, apiBinding)
-
-			logger.V(2).Info("trying to create APIBinding")
-			if _, err := b.createAPIBinding(ctx, clusterName.Path(), apiBinding); err != nil {
-				if apierrors.IsAlreadyExists(err) {
-					logger.V(2).Info("APIBinding already exists")
+			existingBinding, err := c.getAPIBinding(clusterName, apiBindingName)
+			if err != nil {
+				if !apierrors.IsNotFound(err) {
+					errors = append(errors, err)
 					continue
 				}
-
-				errors = append(errors, err)
-				continue
+				if _, err := c.createAPIBinding(ctx, clusterName.Path(), &apisv1alpha2.APIBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: apiBindingName,
+					},
+					Spec: apiBindingSpec,
+				}); err != nil {
+					errors = append(errors, err)
+					continue
+				}
+				logger.V(2).Info("created APIBinding")
+			} else {
+				apiBinding := existingBinding.DeepCopy()
+				apiBinding.Spec = apiBindingSpec
+				oldResource := &apiBindingResource{ObjectMeta: existingBinding.ObjectMeta, Spec: &existingBinding.Spec, Status: &existingBinding.Status}
+				newResource := &apiBindingResource{ObjectMeta: apiBinding.ObjectMeta, Spec: &apiBinding.Spec, Status: &existingBinding.Status}
+				if err := c.commitApiBinding(ctx, oldResource, newResource); err != nil {
+					errors = append(errors, err)
+					continue
+				}
+				logger.V(2).Info("updated APIBinding")
 			}
-
-			logger.V(2).Info("created APIBinding")
 		}
 	}
 
 	if len(errors) > 0 {
-		logger.Error(utilerrors.NewAggregate(errors), "error initializing APIBindings")
-
-		conditions.MarkFalse(
-			logicalCluster,
-			tenancyv1alpha1.WorkspaceAPIBindingsInitialized,
-			tenancyv1alpha1.WorkspaceInitializedAPIBindingErrors,
-			conditionsv1alpha1.ConditionSeverityError,
-			"encountered errors: %v",
-			utilerrors.NewAggregate(errors),
-		)
+		logger.Error(utilerrors.NewAggregate(errors), "error reconciling APIBindings")
 
 		if someExportsMissing {
 			// Retry if any APIExports are missing, as it's possible they'll show up (cache server slow to catch up,
@@ -232,55 +206,16 @@ func (b *APIBinder) reconcile(ctx context.Context, logicalCluster *corev1alpha1.
 
 		conditions.MarkFalse(
 			logicalCluster,
-			tenancyv1alpha1.WorkspaceAPIBindingsInitialized,
+			tenancyv1alpha1.WorkspaceAPIBindingsReconciled,
 			tenancyv1alpha1.WorkspaceInitializedWaitingOnAPIBindings,
 			conditionsv1alpha1.ConditionSeverityInfo,
-			"APIBinding(s) not yet fully bound: %s",
+			"APIBinding(s) not yet fully reconciled: %s",
 			strings.Join(incomplete, ", "),
 		)
-
-		return nil
+	} else {
+		conditions.MarkTrue(logicalCluster, tenancyv1alpha1.WorkspaceAPIBindingsReconciled)
 	}
 
-	logicalCluster.Status.Initializers = initialization.EnsureInitializerAbsent(tenancyv1alpha1.WorkspaceAPIBindingsInitializer, logicalCluster.Status.Initializers)
-
+	logger.V(4).Info("completed default APIBinding reconciliation")
 	return nil
-}
-
-// maxExportNamePrefixLength is the maximum allowed length for the export name portion of the generated API binding
-// name. Subtrace 1 for the dash ("-") that separates the export name prefix from the hash suffix, and 5 for the
-// hash length.
-const maxExportNamePrefixLength = validation.DNS1123SubdomainMaxLength - 1 - 5
-
-func GenerateAPIBindingName(clusterName logicalcluster.Name, exportPath, exportName string) string {
-	return generateAPIBindingName(clusterName, exportPath, exportName)
-}
-
-func generateAPIBindingName(clusterName logicalcluster.Name, exportPath, exportName string) string {
-	maxLen := len(exportName)
-	if maxLen > maxExportNamePrefixLength {
-		maxLen = maxExportNamePrefixLength
-	}
-
-	exportNamePrefix := exportName[:maxLen]
-
-	hash := toBase36Sha224(
-		clusterName.String() + "|" + exportPath + "|" + exportName,
-	)
-
-	hash = hash[0:5]
-	// Have to lowercase because Kubernetes names must be lowercase
-	hash = strings.ToLower(hash)
-
-	return fmt.Sprintf("%s-%s", exportNamePrefix, hash)
-}
-
-func toBase36(hash [28]byte) string {
-	var i big.Int
-	i.SetBytes(hash[:])
-	return i.Text(62)
-}
-
-func toBase36Sha224(s string) string {
-	return toBase36(sha256.Sum224([]byte(s)))
 }

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -84,6 +84,7 @@ import (
 	"github.com/kcp-dev/kcp/pkg/reconciler/garbagecollector"
 	"github.com/kcp-dev/kcp/pkg/reconciler/kubequota"
 	"github.com/kcp-dev/kcp/pkg/reconciler/tenancy/bootstrap"
+	"github.com/kcp-dev/kcp/pkg/reconciler/tenancy/defaultapibindinglifecycle"
 	"github.com/kcp-dev/kcp/pkg/reconciler/tenancy/initialization"
 	tenancylogicalcluster "github.com/kcp-dev/kcp/pkg/reconciler/tenancy/logicalcluster"
 	tenancyreplicateclusterrole "github.com/kcp-dev/kcp/pkg/reconciler/tenancy/replicateclusterrole"
@@ -890,6 +891,65 @@ func (s *Server) installAPIBindingController(ctx context.Context, config *rest.C
 		},
 		Runner: func(ctx context.Context) {
 			apibindingDeletionController.Start(ctx, 10)
+		},
+	})
+}
+
+func (s *Server) installDefaultAPIBindingController(ctx context.Context, config *rest.Config) error {
+	// Client used to maintain APIBindings within the workspaces
+	config = rest.CopyConfig(config)
+	config = rest.AddUserAgent(config, defaultapibindinglifecycle.ControllerName)
+
+	if !s.Options.Virtual.Enabled && s.Options.Extra.ShardVirtualWorkspaceURL != "" {
+		if s.Options.Extra.ShardVirtualWorkspaceCAFile == "" {
+			// TODO move verification up
+			return fmt.Errorf("s.Options.Extra.ShardVirtualWorkspaceCAFile is required")
+		}
+		if s.Options.Extra.ShardClientCertFile == "" {
+			// TODO move verification up
+			return fmt.Errorf("s.Options.Extra.ShardClientCertFile is required")
+		}
+		if s.Options.Extra.ShardClientKeyFile == "" {
+			// TODO move verification up
+			return fmt.Errorf("s.Options.Extra.ShardClientKeyFile is required")
+		}
+		config.TLSClientConfig.CAFile = s.Options.Extra.ShardVirtualWorkspaceCAFile
+		config.TLSClientConfig.CertFile = s.Options.Extra.ShardClientCertFile
+		config.TLSClientConfig.KeyFile = s.Options.Extra.ShardClientKeyFile
+	}
+
+	kcpClusterClient, err := kcpclientset.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+
+	c, err := defaultapibindinglifecycle.NewDefaultAPIBindingController(
+		kcpClusterClient,
+		s.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters(),
+		s.KcpSharedInformerFactory.Tenancy().V1alpha1().WorkspaceTypes(),
+		s.CacheKcpSharedInformerFactory.Tenancy().V1alpha1().WorkspaceTypes(),
+		s.KcpSharedInformerFactory.Apis().V1alpha2().APIBindings(),
+		s.KcpSharedInformerFactory.Apis().V1alpha2().APIExports(),
+		s.CacheKcpSharedInformerFactory.Apis().V1alpha2().APIExports(),
+	)
+	if err != nil {
+		return err
+	}
+
+	return s.registerController(&controllerWrapper{
+		Name: defaultapibindinglifecycle.ControllerName,
+		Wait: func(ctx context.Context, s *Server) error {
+			return wait.PollUntilContextCancel(ctx, waitPollInterval, true, func(ctx context.Context) (bool, error) {
+				return s.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters().Informer().HasSynced() &&
+					s.KcpSharedInformerFactory.Tenancy().V1alpha1().WorkspaceTypes().Informer().HasSynced() &&
+					s.CacheKcpSharedInformerFactory.Tenancy().V1alpha1().WorkspaceTypes().Informer().HasSynced() &&
+					s.KcpSharedInformerFactory.Apis().V1alpha2().APIBindings().Informer().HasSynced() &&
+					s.KcpSharedInformerFactory.Apis().V1alpha2().APIExports().Informer().HasSynced() &&
+					s.CacheKcpSharedInformerFactory.Apis().V1alpha2().APIExports().Informer().HasSynced(), nil
+			})
+		},
+		Runner: func(ctx context.Context) {
+			c.Start(ctx, 2)
 		},
 	})
 }
@@ -1737,6 +1797,10 @@ func (s *Server) addIndexersToInformers(_ context.Context) map[schema.GroupVersi
 		s.CacheKcpSharedInformerFactory.Tenancy().V1alpha1().WorkspaceTypes())
 	crdcleanup.InstallIndexers(
 		s.KcpSharedInformerFactory.Apis().V1alpha2().APIBindings(),
+	)
+	defaultapibindinglifecycle.InstallIndexers(
+		s.KcpSharedInformerFactory.Apis().V1alpha2().APIExports(),
+		s.CacheKcpSharedInformerFactory.Apis().V1alpha2().APIExports(),
 	)
 	return replication.InstallIndexers(
 		s.KcpSharedInformerFactory,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -340,6 +340,12 @@ func (s *Server) installControllers(ctx context.Context, controllerConfig *rest.
 		}
 	}
 
+	if s.Options.Controllers.EnableAll || enabled.Has("defaultapibindinglifecycle") {
+		if err := s.installDefaultAPIBindingController(ctx, controllerConfig); err != nil {
+			return err
+		}
+	}
+
 	if s.Options.Controllers.EnableAll || enabled.Has("partition") {
 		if err := s.installPartitionSetController(ctx, controllerConfig); err != nil {
 			return err

--- a/sdk/apis/tenancy/v1alpha1/types_workspace.go
+++ b/sdk/apis/tenancy/v1alpha1/types_workspace.go
@@ -94,6 +94,19 @@ const (
 	// WorkspaceInitializedAPIBindingErrors is a reason for the APIBindingsInitialized condition that indicates there
 	// were errors trying to initialize APIBindings for the workspace.
 	WorkspaceInitializedAPIBindingErrors = "APIBindingErrors"
+
+	// WorkspaceAPIBindingsReconciled represents the status of the reconcile APIBindings for the workspace.
+	WorkspaceAPIBindingsReconciled conditionsv1alpha1.ConditionType = "APIBindingsReconciled"
+	// WorkspaceInitializedWaitingOnAPIBindings is a reason for the APIBindingsInitialized condition that indicates
+	// at least one APIBinding is not ready.
+	WorkspaceReconciledWaitingOnAPIBindings = WorkspaceInitializedWaitingOnAPIBindings
+	// WorkspaceInitializedWorkspaceTypeInvalid is a reason for the APIBindingsInitialized
+	// condition that indicates something is invalid with the WorkspaceType (e.g. a cycle trying
+	// to resolve all the transitive types).
+	WorkspaceReconciledWorkspaceTypeInvalid = WorkspaceInitializedWorkspaceTypeInvalid
+	// WorkspaceInitializedAPIBindingErrors is a reason for the APIBindingsInitialized condition that indicates there
+	// were errors trying to initialize APIBindings for the workspace.
+	WorkspaceReconciledAPIBindingErrors = WorkspaceInitializedAPIBindingErrors
 )
 
 // LogicalClusterTypeAnnotationKey is the annotation key used to indicate

--- a/sdk/apis/tenancy/v1alpha1/types_workspacetype.go
+++ b/sdk/apis/tenancy/v1alpha1/types_workspacetype.go
@@ -23,6 +23,11 @@ import (
 	conditionsv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/third_party/conditions/apis/conditions/v1alpha1"
 )
 
+const (
+	// ExperimentalDefaultAPIBindingLifecycleAnnotationKey is used to configure the maintenance mode of the defaultAPIBindings.
+	ExperimentalDefaultAPIBindingLifecycleAnnotationKey string = "experimental.tenancy.kcp.io/default-api-binding-lifecycle"
+)
+
 // WorkspaceTypeReservedNames defines the set of names that may not be
 // used on user-supplied WorkspaceTypes.
 // TODO(hasheddan): tie this definition of reserved names to the patches used to
@@ -116,6 +121,12 @@ type WorkspaceTypeSpec struct {
 	//
 	// +optional
 	DefaultAPIBindings []APIExportReference `json:"defaultAPIBindings,omitempty"`
+
+	// Configure the lifecycle behaviour of defaultAPIBindings.
+	//
+	// +optional
+	// +kubebuilder:validation:Enum=InitializeOnly;Maintain
+	DefaultAPIBindingLifecycle *APIBindingLifecycleMode `json:"defaultAPIBindingLifecycle,omitempty"`
 }
 
 // APIExportReference provides the fields necessary to resolve an APIExport.
@@ -135,6 +146,19 @@ type APIExportReference struct {
 	// +kube:validation:MinLength=1
 	Export string `json:"export"`
 }
+
+// APIBindingLifecycleMode defines how the lifecycle of an APIBinding is
+// managed.
+type APIBindingLifecycleMode string
+
+const (
+	// APIBindingLifecycleModeInitializeOnly defines that the APIBinding is
+	// only initialized once upon workspace creation.
+	APIBindingLifecycleModeInitializeOnly APIBindingLifecycleMode = "InitializeOnly"
+	// APIBindingLifecycleModeInitializeOnly defines that the APIBinding is
+	// continuesly reconciled.
+	APIBindingLifecycleModeMaintain APIBindingLifecycleMode = "Maintain"
+)
 
 // WorkspaceTypeSelector describes a set of types.
 type WorkspaceTypeSelector struct {

--- a/sdk/apis/tenancy/v1alpha1/zz_generated.deepcopy.go
+++ b/sdk/apis/tenancy/v1alpha1/zz_generated.deepcopy.go
@@ -385,6 +385,11 @@ func (in *WorkspaceTypeSpec) DeepCopyInto(out *WorkspaceTypeSpec) {
 		*out = make([]APIExportReference, len(*in))
 		copy(*out, *in)
 	}
+	if in.DefaultAPIBindingLifecycle != nil {
+		in, out := &in.DefaultAPIBindingLifecycle, &out.DefaultAPIBindingLifecycle
+		*out = new(APIBindingLifecycleMode)
+		**out = **in
+	}
 	return
 }
 

--- a/sdk/client/applyconfiguration/tenancy/v1alpha1/workspacetypespec.go
+++ b/sdk/client/applyconfiguration/tenancy/v1alpha1/workspacetypespec.go
@@ -18,16 +18,21 @@ limitations under the License.
 
 package v1alpha1
 
+import (
+	tenancyv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/tenancy/v1alpha1"
+)
+
 // WorkspaceTypeSpecApplyConfiguration represents a declarative configuration of the WorkspaceTypeSpec type for use
 // with apply.
 type WorkspaceTypeSpecApplyConfiguration struct {
-	Initializer               *bool                                     `json:"initializer,omitempty"`
-	Extend                    *WorkspaceTypeExtensionApplyConfiguration `json:"extend,omitempty"`
-	AdditionalWorkspaceLabels map[string]string                         `json:"additionalWorkspaceLabels,omitempty"`
-	DefaultChildWorkspaceType *WorkspaceTypeReferenceApplyConfiguration `json:"defaultChildWorkspaceType,omitempty"`
-	LimitAllowedChildren      *WorkspaceTypeSelectorApplyConfiguration  `json:"limitAllowedChildren,omitempty"`
-	LimitAllowedParents       *WorkspaceTypeSelectorApplyConfiguration  `json:"limitAllowedParents,omitempty"`
-	DefaultAPIBindings        []APIExportReferenceApplyConfiguration    `json:"defaultAPIBindings,omitempty"`
+	Initializer                *bool                                     `json:"initializer,omitempty"`
+	Extend                     *WorkspaceTypeExtensionApplyConfiguration `json:"extend,omitempty"`
+	AdditionalWorkspaceLabels  map[string]string                         `json:"additionalWorkspaceLabels,omitempty"`
+	DefaultChildWorkspaceType  *WorkspaceTypeReferenceApplyConfiguration `json:"defaultChildWorkspaceType,omitempty"`
+	LimitAllowedChildren       *WorkspaceTypeSelectorApplyConfiguration  `json:"limitAllowedChildren,omitempty"`
+	LimitAllowedParents        *WorkspaceTypeSelectorApplyConfiguration  `json:"limitAllowedParents,omitempty"`
+	DefaultAPIBindings         []APIExportReferenceApplyConfiguration    `json:"defaultAPIBindings,omitempty"`
+	DefaultAPIBindingLifecycle *tenancyv1alpha1.APIBindingLifecycleMode  `json:"defaultAPIBindingLifecycle,omitempty"`
 }
 
 // WorkspaceTypeSpecApplyConfiguration constructs a declarative configuration of the WorkspaceTypeSpec type for use with
@@ -100,5 +105,13 @@ func (b *WorkspaceTypeSpecApplyConfiguration) WithDefaultAPIBindings(values ...*
 		}
 		b.DefaultAPIBindings = append(b.DefaultAPIBindings, *values[i])
 	}
+	return b
+}
+
+// WithDefaultAPIBindingLifecycle sets the DefaultAPIBindingLifecycle field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the DefaultAPIBindingLifecycle field is set to the value of the last call.
+func (b *WorkspaceTypeSpecApplyConfiguration) WithDefaultAPIBindingLifecycle(value tenancyv1alpha1.APIBindingLifecycleMode) *WorkspaceTypeSpecApplyConfiguration {
+	b.DefaultAPIBindingLifecycle = &value
 	return b
 }

--- a/test/e2e/apibinding/default_apibinding_test.go
+++ b/test/e2e/apibinding/default_apibinding_test.go
@@ -1,0 +1,245 @@
+/*
+Copyright 2021 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apibinding
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/restmapper"
+	"k8s.io/utils/ptr"
+
+	kcpdynamic "github.com/kcp-dev/client-go/dynamic"
+
+	"github.com/kcp-dev/kcp/config/helpers"
+	"github.com/kcp-dev/kcp/pkg/reconciler/committer"
+	apisv1alpha2 "github.com/kcp-dev/kcp/sdk/apis/apis/v1alpha2"
+	tenancyv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/tenancy/v1alpha1"
+	kcpclientset "github.com/kcp-dev/kcp/sdk/client/clientset/versioned/cluster"
+	apisv1alpha2client "github.com/kcp-dev/kcp/sdk/client/clientset/versioned/typed/apis/v1alpha2"
+	kcptesting "github.com/kcp-dev/kcp/sdk/testing"
+	kcptestinghelpers "github.com/kcp-dev/kcp/sdk/testing/helpers"
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+)
+
+func TestDefaultAPIBinding(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "control-plane")
+
+	server := kcptesting.SharedKcpServer(t)
+
+	orgPath, _ := framework.NewOrganizationFixture(t, server) //nolint:staticcheck // TODO: switch to NewWorkspaceFixture.
+	providerPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)
+
+	t.Logf("providerPath: %v", providerPath)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	cfg := server.BaseConfig(t)
+
+	kcpClusterClient, err := kcpclientset.NewForConfig(cfg)
+	require.NoError(t, err, "failed to construct kcp cluster client for server")
+
+	_, err = kcpClusterClient.Cluster(orgPath).CoreV1alpha1().LogicalClusters().List(ctx, metav1.ListOptions{})
+	require.NoError(t, err, "failed to list logical clusters")
+
+	dynamicClusterClient, err := kcpdynamic.NewForConfig(cfg)
+	require.NoError(t, err, "failed to construct dynamic cluster client for server")
+
+	serviceProviderClient, err := kcpclientset.NewForConfig(cfg)
+	require.NoError(t, err)
+
+	t.Logf("Install today cowboys APIResourceSchema into service provider workspace %q", providerPath)
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(serviceProviderClient.Cluster(providerPath).Discovery()))
+	err = helpers.CreateResourceFromFS(ctx, dynamicClusterClient.Cluster(providerPath), mapper, nil, "apiresourceschema_cowboys.yaml", testFiles)
+	require.NoError(t, err)
+
+	t.Logf("Create an APIExport for it")
+	apiExport := &apisv1alpha2.APIExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "today-cowboys",
+		},
+		Spec: apisv1alpha2.APIExportSpec{
+			Resources: []apisv1alpha2.ResourceSchema{
+				{
+					Group:  "wildwest.dev",
+					Name:   "cowboys",
+					Schema: "today.cowboys.wildwest.dev",
+					Storage: apisv1alpha2.ResourceSchemaStorage{
+						CRD: &apisv1alpha2.ResourceSchemaStorageCRD{},
+					},
+				},
+			},
+			PermissionClaims: []apisv1alpha2.PermissionClaim{
+				{
+					GroupResource: apisv1alpha2.GroupResource{
+						Group:    "",
+						Resource: "configmaps",
+					},
+					Verbs: []string{"get"},
+					ResourceSelector: []apisv1alpha2.ResourceSelector{
+						{
+							Name:      "test",
+							Namespace: "test-namespace",
+						},
+					},
+				},
+			},
+		},
+	}
+	apiExportCreated, err := kcpClusterClient.Cluster(providerPath).ApisV1alpha2().APIExports().Create(ctx, apiExport, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	workspaceType := tenancyv1alpha1.WorkspaceType{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-consumer-type",
+		},
+		Spec: tenancyv1alpha1.WorkspaceTypeSpec{
+			DefaultChildWorkspaceType: &tenancyv1alpha1.WorkspaceTypeReference{
+				Name: "universal",
+				Path: "root",
+			},
+			Extend: tenancyv1alpha1.WorkspaceTypeExtension{
+				With: []tenancyv1alpha1.WorkspaceTypeReference{
+					{
+						Name: "universal",
+						Path: "root",
+					},
+				},
+			},
+			DefaultAPIBindings: []tenancyv1alpha1.APIExportReference{
+				{
+					Export: apiExport.GetName(),
+				},
+			},
+			DefaultAPIBindingLifecycle: ptr.To(tenancyv1alpha1.APIBindingLifecycleModeMaintain),
+		},
+	}
+
+	_, err = kcpClusterClient.Cluster(providerPath).TenancyV1alpha1().WorkspaceTypes().Create(ctx, &workspaceType, metav1.CreateOptions{})
+	require.NoError(t, err, "failed to create workspace type")
+
+	consumerPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath, kcptesting.WithType(providerPath, tenancyv1alpha1.WorkspaceTypeName(workspaceType.GetName())))
+	t.Logf("consumerPath: %v", consumerPath)
+
+	awaitAPIBinding := func(apiExport *apisv1alpha2.APIExport, group, resource string, expectedAppliedPermissionsClaims ...apisv1alpha2.PermissionClaim) {
+		kcptestinghelpers.Eventually(t, func() (bool, string) {
+			list, err := kcpClusterClient.Cluster(consumerPath).ApisV1alpha2().APIBindings().List(ctx, metav1.ListOptions{})
+			if err != nil {
+				return false, fmt.Sprintf("failed to list api bindings: %v", err)
+			}
+			for _, ab := range list.Items {
+				if !strings.HasPrefix(ab.GetName(), apiExport.GetName()) {
+					continue
+				}
+				hasBoundAPI := slices.ContainsFunc(ab.Status.BoundResources, func(br apisv1alpha2.BoundAPIResource) bool {
+					return br.Group == group && br.Resource == resource
+				})
+				if !hasBoundAPI {
+					continue
+				}
+				for _, epc := range expectedAppliedPermissionsClaims {
+					hasAppliedPermissionClaim := slices.ContainsFunc(ab.Status.AppliedPermissionClaims, func(pc apisv1alpha2.PermissionClaim) bool {
+						return epc.Group == pc.Group && epc.Resource == pc.Resource
+					})
+					if !hasAppliedPermissionClaim {
+						return false, fmt.Sprintf("found api binding %q but missing permission claim %s/%s", ab.GetName(), epc.Group, epc.Resource)
+					}
+				}
+				return true, fmt.Sprintf("found api binding %q", ab.GetName())
+			}
+			return false, ""
+		}, wait.ForeverTestTimeout, time.Second*2, fmt.Sprintf("failed to wait for default api binding %q %q from export %q", group, resource, apiExport.GetName()))
+	}
+
+	awaitAPIBinding(
+		apiExport, "wildwest.dev", "cowboys",
+		apisv1alpha2.PermissionClaim{
+			GroupResource: apisv1alpha2.GroupResource{
+				Group:    "",
+				Resource: "configmaps",
+			},
+		},
+	)
+
+	t.Logf("Install today TLSRoutes APIResourceSchema into service provider workspace %q", providerPath)
+	err = helpers.CreateResourceFromFS(ctx, dynamicClusterClient.Cluster(providerPath), mapper, nil, "apiresourceschema_tlsroutes.yaml", testFiles)
+	require.NoError(t, err)
+
+	currentAPIExport, err := kcpClusterClient.Cluster(providerPath).ApisV1alpha2().APIExports().Get(ctx, apiExport.GetName(), metav1.GetOptions{})
+	require.NoError(t, err)
+
+	updatedAPIExport := currentAPIExport.DeepCopy()
+
+	updatedAPIExport.Spec.Resources = append(apiExportCreated.Spec.Resources, apisv1alpha2.ResourceSchema{
+		Group:  "gateway.networking.k8s.io",
+		Name:   "tlsroutes",
+		Schema: "latest.tlsroutes.gateway.networking.k8s.io",
+		Storage: apisv1alpha2.ResourceSchemaStorage{
+			CRD: &apisv1alpha2.ResourceSchemaStorageCRD{},
+		},
+	})
+	updatedAPIExport.Spec.PermissionClaims = append(updatedAPIExport.Spec.PermissionClaims, apisv1alpha2.PermissionClaim{
+		GroupResource: apisv1alpha2.GroupResource{
+			Group:    "",
+			Resource: "secrets",
+		},
+		Verbs: []string{"get"},
+		ResourceSelector: []apisv1alpha2.ResourceSelector{
+			{
+				Name:      "test",
+				Namespace: "test-namespace",
+			},
+		},
+	})
+
+	commitAPIExport := committer.NewCommitter[*apisv1alpha2.APIExport, apisv1alpha2client.APIExportInterface, *apisv1alpha2.APIExportSpec, *apisv1alpha2.APIExportStatus](kcpClusterClient.ApisV1alpha2().APIExports())
+
+	type apiExportResource = committer.Resource[*apisv1alpha2.APIExportSpec, *apisv1alpha2.APIExportStatus]
+
+	oldResource := &apiExportResource{ObjectMeta: currentAPIExport.ObjectMeta, Spec: &currentAPIExport.Spec, Status: &currentAPIExport.Status}
+	newResource := &apiExportResource{ObjectMeta: currentAPIExport.ObjectMeta, Spec: &updatedAPIExport.Spec, Status: &currentAPIExport.Status}
+
+	err = commitAPIExport(ctx, oldResource, newResource)
+	require.NoError(t, err)
+
+	awaitAPIBinding(
+		apiExport, "gateway.networking.k8s.io", "tlsroutes",
+		apisv1alpha2.PermissionClaim{
+			GroupResource: apisv1alpha2.GroupResource{
+				Group:    "",
+				Resource: "configmaps",
+			},
+		},
+		apisv1alpha2.PermissionClaim{
+			GroupResource: apisv1alpha2.GroupResource{
+				Group:    "",
+				Resource: "secrets",
+			},
+		},
+	)
+}


### PR DESCRIPTION

<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Add a controller to automatically keep defaultAPIBindings defined in a workspacetype up to date in all workspaces that derive from it.

on-behalf-of: @eon-se opensource@eon.com

## What Type of PR Is This?

/kind feature
/kind api-change

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

* Fixes https://github.com/kcp-dev/kcp/issues/3248
* Replaces: https://github.com/kcp-dev/kcp/pull/3279


## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Add a controller to automatically keep defaultAPIBindings defined in a workspacetype up to date in all workspaces that derive from it.
```
