### PR TITLE
Remove VOLUME directive from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,11 +64,9 @@ COPY --from=builder /etc/ssl/certs /etc/ssl/certs
 COPY --from=builder workspace/bin/kcp-front-proxy workspace/bin/kcp workspace/bin/virtual-workspaces workspace/bin/cache-server /
 COPY --from=builder workspace/bin/kubectl-* /usr/local/bin/
 COPY --from=builder workspace/bin/kubectl /usr/local/bin/
+
 ENV KUBECONFIG=/etc/kcp/config/admin.kubeconfig
-# Use uid of nonroot user (65532) because kubernetes expects numeric user when applying pod security policies
-RUN ["/busybox/sh", "-c", "mkdir -p /data && chown 65532:65532 /data"]
 USER 65532:65532
-WORKDIR /data
-VOLUME /data
+
 ENTRYPOINT ["/kcp"]
 CMD ["start"]


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

It looks like we never removed this directive from our Dockerfile, which resulted in unexpected behaviour when running this image on containerd vs CRI-O (containerd mounts a temporary volume into it, CRI-O does not and fails with a "read-only filesystem" error in the Helm chart).

Given that we removed the need for this directory in https://github.com/kcp-dev/kcp-operator/pull/22/commits/06541c98c97a51a91143a506a8d793b17298a6e5, I would vote for removing this volume as well as it shadowed a misconfiguration of the Helm chart that only happens on CRI-O based clusters.

## What Type of PR Is This?

/kind bug
/kind cleanup


## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Remove `VOLUME` from Dockerfile so no `/data` volume is mounted anymore
```
