### PR TITLE
Bootstrap with pre-defined identities

### DIFF
--- a/config/root-identities/bootstrap.go
+++ b/config/root-identities/bootstrap.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rootidentities
+
+import (
+	"context"
+	"embed"
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+
+	confighelpers "github.com/kcp-dev/kcp/config/helpers"
+)
+
+//go:embed *.yaml
+var fs embed.FS
+
+// bootstrapIdentities is the structure we expect to receive
+// from --root-identities-file in YAML format.
+type bootstrapIdentities struct {
+	Identities []struct {
+		Export   string `json:"export"`
+		Identity string `json:"identity"`
+	} `json:"identities"`
+}
+
+// Bootstrap creates resources in this package by continuously retrying the list.
+// This is blocking, i.e. it only returns (with error) when the context is closed or with nil when
+// the bootstrapping is successfully completed.
+func Bootstrap(
+	ctx context.Context,
+	rootDiscoveryClient discovery.DiscoveryInterface,
+	rootDynamicClient dynamic.Interface,
+	kubeClient kubernetes.Interface,
+	bootstrapIdentitiesBytes []byte,
+) error {
+	var identities bootstrapIdentities
+	if err := yaml.UnmarshalStrict(bootstrapIdentitiesBytes, &identities); err != nil {
+		return fmt.Errorf("failed to parse bootstrap identities: %v", err)
+	}
+
+	for _, identity := range identities.Identities {
+		err := confighelpers.Bootstrap(ctx, kubeClient.Discovery(), rootDynamicClient, nil, fs, confighelpers.ReplaceOption(
+			"IDENTITY_APIEXPORT", identity.Export,
+			"IDENTITY_KEY", identity.Identity,
+		))
+		if err != nil {
+			return fmt.Errorf("failed to bootstrap identity secret for %s: %v", identity.Export, err)
+		}
+	}
+
+	return nil
+}

--- a/config/root-identities/namespace/bootstrap.go
+++ b/config/root-identities/namespace/bootstrap.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace
+
+import (
+	"context"
+	"embed"
+
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+
+	confighelpers "github.com/kcp-dev/kcp/config/helpers"
+)
+
+//go:embed *.yaml
+var fs embed.FS
+
+// Bootstrap creates resources in this package by continuously retrying the list.
+// This is blocking, i.e. it only returns (with error) when the context is closed or with nil when
+// the bootstrapping is successfully completed.
+func Bootstrap(
+	ctx context.Context,
+	rootDiscoveryClient discovery.DiscoveryInterface,
+	rootDynamicClient dynamic.Interface,
+	kubeClient kubernetes.Interface,
+) error {
+	return confighelpers.Bootstrap(ctx, kubeClient.Discovery(), rootDynamicClient, nil, fs)
+}

--- a/config/root-identities/namespace/namespace-kcp-system.yaml
+++ b/config/root-identities/namespace/namespace-kcp-system.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kcp-system
+  annotations:
+    bootstrap.kcp.io/create-only: "true"
+    kcp.io/cluster: root

--- a/config/root-identities/secret-identity.yaml
+++ b/config/root-identities/secret-identity.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: IDENTITY_APIEXPORT
+  namespace: kcp-system
+  annotations:
+    bootstrap.kcp.io/create-only: "true"
+stringData:
+  key: IDENTITY_KEY

--- a/pkg/server/options/options.go
+++ b/pkg/server/options/options.go
@@ -67,6 +67,7 @@ type ExtraOptions struct {
 	LogicalClusterAdminKubeconfig         string
 	ExternalLogicalClusterAdminKubeconfig string
 	ConversionCELTransformationTimeout    time.Duration
+	RootIdentitiesFile                    string
 	BatteriesIncluded                     []string
 	// DEVELOPMENT ONLY. AdditionalMappingsFile is the path to a file that contains additional mappings
 	// for the mini-front-proxy to use. The file should be in the format of the
@@ -166,6 +167,7 @@ func (o *Options) AddFlags(fss *cliflag.NamedFlagSets) {
 	fs.StringVar(&o.Extra.ShardClientKeyFile, "shard-client-key-file", o.Extra.ShardClientKeyFile, "Path to a client certificate key file the shard uses to communicate with other system components.")
 	fs.StringVar(&o.Extra.LogicalClusterAdminKubeconfig, "logical-cluster-admin-kubeconfig", o.Extra.LogicalClusterAdminKubeconfig, "Kubeconfig holding system:kcp:logical-cluster-admin credentials for connecting to other shards. Defaults to the loopback client")
 	fs.StringVar(&o.Extra.ExternalLogicalClusterAdminKubeconfig, "external-logical-cluster-admin-kubeconfig", o.Extra.ExternalLogicalClusterAdminKubeconfig, "Kubeconfig holding system:kcp:external-logical-cluster-admin credentials for connecting to the external address (e.g. the front-proxy). Defaults to the loopback client")
+	fs.StringVar(&o.Extra.RootIdentitiesFile, "root-identities-file", "", "Path to a YAML file used to bootstrap APIExport identities inside the root workspace. The YAML file must be structured as {\"identities\": [ {\"export\": \"<APIExport name>\", \"identity\": \"<APIExport identity>\"}, ... ]}. If a secret with matching APIExport name already exists inside kcp-system namespace, it will be left unchanged. Defaults to empty, i.e. no identities are bootstrapped.")
 
 	fs.BoolVar(&o.Extra.ExperimentalBindFreePort, "experimental-bind-free-port", o.Extra.ExperimentalBindFreePort, "Bind to a free port. --secure-port must be 0. Use the admin.kubeconfig to extract the chosen port.")
 	fs.MarkHidden("experimental-bind-free-port") //nolint:errcheck


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

This PR adds a way to inject identities from a file while performing phase0 bootstrapping, making it possible to override core identities with pre-defined ones.

The file is expected to by YAML-formatted, passed via `--root-identities-file` kcp command line flag; its structure is rather simple, see the linked issue for reference.

## What Type of PR Is This?

/kind feature

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes https://github.com/kcp-dev/kcp/issues/3320

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Adds a new --root-identities-file kcp cli flag used to bootstrap APIExport identities inside the root workspace
```
