### PR TITLE
Disable notice on `--short`

### DIFF
--- a/cli/pkg/workspace/plugin/use.go
+++ b/cli/pkg/workspace/plugin/use.go
@@ -127,17 +127,19 @@ func (o *UseWorkspaceOptions) Run(ctx context.Context) (err error) {
 		name = "~" + strings.TrimPrefix(name, home)
 	}
 	name = strings.ReplaceAll(name, "/", ":")
-	if name == core.RootCluster.String() || strings.HasPrefix(name, core.RootCluster.String()+":") {
+	if name == core.RootCluster.String() || strings.HasPrefix(name, core.RootCluster.String()+":") && !o.ShortWorkspaceOutput {
 		// LEGACY(mjudeikis): Remove once everybody gets used to this
 		name = ":" + name
 		fmt.Fprintf(o.ErrOut, "Note: Using 'root:' to define an absolute path is no longer supported. Instead, use ':root' to specify an absolute path.\n")
 	}
 	if name == "" {
-		defer func() {
-			if err == nil {
-				_, err = fmt.Fprintf(o.ErrOut, "Note: 'kubectl ws' now matches 'cd' semantics: go to home workspace. 'kubectl ws -' to go back. 'kubectl ws .' to print current workspace.\n")
-			}
-		}()
+		if !o.ShortWorkspaceOutput {
+			defer func() {
+				if err == nil {
+					_, err = fmt.Fprintf(o.ErrOut, "Note: 'kubectl ws' now matches 'cd' semantics: go to home workspace. 'kubectl ws -' to go back. 'kubectl ws .' to print current workspace.\n")
+				}
+			}()
+		}
 		name = "~"
 	}
 


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

See #657 

## What Type of PR Is This?

/kind bug

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #657

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Disable the `cd semantic` notice when `--short` is provided
```
