### PR TITLE
Disable APIExport VirtualWorkspace URL population

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -349,7 +349,7 @@ test-e2e-sharded-minimal: build-all
 
 # This is just easy target to run 2 shard test server locally until manually killed.
 # You can targer test to it by running:
-# go test ./test/e2e/apibinding/... --kcp-kubeconfig=${WORK_DIR:-.}/.kcp/admin.kubeconfig --shard-kubeconfigs=root=${WORK_DIR:-.}/.kcp-0/admin.kubeconfig -run=^TestAPIBindingEndpointSlicesSharded$
+# go test ./test/e2e/apibinding/... --kcp-kubeconfig=$(pwd)/.kcp/admin.kubeconfig --shard-kubeconfigs=root=$(pwd)/.kcp-0/admin.kubeconfig -run=^TestAPIBinding$
 test-run-sharded-server: WORK_DIR ?= $(PWD)
 test-run-sharded-server: LOG_DIR ?= $(WORK_DIR)/.kcp
 test-run-sharded-server:

--- a/pkg/features/kcp_features.go
+++ b/pkg/features/kcp_features.go
@@ -47,6 +47,12 @@ const (
 	// alpha: v0.1
 	// Enables cache apis and controllers.
 	CacheAPIs featuregate.Feature = "CacheAPIs"
+
+	// owner: @mjudeikis
+	// alpha: v0.1
+	// Enables VirtualWorkspace urls on APIExport. This enables to use Deprecated APIExport VirtualWorkspace urls.
+	// This is a temporary feature to ease the migration to the new VirtualWorkspace urls.
+	EnableDeprecatedAPIExportVirtualWorkspacesUrls featuregate.Feature = "EnableDeprecatedAPIExportVirtualWorkspacesUrls"
 )
 
 // DefaultFeatureGate exposes the upstream feature gate, but with our gate setting applied.
@@ -120,7 +126,9 @@ var defaultVersionedGenericControlPlaneFeatureGates = map[featuregate.Feature]fe
 	CacheAPIs: {
 		{Version: version.MustParse("1.32"), Default: false, PreRelease: featuregate.Alpha},
 	},
