### PR TITLE
Do not set the owner annotation on `LogicalClusters` to empty value

### DIFF
--- a/pkg/reconciler/tenancy/logicalcluster/logicalcluster_controller.go
+++ b/pkg/reconciler/tenancy/logicalcluster/logicalcluster_controller.go
@@ -201,9 +201,11 @@ func (c *Controller) process(ctx context.Context, key string) error {
 		return nil
 	}
 
-	// need to create
-	ownerAnnotation, found := logicalCluster.Annotations[tenancyv1alpha1.ExperimentalWorkspaceOwnerAnnotationKey]
-	if !found {
+	// need to create ClusterRoleBinding for owner.
+	ownerAnnotation := logicalCluster.Annotations[tenancyv1alpha1.ExperimentalWorkspaceOwnerAnnotationKey]
+	// some older installations of kcp might have produced an annotation with empty value, so we should
+	// not care whether the annotation is set or if it's empty.
+	if ownerAnnotation == "" {
 		// no owner - can't create
 		return nil
 	}

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_scheduling.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_scheduling.go
@@ -247,9 +247,8 @@ func (r *schedulingReconciler) createLogicalCluster(ctx context.Context, shard *
 		ObjectMeta: metav1.ObjectMeta{
 			Name: corev1alpha1.LogicalClusterName,
 			Annotations: map[string]string{
-				tenancyv1alpha1.ExperimentalWorkspaceOwnerAnnotationKey: workspace.Annotations[tenancyv1alpha1.ExperimentalWorkspaceOwnerAnnotationKey],
-				tenancyv1alpha1.LogicalClusterTypeAnnotationKey:         logicalcluster.NewPath(workspace.Spec.Type.Path).Join(string(workspace.Spec.Type.Name)).String(),
-				core.LogicalClusterPathAnnotationKey:                    canonicalPath.String(),
+				tenancyv1alpha1.LogicalClusterTypeAnnotationKey: logicalcluster.NewPath(workspace.Spec.Type.Path).Join(string(workspace.Spec.Type.Name)).String(),
+				core.LogicalClusterPathAnnotationKey:            canonicalPath.String(),
 			},
 		},
 		Spec: corev1alpha1.LogicalClusterSpec{


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

It looks like all the way back in #2510, we added some logic to mirror the `experimental.tenancy.kcp.io/owner` annotation from `Workspace` objects to `LogicalClusters`. Unfortunately, this is how `pkg/reconciler/tenancy/workspace/workspace_reconcile_scheduling.go` ended up looking like:

https://github.com/kcp-dev/kcp/blob/68596e1e59e966cfc44b1c3c1e6287193f27ca38/pkg/reconciler/tenancy/workspace/workspace_reconcile_scheduling.go#L246-L270

There is a check if `ExperimentalWorkspaceOwnerAnnotationKey` is set on the workspace later on in the code, but the annotation is already set by this time (see the initial set of annotations). This produces an annotation with an empty value, which trips up the owner annotation parser.

Since there might be existing kcp installations out there with bad owner annotations on `LogicalCluster` objects caused by this bug, this PR also skips parsing the annotation if it's empty.

## What Type of PR Is This?
/kind bug

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Only set `experimental.tenancy.kcp.io/owner` annotation on `LogicalCluster` if `Workspace` has the annotation
```
