### PR TITLE
Honour `WORK_DIR`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -313,7 +313,7 @@ test-e2e-shared-minimal: build-all
 	echo 'Starting test(s)' && \
 	NO_GORUN=1 GOOS=$(OS) GOARCH=$(ARCH) \
 		$(GO_TEST) -race $(COUNT_ARG) $(PARALLELISM_ARG) $(WHAT) $(TEST_ARGS) \
-		-args --kcp-kubeconfig=$(WORK_DIR)/.kcp/admin.kubeconfig $(SUITES_ARGS) \
+		-args --kcp-kubeconfig=$(WORK_DIR)/.kcp/admin.kubeconfig $(SUITES_ARG) \
 	$(if $(value WAIT),|| { echo "Terminated with $$?"; wait "$$PID"; },)
 
 .PHONY: test-e2e-sharded-minimal
@@ -339,7 +339,7 @@ test-e2e-sharded-minimal: build-all
 	echo 'Starting test(s)' && \
 	NO_GORUN=1 GOOS=$(OS) GOARCH=$(ARCH) $(GO_TEST) -race $(COUNT_ARG) $(PARALLELISM_ARG) $(WHAT) $(TEST_ARGS) \
 		-args --kcp-kubeconfig=$(WORK_DIR)/.kcp/admin.kubeconfig --shard-kubeconfigs=root=$(WORK_DIR)/.kcp-0/admin.kubeconfig$(shell if [ $(SHARDS) -gt 1 ]; then seq 1 $$[$(SHARDS) - 1]; fi | while read n; do echo -n ",shard-$$n=$(WORK_DIR)/.kcp-$$n/admin.kubeconfig"; done) \
-		$(SUITES_ARGS) \
+		$(SUITES_ARG) \
 	$(if $(value WAIT),|| { echo "Terminated with $$?"; wait "$$PID"; },)
 
 # This is just easy target to run 2 shard test server locally until manually killed.

--- a/Makefile
+++ b/Makefile
@@ -297,7 +297,7 @@ endif
 test-e2e-shared-minimal: $(HTTEST)
 test-e2e-shared-minimal: TEST_ARGS ?=
 test-e2e-shared-minimal: WHAT ?= ./test/e2e...
-test-e2e-shared-minimal: WORK_DIR ?= .
+test-e2e-shared-minimal: WORK_DIR ?= $(PWD)
 ifdef ARTIFACT_DIR
 test-e2e-shared-minimal: LOG_DIR ?= $(ARTIFACT_DIR)/kcp
 else
@@ -323,7 +323,7 @@ endif
 test-e2e-sharded-minimal: $(HTTEST)
 test-e2e-sharded-minimal: TEST_ARGS ?=
 test-e2e-sharded-minimal: WHAT ?= ./test/e2e...
-test-e2e-sharded-minimal: WORK_DIR ?= .
+test-e2e-sharded-minimal: WORK_DIR ?= $(PWD)
 test-e2e-sharded-minimal: SHARDS ?= 2
 ifdef ARTIFACT_DIR
 test-e2e-sharded-minimal: LOG_DIR ?= $(ARTIFACT_DIR)/kcp
@@ -345,7 +345,7 @@ test-e2e-sharded-minimal: build-all
 # This is just easy target to run 2 shard test server locally until manually killed.
 # You can targer test to it by running:
 # go test ./test/e2e/apibinding/... --kcp-kubeconfig=${WORK_DIR:-.}/.kcp/admin.kubeconfig --shard-kubeconfigs=root=${WORK_DIR:-.}/.kcp-0/admin.kubeconfig -run=^TestAPIBindingEndpointSlicesSharded$
-test-run-sharded-server: WORK_DIR ?= .
+test-run-sharded-server: WORK_DIR ?= $(PWD)
 test-run-sharded-server: LOG_DIR ?= $(WORK_DIR)/.kcp
 test-run-sharded-server:
 	mkdir -p "$(LOG_DIR)" "$(WORK_DIR)/.kcp"
