### PR TITLE
Use 'core' group to replicate core API objects

### DIFF
--- a/pkg/reconciler/cache/cachedresources/cachedresources_reconcile.go
+++ b/pkg/reconciler/cache/cachedresources/cachedresources_reconcile.go
@@ -140,6 +140,10 @@ func (c *Controller) deleteSelectedCacheResources(ctx context.Context, cluster l
 		Version:  cachedResource.Spec.Version,
 		Resource: cachedResource.Spec.Resource,
 	}
+	if gvr.Group == "" {
+		gvr.Group = "core"
+	}
+
 	selector := labels.SelectorFromSet(labels.Set{
 		replicationcontroller.LabelKeyObjectSchema: gvr.Version + "." + gvr.Resource + "." + gvr.Group,
 	})
@@ -160,6 +164,9 @@ func (c *Controller) listSelectedCacheResources(ctx context.Context, cluster log
 		Group:    cachedResource.Spec.Group,
 		Version:  cachedResource.Spec.Version,
 		Resource: cachedResource.Spec.Resource,
+	}
+	if gvr.Group == "" {
+		gvr.Group = "core"
 	}
 
 	selector := labels.SelectorFromSet(labels.Set{

--- a/pkg/reconciler/cache/cachedresources/replication/replication_reconcile.go
+++ b/pkg/reconciler/cache/cachedresources/replication/replication_reconcile.go
@@ -122,6 +122,9 @@ func (c *Controller) reconcile(ctx context.Context, gvrKey string) error {
 		},
 		createObject: func(ctx context.Context, cluster logicalcluster.Name, obj *unstructured.Unstructured) (*cachev1alpha1.CachedObject, error) {
 			gvr := obj.GroupVersionKind()
+			if gvr.Group == "" {
+				gvr.Group = "core"
+			}
 
 			objBytes, err := json.Marshal(obj)
 			if err != nil {
@@ -159,6 +162,9 @@ func (c *Controller) reconcile(ctx context.Context, gvrKey string) error {
 		},
 		updateObject: func(ctx context.Context, cluster logicalcluster.Name, obj *unstructured.Unstructured) (*cachev1alpha1.CachedObject, error) {
 			gvr := obj.GroupVersionKind()
+			if gvr.Group == "" {
+				gvr.Group = "core"
+			}
 
 			objBytes, err := json.Marshal(obj)
 			if err != nil {


### PR DESCRIPTION
## Summary

Resources from core API use empty group, but this breaks
label selectors that end up being empty, and fail validation.
This PR replaces empty group with 'core'.


## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind bug

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
