### PR TITLE
Fix `--bind-address`

### DIFF
--- a/cmd/sharded-test-server/cache.go
+++ b/cmd/sharded-test-server/cache.go
@@ -39,7 +39,7 @@ import (
 	kcptestingserver "github.com/kcp-dev/kcp/sdk/testing/server"
 )
 
-func startCacheServer(ctx context.Context, logDirPath, workingDir string, syntheticDelay time.Duration) (<-chan error, string, error) {
+func startCacheServer(ctx context.Context, logDirPath, workingDir, hostIP string, syntheticDelay time.Duration) (<-chan error, string, error) {
 	cyan := color.New(color.BgHiCyan, color.FgHiWhite).SprintFunc()
 	inverse := color.New(color.BgHiWhite, color.FgHiCyan).SprintFunc()
 	out := lineprefix.New(
@@ -56,6 +56,7 @@ func startCacheServer(ctx context.Context, logDirPath, workingDir string, synthe
 	commandLine = append(
 		commandLine,
 		fmt.Sprintf("--root-directory=%s", cacheWorkingDir),
+		"--bind-address="+hostIP,
 		"--embedded-etcd-client-port=8010",
 		"--embedded-etcd-peer-port=8011",
 		fmt.Sprintf("--secure-port=%d", cachePort),

--- a/cmd/sharded-test-server/frontproxy.go
+++ b/cmd/sharded-test-server/frontproxy.go
@@ -132,6 +132,7 @@ func startFrontProxy(
 
 	// run front-proxy command
 	commandLine := append(kcptestingserver.Command("kcp-front-proxy", "front-proxy"),
+		"--bind-address="+hostIP,
 		fmt.Sprintf("--mapping-file=%s", filepath.Join(workDirPath, ".kcp-front-proxy/mapping.yaml")),
 		fmt.Sprintf("--root-directory=%s", filepath.Join(workDirPath, ".kcp-front-proxy")),
 		fmt.Sprintf("--root-kubeconfig=%s", filepath.Join(workDirPath, ".kcp/root.kubeconfig")),

--- a/cmd/sharded-test-server/main.go
+++ b/cmd/sharded-test-server/main.go
@@ -28,7 +28,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	machineryutilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	kuser "k8s.io/apiserver/pkg/authentication/user"
@@ -192,17 +191,13 @@ func start(proxyFlags, shardFlags []string, logDirPath, workDirPath string, numb
 		return fmt.Errorf("failed to create service-account-signing-ca: %w", err)
 	}
 
-	// find external IP to put into certs as valid IPs
-	hostIP, err := machineryutilnet.ResolveBindAddress(net.IPv4(0, 0, 0, 0))
-	if err != nil {
-		return err
-	}
+	hostIP := net.IPv4(127, 0, 0, 1)
 
 	standaloneVW := sets.New[string](shardFlags...).Has("--run-virtual-workspaces=false")
 
 	cacheServerErrCh := make(chan indexErrTuple)
 	cacheServerConfigPath := ""
-	cacheServerCh, configPath, err := startCacheServer(ctx, logDirPath, workDirPath, cacheSyntheticDelay)
+	cacheServerCh, configPath, err := startCacheServer(ctx, logDirPath, workDirPath, hostIP.String(), cacheSyntheticDelay)
 	if err != nil {
 		return fmt.Errorf("error starting the cache server: %w", err)
 	}

--- a/cmd/sharded-test-server/virtual.go
+++ b/cmd/sharded-test-server/virtual.go
@@ -142,8 +142,7 @@ func newVirtualWorkspace(ctx context.Context, index int, servingCA *crypto.CA, h
 		return nil, err
 	}
 
-	var args []string
-	args = append(args,
+	args := []string{
 		fmt.Sprintf("--kubeconfig=%s", kubeconfigPath),
 		fmt.Sprintf("--shard-external-url=https://%s:%d", hostIP, 6443),
 		fmt.Sprintf("--cache-kubeconfig=%s", cacheServerConfigPath),
@@ -151,6 +150,7 @@ func newVirtualWorkspace(ctx context.Context, index int, servingCA *crypto.CA, h
 		fmt.Sprintf("--client-ca-file=%s", clientCAFilePath),
 		fmt.Sprintf("--tls-private-key-file=%s", servingKeyFile),
 		fmt.Sprintf("--tls-cert-file=%s", servingCertFile),
+		fmt.Sprintf("--bind-address=%s", hostIP),
 		fmt.Sprintf("--secure-port=%s", virtualWorkspacePort(index)),
 		"--audit-log-maxsize=1024",
 		"--audit-log-mode=batch",
@@ -161,7 +161,7 @@ func newVirtualWorkspace(ctx context.Context, index int, servingCA *crypto.CA, h
 		"--audit-log-batch-throttle-enable=true",
 		"--audit-log-batch-throttle-qps=10",
 		fmt.Sprintf("--audit-policy-file=%s", auditPolicyFile),
-	)
+	}
 
 	return &VirtualWorkspace{
 		index:       index,

--- a/cmd/test-server/kcp/shard.go
+++ b/cmd/test-server/kcp/shard.go
@@ -99,6 +99,7 @@ func (s *Shard) Start(ctx context.Context, quiet bool) error {
 	commandLine = append(commandLine, s.args...)
 	commandLine = append(commandLine,
 		"--root-directory", s.runtimeDir,
+		"--bind-address=127.0.0.1",
 		"--token-auth-file", framework.DefaultTokenAuthFile,
 		"--audit-log-maxsize", "1024",
 		"--audit-log-mode=batch",

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -155,6 +155,7 @@ type CompletedConfig struct {
 // Complete fills in any fields not set that are required to have valid data. It's mutating the receiver.
 func (c *Config) Complete() (CompletedConfig, error) {
 	miniAggregator := c.MiniAggregator.Complete()
+
 	return CompletedConfig{&completedConfig{
 		Options: c.Options,
 

--- a/pkg/server/options/options.go
+++ b/pkg/server/options/options.go
@@ -287,6 +287,22 @@ func (o *Options) Complete(ctx context.Context, rootDir string) (*CompletedOptio
 		}
 	}
 
+	// ExternalAddress is the address used e.g. when generating
+	// kubeconfigs. It defaults to the default interface, usually the
+	// first non-loopback interface, e.g. 192.168.0.1.
+	// BindAddress is the address the server binds to, it defaults to
+	// 0.0.0.0 or ::.
+	//
+	// If BindAddress is set to a specific address, e.g. the loopback
+	// 127.0.0.1 the ExternalAddress is invalid and all URLs generated
+	// from it will not work.
+	//
+	// To prevent this ExternalAddress is set to the value of
+	// BindAddress if it wasn't set to a specific address.
+	if o.GenericControlPlane.GenericServerRunOptions.ExternalHost == "" && !o.GenericControlPlane.SecureServing.BindAddress.IsUnspecified() {
+		o.GenericControlPlane.GenericServerRunOptions.ExternalHost = o.GenericControlPlane.SecureServing.BindAddress.String()
+	}
+
 	if o.Extra.ExperimentalBindFreePort {
 		listener, _, err := genericapiserveroptions.CreateListener("tcp", fmt.Sprintf("%s:0", o.GenericControlPlane.SecureServing.BindAddress), net.ListenConfig{})
 		if err != nil {

--- a/sdk/testing/config.go
+++ b/sdk/testing/config.go
@@ -28,7 +28,8 @@ type SharedKcpOption func()
 
 var (
 	sharedConfig = kcptestingserver.Config{
-		Name: "shared",
+		Name:        "shared",
+		BindAddress: "127.0.0.1",
 	}
 	externalConfig = struct {
 		kubeconfigPath       string

--- a/sdk/testing/kcp.go
+++ b/sdk/testing/kcp.go
@@ -35,7 +35,10 @@ var fs embed.FS
 func PrivateKcpServer(t TestingT, options ...kcptestingserver.Option) kcptestingserver.RunningServer {
 	t.Helper()
 
-	cfg := &kcptestingserver.Config{Name: "main"}
+	cfg := &kcptestingserver.Config{
+		Name:        "main",
+		BindAddress: "127.0.0.1",
+	}
 	for _, opt := range options {
 		opt(cfg)
 	}

--- a/sdk/testing/server/config.go
+++ b/sdk/testing/server/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	ArtifactDir string
 	DataDir     string
 	ClientCADir string
+	BindAddress string
 
 	LogToConsole bool
 	RunInProcess bool
@@ -82,5 +83,12 @@ func WithRunInProcess() Option {
 func WithLogToConsole() Option {
 	return func(cfg *Config) {
 		cfg.LogToConsole = true
+	}
+}
+
+// WithBindAddress sets the kcp server to log to console.
+func WithBindAddress(addr string) Option {
+	return func(cfg *Config) {
+		cfg.BindAddress = addr
 	}
 }

--- a/sdk/testing/server/fixture.go
+++ b/sdk/testing/server/fixture.go
@@ -203,21 +203,23 @@ func newKcpServer(t TestingT, cfg Config) (*kcpServer, error) {
 		return nil, err
 	}
 
-	s.cfg.Args = append(
-		[]string{
-			"--root-directory",
-			s.cfg.DataDir,
-			"--secure-port=" + kcpListenPort,
-			"--embedded-etcd-client-port=" + etcdClientPort,
-			"--embedded-etcd-peer-port=" + etcdPeerPort,
-			"--embedded-etcd-wal-size-bytes=" + strconv.Itoa(5*1000), // 5KB
-			"--kubeconfig-path=" + s.KubeconfigPath(),
-			"--feature-gates=" + fmt.Sprintf("%s", utilfeature.DefaultFeatureGate),
-			"--audit-log-path", filepath.Join(s.cfg.ArtifactDir, "kcp.audit"),
-			"--v=4",
-		},
-		s.cfg.Args...,
-	)
+	args := []string{
+		"--root-directory", s.cfg.DataDir,
+		"--secure-port=" + kcpListenPort,
+		"--embedded-etcd-client-port=" + etcdClientPort,
+		"--embedded-etcd-peer-port=" + etcdPeerPort,
+		"--embedded-etcd-wal-size-bytes=" + strconv.Itoa(5*1000), // 5KB
+		"--kubeconfig-path=" + s.KubeconfigPath(),
+		"--feature-gates=" + fmt.Sprintf("%s", utilfeature.DefaultFeatureGate),
+		"--audit-log-path", filepath.Join(s.cfg.ArtifactDir, "kcp.audit"),
+		"--v=4",
+	}
+
+	if cfg.BindAddress != "" {
+		args = append(args, "--bind-address="+cfg.BindAddress)
+	}
+
+	s.cfg.Args = append(args, s.cfg.Args...)
 
 	return s, nil
 }

--- a/test/e2e/apibinding/apibinding_webhook_test.go
+++ b/test/e2e/apibinding/apibinding_webhook_test.go
@@ -157,7 +157,7 @@ func TestAPIBindingMutatingWebhook(t *testing.T) {
 		port, err := kcptestingserver.GetFreePort(t)
 		require.NoError(t, err, "failed to get free port for test webhook")
 		dirPath := filepath.Dir(server.KubeconfigPath())
-		testWebhooks[cluster].StartTLS(t, filepath.Join(dirPath, "apiserver.crt"), filepath.Join(dirPath, "apiserver.key"), port)
+		testWebhooks[cluster].StartTLS(t, filepath.Join(dirPath, "apiserver.crt"), filepath.Join(dirPath, "apiserver.key"), cfg.Host, port)
 
 		sideEffect := admissionregistrationv1.SideEffectClassNone
 		url := testWebhooks[cluster].GetURL()
@@ -312,7 +312,7 @@ func TestAPIBindingValidatingWebhook(t *testing.T) {
 		port, err := kcptestingserver.GetFreePort(t)
 		require.NoError(t, err, "failed to get free port for test webhook")
 		dirPath := filepath.Dir(server.KubeconfigPath())
-		testWebhooks[cluster].StartTLS(t, filepath.Join(dirPath, "apiserver.crt"), filepath.Join(dirPath, "apiserver.key"), port)
+		testWebhooks[cluster].StartTLS(t, filepath.Join(dirPath, "apiserver.crt"), filepath.Join(dirPath, "apiserver.key"), cfg.Host, port)
 
 		kcptestinghelpers.Eventually(t, func() (bool, string) {
 			cl := gohttp.Client{Transport: &gohttp.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}

--- a/test/e2e/conformance/webhook_test.go
+++ b/test/e2e/conformance/webhook_test.go
@@ -94,7 +94,7 @@ func TestMutatingWebhookInWorkspace(t *testing.T) {
 	port, err := kcptestingserver.GetFreePort(t)
 	require.NoError(t, err, "failed to get free port for test webhook")
 	dirPath := filepath.Dir(server.KubeconfigPath())
-	testWebhook.StartTLS(t, filepath.Join(dirPath, "apiserver.crt"), filepath.Join(dirPath, "apiserver.key"), port)
+	testWebhook.StartTLS(t, filepath.Join(dirPath, "apiserver.crt"), filepath.Join(dirPath, "apiserver.key"), cfg.Host, port)
 
 	orgPath, _ := framework.NewOrganizationFixture(t, server) //nolint:staticcheck // TODO: switch to NewWorkspaceFixture.
 	ws1Path, ws1 := kcptesting.NewWorkspaceFixture(t, server, orgPath)
@@ -212,7 +212,7 @@ func TestValidatingWebhookInWorkspace(t *testing.T) {
 	port, err := kcptestingserver.GetFreePort(t)
 	require.NoError(t, err, "failed to get free port for test webhook")
 	dirPath := filepath.Dir(server.KubeconfigPath())
-	testWebhook.StartTLS(t, filepath.Join(dirPath, "apiserver.crt"), filepath.Join(dirPath, "apiserver.key"), port)
+	testWebhook.StartTLS(t, filepath.Join(dirPath, "apiserver.crt"), filepath.Join(dirPath, "apiserver.key"), cfg.Host, port)
 
 	orgPath, _ := framework.NewOrganizationFixture(t, server) //nolint:staticcheck // TODO: switch to NewWorkspaceFixture.
 	ws1, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)

--- a/test/integration/framework/server.go
+++ b/test/integration/framework/server.go
@@ -44,6 +44,7 @@ func StartTestServer(tb testing.TB, opts ...kcptestingserver.Option) (kcptesting
 			[]kcptestingserver.Option{
 				kcptestingserver.WithDefaultsFrom(tb),
 				kcptestingserver.WithRunInProcess(),
+				kcptestingserver.WithBindAddress("127.0.0.1"),
 			},
 			opts...,
 		)...,


### PR DESCRIPTION
## Summary

Fix `--bind-address`

The fix is really only this commit, that sets the ExternalAddress if BindAddress is set:  [`eff92dd` (#3418)](https://github.com/kcp-dev/kcp/pull/3418/commits/eff92ddf7200ea05a19416193fbcaced39038cbc)

The others are changing the tests to run on localhost, which I had wanted to implement previously but failed one one hand because the ExternalAddress was the default IP rather than the BindAddress and because the loopback addresses were missing the in the certificates.

## What Type of PR Is This?

/kind bug

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #3404 

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Fix `--bind-address` not being honoured in some generated configuration files
```