@@ -392,7 +392,7 @@ clean: clean-workdir ## Clean all
 	rm -f $(GOBIN_DIR)/*
 
 .PHONY: clean-workdir
-clean-workdir: WORK_DIR ?= .
+clean-workdir: WORK_DIR ?= $(PWD)
 clean-workdir: ## Clean workdir
 	rm -fr $(WORK_DIR)/.kcp*
 

--- a/Makefile
+++ b/Makefile
@@ -338,13 +338,13 @@ test-e2e-sharded-minimal: build-all
 	while [ ! -f "$(WORK_DIR)/.kcp/ready-to-test" ]; do sleep 1; done && \
 	echo 'Starting test(s)' && \
 	NO_GORUN=1 GOOS=$(OS) GOARCH=$(ARCH) $(GO_TEST) -race $(COUNT_ARG) $(PARALLELISM_ARG) $(WHAT) $(TEST_ARGS) \
-		-args --use-default-kcp-server --shard-kubeconfigs=root=$(PWD)/.kcp-0/admin.kubeconfig$(shell if [ $(SHARDS) -gt 1 ]; then seq 1 $$[$(SHARDS) - 1]; fi | while read n; do echo -n ",shard-$$n=$(PWD)/.kcp-$$n/admin.kubeconfig"; done) \
+		-args --kcp-kubeconfig=$(WORK_DIR)/.kcp/admin.kubeconfig --shard-kubeconfigs=root=$(WORK_DIR)/.kcp-0/admin.kubeconfig$(shell if [ $(SHARDS) -gt 1 ]; then seq 1 $$[$(SHARDS) - 1]; fi | while read n; do echo -n ",shard-$$n=$(WORK_DIR)/.kcp-$$n/admin.kubeconfig"; done) \
 		$(SUITES_ARGS) \
 	$(if $(value WAIT),|| { echo "Terminated with $$?"; wait "$$PID"; },)
 
 # This is just easy target to run 2 shard test server locally until manually killed.
 # You can targer test to it by running:
-# go test ./test/e2e/apibinding/... --kcp-kubeconfig=$(pwd)/.kcp/admin.kubeconfig --shard-kubeconfigs=root=$(pwd)/.kcp-0/admin.kubeconfig -run=^TestAPIBindingEndpointSlicesSharded$
+# go test ./test/e2e/apibinding/... --kcp-kubeconfig=${WORK_DIR:-.}/.kcp/admin.kubeconfig --shard-kubeconfigs=root=${WORK_DIR:-.}/.kcp-0/admin.kubeconfig -run=^TestAPIBindingEndpointSlicesSharded$
 test-run-sharded-server: WORK_DIR ?= .
 test-run-sharded-server: LOG_DIR ?= $(WORK_DIR)/.kcp
 test-run-sharded-server:

--- a/Makefile
+++ b/Makefile
@@ -307,13 +307,13 @@ test-e2e-shared-minimal: build-all
 	mkdir -p "$(LOG_DIR)" "$(WORK_DIR)/.kcp"
 	rm -f "$(WORK_DIR)/.kcp/ready-to-test"
 	UNSAFE_E2E_HACK_DISABLE_ETCD_FSYNC=true NO_GORUN=1 \
-		./bin/test-server --quiet --log-dir-path="$(LOG_DIR)" $(TEST_SERVER_ARGS) -- --feature-gates=$(TEST_FEATURE_GATES) 2>&1 & PID=$$! && echo "PID $$PID" && \
+		./bin/test-server --quiet --work-dir-path="$(WORK_DIR)" --log-dir-path="$(LOG_DIR)" $(TEST_SERVER_ARGS) -- --feature-gates=$(TEST_FEATURE_GATES) 2>&1 & PID=$$! && echo "PID $$PID" && \
 	trap 'kill -TERM $$PID && wait $$PID' TERM INT EXIT && \
 	while [ ! -f "$(WORK_DIR)/.kcp/ready-to-test" ]; do sleep 1; done && \
 	echo 'Starting test(s)' && \
 	NO_GORUN=1 GOOS=$(OS) GOARCH=$(ARCH) \
 		$(GO_TEST) -race $(COUNT_ARG) $(PARALLELISM_ARG) $(WHAT) $(TEST_ARGS) \
-		-args --use-default-kcp-server $(SUITES_ARG) \
+		-args --kcp-kubeconfig=$(WORK_DIR)/.kcp/admin.kubeconfig $(SUITES_ARGS) \
 	$(if $(value WAIT),|| { echo "Terminated with $$?"; wait "$$PID"; },)
 
 .PHONY: test-e2e-sharded-minimal

--- a/cmd/test-server/kcp/shard.go
+++ b/cmd/test-server/kcp/shard.go
@@ -98,6 +98,7 @@ func (s *Shard) Start(ctx context.Context, quiet bool) error {
 	commandLine = append(commandLine, kcptestingserver.StartKcpCommand(s.name)...)
 	commandLine = append(commandLine, s.args...)
 	commandLine = append(commandLine,
+		"--root-directory", s.runtimeDir,
 		"--token-auth-file", framework.DefaultTokenAuthFile,
 		"--audit-log-maxsize", "1024",
 		"--audit-log-mode=batch",

--- a/sdk/testing/config.go
+++ b/sdk/testing/config.go
@@ -61,3 +61,11 @@ func setupExternal() {
 		}
 	})
 }
+
+func KubeconfigPath() string {
+	return externalConfig.kubeconfigPath
+}
+
+func ShardKubeconfigPaths(shard string) string {
+	return externalConfig.shardKubeconfigPaths[shard]
+}

--- a/sdk/testing/kcp.go
+++ b/sdk/testing/kcp.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	kcptestinghelpers "github.com/kcp-dev/kcp/sdk/testing/helpers"
 	kcptestingserver "github.com/kcp-dev/kcp/sdk/testing/server"
 	"github.com/kcp-dev/kcp/sdk/testing/third_party/library-go/crypto"
 )
@@ -78,7 +77,7 @@ func SharedKcpServer(t TestingT) kcptestingserver.RunningServer {
 		// Use a pre-existing external server
 
 		t.Logf("Shared kcp server will target configuration %q", externalConfig.kubeconfigPath)
-		s, err := kcptestingserver.NewExternalKCPServer(sharedConfig.Name, externalConfig.kubeconfigPath, externalConfig.shardKubeconfigPaths, filepath.Join(kcptestinghelpers.RepositoryDir(), ".kcp"))
+		s, err := kcptestingserver.NewExternalKCPServer(sharedConfig.Name, externalConfig.kubeconfigPath, externalConfig.shardKubeconfigPaths, filepath.Dir(KubeconfigPath()))
 		require.NoError(t, err, "failed to create persistent server fixture")
 
 		ctx, cancel := context.WithCancel(context.Background())

--- a/test/e2e/reconciler/cache/replication_test.go
+++ b/test/e2e/reconciler/cache/replication_test.go
@@ -754,7 +754,7 @@ func createCacheClientConfigForEnvironment(ctx context.Context, t *testing.T, kc
 	}
 
 	// assume multi-shard env created by the sharded-test-server
-	cacheServerKubeConfigPath := filepath.Join(kcptestinghelpers.RepositoryDir(), ".kcp-cache", "cache.kubeconfig")
+	cacheServerKubeConfigPath := filepath.Join(filepath.Dir(kcptesting.KubeconfigPath()), "..", ".kcp-cache", "cache.kubeconfig")
 	cacheServerKubeConfig, err := kcptestinghelpers.LoadKubeConfig(cacheServerKubeConfigPath, "cache")
 	require.NoError(t, err)
 	cacheServerRestConfig, err := cacheServerKubeConfig.ClientConfig()


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

I prefer having temporary files, artifacts and the like under e.g. `TMPDIR` and noticed that `WORK_DIR` isn't always honoured.
For the sharded and shared recipes setting `WORK_DIR` actually breaks the runs because the servers are setup with `WORK_DIR` but the clients aren't.

## What Type of PR Is This?

/kind bug

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
