### PR TITLE
update to Go 1.23.10

### DIFF
--- a/.github/workflows/docs-gen-and-push.yaml
+++ b/.github/workflows/docs-gen-and-push.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # tag=v5.5.0
         with:
-          go-version: v1.23.7
+          go-version: v1.23.10
           cache: true
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 #tag=v5.6.0

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -20,13 +20,17 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag=v4.2.2
       with:
         fetch-depth: 0
+
     - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # tag=v5.5.0
       with:
-        go-version: v1.23.7
+        go-version: v1.23.10
+
     - name: Delete non-semver tags
       run: 'git tag -d $(git tag -l | grep -v "^v")'
+
     - name: Set LDFLAGS
       run: echo LDFLAGS="$(make ldflags)" >> $GITHUB_ENV
+
     - name: Run GoReleaser on tag
       if: github.event_name != 'pull_request'
       uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # tag=v6.3.0
@@ -37,6 +41,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         KREW_GITHUB_TOKEN: ${{ secrets.KREW_GITHUB_TOKEN }}
+
     - name: Run GoReleaser on pull request
       if: github.event_name == 'pull_request'
       uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # tag=v6.3.0
@@ -47,6 +52,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         KREW_GITHUB_TOKEN: ${{ secrets.KREW_GITHUB_TOKEN }}
+
     - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag=v4.6.2
       if: ${{ always() }}
       with:

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.23.7-2
+        - image: ghcr.io/kcp-dev/infra/build:1.23.10-1
           command:
             - make
             - verify-boilerplate
@@ -27,7 +27,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.23.7-2
+        - image: ghcr.io/kcp-dev/infra/build:1.23.10-1
           command:
             - make
             - verify-codegen
@@ -44,7 +44,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.23.7-2
+        - image: ghcr.io/kcp-dev/infra/build:1.23.10-1
           command:
             - make
             - lint
@@ -83,7 +83,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.23.7-2
+        - image: ghcr.io/kcp-dev/infra/build:1.23.10-1
           command:
             - make
             - test
@@ -104,7 +104,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.23.7-2
+        - image: ghcr.io/kcp-dev/infra/build:1.23.10-1
           command:
             - ./hack/run-with-prow.sh
             - ./hack/run-with-prometheus.sh
@@ -131,7 +131,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.23.7-2
+        - image: ghcr.io/kcp-dev/infra/build:1.23.10-1
           command:
             - ./hack/run-with-prow.sh
             - ./hack/run-with-prometheus.sh
@@ -160,7 +160,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.23.7-2
+        - image: ghcr.io/kcp-dev/infra/build:1.23.10-1
           command:
             - ./hack/run-with-prow.sh
             - ./hack/run-with-prometheus.sh
@@ -191,7 +191,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.23.7-2
+        - image: ghcr.io/kcp-dev/infra/build:1.23.10-1
           command:
             - ./hack/run-with-prow.sh
             - ./hack/run-with-prometheus.sh
@@ -220,7 +220,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.23.7-2
+        - image: ghcr.io/kcp-dev/infra/build:1.23.10-1
           command:
             - ./hack/run-with-prow.sh
             - ./hack/run-with-prometheus.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Build the binary
-FROM --platform=${BUILDPLATFORM} docker.io/golang:1.23.7 AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/golang:1.23.10 AS builder
 WORKDIR /workspace
 
 # Install dependencies.

--- a/docs/content/contributing/index.md
+++ b/docs/content/contributing/index.md
@@ -17,7 +17,7 @@ contribution. See the [DCO](https://github.com/kcp-dev/kcp/tree/main/DCO) file f
 ### Prerequisites
 
 1. Clone this repository.
-2. [Install Go](https://golang.org/doc/install) (currently 1.23.7).
+2. [Install Go](https://golang.org/doc/install) (currently 1.23.10).
 3. Install [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl).
 
 Please note that the go language version numbers in these files must exactly agree: go/go.mod file, kcp/.ci-operator.yaml, kcp/Dockerfile, and in all the kcp/.github/workflows yaml files that specify go-version. In kcp/.ci-operator.yaml the go version is indicated by the "tag" attribute. In kcp/Dockerfile it is indicated by the "golang" attribute. In go.mod it is indicated by the "go" directive." In the .github/workflows yaml files it is indicated by "go-version"


### PR DESCRIPTION
## Summary
Go 1.23.10 fixes these CVEs:

* CVE-2025-4673: net/http: sensitive headers not cleared on cross-origin redirect
* CVE-2025-0913: os: inconsistent handling of O_CREATE|O_EXCL on Unix and Windows
* CVE-2025-22874: crypto/x509: usage of ExtKeyUsageAny disables policy validation

## What Type of PR Is This?
/kind cleanup

## Release Notes
```release-note
Update to Go 1.23.10.
```
