### PR TITLE
Authorize server-side apply as create in `forwardingregistry`

### DIFF
--- a/pkg/virtual/framework/forwardingregistry/store.go
+++ b/pkg/virtual/framework/forwardingregistry/store.go
@@ -219,6 +219,13 @@ func DefaultDynamicDelegatedStoreFuncs(
 				// The object does not currently exist.
 				// We switch to calling a create operation on the forwarding registry.
 				// This enables support for server-side apply requests, to create non-existent objects.
+				//
+				// Before creating the object, we want to run the admission chain (including the authorization)
+				// to make sure that we're allowed to create objects.
+				if err := createValidation(ctx, obj); err != nil {
+					return nil, err
+				}
+
 				return delegate.Create(ctx, unstructuredObj, updateToCreateOptions(options), subResources...)
 			}
 			return delegate.Update(ctx, unstructuredObj, *options, subResources...)


### PR DESCRIPTION
## Summary

At the moment, server-side apply requests in the virtual workspaces are authorized exclusively as `patch`. This doesn't match the upstream Kubernetes behavior where such requests are authorized as `create`. This is documented here: https://kubernetes.io/docs/reference/using-api/api-concepts/#patch-and-apply

The initial idea for mitigating this issue, for the APIExport Virtual Workspace, was to bundle `patch` and `create` verbs. In other words, if you request `patch`, you must request `create` as well. However, this doesn't solve the issue that exclusive `patch` can create new resources using SSA, it only "hides" the issue.

This PR takes another approach by running the admission chain if it is determined that the object needs to be created. The admission chain in this case includes the authorizers, but instead of running them with `patch`, it runs them with `create`. If that fails, we are not proceeding with creation but instead return 403 Forbidden (as is done in Kubernetes).

This taps into the `forwardingregistry` which is used by other Virtual Workspaces. However, for all other workspaces (i.e. workspaces that are not APIExport VW), this change is supposedly INOP as long as they do not forbid `create` request. The same admission chain is anyways being used before handling the request, just with a different verb (`patch` instead of `create`). This only ensures we run the admission chain with the correct verb (`create`) once it is determined that we want to create a new object.

## What Type of PR Is This?

/kind feature

## Related Issue(s)

xref #3429 

## Release Notes
```release-note
Run the admission chain in the virtual workspace (forwarding) registry with the `create` verb upon creating a new object using server-side apply. As a result, running the server-side apply for a claimed resource in the APIExport Virtual Workspace requires the `create` verb
```

/assign @sttts @mjudeikis @embik 