### PR TITLE
kube-front-proxy: add named flags

### DIFF
--- a/cmd/kcp-front-proxy/options/options.go
+++ b/cmd/kcp-front-proxy/options/options.go
@@ -17,8 +17,7 @@ limitations under the License.
 package options
 
 import (
-	"github.com/spf13/pflag"
-
+	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
 	logsapiv1 "k8s.io/component-base/logs/api/v1"
 
@@ -41,9 +40,9 @@ func NewOptions() *Options {
 	return o
 }
 
-func (o *Options) AddFlags(fs *pflag.FlagSet) {
-	o.Proxy.AddFlags(fs)
-	logsapiv1.AddFlags(o.Logs, fs)
+func (o *Options) AddFlags(fss *cliflag.NamedFlagSets) {
+	o.Proxy.AddFlags(fss)
+	logsapiv1.AddFlags(o.Logs, fss.FlagSet("logging"))
 }
 
 func (o *Options) Complete() error {

--- a/pkg/proxy/options/options.go
+++ b/pkg/proxy/options/options.go
@@ -21,9 +21,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/spf13/pflag"
-
 	apiserveroptions "k8s.io/apiserver/pkg/server/options"
+	cliflag "k8s.io/component-base/cli/flag"
 )
 
 type Options struct {
@@ -52,9 +51,11 @@ func NewOptions() *Options {
 	return o
 }
 
-func (o *Options) AddFlags(fs *pflag.FlagSet) {
-	o.SecureServing.AddFlags(fs)
-	o.Authentication.AddFlags(fs)
+func (o *Options) AddFlags(fss *cliflag.NamedFlagSets) {
+	o.SecureServing.AddFlags(fss.FlagSet("secure-serving"))
+	o.Authentication.AddFlags(fss.FlagSet("authentication"))
+
+	fs := fss.FlagSet("proxy")
 	fs.StringVar(&o.MappingFile, "mapping-file", o.MappingFile, "Config file mapping paths to backends")
 	fs.StringVar(&o.RootDirectory, "root-directory", o.RootDirectory, "Root directory.")
 	fs.StringVar(&o.RootKubeconfig, "root-kubeconfig", o.RootKubeconfig, "The path to the kubeconfig of the root shard.")


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

## What Type of PR Is This?

/kind feature

<img width="918" alt="Bildschirmfoto 2025-04-26 um 20 51 32" src="https://github.com/user-attachments/assets/d83ef4f4-02d9-49ed-b79a-f56d84bd2f2b" />


<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
kube-front-proxy: print flags in sections.
```
