### PR TITLE
Improvements for webhooks docs and tests

### DIFF
--- a/docs/content/concepts/apis/admission-webhooks.md
+++ b/docs/content/concepts/apis/admission-webhooks.md
@@ -1,0 +1,48 @@
+# Admission Webhooks
+
+kcp extends the vanilla [admission plugins](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/) for webhooks, and makes them cluster-aware.
+
+```
+                                                          ┌────────────────────────┐
+                                                          │ Consumer Workspace ws2 │
+                                                          ├────────────────────────┤
+                                                          │                        │
+                                                     ┌────┼─ Widgets APIBinding    │
+                                                     │    │                        │
+                                                     │    │  Widget a              │
+┌───────────────────────────────────────────────┐    │    │  Widget b              │
+│            API Provider Workspace ws1         │    │    │  Widget c              │
+├───────────────────────────────────────────────┤    │    │                        │
+│                                               │    │    └────────────────────────┘
+│              Widgets APIExport ◄──────────────┼────┤                              
+│                      │                        │    │                              
+│                      ▼                        │    │                              
+│          Widgets APIResourceSchema            │    │    ┌────────────────────────┐
+│           (widgets.v1.example.org)            │    │    │ Consumer Workspace ws3 │
+│                      ▲                        │    │    ├────────────────────────┤
+│                      │                        │    │    │                        │
+│  ┌───────────────────┴─────────────────────┐  │    └────┼─ Widgets APIBinding    │
+│  │ Mutating/ValidatingWebhookConfiguration │  │         │                        │
+│  │   for widgets.v1.example.org            │  │         │  Widget a              │
+│  │                                         │  │         │  Widget b              │
+│  │   Handle a from ws2 (APIResourceSchema) │  │         │  Widget c              │
+│  │   Handle b from ws3 (APIResourceSchema) │  │         │                        │
+│  │   Handle a from ws1 (CRD)               │  │         └────────────────────────┘
+│  │   ...                                   │  │                                   
+│  └───────────────────┬─────────────────────┘  │                                   
+│                      │                        │                                   
+│                      ▼                        │                                   
+│       Widgets CustomResourceDefinition        │                                   
+│        (widgets.v1.example.org)               │
+│                                               │                                   
+│       Widget a                                │                                   
+│                                               │                                   
+└───────────────────────────────────────────────┘                                   
+```
+
+When an object is to be mutated or validated, the webhook admission plugin ([`apis.kcp.io/MutatingWebhook`](https://github.com/kcp-dev/kcp/tree/main/pkg/admission/mutatingwebhook) and [`apis.kcp.io/ValidatingWebhook`](https://github.com/kcp-dev/kcp/tree/main/pkg/admission/validatingwebhook) respectively) looks for the owner of the resource schema. Once found, it then dispatches the handling for that object in the owner's workspace. There are two such cases in the diagram above:
+
+* **Admitting bound resources.** During the request handling, Widget objects inside the consumer workspaces `ws2` and `ws3` are picked up by the respective webhook admission plugin. The plugin sees the resource's schema comes from an APIBinding, and so it sets up an instance of `{Mutating,Validating}Webhook` to be working with its APIExport's workspace, in `ws1`. Afterwards, normal webhook admission flow continues: the request is dispatched to all eligible webhook configurations inside `ws1` and the object in request is mutated or validated.
+* **Admitting local resources.** The second case is when the webhook configuration exists in the same workspace as the object it's handling. The admission plugin sees the resource is not sourced via an APIBinding, and so it looks for eligible webhook configurations locally, and dispatches the request to the webhooks there. The same would of course be true if APIExport and its APIBinding lived in the same workspace: the APIExport would resolve to the same cluster.
+
+Lastly, objects in admission review are annotated with the name of the workspace that owns that object. For example, when Widget `b` from `ws3` is being validated, its caught by `ValidatingWebhookConfiguration` in `ws1`, but the webhook will see `kcp.io/cluster: ws3` annotation on the reviewed object.

--- a/test/e2e/fixtures/webhook/webhook.go
+++ b/test/e2e/fixtures/webhook/webhook.go
@@ -34,7 +34,7 @@ import (
 )
 
 type AdmissionWebhookServer struct {
-	ResponseFn   func(review *admissionv1.AdmissionReview) (*admissionv1.AdmissionResponse, error)
+	ResponseFn   func(obj runtime.Object, review *admissionv1.AdmissionReview) (*admissionv1.AdmissionResponse, error)
 	ObjectGVK    schema.GroupVersionKind
 	Deserializer runtime.Decoder
 
@@ -156,7 +156,7 @@ func (s *AdmissionWebhookServer) ServeHTTP(resp http.ResponseWriter, req *http.R
 	responseAdmissionReview := &admissionv1.AdmissionReview{
 		TypeMeta: requestedAdmissionReview.TypeMeta,
 	}
-	r, err := s.ResponseFn(requestedAdmissionReview)
+	r, err := s.ResponseFn(obj, requestedAdmissionReview)
 	if err != nil {
 		s.t.Logf("%v", err)
 		http.Error(resp, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

This PR adds more checks for apibinding webhook tests. Also adds docs to note down the behavior of kcp's webhook admission plugins.

## What Type of PR Is This?

/kind documentation

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes https://github.com/kcp-dev/kcp/issues/3294

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
