### PR TITLE
Fix dynamicRestMapper consistency

### DIFF
--- a/pkg/reconciler/apis/logicalclustercleanup/logicalclustercleanup_controller.go
+++ b/pkg/reconciler/apis/logicalclustercleanup/logicalclustercleanup_controller.go
@@ -94,6 +94,9 @@ func NewController(
 		AddFunc: func(obj interface{}) {
 			c.enqueueCRD(obj.(*apiextensionsv1.CustomResourceDefinition), false)
 		},
+		UpdateFunc: func(_, obj interface{}) {
+			c.enqueueCRD(obj.(*apiextensionsv1.CustomResourceDefinition), false)
+		},
 		DeleteFunc: func(obj interface{}) {
 			if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
 				obj = tombstone.Obj
@@ -282,6 +285,7 @@ func (c *controller) process(ctx context.Context, key string) error {
 		crdNames[crd.Name] = true
 
 		if !apihelpers.IsCRDConditionTrue(crd, apiextensionsv1.Established) {
+			logger.V(4).Info("CRD is not established, skipping", "crd", crd.Name)
 			continue
 		}
 

--- a/pkg/reconciler/dynamicrestmapper/dynamicrestmapper_controller.go
+++ b/pkg/reconciler/dynamicrestmapper/dynamicrestmapper_controller.go
@@ -52,6 +52,24 @@ const (
 	ControllerName = "kcp-dynamicrestmapper"
 )
 
+// When we detect a new LogicalCluster, we add builtinGVKRs mappings to it.
+// Since they are always the same, we stash them away to be reused.
+var builtinGVKRs []typeMeta
+
+func init() {
+	builtinGVKRs = make([]typeMeta, len(builtinschemas.BuiltInAPIs))
+	for i := range builtinschemas.BuiltInAPIs {
+		builtinGVKRs[i] = newTypeMeta(
+			builtinschemas.BuiltInAPIs[i].GroupVersion.Group,
+			builtinschemas.BuiltInAPIs[i].GroupVersion.Version,
+			builtinschemas.BuiltInAPIs[i].Names.Kind,
+			builtinschemas.BuiltInAPIs[i].Names.Singular,
+			builtinschemas.BuiltInAPIs[i].Names.Plural,
+			resourceScopeToRESTScope(builtinschemas.BuiltInAPIs[i].ResourceScope),
+		)
+	}
+}
+
 // Describes which handler triggered enqueueLogicalCluster.
 type ctrlOp string
 
@@ -152,24 +170,6 @@ type Controller struct {
 	getAPIBinding        func(clusterName logicalcluster.Name, name string) (*apibinding.APIBinding, error)
 }
 
-// When we detect a new LogicalCluster, we add builtinGVKRs mappings to it.
-// Since they are always the same, we stash them away to be reused.
-var builtinGVKRs []typeMeta
-
-func init() {
-	builtinGVKRs = make([]typeMeta, len(builtinschemas.BuiltInAPIs))
-	for i := range builtinschemas.BuiltInAPIs {
-		builtinGVKRs[i] = newTypeMeta(
-			builtinschemas.BuiltInAPIs[i].GroupVersion.Group,
-			builtinschemas.BuiltInAPIs[i].GroupVersion.Version,
-			builtinschemas.BuiltInAPIs[i].Names.Kind,
-			builtinschemas.BuiltInAPIs[i].Names.Singular,
-			builtinschemas.BuiltInAPIs[i].Names.Plural,
-			resourceScopeToRESTScope(builtinschemas.BuiltInAPIs[i].ResourceScope),
-		)
-	}
-}
-
 func getResourceBindingsAnnJSON(lc *corev1alpha1.LogicalCluster) string {
 	const jsonEmptyObj = "{}"
 
@@ -207,6 +207,9 @@ func diffResourceBindingsAnn(oldAnn, newAnn apibinding.ResourceBindingsAnnotatio
 func (c *Controller) enqueueLogicalCluster(oldObj *corev1alpha1.LogicalCluster, newObj *corev1alpha1.LogicalCluster, op ctrlOp) {
 	oldBoundResourcesAnnStr := getResourceBindingsAnnJSON(oldObj)
 	newBoundResourcesAnnStr := getResourceBindingsAnnJSON(newObj)
+
+	logging.WithReconciler(klog.Background(), ControllerName).
+		V(4).Info("queueing LogicalCluster", "old", oldBoundResourcesAnnStr, "new", newBoundResourcesAnnStr)
 
 	if op == opUpdate && oldBoundResourcesAnnStr == newBoundResourcesAnnStr {
 		// Nothing to do.

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -1617,13 +1617,13 @@ func (s *Server) installDynamicRESTMapper(ctx context.Context, config *rest.Conf
 		Name: dynamicrestmapper.ControllerName,
 		Wait: func(ctx context.Context, s *Server) error {
 			return wait.PollUntilContextCancel(ctx, waitPollInterval, true, func(ctx context.Context) (bool, error) {
-				return s.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters().Informer().HasSynced() &&
-					s.ApiExtensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions().Informer().HasSynced() &&
+				return s.ApiExtensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions().Informer().HasSynced() &&
+					s.KcpSharedInformerFactory.Apis().V1alpha1().APIBindings().Informer().HasSynced() &&
 					s.KcpSharedInformerFactory.Apis().V1alpha2().APIExports().Informer().HasSynced() &&
-					s.CacheKcpSharedInformerFactory.Apis().V1alpha2().APIExports().Informer().HasSynced() &&
 					s.KcpSharedInformerFactory.Apis().V1alpha1().APIResourceSchemas().Informer().HasSynced() &&
+					s.CacheKcpSharedInformerFactory.Apis().V1alpha2().APIExports().Informer().HasSynced() &&
 					s.CacheKcpSharedInformerFactory.Apis().V1alpha1().APIResourceSchemas().Informer().HasSynced() &&
-					s.KcpSharedInformerFactory.Apis().V1alpha1().APIBindings().Informer().HasSynced(), nil
+					s.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters().Informer().HasSynced(), nil
 			})
 		},
 		Runner: func(ctx context.Context) {

--- a/test/integration/framework/assets/assets.go
+++ b/test/integration/framework/assets/assets.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package assets
+
+import "embed"
+
+//go:embed *.yaml
+var EmbeddedResources embed.FS

--- a/test/integration/framework/assets/crd_kubecluster.yaml
+++ b/test/integration/framework/assets/crd_kubecluster.yaml
@@ -1,0 +1,144 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  name: kubeclusters.contrib.kcp.io
+spec:
+  group: contrib.kcp.io
+  names:
+    kind: KubeCluster
+    listKind: KubeClusterList
+    plural: kubeclusters
+    singular: kubecluster
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="KubeClusterReady")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KubeCluster describes the current KubeCluster proxy object.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KubeClusterSpec is the specification of the Kube cluster
+              proxy resource.
+            properties:
+              workspaceURL:
+                description: workspaceURL is the address under which the workspace
+                  can be found.
+                type: string
+            type: object
+          status:
+            description: KubeClusterStatus communicates the observed state of the
+              Kube cluster proxy.
+            properties:
+              URL:
+                description: |-
+                  url is the address under which the Kubernetes-cluster-like endpoint
+                  can be found. This URL can be used to access the cluster with standard Kubernetes
+                  client libraries and command line tools via proxy.
+                type: string
+              conditions:
+                description: Current processing state of the Cluster proxy.
+                items:
+                  description: Condition defines an observation of a object operational
+                    state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastProxyHeartbeatTime:
+                description: A timestamp indicating when the proxy last reported status.
+                format: date-time
+                type: string
+              phase:
+                default: Initializing
+                description: Phase of the cluster proxy (Initializing, Ready).
+                enum:
+                - Initializing
+                - Connecting
+                - Ready
+                - Unknown
+                type: string
+              tunnelWorkspaces:
+                description: |-
+                  TunnelWorkspaces contains all URLs (one per shard) that is being used
+                  by the proxy to connect to the tunnel for a given shard.
+                items:
+                  properties:
+                    url:
+                      description: |-
+                        url is the URL the Proxy should use to connect
+                        to the Proxy tunnel for a given shard.
+                      minLength: 1
+                      type: string
+                  required:
+                  - url
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/test/integration/framework/dynamicrestmapper_test.go
+++ b/test/integration/framework/dynamicrestmapper_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/martinlindhe/base36"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+
+	crdhelpers "k8s.io/apiextensions-apiserver/pkg/apihelpers"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/restmapper"
+
+	kcpapiextensionsv1client "github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1"
+	kcpdynamic "github.com/kcp-dev/client-go/dynamic"
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	"github.com/kcp-dev/kcp/config/helpers"
+	"github.com/kcp-dev/kcp/sdk/apis/core"
+	kcptesting "github.com/kcp-dev/kcp/sdk/testing"
+	kcptestinghelpers "github.com/kcp-dev/kcp/sdk/testing/helpers"
+	"github.com/kcp-dev/kcp/test/integration/framework/assets"
+)
+
+func TestDynamicRestMapper(t *testing.T) {
+	ctx := context.Background()
+
+	server, kcpClientSet, _ := StartTestServer(t)
+
+	name := "test-workspace-" + strings.ToLower(base36.Encode(rand.Uint64())[:8])
+
+	cfg, err := server.ClientConfig.ClientConfig()
+	require.NoError(t, err, "error creating client config")
+
+	dynamicClusterClient, err := kcpdynamic.NewForConfig(cfg)
+	require.NoError(t, err, "error creating dynamic cluster client")
+
+	extensionsClusterClient, err := kcpapiextensionsv1client.NewForConfig(cfg)
+	require.NoError(t, err, "error creating apiextensions cluster client")
+
+	workspace := kcptesting.NewLowLevelWorkspaceFixture(t, kcpClientSet, kcpClientSet, core.RootCluster.Path(), kcptesting.WithName(name))
+
+	logicalClusterName := logicalcluster.Name(workspace.Spec.Cluster)
+
+	drm := server.Server.DynRESTMapper.ForCluster(logicalClusterName)
+
+	t.Logf("Testing if we can resolve the ConfigMap kind")
+	var gvk schema.GroupVersionKind
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		gvk, err = drm.KindFor(schema.GroupVersionResource{
+			Group:    "",
+			Version:  "v1",
+			Resource: "configmaps",
+		})
+		return err == nil, fmt.Sprintf("%v", err)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "waiting for CRD to be established")
+	require.NoError(t, err)
+
+	require.Equal(t, "ConfigMap", gvk.Kind)
+
+	t.Logf("Testing if we can resolve the KubeCluster kind")
+
+	t.Logf("Install a mount object CRD into workspace %q", workspace.Name)
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(kcpClientSet.Cluster(logicalClusterName.Path()).Discovery()))
+	err = helpers.CreateResourceFromFS(ctx, dynamicClusterClient.Cluster(logicalClusterName.Path()), mapper, nil, "crd_kubecluster.yaml", assets.EmbeddedResources)
+	require.NoError(t, err)
+
+	t.Logf("Waiting for CRD to be established")
+	crdName := "kubeclusters.contrib.kcp.io"
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		crd, err := extensionsClusterClient.Cluster(logicalClusterName.Path()).CustomResourceDefinitions().Get(ctx, crdName, metav1.GetOptions{})
+		require.NoError(t, err)
+		return crdhelpers.IsCRDConditionTrue(crd, apiextensionsv1.Established), yamlMarshal(t, crd)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "waiting for CRD to be established")
+
+	t.Logf("Testing if we can resolve the KubeCluster kind")
+
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		gvk, err = drm.KindFor(schema.GroupVersionResource{
+			Group:    "contrib.kcp.io",
+			Version:  "v1alpha1",
+			Resource: "kubeclusters",
+		})
+		return err == nil, fmt.Sprintf("%v", err)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "waiting for CRD to be established")
+
+	require.NoError(t, err)
+	require.Equal(t, "KubeCluster", gvk.Kind)
+}
+
+func yamlMarshal(t *testing.T, obj interface{}) string {
+	data, err := yaml.Marshal(obj)
+	require.NoError(t, err)
+	return string(data)
+}


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

If CRD is added, it goes to the initialisation phase. We skip it and never come back to it in the update when it becomes ready. Hence, it was making dynamicrestmapper inconsistent. 

## What Type of PR Is This?
/kind bug

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
