### PR TITLE
Point PermissionClaim verbs test to the correct workspace

### DIFF
--- a/test/e2e/virtual/apiexport/binding_test.go
+++ b/test/e2e/virtual/apiexport/binding_test.go
@@ -230,7 +230,7 @@ func TestAPIBindingPermissionClaimsVerbs(t *testing.T) {
 	t.Cleanup(cancel)
 
 	orgPath, _ := framework.NewOrganizationFixture(t, server) //nolint:staticcheck // TODO: switch to NewWorkspaceFixture.
-	providerPath, providerWorkspace := kcptesting.NewWorkspaceFixture(t, server, orgPath)
+	providerPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)
 	consumerPath, consumerWorkspace := kcptesting.NewWorkspaceFixture(t, server, orgPath)
 	consumerClusterName := logicalcluster.Name(consumerWorkspace.Spec.Cluster)
 
@@ -288,7 +288,7 @@ func TestAPIBindingPermissionClaimsVerbs(t *testing.T) {
 		apiExport, err := kcpClusterClient.Cluster(providerPath).ApisV1alpha2().APIExports().Get(ctx, "today-cowboys", metav1.GetOptions{})
 		require.NoError(t, err)
 		var found bool
-		apiExportVWCfg.Host, found, err = framework.VirtualWorkspaceURL(ctx, kcpClusterClient, providerWorkspace, framework.ExportVirtualWorkspaceURLs(apiExport))
+		apiExportVWCfg.Host, found, err = framework.VirtualWorkspaceURL(ctx, kcpClusterClient, consumerWorkspace, framework.ExportVirtualWorkspaceURLs(apiExport))
 		require.NoError(t, err)
 		//nolint:staticcheck // SA1019 VirtualWorkspaces is deprecated but not removed yet
 		return found, fmt.Sprintf("waiting for virtual workspace URLs to be available: %v", apiExport.Status.VirtualWorkspaces)


### PR DESCRIPTION
## Summary

Point the `TestAPIBindingPermissionClaimsVerbs` to the consumer workspace (where the APIBinding is) instead to the provider workspace. This caused the sharded test to flake because it couldn't access the APIBinding to read verbs from.

## What Type of PR Is This?

/kind flake

## Related Issue(s)

xref #3255 

## Release Notes
```release-note
NONE
```