### PR TITLE
Serve both v1alpha1 and v1alpha2 APIBindings in APIExport VW, fix virtual workspace OpenAPI v3 panics

### DIFF
--- a/pkg/virtual/apiexport/builder/build.go
+++ b/pkg/virtual/apiexport/builder/build.go
@@ -179,7 +179,7 @@ func BuildVirtualWorkspace(
 						cancelFn:      cancelFn,
 					}, nil
 				},
-				func(ctx context.Context, clusterName logicalcluster.Name, apiExportName string) (apidefinition.APIDefinition, error) {
+				func(ctx context.Context, apibindingVersion string, clusterName logicalcluster.Name, apiExportName string) (apidefinition.APIDefinition, error) {
 					restProvider, err := provideAPIExportFilteredRestStorage(ctx, impersonatedDynamicClientGetter, clusterName, apiExportName)
 					if err != nil {
 						return nil, err
@@ -188,7 +188,7 @@ func BuildVirtualWorkspace(
 					return apiserver.CreateServingInfoFor(
 						mainConfig,
 						schemas.ApisKcpDevSchemas["apibindings"],
-						apisv1alpha1.SchemeGroupVersion.Version,
+						apibindingVersion,
 						restProvider,
 					)
 				},

--- a/pkg/virtual/apiexport/controllers/apireconciler/apiexport_apireconciler_controller.go
+++ b/pkg/virtual/apiexport/controllers/apireconciler/apiexport_apireconciler_controller.go
@@ -62,7 +62,7 @@ func NewAPIReconciler(
 	apiResourceSchemaInformer apisv1alpha1informers.APIResourceSchemaClusterInformer,
 	apiExportInformer apisv1alpha2informers.APIExportClusterInformer,
 	createAPIDefinition CreateAPIDefinitionFunc,
-	createAPIBindingAPIDefinition func(ctx context.Context, clusterName logicalcluster.Name, apiExportName string) (apidefinition.APIDefinition, error),
+	createAPIBindingAPIDefinition func(ctx context.Context, apibindingVersion string, clusterName logicalcluster.Name, apiExportName string) (apidefinition.APIDefinition, error),
 ) (*APIReconciler, error) {
 	c := &APIReconciler{
 		kcpClusterClient: kcpClusterClient,
@@ -138,7 +138,7 @@ type APIReconciler struct {
 	queue workqueue.TypedRateLimitingInterface[string]
 
 	createAPIDefinition           CreateAPIDefinitionFunc
-	createAPIBindingAPIDefinition func(ctx context.Context, clusterName logicalcluster.Name, apiExportName string) (apidefinition.APIDefinition, error)
+	createAPIBindingAPIDefinition func(ctx context.Context, apibindingVersion string, clusterName logicalcluster.Name, apiExportName string) (apidefinition.APIDefinition, error)
 
 	mutex   sync.RWMutex // protects the map, not the values!
 	apiSets map[dynamiccontext.APIDomainKey]apidefinition.APIDefinitionSet

--- a/pkg/virtual/apiexport/controllers/apireconciler/apiexport_apireconciler_reconcile.go
+++ b/pkg/virtual/apiexport/controllers/apireconciler/apiexport_apireconciler_reconcile.go
@@ -244,19 +244,20 @@ func (c *APIReconciler) reconcile(ctx context.Context, apiExport *apisv1alpha2.A
 
 	// always serve apibindings, either through a claim, or with this fallback
 	if !claimsAPIBindings {
-		d, err := c.createAPIBindingAPIDefinition(ctx, clusterName, apiExport.Name)
-		if err != nil {
-			// TODO(ncdc): would be nice to expose some sort of user-visible error
-			logger.Error(err, "error creating api definition for apibindings")
-		}
+		for _, gvr := range []schema.GroupVersionResource{apisv1alpha1.SchemeGroupVersion.WithResource("apibindings"), apisv1alpha2.SchemeGroupVersion.WithResource("apibindings")} {
+			d, err := c.createAPIBindingAPIDefinition(ctx, gvr.Version, clusterName, apiExport.Name)
+			if err != nil {
+				// TODO(ncdc): would be nice to expose some sort of user-visible error
+				logger.Error(err, "error creating api definition for apibindings")
+			}
 
-		gvr := apisv1alpha2.SchemeGroupVersion.WithResource("apibindings")
-		newSet[gvr] = apiResourceSchemaApiDefinition{
-			APIDefinition: d,
-		}
-		newGVRs = append(newGVRs, gvrString(gvr))
-		if _, ok := oldSet[gvr]; ok {
-			preservedGVR = append(preservedGVR, gvrString(gvr))
+			newSet[gvr] = apiResourceSchemaApiDefinition{
+				APIDefinition: d,
+			}
+			newGVRs = append(newGVRs, gvrString(gvr))
+			if _, ok := oldSet[gvr]; ok {
+				preservedGVR = append(preservedGVR, gvrString(gvr))
+			}
 		}
 	}
 

--- a/pkg/virtual/framework/dynamic/apiserver/openapi.go
+++ b/pkg/virtual/framework/dynamic/apiserver/openapi.go
@@ -228,7 +228,9 @@ func (o *openAPIHandler) handleOpenAPIRequest(apiSet apidefinition.APIDefinition
 		}
 
 		groupPath := "apis/" + gv.Group
-		webservices[groupPath] = append(webservices[groupPath], discovery.NewAPIGroupHandler(codecs, apiGroup).WebService())
+		if _, ok := webservices[groupPath]; !ok {
+			webservices[groupPath] = append(webservices[groupPath], discovery.NewAPIGroupHandler(codecs, apiGroup).WebService())
+		}
 	}
 
 	// Build OpenAPI v3 spec for /apis/<group> webservices

--- a/test/e2e/virtual/apiexport/apiresourceschema_cowboys_versions.yaml
+++ b/test/e2e/virtual/apiexport/apiresourceschema_cowboys_versions.yaml
@@ -1,0 +1,81 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIResourceSchema
+metadata:
+  name: today.cowboys.wildwest.dev
+spec:
+  group: wildwest.dev
+  names:
+    kind: Cowboy
+    listKind: CowboyList
+    plural: cowboys
+    singular: cowboy
+  scope: Namespaced
+  conversion:
+    strategy: None
+  versions:
+  - name: v1alpha1
+    schema:
+      description: Cowboy is part of the wild west
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CowboySpec holds the desired state of the Cowboy.
+          properties:
+            intent:
+              type: string
+          type: object
+        status:
+          description: CowboyStatus communicates the observed state of the Cowboy.
+          properties:
+            result:
+              type: string
+          type: object
+      type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - name: v1alpha2
+    schema:
+      description: Cowboy is part of the wild west
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CowboySpec holds the desired state of the Cowboy.
+          properties:
+            intent:
+              type: string
+          type: object
+        status:
+          description: CowboyStatus communicates the observed state of the Cowboy.
+          properties:
+            result:
+              type: string
+          type: object
+      type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}

--- a/test/e2e/virtual/apiexport/binding_test.go
+++ b/test/e2e/virtual/apiexport/binding_test.go
@@ -262,7 +262,7 @@ func TestAPIBindingPermissionClaimsVerbs(t *testing.T) {
 	permissionClaims := defaultPermissionsClaims(identityHash, pcModifiers...)
 
 	t.Logf("set up service provider with permission claims")
-	setUpServiceProvider(ctx, t, dynamicClusterClient, kcpClusterClient, providerPath, cfg, permissionClaims)
+	setUpServiceProvider(ctx, t, dynamicClusterClient, kcpClusterClient, false, providerPath, cfg, permissionClaims)
 
 	t.Logf("set up binding")
 	bindConsumerToProvider(ctx, t, consumerPath, providerPath, kcpClusterClient, cfg, permissionClaimsToAcceptable(permissionClaims)...)

--- a/test/e2e/virtual/apiexport/openapi_test.go
+++ b/test/e2e/virtual/apiexport/openapi_test.go
@@ -67,7 +67,7 @@ func TestAPIExportOpenAPI(t *testing.T) {
 
 	framework.AdmitWorkspaceAccess(ctx, t, kubeClusterClient, serviceProviderPath, []string{"user-1"}, nil, false)
 
-	setUpServiceProvider(ctx, t, dynamicClusterClient, kcpClients, serviceProviderPath, cfg, nil)
+	setUpServiceProvider(ctx, t, dynamicClusterClient, kcpClients, true, serviceProviderPath, cfg, nil)
 
 	t.Logf("Waiting for APIExport to have a virtual workspace URL for the bound workspace %q", consumerWorkspace.Name)
 	apiExportVWCfg := rest.CopyConfig(cfg)

--- a/test/e2e/virtual/apiexport/virtualworkspace_test.go
+++ b/test/e2e/virtual/apiexport/virtualworkspace_test.go
@@ -133,6 +133,10 @@ func TestAPIExportVirtualWorkspace(t *testing.T) {
 	require.NoError(t, err, "error retrieving APIExport discovery")
 	require.True(t, resourceExists(resources, "apibindings"), "missing apibindings")
 
+	resources, err = discoveryVCClusterClient.ServerResourcesForGroupVersion(apisv1alpha1.SchemeGroupVersion.String())
+	require.NoError(t, err, "error retrieving APIExport discovery")
+	require.True(t, resourceExists(resources, "apibindings"), "missing apibindings")
+
 	user1VWCfg := framework.StaticTokenUserConfig("user-1", apiExportVWCfg)
 	wwUser1VC, err := wildwestclientset.NewForConfig(user1VWCfg)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

At the moment, `kubectl api-resources` in the APIExport Virtual Workspace shows that we serve APIBindings v1alpha2. However, getting an APIBinding (`kubectl get apibinding`) results into getting the v1alpha1 version of the object (it's impossible to get the `v1alpha2` version at all).

This PR addresses this by ensuring both v1alpha1 and v1alpha2 are available via the APIExport Virtual Workspace.

Additionally, fixing this bug undercovered an issue with the virtual workspace OpenAPI v3 endpoint/implementation. If there's a resource with two different versions, it'll cause a panic because we try to register the same GR (GroupResource) two times. This is fixed in this PR as well and it needs to be cherry-picked to `release-0.27`.

Tests are added to cover both of these bugs.

## What Type of PR Is This?

/kind bug

## Related Issue(s)

None

## Release Notes
```release-note
- Serve both v1alpha1 and v1alpha2 of APIBindings in the APIExport Virtual Workspace
- Fix a panic in the OpenAPI v3 endpoint for Virtual Workspaces happening if there's a resource with two or more versions
```