-
+	EnableDeprecatedAPIExportVirtualWorkspacesUrls: {
+		{Version: version.MustParse("1.32"), Default: false, PreRelease: featuregate.Alpha},
+	},
 	// inherited features from generic apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:
 	genericfeatures.APIResponseCompression: {

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -1050,6 +1050,7 @@ func (s *Server) installAPIExportController(ctx context.Context, config *rest.Co
 	c, err := apiexport.NewController(
 		kcpClusterClient,
 		s.KcpSharedInformerFactory.Apis().V1alpha2().APIExports(),
+		s.KcpSharedInformerFactory.Apis().V1alpha1().APIExportEndpointSlices(),
 		s.CacheKcpSharedInformerFactory.Core().V1alpha1().Shards(),
 		kubeClusterClient,
 		s.KubeSharedInformerFactory.Core().V1().Namespaces(),
@@ -1068,6 +1069,7 @@ func (s *Server) installAPIExportController(ctx context.Context, config *rest.Co
 			return wait.PollUntilContextCancel(ctx, waitPollInterval, true, func(ctx context.Context) (bool, error) {
 				return s.ApiExtensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions().Informer().HasSynced() &&
 					s.KcpSharedInformerFactory.Apis().V1alpha2().APIExports().Informer().HasSynced() &&
+					s.KcpSharedInformerFactory.Apis().V1alpha1().APIExportEndpointSlices().Informer().HasSynced() &&
 					s.KubeSharedInformerFactory.Core().V1().Namespaces().Informer().HasSynced() &&
 					s.KubeSharedInformerFactory.Core().V1().Secrets().Informer().HasSynced(), nil
 			})

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -439,6 +439,7 @@ func (s *Server) Run(ctx context.Context) error {
 		logger.Info("finished bootstrapping the shard workspace")
 
 		go s.KcpSharedInformerFactory.Apis().V1alpha2().APIExports().Informer().Run(hookContext.Done())
+		go s.KcpSharedInformerFactory.Apis().V1alpha1().APIExportEndpointSlices().Informer().Run(hookContext.Done())
 		go s.CacheKcpSharedInformerFactory.Apis().V1alpha2().APIExports().Informer().Run(hookContext.Done())
 		go s.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters().Informer().Run(hookContext.Done())
 		go s.KcpSharedInformerFactory.Cache().V1alpha1().CachedResources().Informer().Run(hookContext.Done())

--- a/sdk/apis/apis/v1alpha2/types_apiexport.go
+++ b/sdk/apis/apis/v1alpha2/types_apiexport.go
@@ -26,6 +26,11 @@ import (
 	conditionsv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/third_party/conditions/apis/conditions/v1alpha1"
 )
 
+const (
+	// APIExportEndpointSliceSkipAnnotation is an annotation that can be set on an APIExport to skip the creation of default APIExportEndpointSlice.
+	APIExportEndpointSliceSkipAnnotation = "apiexports.apis.kcp.io/skip-endpointslice"
+)
+
 // These are valid conditions of APIExport.
 const (
 	APIExportIdentityValid conditionsv1alpha1.ConditionType = "IdentityValid"

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -32,7 +32,7 @@ import (
 	"github.com/kcp-dev/kcp/pkg/authorization"
 	bootstrappolicy "github.com/kcp-dev/kcp/pkg/authorization/bootstrap"
 	"github.com/kcp-dev/kcp/pkg/server"
-	apisv1alpha2 "github.com/kcp-dev/kcp/sdk/apis/apis/v1alpha2"
+	apisv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/apis/v1alpha1"
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/tenancy/v1alpha1"
 	kcpclientset "github.com/kcp-dev/kcp/sdk/client/clientset/versioned/cluster"
 	testing2 "github.com/kcp-dev/kcp/sdk/testing"
@@ -84,12 +84,10 @@ func VirtualWorkspaceURL(ctx context.Context, kcpClusterClient kcpclientset.Clus
 }
 
 // ExportVirtualWorkspaceURLs returns the URLs of the virtual workspaces of the
-// given APIExport.
-func ExportVirtualWorkspaceURLs(export *apisv1alpha2.APIExport) []string {
-	//nolint:staticcheck // SA1019 VirtualWorkspaces is deprecated but not removed yet
-	urls := make([]string, 0, len(export.Status.VirtualWorkspaces))
-	//nolint:staticcheck // SA1019 VirtualWorkspaces is deprecated but not removed yet
-	for _, vw := range export.Status.VirtualWorkspaces {
+// given APIExportEndpointSlice.
+func ExportVirtualWorkspaceURLs(export *apisv1alpha1.APIExportEndpointSlice) []string {
+	urls := make([]string, 0, len(export.Status.APIExportEndpoints))
+	for _, vw := range export.Status.APIExportEndpoints {
 		urls = append(urls, vw.URL)
 	}
 	return urls

--- a/test/e2e/reconciler/apiexportendpointslice/apiexportendpointslice_test.go
+++ b/test/e2e/reconciler/apiexportendpointslice/apiexportendpointslice_test.go
@@ -275,19 +275,6 @@ func TestAPIBindingEndpointSlicesSharded(t *testing.T) {
 		}
 	}
 
-	// TODO(mjudeikis): This will be deprecated when we deperecate APIExport urls.
-	t.Logf("Check that APIExport has 2 virtual workspaces")
-	{
-		kcpClusterClient, err := kcpclientset.NewForConfig(cfg)
-		require.NoError(t, err, "failed to construct kcp cluster client for server")
-
-		apiExport, err := kcpClusterClient.Cluster(providerPath).ApisV1alpha2().APIExports().Get(ctx, "today-cowboys", metav1.GetOptions{})
-		require.NoError(t, err)
-
-		//nolint:staticcheck // SA1019 VirtualWorkspaces is deprecated but not removed yet
-		require.Len(t, apiExport.Status.VirtualWorkspaces, len(shards.Items))
-	}
-
 	t.Logf("Create a topology PartitionSet for the providers")
 	var partition *topologyv1alpha1.Partition
 	{

--- a/test/e2e/virtual/apiexport/openapi_test.go
+++ b/test/e2e/virtual/apiexport/openapi_test.go
@@ -62,23 +62,25 @@ func TestAPIExportOpenAPI(t *testing.T) {
 
 	orgPath, _ := framework.NewOrganizationFixture(t, server) //nolint:staticcheck // TODO: switch to NewWorkspaceFixture.
 	serviceProviderPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)
-	_, consumerWorkspace := kcptesting.NewWorkspaceFixture(t, server, orgPath)
+	consumerPath, consumerWorkspace := kcptesting.NewWorkspaceFixture(t, server, orgPath)
 	consumerClusterName := logicalcluster.Name(consumerWorkspace.Spec.Cluster)
 
 	framework.AdmitWorkspaceAccess(ctx, t, kubeClusterClient, serviceProviderPath, []string{"user-1"}, nil, false)
 
 	setUpServiceProvider(ctx, t, dynamicClusterClient, kcpClients, serviceProviderPath, cfg, nil)
 
+	t.Logf("set up binding")
+	bindConsumerToProvider(ctx, t, consumerPath, serviceProviderPath, kcpClients, cfg)
+
 	t.Logf("Waiting for APIExport to have a virtual workspace URL for the bound workspace %q", consumerWorkspace.Name)
 	apiExportVWCfg := rest.CopyConfig(cfg)
 	kcptestinghelpers.Eventually(t, func() (bool, string) {
-		apiExport, err := kcpClients.Cluster(serviceProviderPath).ApisV1alpha2().APIExports().Get(ctx, "today-cowboys", metav1.GetOptions{})
+		apiExportEndpointSlice, err := kcpClients.Cluster(serviceProviderPath).ApisV1alpha1().APIExportEndpointSlices().Get(ctx, "today-cowboys", metav1.GetOptions{})
 		require.NoError(t, err)
 		var found bool
-		apiExportVWCfg.Host, found, err = framework.VirtualWorkspaceURL(ctx, kcpClients, consumerWorkspace, framework.ExportVirtualWorkspaceURLs(apiExport))
+		apiExportVWCfg.Host, found, err = framework.VirtualWorkspaceURL(ctx, kcpClients, consumerWorkspace, framework.ExportVirtualWorkspaceURLs(apiExportEndpointSlice))
 		require.NoError(t, err)
-		//nolint:staticcheck // SA1019 VirtualWorkspaces is deprecated but not removed yet
-		return found, fmt.Sprintf("waiting for virtual workspace URLs to be available: %v", apiExport.Status.VirtualWorkspaces)
+		return found, fmt.Sprintf("waiting for virtual workspace URLs to be available: %v", apiExportEndpointSlice.Status.APIExportEndpoints)
 	}, wait.ForeverTestTimeout, time.Millisecond*100)
 
 	t.Logf("Checking /openapi/v3 paths for %q", orgPath)

--- a/test/e2e/virtual/apiexport/virtualworkspace_test.go
+++ b/test/e2e/virtual/apiexport/virtualworkspace_test.go
@@ -110,13 +110,12 @@ func TestAPIExportVirtualWorkspace(t *testing.T) {
 	t.Logf("Waiting for APIExport to have a virtual workspace URL for the bound workspace %q", consumerWorkspace.Name)
 	apiExportVWCfg := rest.CopyConfig(cfg)
 	kcptestinghelpers.Eventually(t, func() (bool, string) {
-		apiExport, err := kcpClients.Cluster(serviceProviderPath).ApisV1alpha2().APIExports().Get(ctx, "today-cowboys", metav1.GetOptions{})
+		apiExportEndpointSlice, err := kcpClients.Cluster(serviceProviderPath).ApisV1alpha1().APIExportEndpointSlices().Get(ctx, "today-cowboys", metav1.GetOptions{})
 		require.NoError(t, err)
 		var found bool
-		apiExportVWCfg.Host, found, err = framework.VirtualWorkspaceURL(ctx, kcpClients, consumerWorkspace, framework.ExportVirtualWorkspaceURLs(apiExport))
+		apiExportVWCfg.Host, found, err = framework.VirtualWorkspaceURL(ctx, kcpClients, consumerWorkspace, framework.ExportVirtualWorkspaceURLs(apiExportEndpointSlice))
 		require.NoError(t, err)
-		//nolint:staticcheck // SA1019 VirtualWorkspaces is deprecated but not removed yet
-		return found, fmt.Sprintf("waiting for virtual workspace URLs to be available: %v", apiExport.Status.VirtualWorkspaces)
+		return found, fmt.Sprintf("waiting for virtual workspace URLs to be available: %v", apiExportEndpointSlice.Status.APIExportEndpoints)
 	}, wait.ForeverTestTimeout, time.Millisecond*100)
 
 	t.Logf("Verifying that the virtual workspace includes the cowboy resource")
@@ -611,13 +610,12 @@ func TestAPIExportPermissionClaims(t *testing.T) {
 	t.Logf("Waiting for cowboy APIExport to have a virtual workspace URL for the bound workspaces %q", consumer1Path)
 	consumer1VWCfg := rest.CopyConfig(cfg)
 	kcptestinghelpers.Eventually(t, func() (bool, string) {
-		apiExport, err := kcpClusterClient.Cluster(claimerPath).ApisV1alpha2().APIExports().Get(ctx, "today-cowboys", metav1.GetOptions{})
+		apiExportEndpointSlice, err := kcpClusterClient.Cluster(claimerPath).ApisV1alpha1().APIExportEndpointSlices().Get(ctx, "today-cowboys", metav1.GetOptions{})
 		require.NoError(t, err)
 		var found bool
-		consumer1VWCfg.Host, found, err = framework.VirtualWorkspaceURL(ctx, kcpClusterClient, consumer1, framework.ExportVirtualWorkspaceURLs(apiExport))
+		consumer1VWCfg.Host, found, err = framework.VirtualWorkspaceURL(ctx, kcpClusterClient, consumer1, framework.ExportVirtualWorkspaceURLs(apiExportEndpointSlice))
 		require.NoError(t, err)
-		//nolint:staticcheck // SA1019 VirtualWorkspaces is deprecated but not removed yet
-		return found, fmt.Sprintf("waiting for virtual workspace URLs to be available: %v", apiExport.Status.VirtualWorkspaces)
+		return found, fmt.Sprintf("waiting for virtual workspace URLs to be available: %v", apiExportEndpointSlice.Status.APIExportEndpoints)
 	}, wait.ForeverTestTimeout, time.Millisecond*100)
 
 	t.Logf("Verify that the exported resource is retrievable")


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Disable APIExport URL population. 

## What Type of PR Is This?
/kind feature
/kind deprecation
<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes https://github.com/kcp-dev/kcp/issues/3366

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Deprecated APIExport VirtualWorksapce URL population
Add FeatureFlag to re-enable deprecated APIExport VirtualWorkspace URLs. 
```
