### PR TITLE
Update sdk/testing/server

### DIFF
--- a/sdk/testing/server/config.go
+++ b/sdk/testing/server/config.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package server
 
+import "path/filepath"
+
 // Config qualify a kcp server to start
 //
 // Deprecated for use outside this package. Prefer PrivateKcpServer().
@@ -32,6 +34,17 @@ type Config struct {
 
 // Option a function that wish to modify a given kcp configuration.
 type Option func(*Config)
+
+// WithDefaultsFrom sets defaults on Config based off of the passed
+// TestingT.
+func WithDefaultsFrom(t TestingT) Option {
+	return func(cfg *Config) {
+		cfg.Name = t.Name()
+		cfg.ArtifactDir = filepath.Join(t.TempDir(), "artifacts")
+		cfg.DataDir = filepath.Join(t.TempDir(), "artifacts")
+		cfg.ClientCADir = filepath.Join(t.TempDir(), "certs")
+	}
+}
 
 // WithScratchDirectories adds custom scratch directories to a kcp configuration.
 func WithScratchDirectories(artifactDir, dataDir string) Option {

--- a/sdk/testing/server/external.go
+++ b/sdk/testing/server/external.go
@@ -159,6 +159,16 @@ func (s *externalKCPServer) Artifact(t TestingT, producer func() (runtime.Object
 	artifact(t, s, producer)
 }
 
+// Stop is a noop to satisfy the RunningServer interface.
+func (s *externalKCPServer) Stop() {
+	return
+}
+
+// Stopped is a noop to satisfy the RunningServer interface.
+func (s *externalKCPServer) Stopped() bool {
+	return false
+}
+
 // LoadKubeConfig loads a kubeconfig from disk. This method is
 // intended to be common between fixture for servers whose lifecycle
 // is test-managed and fixture for servers whose lifecycle is managed

--- a/sdk/testing/server/fixture.go
+++ b/sdk/testing/server/fixture.go
@@ -90,11 +90,11 @@ func NewFixture(t TestingT, cfgs ...Config) Fixture {
 		if len(cfg.DataDir) == 0 {
 			panic(fmt.Sprintf("provided kcpConfig for %s is incorrect, missing DataDir", cfg.Name))
 		}
-		srv, err := newKcpServer(t, cfg, cfg.ArtifactDir, cfg.DataDir, cfg.ClientCADir)
+		srv, err := newKcpServer(t, cfg)
 		require.NoError(t, err)
 
 		servers = append(servers, srv)
-		ret[srv.name] = srv
+		ret[srv.Name()] = srv
 	}
 
 	// Launch kcp servers and ensure they are ready before starting the test
@@ -104,14 +104,7 @@ func NewFixture(t TestingT, cfgs ...Config) Fixture {
 	t.Cleanup(cancel)
 	g, ctx := errgroup.WithContext(ctx)
 	for i, srv := range servers {
-		var opts []RunOption
-		if env.LogToConsoleEnvSet() || cfgs[i].LogToConsole {
-			opts = append(opts, WithLogStreaming)
-		}
-		if env.InProcessEnvSet() || cfgs[i].RunInProcess {
-			opts = append(opts, RunInProcess)
-		}
-		err := srv.Run(opts...)
+		err := srv.Run(t)
 		require.NoError(t, err)
 
 		// Wait for the server to become ready
@@ -151,8 +144,8 @@ func NewFixture(t TestingT, cfgs ...Config) Fixture {
 		defer cancel()
 
 		for _, s := range servers {
-			t.Log("Gathering metrics for kcp server", s.name)
-			gatherMetrics(ctx, t, s, s.artifactDir)
+			t.Log("Gathering metrics for kcp server", s.Name())
+			gatherMetrics(s.ctx, t, s, s.cfg.ArtifactDir)
 		}
 	})
 
@@ -167,22 +160,31 @@ func NewFixture(t TestingT, cfgs ...Config) Fixture {
 //   - all ports and data directories are unique to support
 //     concurrent execution within a test case and across tests
 type kcpServer struct {
-	name        string
-	args        []string
-	ctx         context.Context //nolint:containedctx
-	dataDir     string
-	artifactDir string
-	clientCADir string
-
-	lock           *sync.Mutex
-	cfg            clientcmd.ClientConfig
-	kubeconfigPath string
-
-	t TestingT
+	cfg              Config
+	lock             *sync.Mutex
+	clientCfg        clientcmd.ClientConfig
+	ctx              context.Context //nolint:containedctx
+	cancel           func()
+	shutdownComplete bool
 }
 
-func newKcpServer(t TestingT, cfg Config, artifactDir, dataDir, clientCADir string) (*kcpServer, error) {
+func newKcpServer(t TestingT, cfg Config) (*kcpServer, error) {
 	t.Helper()
+
+	s := &kcpServer{
+		cfg:  cfg,
+		lock: &sync.Mutex{},
+	}
+
+	s.cfg.ArtifactDir = filepath.Join(s.cfg.ArtifactDir, "kcp", cfg.Name)
+	if err := os.MkdirAll(s.cfg.ArtifactDir, 0755); err != nil {
+		return nil, fmt.Errorf("could not create artifact dir: %w", err)
+	}
+
+	s.cfg.DataDir = filepath.Join(s.cfg.DataDir, "kcp", cfg.Name)
+	if err := os.MkdirAll(s.cfg.DataDir, 0755); err != nil {
+		return nil, fmt.Errorf("could not create data dir: %w", err)
+	}
 
 	kcpListenPort, err := GetFreePort(t)
 	if err != nil {
@@ -196,51 +198,21 @@ func newKcpServer(t TestingT, cfg Config, artifactDir, dataDir, clientCADir stri
 	if err != nil {
 		return nil, err
 	}
-	artifactDir = filepath.Join(artifactDir, "kcp", cfg.Name)
-	if err := os.MkdirAll(artifactDir, 0755); err != nil {
-		return nil, fmt.Errorf("could not create artifact dir: %w", err)
-	}
-	dataDir = filepath.Join(dataDir, "kcp", cfg.Name)
-	if err := os.MkdirAll(dataDir, 0755); err != nil {
-		return nil, fmt.Errorf("could not create data dir: %w", err)
-	}
 
-	return &kcpServer{
-		name: cfg.Name,
-		args: append([]string{
-			"--root-directory",
-			dataDir,
-			"--secure-port=" + kcpListenPort,
-			"--embedded-etcd-client-port=" + etcdClientPort,
-			"--embedded-etcd-peer-port=" + etcdPeerPort,
-			"--embedded-etcd-wal-size-bytes=" + strconv.Itoa(5*1000), // 5KB
-			"--kubeconfig-path=" + filepath.Join(dataDir, "admin.kubeconfig"),
-			"--feature-gates=" + fmt.Sprintf("%s", utilfeature.DefaultFeatureGate),
-			"--audit-log-path", filepath.Join(artifactDir, "kcp.audit"),
-			"--v=4",
-		},
-			cfg.Args...),
-		dataDir:     dataDir,
-		artifactDir: artifactDir,
-		clientCADir: clientCADir,
-		t:           t,
-		lock:        &sync.Mutex{},
-	}, nil
-}
+	s.cfg.Args = append(s.cfg.Args,
+		"--root-directory",
+		s.cfg.DataDir,
+		"--secure-port="+kcpListenPort,
+		"--embedded-etcd-client-port="+etcdClientPort,
+		"--embedded-etcd-peer-port="+etcdPeerPort,
+		"--embedded-etcd-wal-size-bytes="+strconv.Itoa(5*1000), // 5KB
+		"--kubeconfig-path="+s.KubeconfigPath(),
+		"--feature-gates="+fmt.Sprintf("%s", utilfeature.DefaultFeatureGate),
+		"--audit-log-path", filepath.Join(s.cfg.ArtifactDir, "kcp.audit"),
+		"--v=4",
+	)
 
-type runOptions struct {
-	runInProcess bool
-	streamLogs   bool
-}
-
-type RunOption func(o *runOptions)
-
-func RunInProcess(o *runOptions) {
-	o.runInProcess = true
-}
-
-func WithLogStreaming(o *runOptions) {
-	o.streamLogs = true
+	return s, nil
 }
 
 // StartKcpCommand returns the string tokens required to start kcp in
@@ -283,126 +255,50 @@ func Command(executableName, identity string) []string {
 
 // Run runs the kcp server while the parent context is active. This call is not blocking,
 // callers should ensure that the server is Ready() before using it.
-func (c *kcpServer) Run(opts ...RunOption) error {
-	runOpts := runOptions{}
-	for _, opt := range opts {
-		opt(&runOpts)
+func (c *kcpServer) Run(t TestingT) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	var runner KcpRunner = runExternal
+	if c.cfg.RunInProcess {
+		if RunInProcessFunc == nil {
+			// No RunInProcessFunc set, can safely default to context
+			// variant
+			runner = ContextRunInProcessFunc
+		} else {
+			runner = func(ctx context.Context, t TestingT, cfg Config) (<-chan struct{}, error) {
+				t.Log("RunInProcessFunc is deprecated, please migrate to ContextRunInProcessFunc")
+				t.Log("RunInProcessFunc is deprecated, stopping the server will not work")
+				return RunInProcessFunc(t, cfg.DataDir, cfg.Args)
+			}
+		}
+	}
+	if runner == nil {
+		return fmt.Errorf("runner is nil")
 	}
 
-	// We close this channel when the kcp server has stopped
-	shutdownComplete := make(chan struct{})
-
-	ctx, cancel := context.WithCancel(context.Background())
-
-	cleanup := func() {
-		cancel()
-		close(shutdownComplete)
-	}
-
-	c.t.Cleanup(func() {
-		c.t.Log("cleanup: canceling context")
-		cancel()
-
-		// Wait for the kcp server to stop
-		c.t.Log("cleanup: waiting for shutdownComplete")
-
-		<-shutdownComplete
-
-		c.t.Log("cleanup: received shutdownComplete")
-	})
+	ctx, ctxCancel := context.WithCancel(context.Background())
 	c.ctx = ctx
 
-	// run kcp start in-process for easier debugging
-	if runOpts.runInProcess {
-		if RunInProcessFunc == nil {
-			return fmt.Errorf("RunInProcessFunc is not set")
-		}
-		rootDir := ".kcp"
-		if c.dataDir != "" {
-			rootDir = c.dataDir
-		}
-		stopCh, err := RunInProcessFunc(c.t, rootDir, c.args)
-		if err != nil {
-			cleanup()
-			return err
-		}
-		go func() {
-			defer cleanup()
-			<-stopCh
-		}()
-		return nil
-	}
-
-	commandLine := append(StartKcpCommand("KCP"), c.args...)
-	c.t.Logf("running: %v", strings.Join(commandLine, " "))
-
-	// NOTE: do not use exec.CommandContext here. That method issues a SIGKILL when the context is done, and we
-	// want to issue SIGTERM instead, to give the server a chance to shut down cleanly.
-	cmd := exec.Command(commandLine[0], commandLine[1:]...)
-
-	// Create a new process group for the child/forked process (which is either 'go run ...' or just 'kcp
-	// ...'). This is necessary so the SIGTERM we send to terminate the kcp server works even with the
-	// 'go run' variant - we have to work around this issue: https://github.com/golang/go/issues/40467.
-	// Thanks to
-	// https://medium.com/@felixge/killing-a-child-process-and-all-of-its-children-in-go-54079af94773 for
-	// the idea!
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-
-	logFile, err := os.Create(filepath.Join(c.artifactDir, "kcp.log"))
+	shutdownComplete, err := runner(ctx, t, c.cfg)
 	if err != nil {
-		cleanup()
-		return fmt.Errorf("could not create log file: %w", err)
+		ctxCancel()
+		return err
 	}
 
-	// Closing the logfile is necessary so the cmd.Wait() call in the goroutine below can finish (it only finishes
-	// waiting when the internal io.Copy goroutines for stdin/stdout/stderr are done, and that doesn't happen if
-	// the log file remains open.
-	c.t.Cleanup(func() {
-		logFile.Close()
-	})
+	c.cancel = func() {
+		t.Log("cleanup: canceling context")
+		ctxCancel()
 
-	log := bytes.Buffer{}
-
-	writers := []io.Writer{&log, logFile}
-
-	if runOpts.streamLogs {
-		prefix := fmt.Sprintf("%s: ", c.name)
-		writers = append(writers, prefixer.New(os.Stdout, func() string { return prefix }))
+		// Wait for the kcp server to stop
+		t.Log("cleanup: waiting for shutdownComplete")
+		<-shutdownComplete
+		c.lock.Lock()
+		c.shutdownComplete = true
+		c.lock.Unlock()
+		t.Log("cleanup: received shutdownComplete")
 	}
-
-	mw := io.MultiWriter(writers...)
-	cmd.Stdout = mw
-	cmd.Stderr = mw
-
-	if err := cmd.Start(); err != nil {
-		cleanup()
-		if os.Getenv(kcpBinariesDirEnvDir) == "" && commandLine[0] == "kcp" {
-			c.t.Log("Consider setting KCP_BINARIES_DIR pointing to a directory with a kcp binary.")
-		}
-		return fmt.Errorf("failed to start kcp: %w", err)
-	}
-
-	c.t.Cleanup(func() {
-		// Ensure child process is killed on cleanup - send the negative of the pid, which is the process group id.
-		// See https://medium.com/@felixge/killing-a-child-process-and-all-of-its-children-in-go-54079af94773 for details.
-		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM); err != nil {
-			c.t.Errorf("Saw an error trying to kill `kcp`: %v", err)
-		}
-	})
-
-	go func() {
-		defer cleanup()
-
-		err := cmd.Wait()
-
-		if err != nil && ctx.Err() == nil {
-			// we care about errors in the process that did not result from the
-			// context expiring and us ending the process
-			data := c.filterKcpLogs(&log)
-			c.t.Errorf("`kcp` failed: %v logs:\n%v", err, data)
-			c.t.Errorf("`kcp` failed: %v", err)
-		}
-	}()
+	t.Cleanup(c.cancel)
 
 	return nil
 }
@@ -423,10 +319,88 @@ func (c *kcpServer) Stopped() bool {
 	return c.shutdownComplete
 }
 
+func runExternal(ctx context.Context, t TestingT, cfg Config) (<-chan struct{}, error) {
+	commandLine := append(StartKcpCommand("KCP"), cfg.Args...)
+
+	t.Logf("running: %v", strings.Join(commandLine, " "))
+
+	// NOTE: do not use exec.CommandContext here. That method issues a SIGKILL when the context is done, and we
+	// want to issue SIGTERM instead, to give the server a chance to shut down cleanly.
+	cmd := exec.Command(commandLine[0], commandLine[1:]...)
+
+	// Create a new process group for the child/forked process (which is either 'go run ...' or just 'kcp
+	// ...'). This is necessary so the SIGTERM we send to terminate the kcp server works even with the
+	// 'go run' variant - we have to work around this issue: https://github.com/golang/go/issues/40467.
+	// Thanks to
+	// https://medium.com/@felixge/killing-a-child-process-and-all-of-its-children-in-go-54079af94773 for
+	// the idea!
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	logFile, err := os.Create(filepath.Join(cfg.ArtifactDir, "kcp.log"))
+	if err != nil {
+		return nil, fmt.Errorf("could not create log file: %w", err)
+	}
+
+	// Closing the logfile is necessary so the cmd.Wait() call in the goroutine below can finish (it only finishes
+	// waiting when the internal io.Copy goroutines for stdin/stdout/stderr are done, and that doesn't happen if
+	// the log file remains open.
+	t.Cleanup(func() {
+		logFile.Close()
+	})
+
+	log := bytes.Buffer{}
+
+	writers := []io.Writer{&log, logFile}
+
+	if cfg.LogToConsole {
+		prefix := fmt.Sprintf("%s: ", t.Name())
+		writers = append(writers, prefixer.New(os.Stdout, func() string { return prefix }))
+	}
+
+	mw := io.MultiWriter(writers...)
+	cmd.Stdout = mw
+	cmd.Stderr = mw
+
+	if err := cmd.Start(); err != nil {
+		if os.Getenv(kcpBinariesDirEnvDir) == "" && commandLine[0] == "kcp" {
+			t.Log("Consider setting KCP_BINARIES_DIR pointing to a directory with a kcp binary.")
+		}
+		return nil, fmt.Errorf("failed to start kcp: %w", err)
+	}
+
+	go func() {
+		<-ctx.Done()
+		if cmd.Process != nil && cmd.Process.Pid > 0 {
+			// Ensure child process is killed on cleanup - send the negative of the pid, which is the process group id.
+			// See https://medium.com/@felixge/killing-a-child-process-and-all-of-its-children-in-go-54079af94773 for details.
+			if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM); err != nil {
+				t.Errorf("Saw an error trying to kill `kcp`: %v", err)
+			}
+		}
+	}()
+
+	shutdownComplete := make(chan struct{})
+
+	go func() {
+		err := cmd.Wait()
+		close(shutdownComplete)
+
+		if err != nil && ctx.Err() == nil {
+			// we care about errors in the process that did not result from the
+			// context expiring and us ending the process
+			data := filterKcpLogs(t, &log)
+			t.Errorf("`kcp` failed: %v logs:\n%v", err, data)
+			t.Errorf("`kcp` failed: %v", err)
+		}
+	}()
+
+	return shutdownComplete, nil
+}
+
 // filterKcpLogs is a silly hack to get rid of the nonsense output that
 // currently plagues kcp. Yes, in the future we want to actually fix these
 // issues but until we do, there's no reason to force awful UX onto users.
-func (c *kcpServer) filterKcpLogs(logs *bytes.Buffer) string {
+func filterKcpLogs(t TestingT, logs *bytes.Buffer) string {
 	output := strings.Builder{}
 	scanner := bufio.NewScanner(logs)
 	for scanner.Scan() {
@@ -446,7 +420,7 @@ func (c *kcpServer) filterKcpLogs(logs *bytes.Buffer) string {
 		}
 		_, err := output.Write(append(line, []byte("\n")...))
 		if err != nil {
-			c.t.Logf("failed to write log line: %v", err)
+			t.Logf("failed to write log line: %v", err)
 		}
 	}
 	return output.String()
@@ -454,22 +428,22 @@ func (c *kcpServer) filterKcpLogs(logs *bytes.Buffer) string {
 
 // Name exposes the name of this kcp server.
 func (c *kcpServer) Name() string {
-	return c.name
+	return c.cfg.Name
 }
 
 // KubeconfigPath exposes the path of the kubeconfig file of this kcp server.
 func (c *kcpServer) KubeconfigPath() string {
-	return c.kubeconfigPath
+	return filepath.Join(c.cfg.DataDir, "admin.kubeconfig")
 }
 
 // Config exposes a copy of the base client config for this server. Client-side throttling is disabled (QPS=-1).
 func (c *kcpServer) config(context string) (*rest.Config, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	if c.cfg == nil {
+	if c.clientCfg == nil {
 		return nil, fmt.Errorf("programmer error: kcpServer.Config() called before load succeeded. Stack: %s", string(debug.Stack()))
 	}
-	raw, err := c.cfg.RawConfig()
+	raw, err := c.clientCfg.RawConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -487,7 +461,7 @@ func (c *kcpServer) config(context string) (*rest.Config, error) {
 }
 
 func (c *kcpServer) ClientCAUserConfig(t TestingT, config *rest.Config, name string, groups ...string) *rest.Config {
-	return clientCAUserConfig(t, config, c.clientCADir, name, groups...)
+	return clientCAUserConfig(t, config, c.cfg.ClientCADir, name, groups...)
 }
 
 // BaseConfig returns a rest.Config for the "base" context. Client-side throttling is disabled (QPS=-1).
@@ -529,17 +503,16 @@ func (c *kcpServer) ShardNames() []string {
 func (c *kcpServer) RawConfig() (clientcmdapi.Config, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	if c.cfg == nil {
+	if c.clientCfg == nil {
 		return clientcmdapi.Config{}, fmt.Errorf("programmer error: kcpServer.RawConfig() called before load succeeded. Stack: %s", string(debug.Stack()))
 	}
-	return c.cfg.RawConfig()
+	return c.clientCfg.RawConfig()
 }
 
 func (c *kcpServer) loadCfg() error {
 	var lastError error
 	if err := wait.PollUntilContextTimeout(c.ctx, 100*time.Millisecond, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
-		c.kubeconfigPath = filepath.Join(c.dataDir, "admin.kubeconfig")
-		config, err := loadKubeConfig(c.kubeconfigPath, "base")
+		config, err := loadKubeConfig(c.KubeconfigPath(), "base")
 		if err != nil {
 			// A missing file is likely caused by the server not
 			// having started up yet. Ignore these errors for the
@@ -552,7 +525,7 @@ func (c *kcpServer) loadCfg() error {
 		}
 
 		c.lock.Lock()
-		c.cfg = config
+		c.clientCfg = config
 		c.lock.Unlock()
 
 		return true, nil
@@ -566,7 +539,7 @@ func (c *kcpServer) loadCfg() error {
 }
 
 func (c *kcpServer) CADirectory() string {
-	return c.dataDir
+	return c.cfg.DataDir
 }
 
 func (c *kcpServer) Artifact(t TestingT, producer func() (runtime.Object, error)) {

--- a/sdk/testing/server/fixture.go
+++ b/sdk/testing/server/fixture.go
@@ -139,13 +139,13 @@ func NewFixture(t TestingT, cfgs ...Config) Fixture {
 	}
 
 	t.Cleanup(func() {
-		t.Logf("Stopping kcp servers...")
-		ctx, cancel := context.WithTimeout(context.Background(), wait.ForeverTestTimeout)
+		t.Logf("Gathering metrics from kcp servers...")
+		ctx, cancel := context.WithTimeout(ctx, wait.ForeverTestTimeout)
 		defer cancel()
 
 		for _, s := range servers {
 			t.Log("Gathering metrics for kcp server", s.Name())
-			gatherMetrics(s.ctx, t, s, s.cfg.ArtifactDir)
+			gatherMetrics(ctx, t, s, s.cfg.ArtifactDir)
 		}
 	})
 

--- a/sdk/testing/server/fixture.go
+++ b/sdk/testing/server/fixture.go
@@ -60,7 +60,16 @@ const kcpBinariesDirEnvDir = "KCP_BINARIES_DIR"
 
 // RunInProcessFunc instantiates the kcp server in process for easier debugging.
 // It is here to decouple the rest of the code from kcp core dependencies.
+// Deprecated: Use ContextRunInProcessFunc instead.
 var RunInProcessFunc func(t TestingT, dataDir string, args []string) (<-chan struct{}, error)
+
+type KcpRunner func(context.Context, TestingT, Config) (<-chan struct{}, error)
+
+// ContextRunInProcessFunc instantiates the kcp server in process for easier debugging.
+// It is here to decouple the rest of the code from kcp core dependencies.
+var ContextRunInProcessFunc KcpRunner = func(ctx context.Context, t TestingT, cfg Config) (<-chan struct{}, error) {
+	return nil, fmt.Errorf("not implemented")
+}
 
 // Fixture manages the lifecycle of a set of kcp servers.
 //

--- a/sdk/testing/server/fixture.go
+++ b/sdk/testing/server/fixture.go
@@ -407,6 +407,22 @@ func (c *kcpServer) Run(opts ...RunOption) error {
 	return nil
 }
 
+func (c *kcpServer) Stop() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if c.cancel == nil {
+		return
+	}
+	c.cancel()
+}
+
+func (c *kcpServer) Stopped() bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.shutdownComplete
+}
+
 // filterKcpLogs is a silly hack to get rid of the nonsense output that
 // currently plagues kcp. Yes, in the future we want to actually fix these
 // issues but until we do, there's no reason to force awful UX onto users.

--- a/sdk/testing/server/fixture.go
+++ b/sdk/testing/server/fixture.go
@@ -199,17 +199,20 @@ func newKcpServer(t TestingT, cfg Config) (*kcpServer, error) {
 		return nil, err
 	}
 
-	s.cfg.Args = append(s.cfg.Args,
-		"--root-directory",
-		s.cfg.DataDir,
-		"--secure-port="+kcpListenPort,
-		"--embedded-etcd-client-port="+etcdClientPort,
-		"--embedded-etcd-peer-port="+etcdPeerPort,
-		"--embedded-etcd-wal-size-bytes="+strconv.Itoa(5*1000), // 5KB
-		"--kubeconfig-path="+s.KubeconfigPath(),
-		"--feature-gates="+fmt.Sprintf("%s", utilfeature.DefaultFeatureGate),
-		"--audit-log-path", filepath.Join(s.cfg.ArtifactDir, "kcp.audit"),
-		"--v=4",
+	s.cfg.Args = append(
+		[]string{
+			"--root-directory",
+			s.cfg.DataDir,
+			"--secure-port=" + kcpListenPort,
+			"--embedded-etcd-client-port=" + etcdClientPort,
+			"--embedded-etcd-peer-port=" + etcdPeerPort,
+			"--embedded-etcd-wal-size-bytes=" + strconv.Itoa(5*1000), // 5KB
+			"--kubeconfig-path=" + s.KubeconfigPath(),
+			"--feature-gates=" + fmt.Sprintf("%s", utilfeature.DefaultFeatureGate),
+			"--audit-log-path", filepath.Join(s.cfg.ArtifactDir, "kcp.audit"),
+			"--v=4",
+		},
+		s.cfg.Args...,
 	)
 
 	return s, nil

--- a/sdk/testing/server/interface.go
+++ b/sdk/testing/server/interface.go
@@ -33,4 +33,10 @@ type RunningServer interface {
 	Artifact(t TestingT, producer func() (runtime.Object, error))
 	ClientCAUserConfig(t TestingT, config *rest.Config, name string, groups ...string) *rest.Config
 	CADirectory() string
+	// Stop signals the server to shutdown and waits until it finishes.
+	// Stop is a noop for external servers.
+	Stop()
+	// Stopped returns true if the server has ran and stopped.
+	// Stopped is a noop for external servers.
+	Stopped() bool
 }

--- a/test/e2e/framework/inprocess.go
+++ b/test/e2e/framework/inprocess.go
@@ -32,18 +32,18 @@ import (
 )
 
 func init() {
-	kcptestingserver.RunInProcessFunc = func(t kcptestingserver.TestingT, rootDir string, args []string) (<-chan struct{}, error) {
-		ctx, cancel := context.WithCancel(context.Background())
+	kcptestingserver.ContextRunInProcessFunc = func(ctx context.Context, t kcptestingserver.TestingT, cfg kcptestingserver.Config) (<-chan struct{}, error) {
+		ctx, cancel := context.WithCancel(ctx)
 		t.Cleanup(cancel)
 
-		serverOptions := kcpoptions.NewOptions(rootDir)
+		serverOptions := kcpoptions.NewOptions(cfg.DataDir)
 		fss := flag.NamedFlagSets{}
 		serverOptions.AddFlags(&fss)
 		all := pflag.NewFlagSet("kcp", pflag.ContinueOnError)
 		for _, fs := range fss.FlagSets {
 			all.AddFlagSet(fs)
 		}
-		if err := all.Parse(args); err != nil {
+		if err := all.Parse(cfg.Args); err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Consolidated running in-process and external test instances into `KcpRunner` and consolidated using the existing `Config` rather than duplicating the same values into the server.

Also passing the `Config` to the runner allows adding more features without changing the interface.

The important part was enabling stopping the server for in-process instances for leak tests.

~~The only breaking change should be that the servers will listen on localhost by default, rather than all interfaces.~~

## What Type of PR Is This?

/kind cleanup
/kind feature

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

-

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Added `sdk/testing/server.ContextRunInProcessFunc`
Deprecated `sdk/testing/server.RunInProcessFunc`
```
