### PR TITLE
Bump prow jobs to infra:1.23.7-2 image for ARM64 support

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.23.7-1
+        - image: ghcr.io/kcp-dev/infra/build:1.23.7-2
           command:
             - make
             - verify-boilerplate
@@ -27,7 +27,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.23.7-1
+        - image: ghcr.io/kcp-dev/infra/build:1.23.7-2
           command:
             - make
             - verify-codegen
@@ -44,7 +44,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.23.7-1
+        - image: ghcr.io/kcp-dev/infra/build:1.23.7-2
           command:
             - make
             - lint
@@ -83,7 +83,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.23.7-1
+        - image: ghcr.io/kcp-dev/infra/build:1.23.7-2
           command:
             - make
             - test
@@ -104,7 +104,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.23.7-1
+        - image: ghcr.io/kcp-dev/infra/build:1.23.7-2
           command:
             - ./hack/run-with-prow.sh
             - ./hack/run-with-prometheus.sh
@@ -133,7 +133,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.23.7-1
+        - image: ghcr.io/kcp-dev/infra/build:1.23.7-2
           command:
             - ./hack/run-with-prow.sh
             - ./hack/run-with-prometheus.sh
@@ -164,7 +164,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.23.7-1
+        - image: ghcr.io/kcp-dev/infra/build:1.23.7-2
           command:
             - ./hack/run-with-prow.sh
             - ./hack/run-with-prometheus.sh
@@ -191,7 +191,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.23.7-1
+        - image: ghcr.io/kcp-dev/infra/build:1.23.7-2
           command:
             - ./hack/run-with-prow.sh
             - ./hack/run-with-prometheus.sh


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

We have been building ARM64 variants of our build image for quite a while, but the build was flawed. We fixed that in https://github.com/kcp-dev/infra/pull/105, but haven't rolled out the new build image to kcp-dev/kcp.

## What Type of PR Is This?

/kind cleanup

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
