### PR TITLE
Improve linting config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -41,27 +41,20 @@ linters:
   settings:
     gocritic:
       disabled-checks:
-        - appendAssign
+        # - appendAssign
         - dupImport # https://github.com/go-critic/go-critic/issues/845
-        - evalOrder
         - ifElseChain
         - octalLiteral
-        - regexpSimplify
-        - sloppyReassign
-        - truncateCmp
         - typeDefFirst
         - unnamedResult
-        - unnecessaryDefer
         - whyNoLint
-        - wrapperFunc
-        - unnecessaryBlock
+        # - unnecessaryBlock
         - rangeValCopy
         - hugeParam
         - commentedOutCode
         - emptyStringTest
         - singleCaseSwitch
-        - nestingReduce
-        - filepathJoin
+        # - nestingReduce
         - tooManyResultsChecker
       enabled-tags:
         - diagnostic

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -22,6 +22,7 @@ linters:
     - govet
     - importas
     - ineffassign
+    - intrange
     - misspell
     - nilerr
     - noctx

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -117,21 +117,11 @@ linters:
       - std-error-handling
     rules:
       - linters:
-          - unparam
-        text: always receives
-      - linters:
-          - gosec
-        path: _test\.go
-        text: 'G112: Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server'
-      - linters:
           - gosec
         path: test/e2e/*
       - linters:
-          - goconst
-        path: (.+)_test\.go
-      - linters:
           - staticcheck
-        text: QF1008
+        text: QF1008 # "could remove embedded field" often impedes readability and clarity
     paths:
       - third_party$
       - builtin$

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -14,6 +14,7 @@ linters:
     - durationcheck
     - errcheck
     - errchkjson
+    - fatcontext
     - gocritic
     - godot
     - goprintffuncname

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -41,20 +41,20 @@ linters:
   settings:
     gocritic:
       disabled-checks:
-        # - appendAssign
+        - appendAssign
         - dupImport # https://github.com/go-critic/go-critic/issues/845
         - ifElseChain
         - octalLiteral
         - typeDefFirst
         - unnamedResult
         - whyNoLint
-        # - unnecessaryBlock
+        - unnecessaryBlock
         - rangeValCopy
         - hugeParam
         - commentedOutCode
         - emptyStringTest
         - singleCaseSwitch
-        # - nestingReduce
+        - nestingReduce
         - tooManyResultsChecker
       enabled-tags:
         - diagnostic
@@ -78,7 +78,7 @@ linters:
       require-specific: true
       allow-unused: false
     revive:
-    # make sure error-strings issues actually surface (default confidence is 0.8)
+      # make sure error-strings issues actually surface (default confidence is 0.8)
       confidence: 0.6
       rules:
         - name: context-keys-type

--- a/cmd/sharded-test-server/cache.go
+++ b/cmd/sharded-test-server/cache.go
@@ -136,7 +136,7 @@ func startCacheServer(ctx context.Context, logDirPath, workingDir, hostIP string
 				},
 				CurrentContext: "cache",
 			}
-			if err = clientcmd.WriteToFile(cacheServerKubeConfig, cacheKubeconfigPath); err != nil {
+			if err := clientcmd.WriteToFile(cacheServerKubeConfig, cacheKubeconfigPath); err != nil {
 				return nil, "", err
 			}
 		}

--- a/cmd/sharded-test-server/frontproxy.go
+++ b/cmd/sharded-test-server/frontproxy.go
@@ -79,17 +79,17 @@ func startFrontProxy(
 			Path: "/services/",
 			// TODO: support multiple virtual workspace backend servers
 			Backend:         fmt.Sprintf("https://localhost:%s", vwPort),
-			BackendServerCA: filepath.Join(workDirPath, ".kcp/serving-ca.crt"),
-			ProxyClientCert: filepath.Join(workDirPath, ".kcp-front-proxy/requestheader.crt"),
-			ProxyClientKey:  filepath.Join(workDirPath, ".kcp-front-proxy/requestheader.key"),
+			BackendServerCA: filepath.Join(workDirPath, ".kcp", "serving-ca.crt"),
+			ProxyClientCert: filepath.Join(workDirPath, ".kcp-front-proxy", "requestheader.crt"),
+			ProxyClientKey:  filepath.Join(workDirPath, ".kcp-front-proxy", "requestheader.key"),
 		},
 		{
 			Path: "/clusters/",
 			// TODO: support multiple shard backend servers
 			Backend:         "https://localhost:6444",
-			BackendServerCA: filepath.Join(workDirPath, ".kcp/serving-ca.crt"),
-			ProxyClientCert: filepath.Join(workDirPath, ".kcp-front-proxy/requestheader.crt"),
-			ProxyClientKey:  filepath.Join(workDirPath, ".kcp-front-proxy/requestheader.key"),
+			BackendServerCA: filepath.Join(workDirPath, ".kcp", "serving-ca.crt"),
+			ProxyClientCert: filepath.Join(workDirPath, ".kcp-front-proxy", "requestheader.crt"),
+			ProxyClientKey:  filepath.Join(workDirPath, ".kcp-front-proxy", "requestheader.key"),
 		},
 	}
 
@@ -98,13 +98,13 @@ func startFrontProxy(
 		return fmt.Errorf("error marshaling mappings yaml: %w", err)
 	}
 
-	if err := os.WriteFile(filepath.Join(workDirPath, ".kcp-front-proxy/mapping.yaml"), mappingsYAML, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workDirPath, ".kcp-front-proxy", "mapping.yaml"), mappingsYAML, 0644); err != nil {
 		return fmt.Errorf("failed to create front-proxy mapping.yaml: %w", err)
 	}
 
 	// write root shard kubeconfig
 	configLoader := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{ExplicitPath: filepath.Join(workDirPath, ".kcp-0/admin.kubeconfig")},
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: filepath.Join(workDirPath, ".kcp-0", "admin.kubeconfig")},
 		&clientcmd.ConfigOverrides{CurrentContext: "shard-base"},
 	)
 	raw, err := configLoader.RawConfig()
@@ -115,31 +115,31 @@ func startFrontProxy(
 	if err := clientcmdapi.MinifyConfig(&raw); err != nil {
 		return err
 	}
-	if err := clientcmd.WriteToFile(raw, filepath.Join(workDirPath, ".kcp/root.kubeconfig")); err != nil {
+	if err := clientcmd.WriteToFile(raw, filepath.Join(workDirPath, ".kcp", "root.kubeconfig")); err != nil {
 		return err
 	}
 
 	// create serving cert
-	hostnames := sets.New[string]("localhost", hostIP)
+	hostnames := sets.New("localhost", hostIP)
 	logger.Info("creating kcp-front-proxy serving cert with hostnames", "hostnames", hostnames)
 	cert, err := servingCA.MakeServerCert(hostnames, 365)
 	if err != nil {
 		return fmt.Errorf("failed to create server cert: %w", err)
 	}
-	if err := cert.WriteCertConfigFile(filepath.Join(workDirPath, ".kcp-front-proxy/apiserver.crt"), filepath.Join(workDirPath, ".kcp-front-proxy/apiserver.key")); err != nil {
+	if err := cert.WriteCertConfigFile(filepath.Join(workDirPath, ".kcp-front-proxy", "apiserver.crt"), filepath.Join(workDirPath, ".kcp-front-proxy", "apiserver.key")); err != nil {
 		return fmt.Errorf("failed to write server cert: %w", err)
 	}
 
 	// run front-proxy command
 	commandLine := append(kcptestingserver.Command("kcp-front-proxy", "front-proxy"),
 		"--bind-address="+hostIP,
-		fmt.Sprintf("--mapping-file=%s", filepath.Join(workDirPath, ".kcp-front-proxy/mapping.yaml")),
+		fmt.Sprintf("--mapping-file=%s", filepath.Join(workDirPath, ".kcp-front-proxy", "mapping.yaml")),
 		fmt.Sprintf("--root-directory=%s", filepath.Join(workDirPath, ".kcp-front-proxy")),
-		fmt.Sprintf("--root-kubeconfig=%s", filepath.Join(workDirPath, ".kcp/root.kubeconfig")),
-		fmt.Sprintf("--shards-kubeconfig=%s", filepath.Join(workDirPath, ".kcp-front-proxy/shards.kubeconfig")),
-		fmt.Sprintf("--client-ca-file=%s", filepath.Join(workDirPath, ".kcp/client-ca.crt")),
-		fmt.Sprintf("--tls-cert-file=%s", filepath.Join(workDirPath, ".kcp-front-proxy/apiserver.crt")),
-		fmt.Sprintf("--tls-private-key-file=%s", filepath.Join(workDirPath, ".kcp-front-proxy/apiserver.key")),
+		fmt.Sprintf("--root-kubeconfig=%s", filepath.Join(workDirPath, ".kcp", "root.kubeconfig")),
+		fmt.Sprintf("--shards-kubeconfig=%s", filepath.Join(workDirPath, ".kcp-front-proxy", "shards.kubeconfig")),
+		fmt.Sprintf("--client-ca-file=%s", filepath.Join(workDirPath, ".kcp", "client-ca.crt")),
+		fmt.Sprintf("--tls-cert-file=%s", filepath.Join(workDirPath, ".kcp-front-proxy", "apiserver.crt")),
+		fmt.Sprintf("--tls-private-key-file=%s", filepath.Join(workDirPath, ".kcp-front-proxy", "apiserver.key")),
 		"--secure-port=6443",
 		"--v=4",
 	)
@@ -148,7 +148,7 @@ func startFrontProxy(
 
 	cmd := exec.CommandContext(ctx, commandLine[0], commandLine[1:]...) //nolint:gosec
 
-	logFilePath := filepath.Join(workDirPath, ".kcp-front-proxy/proxy.log")
+	logFilePath := filepath.Join(workDirPath, ".kcp-front-proxy", "proxy.log")
 	if logDirPath != "" {
 		logFilePath = filepath.Join(logDirPath, "kcp-front-proxy.log")
 	}
@@ -204,7 +204,7 @@ func startFrontProxy(
 		}
 
 		// intentionally load again every iteration because it can change
-		configLoader := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(&clientcmd.ClientConfigLoadingRules{ExplicitPath: filepath.Join(workDirPath, ".kcp/admin.kubeconfig")},
+		configLoader := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(&clientcmd.ClientConfigLoadingRules{ExplicitPath: filepath.Join(workDirPath, ".kcp", "admin.kubeconfig")},
 			&clientcmd.ConfigOverrides{CurrentContext: "base"},
 		)
 		config, err := configLoader.ClientConfig()
@@ -249,7 +249,7 @@ func scrapeMetrics(ctx context.Context, cfg *rest.Config, workDir string) error 
 	if !set || promUrl == "" {
 		return nil
 	}
-	return kcptestingserver.ScrapeMetrics(ctx, cfg, promUrl, workDir, "kcp-front-proxy", filepath.Join(workDir, ".kcp-front-proxy/apiserver.crt"), map[string]string{
+	return kcptestingserver.ScrapeMetrics(ctx, cfg, promUrl, workDir, "kcp-front-proxy", filepath.Join(workDir, ".kcp-front-proxy", "apiserver.crt"), map[string]string{
 		"server": "kcp-front-proxy",
 	})
 }
@@ -260,18 +260,18 @@ func writeAdminKubeConfig(hostIP string, workDirPath string) error {
 	var kubeConfig clientcmdapi.Config
 	kubeConfig.AuthInfos = map[string]*clientcmdapi.AuthInfo{
 		"kcp-admin": {
-			ClientKey:         filepath.Join(workDirPath, ".kcp/kcp-admin.key"),
-			ClientCertificate: filepath.Join(workDirPath, ".kcp/kcp-admin.crt"),
+			ClientKey:         filepath.Join(workDirPath, ".kcp", "kcp-admin.key"),
+			ClientCertificate: filepath.Join(workDirPath, ".kcp", "kcp-admin.crt"),
 		},
 	}
 	kubeConfig.Clusters = map[string]*clientcmdapi.Cluster{
 		"root": {
 			Server:               baseHost + "/clusters/root",
-			CertificateAuthority: filepath.Join(workDirPath, ".kcp/serving-ca.crt"),
+			CertificateAuthority: filepath.Join(workDirPath, ".kcp", "serving-ca.crt"),
 		},
 		"base": {
 			Server:               baseHost,
-			CertificateAuthority: filepath.Join(workDirPath, ".kcp/serving-ca.crt"),
+			CertificateAuthority: filepath.Join(workDirPath, ".kcp", "serving-ca.crt"),
 		},
 	}
 	kubeConfig.Contexts = map[string]*clientcmdapi.Context{
@@ -284,20 +284,20 @@ func writeAdminKubeConfig(hostIP string, workDirPath string) error {
 		return err
 	}
 
-	return clientcmd.WriteToFile(kubeConfig, filepath.Join(workDirPath, ".kcp/admin.kubeconfig"))
+	return clientcmd.WriteToFile(kubeConfig, filepath.Join(workDirPath, ".kcp", "admin.kubeconfig"))
 }
 
 func writeShardKubeConfig(workDirPath string) error {
 	var kubeConfig clientcmdapi.Config
 	kubeConfig.AuthInfos = map[string]*clientcmdapi.AuthInfo{
 		"shard-admin": {
-			ClientKey:         filepath.Join(workDirPath, ".kcp-front-proxy/shard-admin.key"),
-			ClientCertificate: filepath.Join(workDirPath, ".kcp-front-proxy/shard-admin.crt"),
+			ClientKey:         filepath.Join(workDirPath, ".kcp-front-proxy", "shard-admin.key"),
+			ClientCertificate: filepath.Join(workDirPath, ".kcp-front-proxy", "shard-admin.crt"),
 		},
 	}
 	kubeConfig.Clusters = map[string]*clientcmdapi.Cluster{
 		"base": {
-			CertificateAuthority: filepath.Join(workDirPath, ".kcp/serving-ca.crt"),
+			CertificateAuthority: filepath.Join(workDirPath, ".kcp", "serving-ca.crt"),
 		},
 	}
 	kubeConfig.Contexts = map[string]*clientcmdapi.Context{
@@ -309,7 +309,7 @@ func writeShardKubeConfig(workDirPath string) error {
 		return err
 	}
 
-	return clientcmd.WriteToFile(kubeConfig, filepath.Join(workDirPath, ".kcp-front-proxy/shards.kubeconfig"))
+	return clientcmd.WriteToFile(kubeConfig, filepath.Join(workDirPath, ".kcp-front-proxy", "shards.kubeconfig"))
 }
 
 func writeLogicalClusterAdminKubeConfig(hostIP, workDirPath string) error {
@@ -321,14 +321,14 @@ func writeLogicalClusterAdminKubeConfig(hostIP, workDirPath string) error {
 	var kubeConfig clientcmdapi.Config
 	kubeConfig.AuthInfos = map[string]*clientcmdapi.AuthInfo{
 		"logical-cluster-admin": {
-			ClientKey:         filepath.Join(workDirPath, ".kcp/logical-cluster-admin.key"),
-			ClientCertificate: filepath.Join(workDirPath, ".kcp/logical-cluster-admin.crt"),
+			ClientKey:         filepath.Join(workDirPath, ".kcp", "logical-cluster-admin.key"),
+			ClientCertificate: filepath.Join(workDirPath, ".kcp", "logical-cluster-admin.crt"),
 		},
 	}
 	kubeConfig.Clusters = map[string]*clientcmdapi.Cluster{
 		"base": {
 			Server:               baseHost,
-			CertificateAuthority: filepath.Join(workDirPath, ".kcp/serving-ca.crt"),
+			CertificateAuthority: filepath.Join(workDirPath, ".kcp", "serving-ca.crt"),
 		},
 	}
 	kubeConfig.Contexts = map[string]*clientcmdapi.Context{
@@ -340,7 +340,7 @@ func writeLogicalClusterAdminKubeConfig(hostIP, workDirPath string) error {
 		return err
 	}
 
-	return clientcmd.WriteToFile(kubeConfig, filepath.Join(workDirPath, ".kcp/logical-cluster-admin.kubeconfig"))
+	return clientcmd.WriteToFile(kubeConfig, filepath.Join(workDirPath, ".kcp", "logical-cluster-admin.kubeconfig"))
 }
 
 func writeExternalLogicalClusterAdminKubeConfig(hostIP, workDirPath string) error {
@@ -350,14 +350,14 @@ func writeExternalLogicalClusterAdminKubeConfig(hostIP, workDirPath string) erro
 	var kubeConfig clientcmdapi.Config
 	kubeConfig.AuthInfos = map[string]*clientcmdapi.AuthInfo{
 		"external-logical-cluster-admin": {
-			ClientKey:         filepath.Join(workDirPath, ".kcp/external-logical-cluster-admin.key"),
-			ClientCertificate: filepath.Join(workDirPath, ".kcp/external-logical-cluster-admin.crt"),
+			ClientKey:         filepath.Join(workDirPath, ".kcp", "external-logical-cluster-admin.key"),
+			ClientCertificate: filepath.Join(workDirPath, ".kcp", "external-logical-cluster-admin.crt"),
 		},
 	}
 	kubeConfig.Clusters = map[string]*clientcmdapi.Cluster{
 		"base": {
 			Server:               baseHost,
-			CertificateAuthority: filepath.Join(workDirPath, ".kcp/serving-ca.crt"),
+			CertificateAuthority: filepath.Join(workDirPath, ".kcp", "serving-ca.crt"),
 		},
 	}
 	kubeConfig.Contexts = map[string]*clientcmdapi.Context{
@@ -369,5 +369,5 @@ func writeExternalLogicalClusterAdminKubeConfig(hostIP, workDirPath string) erro
 		return err
 	}
 
-	return clientcmd.WriteToFile(kubeConfig, filepath.Join(workDirPath, ".kcp/external-logical-cluster-admin.kubeconfig"))
+	return clientcmd.WriteToFile(kubeConfig, filepath.Join(workDirPath, ".kcp", "external-logical-cluster-admin.kubeconfig"))
 }

--- a/cmd/sharded-test-server/main.go
+++ b/cmd/sharded-test-server/main.go
@@ -80,9 +80,9 @@ func start(proxyFlags, shardFlags []string, logDirPath, workDirPath string, numb
 
 	// create request header CA and client cert for front-proxy to connect to shards
 	requestHeaderCA, _, err := crypto.EnsureCA(
-		filepath.Join(workDirPath, ".kcp/requestheader-ca.crt"),
-		filepath.Join(workDirPath, ".kcp/requestheader-ca.key"),
-		filepath.Join(workDirPath, ".kcp/requestheader-ca-serial.txt"),
+		filepath.Join(workDirPath, ".kcp", "requestheader-ca.crt"),
+		filepath.Join(workDirPath, ".kcp", "requestheader-ca.key"),
+		filepath.Join(workDirPath, ".kcp", "requestheader-ca-serial.txt"),
 		"kcp-front-proxy-requestheader-ca",
 		365,
 	)
@@ -90,8 +90,8 @@ func start(proxyFlags, shardFlags []string, logDirPath, workDirPath string, numb
 		return fmt.Errorf("failed to create requestheader-ca: %w", err)
 	}
 	_, _, err = requestHeaderCA.EnsureClientCertificate(
-		filepath.Join(workDirPath, ".kcp-front-proxy/requestheader.crt"),
-		filepath.Join(workDirPath, ".kcp-front-proxy/requestheader.key"),
+		filepath.Join(workDirPath, ".kcp-front-proxy", "requestheader.crt"),
+		filepath.Join(workDirPath, ".kcp-front-proxy", "requestheader.key"),
 		&kuser.DefaultInfo{Name: "kcp-front-proxy"},
 		365,
 	)
@@ -101,9 +101,9 @@ func start(proxyFlags, shardFlags []string, logDirPath, workDirPath string, numb
 
 	// create client CA and kcp-admin client cert to connect through front-proxy
 	clientCA, _, err := crypto.EnsureCA(
-		filepath.Join(workDirPath, ".kcp/client-ca.crt"),
-		filepath.Join(workDirPath, ".kcp/client-ca.key"),
-		filepath.Join(workDirPath, ".kcp/client-ca-serial.txt"),
+		filepath.Join(workDirPath, ".kcp", "client-ca.crt"),
+		filepath.Join(workDirPath, ".kcp", "client-ca.key"),
+		filepath.Join(workDirPath, ".kcp", "client-ca-serial.txt"),
 		"kcp-client-ca",
 		365,
 	)
@@ -111,8 +111,8 @@ func start(proxyFlags, shardFlags []string, logDirPath, workDirPath string, numb
 		return fmt.Errorf("failed to create client-ca: %w", err)
 	}
 	_, _, err = clientCA.EnsureClientCertificate(
-		filepath.Join(workDirPath, ".kcp/kcp-admin.crt"),
-		filepath.Join(workDirPath, ".kcp/kcp-admin.key"),
+		filepath.Join(workDirPath, ".kcp", "kcp-admin.crt"),
+		filepath.Join(workDirPath, ".kcp", "kcp-admin.key"),
 		&kuser.DefaultInfo{
 			Name:   "kcp-admin",
 			Groups: []string{bootstrap.SystemKcpAdminGroup},
@@ -125,8 +125,8 @@ func start(proxyFlags, shardFlags []string, logDirPath, workDirPath string, numb
 
 	// client cert for logical-cluster-admin
 	_, _, err = clientCA.EnsureClientCertificate(
-		filepath.Join(workDirPath, ".kcp/logical-cluster-admin.crt"),
-		filepath.Join(workDirPath, ".kcp/logical-cluster-admin.key"),
+		filepath.Join(workDirPath, ".kcp", "logical-cluster-admin.crt"),
+		filepath.Join(workDirPath, ".kcp", "logical-cluster-admin.key"),
 		&kuser.DefaultInfo{
 			Name:   "logical-cluster-admin",
 			Groups: []string{bootstrap.SystemLogicalClusterAdmin},
@@ -139,8 +139,8 @@ func start(proxyFlags, shardFlags []string, logDirPath, workDirPath string, numb
 
 	// client cert for external-logical-cluster-admin
 	_, _, err = clientCA.EnsureClientCertificate(
-		filepath.Join(workDirPath, ".kcp/external-logical-cluster-admin.crt"),
-		filepath.Join(workDirPath, ".kcp/external-logical-cluster-admin.key"),
+		filepath.Join(workDirPath, ".kcp", "external-logical-cluster-admin.crt"),
+		filepath.Join(workDirPath, ".kcp", "external-logical-cluster-admin.key"),
 		&kuser.DefaultInfo{
 			Name:   "external-logical-cluster-admin",
 			Groups: []string{bootstrap.SystemExternalLogicalClusterAdmin},
@@ -156,8 +156,8 @@ func start(proxyFlags, shardFlags []string, logDirPath, workDirPath string, numb
 	// for now we will use the privileged system group to bypass the authz stack
 	// create privileged system user client cert to connect to shards
 	_, _, err = clientCA.EnsureClientCertificate(
-		filepath.Join(workDirPath, ".kcp-front-proxy/shard-admin.crt"),
-		filepath.Join(workDirPath, ".kcp-front-proxy/shard-admin.key"),
+		filepath.Join(workDirPath, ".kcp-front-proxy", "shard-admin.crt"),
+		filepath.Join(workDirPath, ".kcp-front-proxy", "shard-admin.key"),
 		&kuser.DefaultInfo{
 			Name:   "shard-admin",
 			Groups: []string{kuser.SystemPrivilegedGroup},
@@ -170,9 +170,9 @@ func start(proxyFlags, shardFlags []string, logDirPath, workDirPath string, numb
 
 	// create server CA to be used to sign shard serving certs
 	servingCA, _, err := crypto.EnsureCA(
-		filepath.Join(workDirPath, ".kcp/serving-ca.crt"),
-		filepath.Join(workDirPath, ".kcp/serving-ca.key"),
-		filepath.Join(workDirPath, ".kcp/serving-ca-serial.txt"),
+		filepath.Join(workDirPath, ".kcp", "serving-ca.crt"),
+		filepath.Join(workDirPath, ".kcp", "serving-ca.key"),
+		filepath.Join(workDirPath, ".kcp", "serving-ca-serial.txt"),
 		"kcp-serving-ca",
 		365,
 	)
@@ -182,9 +182,9 @@ func start(proxyFlags, shardFlags []string, logDirPath, workDirPath string, numb
 
 	// create service account signing and verification key
 	if _, _, err := crypto.EnsureCA(
-		filepath.Join(workDirPath, ".kcp/service-account.crt"),
-		filepath.Join(workDirPath, ".kcp/service-account.key"),
-		filepath.Join(workDirPath, ".kcp/service-account-serial.txt"),
+		filepath.Join(workDirPath, ".kcp", "service-account.crt"),
+		filepath.Join(workDirPath, ".kcp", "service-account.key"),
+		filepath.Join(workDirPath, ".kcp", "service-account-serial.txt"),
 		"kcp-service-account-signing-ca",
 		365,
 	); err != nil {
@@ -294,7 +294,7 @@ func start(proxyFlags, shardFlags []string, logDirPath, workDirPath string, numb
 	}
 
 	// Label region of shards
-	clientConfig, err := loadKubeConfig(filepath.Join(workDirPath, ".kcp/admin.kubeconfig"), "base")
+	clientConfig, err := loadKubeConfig(filepath.Join(workDirPath, ".kcp", "admin.kubeconfig"), "base")
 	if err != nil {
 		return err
 	}

--- a/cmd/sharded-test-server/main.go
+++ b/cmd/sharded-test-server/main.go
@@ -217,7 +217,7 @@ func start(proxyFlags, shardFlags []string, logDirPath, workDirPath string, numb
 
 	// start shards
 	var shards []*testshard.Shard
-	for i := 0; i < numberOfShards; i++ {
+	for i := range numberOfShards {
 		shard, err := newShard(ctx, i, shardFlags, standaloneVW, servingCA, hostIP.String(), logDirPath, workDirPath, cacheServerConfigPath, clientCA)
 		if err != nil {
 			return err
@@ -235,7 +235,7 @@ func start(proxyFlags, shardFlags []string, logDirPath, workDirPath string, numb
 		// TODO: support multiple virtual workspace servers (i.e. multiple ports)
 		vwPort = "7444"
 
-		for i := 0; i < numberOfShards; i++ {
+		for i := range numberOfShards {
 			vw, err := newVirtualWorkspace(ctx, i, servingCA, hostIP.String(), logDirPath, workDirPath, clientCA, cacheServerConfigPath)
 			if err != nil {
 				return err

--- a/cmd/sharded-test-server/main.go
+++ b/cmd/sharded-test-server/main.go
@@ -216,7 +216,7 @@ func start(proxyFlags, shardFlags []string, logDirPath, workDirPath string, numb
 	}
 
 	// start shards
-	var shards []*testshard.Shard
+	shards := make([]*testshard.Shard, numberOfShards)
 	for i := range numberOfShards {
 		shard, err := newShard(ctx, i, shardFlags, standaloneVW, servingCA, hostIP.String(), logDirPath, workDirPath, cacheServerConfigPath, clientCA)
 		if err != nil {
@@ -225,7 +225,7 @@ func start(proxyFlags, shardFlags []string, logDirPath, workDirPath string, numb
 		if err := shard.Start(ctx, quiet); err != nil {
 			return err
 		}
-		shards = append(shards, shard)
+		shards[i] = shard
 	}
 
 	// Start virtual-workspace servers

--- a/cmd/test-server/main.go
+++ b/cmd/test-server/main.go
@@ -92,9 +92,9 @@ func start(shardFlags []string, workDirPath, logDirPath string, quiet bool) erro
 
 	// create client CA and kcp-admin client cert to connect through front-proxy
 	_, err := crypto.MakeSelfSignedCA(
-		filepath.Join(workDirPath, ".kcp", "/client-ca.crt"),
-		filepath.Join(workDirPath, ".kcp", "/client-ca.key"),
-		filepath.Join(workDirPath, ".kcp", "/client-ca-serial.txt"),
+		filepath.Join(workDirPath, ".kcp", "client-ca.crt"),
+		filepath.Join(workDirPath, ".kcp", "client-ca.key"),
+		filepath.Join(workDirPath, ".kcp", "client-ca-serial.txt"),
 		"kcp-client-ca",
 		365,
 	)

--- a/pkg/proxy/index/index_controller.go
+++ b/pkg/proxy/index/index_controller.go
@@ -146,7 +146,7 @@ func (c *Controller) Start(ctx context.Context, numThreads int) {
 	logger.Info("Starting controller")
 	defer logger.Info("Shutting down controller")
 
-	for i := 0; i < numThreads; i++ {
+	for range numThreads {
 		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
 	}
 

--- a/pkg/reconciler/apis/apibinding/apibinding_controller.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_controller.go
@@ -420,7 +420,7 @@ func (c *controller) Start(ctx context.Context, numThreads int) {
 	logger.Info("Starting controller")
 	defer logger.Info("Shutting down controller")
 
-	for i := 0; i < numThreads; i++ {
+	for range numThreads {
 		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
 	}
 

--- a/pkg/reconciler/apis/apibindingdeletion/apibinding_deletion_controller.go
+++ b/pkg/reconciler/apis/apibindingdeletion/apibinding_deletion_controller.go
@@ -149,7 +149,7 @@ func (c *Controller) Start(ctx context.Context, numThreads int) {
 	logger.Info("Starting controller")
 	defer logger.Info("Shutting down controller")
 
-	for i := 0; i < numThreads; i++ {
+	for range numThreads {
 		go wait.Until(func() { c.startWorker(ctx) }, time.Second, ctx.Done())
 	}
 

--- a/pkg/reconciler/apis/apibindingdeletion/apibinding_deletor.go
+++ b/pkg/reconciler/apis/apibindingdeletion/apibinding_deletor.go
@@ -66,8 +66,8 @@ func (c *Controller) deleteAllCRs(ctx context.Context, apibinding *apisv1alpha2.
 			}
 
 			logger = logger.WithValues("gvr", gvr.String())
-			ctx = klog.NewContext(ctx, logger)
-			deletionMetadata, err := c.deleteAllCR(ctx, logicalcluster.From(apibinding), gvr)
+			versionCtx := klog.NewContext(ctx, logger)
+			deletionMetadata, err := c.deleteAllCR(versionCtx, logicalcluster.From(apibinding), gvr)
 			if err != nil {
 				deleteContentErrs = append(deleteContentErrs, err)
 			}

--- a/pkg/reconciler/apis/apiexport/apiexport_controller.go
+++ b/pkg/reconciler/apis/apiexport/apiexport_controller.go
@@ -271,7 +271,7 @@ func (c *controller) Start(ctx context.Context, numThreads int) {
 	logger.Info("Starting controller")
 	defer logger.Info("Shutting down controller")
 
-	for i := 0; i < numThreads; i++ {
+	for range numThreads {
 		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
 	}
 

--- a/pkg/reconciler/apis/apiexportendpointslice/apiexportendpointslice_controller.go
+++ b/pkg/reconciler/apis/apiexportendpointslice/apiexportendpointslice_controller.go
@@ -235,7 +235,7 @@ func (c *controller) Start(ctx context.Context, numThreads int) {
 	logger.Info("Starting controller")
 	defer logger.Info("Shutting down controller")
 
-	for i := 0; i < numThreads; i++ {
+	for range numThreads {
 		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
 	}
 

--- a/pkg/reconciler/apis/apiexportendpointsliceurls/apiexportendpointsliceurls_controller.go
+++ b/pkg/reconciler/apis/apiexportendpointsliceurls/apiexportendpointsliceurls_controller.go
@@ -272,7 +272,7 @@ func (c *controller) Start(ctx context.Context, numThreads int) {
 	logger.Info("Starting controller")
 	defer logger.Info("Shutting down controller")
 
-	for i := 0; i < numThreads; i++ {
+	for range numThreads {
 		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
 	}
 

--- a/pkg/reconciler/apis/crdcleanup/crdcleanup_controller.go
+++ b/pkg/reconciler/apis/crdcleanup/crdcleanup_controller.go
@@ -162,7 +162,7 @@ func (c *controller) Start(ctx context.Context, numThreads int) {
 	logger.Info("Starting controller")
 	defer logger.Info("Shutting down controller")
 
-	for i := 0; i < numThreads; i++ {
+	for range numThreads {
 		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
 	}
 

--- a/pkg/reconciler/apis/extraannotationsync/apibindingannotation_controller.go
+++ b/pkg/reconciler/apis/extraannotationsync/apibindingannotation_controller.go
@@ -185,7 +185,7 @@ func (c *controller) Start(ctx context.Context, numThreads int) {
 	logger.Info("Starting controller")
 	defer logger.Info("Shutting down controller")
 
-	for i := 0; i < numThreads; i++ {
+	for range numThreads {
 		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
 	}
 

--- a/pkg/reconciler/apis/logicalclustercleanup/logicalclustercleanup_controller.go
+++ b/pkg/reconciler/apis/logicalclustercleanup/logicalclustercleanup_controller.go
@@ -173,7 +173,7 @@ func (c *controller) Start(ctx context.Context, numThreads int) {
 	logger.Info("Starting controller")
 	defer logger.Info("Shutting down controller")
 
-	for i := 0; i < numThreads; i++ {
+	for range numThreads {
 		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
 	}
 

--- a/pkg/reconciler/apis/permissionclaimlabel/permissionclaimlabel_controller.go
+++ b/pkg/reconciler/apis/permissionclaimlabel/permissionclaimlabel_controller.go
@@ -139,7 +139,7 @@ func (c *controller) Start(ctx context.Context, numThreads int) {
 	logger.Info("starting controller")
 	defer logger.Info("shutting down controller")
 
-	for i := 0; i < numThreads; i++ {
+	for range numThreads {
 		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
 	}
 

--- a/pkg/reconciler/apis/permissionclaimlabel/permissionclaimlabel_resource_controller.go
+++ b/pkg/reconciler/apis/permissionclaimlabel/permissionclaimlabel_resource_controller.go
@@ -112,7 +112,7 @@ func (c *resourceController) Start(ctx context.Context, numThreads int) {
 	logger.Info("starting controller")
 	defer logger.Info("shutting down controller")
 
-	for i := 0; i < numThreads; i++ {
+	for range numThreads {
 		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
 	}
 

--- a/pkg/reconciler/cache/cachedresources/cachedresources_controller.go
+++ b/pkg/reconciler/cache/cachedresources/cachedresources_controller.go
@@ -200,7 +200,7 @@ func (c *Controller) Start(ctx context.Context, numThreads int) {
 	logger.Info("Starting controller")
 	defer logger.Info("Shutting down controller")
 
-	for i := 0; i < numThreads; i++ {
+	for range numThreads {
 		go wait.Until(func() { c.startWorker(ctx) }, time.Second, ctx.Done())
 	}
 	c.started = true

--- a/pkg/reconciler/cache/cachedresources/replication/replication_controller.go
+++ b/pkg/reconciler/cache/cachedresources/replication/replication_controller.go
@@ -154,7 +154,7 @@ func (c *Controller) Start(ctx context.Context, workers int) {
 	logger.Info("Starting controller")
 	defer logger.Info("Shutting down controller")
 
-	for i := 0; i < workers; i++ {
+	for range workers {
 		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
 	}
 	c.started = true

--- a/pkg/reconciler/cache/labelclusterrolebindings/labelclusterrolebinding_controller.go
+++ b/pkg/reconciler/cache/labelclusterrolebindings/labelclusterrolebinding_controller.go
@@ -203,7 +203,7 @@ func (c *controller) Start(ctx context.Context, numThreads int) {
 	logger.Info("Starting controller")
 	defer logger.Info("Shutting down controller")
 
-	for i := 0; i < numThreads; i++ {
+	for range numThreads {
 		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
 	}
 

--- a/pkg/reconciler/cache/labelclusterroles/labelclusterrole_controller.go
+++ b/pkg/reconciler/cache/labelclusterroles/labelclusterrole_controller.go
@@ -203,7 +203,7 @@ func (c *controller) Start(ctx context.Context, numThreads int) {
 	logger.Info("Starting controller")
 	defer logger.Info("Shutting down controller")
 
-	for i := 0; i < numThreads; i++ {
+	for range numThreads {
 		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
 	}
 

--- a/pkg/reconciler/cache/labellogicalcluster/labellogicalcluster_controller.go
+++ b/pkg/reconciler/cache/labellogicalcluster/labellogicalcluster_controller.go
@@ -146,7 +146,7 @@ func (c *controller) Start(ctx context.Context, numThreads int) {
 	logger.Info("Starting controller")
 	defer logger.Info("Shutting down controller")
 
-	for i := 0; i < numThreads; i++ {
+	for range numThreads {
 		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
 	}
 

--- a/pkg/reconciler/cache/replication/replication_controller.go
+++ b/pkg/reconciler/cache/replication/replication_controller.go
@@ -129,7 +129,7 @@ func (c *controller) Start(ctx context.Context, workers int) {
 	logger.Info("Starting controller")
 	defer logger.Info("Shutting down controller")
 
-	for i := 0; i < workers; i++ {
+	for range workers {
 		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
 	}
 	<-ctx.Done()

--- a/pkg/reconciler/core/logicalcluster/logicalcluster_controller.go
+++ b/pkg/reconciler/core/logicalcluster/logicalcluster_controller.go
@@ -109,7 +109,7 @@ func (c *Controller) Start(ctx context.Context, numThreads int) {
 	logger.Info("Starting controller")
 	defer logger.Info("Shutting down controller")
 
-	for i := 0; i < numThreads; i++ {
+	for range numThreads {
 		go wait.Until(func() { c.startWorker(ctx) }, time.Second, ctx.Done())
 	}
 

--- a/pkg/reconciler/core/logicalclusterdeletion/logicalcluster_deletion_controller.go
+++ b/pkg/reconciler/core/logicalclusterdeletion/logicalcluster_deletion_controller.go
@@ -178,7 +178,7 @@ func (c *Controller) Start(ctx context.Context, numThreads int) {
 	}
 	c.dynamicFrontProxyClient = dynamicFrontProxyClient
 
-	for i := 0; i < numThreads; i++ {
+	for range numThreads {
 		go wait.Until(func() { c.startWorker(ctx) }, time.Second, ctx.Done())
 	}
 

--- a/pkg/reconciler/core/shard/shard_controller.go
+++ b/pkg/reconciler/core/shard/shard_controller.go
@@ -108,7 +108,7 @@ func (c *Controller) Start(ctx context.Context, numThreads int) {
 	logger.Info("Starting controller")
 	defer logger.Info("Shutting down controller")
 
-	for i := 0; i < numThreads; i++ {
+	for range numThreads {
 		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
 	}
 

--- a/pkg/reconciler/dynamicrestmapper/dynamicrestmapper_controller.go
+++ b/pkg/reconciler/dynamicrestmapper/dynamicrestmapper_controller.go
@@ -260,7 +260,7 @@ func (c *Controller) Start(ctx context.Context, numThreads int) {
 	logger.Info("Starting controller")
 	defer logger.Info("Shutting down controller")
 
-	for i := 0; i < numThreads; i++ {
+	for range numThreads {
 		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
 	}
 

--- a/pkg/reconciler/garbagecollector/garbagecollector_controller.go
+++ b/pkg/reconciler/garbagecollector/garbagecollector_controller.go
@@ -145,7 +145,7 @@ func (c *Controller) Start(ctx context.Context, numThreads int) {
 	logger.Info("Starting controller")
 	defer logger.Info("Shutting down controller")
 
-	for i := 0; i < numThreads; i++ {
+	for range numThreads {
 		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
 	}
 

--- a/pkg/reconciler/kubequota/kubequota_controller.go
+++ b/pkg/reconciler/kubequota/kubequota_controller.go
@@ -153,7 +153,7 @@ func (c *Controller) Start(ctx context.Context, numThreads int) {
 	logger.Info("Starting controller")
 	defer logger.Info("Shutting down controller")
 
-	for i := 0; i < numThreads; i++ {
+	for range numThreads {
 		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
 	}
 

--- a/pkg/reconciler/tenancy/bootstrap/bootstrap_controller.go
+++ b/pkg/reconciler/tenancy/bootstrap/bootstrap_controller.go
@@ -131,7 +131,7 @@ func (c *controller) Start(ctx context.Context, numThreads int) {
 	logger.Info("Starting controller")
 	defer logger.Info("Shutting down controller")
 
-	for i := 0; i < numThreads; i++ {
+	for range numThreads {
 		go wait.Until(func() { c.startWorker(ctx) }, time.Second, ctx.Done())
 	}
 

--- a/pkg/reconciler/tenancy/defaultapibindinglifecycle/default_apibinding_lifecycle_controller.go
+++ b/pkg/reconciler/tenancy/defaultapibindinglifecycle/default_apibinding_lifecycle_controller.go
@@ -224,7 +224,7 @@ func (c *DefaultAPIBindingController) Start(ctx context.Context, numThreads int)
 	logger.Info("Starting controller")
 	defer logger.Info("Shutting down controller")
 
-	for i := 0; i < numThreads; i++ {
+	for range numThreads {
 		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
 	}
 	<-ctx.Done()

--- a/pkg/reconciler/tenancy/initialization/apibinder_initializer_controller.go
+++ b/pkg/reconciler/tenancy/initialization/apibinder_initializer_controller.go
@@ -244,7 +244,7 @@ func (b *APIBinder) Start(ctx context.Context, numThreads int) {
 	logger.Info("Starting controller")
 	defer logger.Info("Shutting down controller")
 
-	for i := 0; i < numThreads; i++ {
+	for range numThreads {
 		go wait.UntilWithContext(ctx, b.startWorker, time.Second)
 	}
 	<-ctx.Done()

--- a/pkg/reconciler/tenancy/logicalcluster/logicalcluster_controller.go
+++ b/pkg/reconciler/tenancy/logicalcluster/logicalcluster_controller.go
@@ -137,7 +137,7 @@ func (c *Controller) Start(ctx context.Context, numThreads int) {
 	logger.Info("Starting controller")
 	defer logger.Info("Shutting down controller")
 
-	for i := 0; i < numThreads; i++ {
+	for range numThreads {
 		go wait.Until(func() { c.startWorker(ctx) }, time.Second, ctx.Done())
 	}
 

--- a/pkg/reconciler/tenancy/workspace/workspace_controller.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_controller.go
@@ -197,7 +197,7 @@ func (c *Controller) Start(ctx context.Context, numThreads int) {
 	logger.Info("Starting controller")
 	defer logger.Info("Shutting down controller")
 
-	for i := 0; i < numThreads; i++ {
+	for range numThreads {
 		go wait.Until(func() { c.startWorker(ctx) }, time.Second, ctx.Done())
 	}
 

--- a/pkg/reconciler/tenancy/workspacemounts/workspacemounts_controller.go
+++ b/pkg/reconciler/tenancy/workspacemounts/workspacemounts_controller.go
@@ -135,7 +135,7 @@ func (c *Controller) Start(ctx context.Context, numThreads int) {
 	logger.Info("Starting controller")
 	defer logger.Info("Shutting down controller")
 
-	for i := 0; i < numThreads; i++ {
+	for range numThreads {
 		go wait.Until(func() { c.startWorker(ctx) }, time.Second, ctx.Done())
 	}
 

--- a/pkg/reconciler/tenancy/workspacetype/workspacetype_controller.go
+++ b/pkg/reconciler/tenancy/workspacetype/workspacetype_controller.go
@@ -171,7 +171,7 @@ func (c *controller) Start(ctx context.Context, numThreads int) {
 	logger.Info("Starting controller")
 	defer logger.Info("Shutting down controller")
 
-	for i := 0; i < numThreads; i++ {
+	for range numThreads {
 		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
 	}
 

--- a/pkg/reconciler/topology/partitionset/partitionset_controller.go
+++ b/pkg/reconciler/topology/partitionset/partitionset_controller.go
@@ -258,7 +258,7 @@ func (c *controller) Start(ctx context.Context, numThreads int) {
 	logger.Info("Starting controller")
 	defer logger.Info("Shutting down controller")
 
-	for i := 0; i < numThreads; i++ {
+	for range numThreads {
 		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
 	}
 

--- a/pkg/server/filters/filters_test.go
+++ b/pkg/server/filters/filters_test.go
@@ -54,7 +54,7 @@ func Test_isPartialMetadataHeader(t *testing.T) {
 
 func TestWorkspaceNamePattern(t *testing.T) {
 	_, fileName, _, _ := runtime.Caller(0)
-	bs, err := os.ReadFile(filepath.Join(filepath.Dir(fileName), "..", "..", "../config/crds/tenancy.kcp.io_workspaces.yaml"))
+	bs, err := os.ReadFile(filepath.Join(filepath.Dir(fileName), "..", "..", "..", "config", "crds", "tenancy.kcp.io_workspaces.yaml"))
 	require.NoError(t, err)
 	var crd apiextensionsv1.CustomResourceDefinition
 	err = yaml.Unmarshal(bs, &crd)

--- a/pkg/virtual/framework/forwardingregistry/store_test.go
+++ b/pkg/virtual/framework/forwardingregistry/store_test.go
@@ -30,9 +30,9 @@ func TestUpdateToCreateOptions(t *testing.T) {
 	numField := updateOptions.NumField()
 	require.Equalf(t, 4, numField, "UpdateOptions is expected to have 4 fields")
 
-	var fields []string
+	fields := make([]string, numField)
 	for i := range numField {
-		fields = append(fields, updateOptions.Field(i).Name)
+		fields[i] = updateOptions.Field(i).Name
 	}
 
 	// Assert the UpdateOptions struct fields set has not changed

--- a/pkg/virtual/framework/forwardingregistry/store_test.go
+++ b/pkg/virtual/framework/forwardingregistry/store_test.go
@@ -31,7 +31,7 @@ func TestUpdateToCreateOptions(t *testing.T) {
 	require.Equalf(t, 4, numField, "UpdateOptions is expected to have 4 fields")
 
 	var fields []string
-	for i := 0; i < numField; i++ {
+	for i := range numField {
 		fields = append(fields, updateOptions.Field(i).Name)
 	}
 

--- a/sdk/apis/apis/fuzzer/fuzzer.go
+++ b/sdk/apis/apis/fuzzer/fuzzer.go
@@ -58,7 +58,7 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 		func(r *v1alpha2.APIExportSpec, c fuzz.Continue) {
 			c.FuzzNoCustom(r)
 			r.Resources = nil
-			for i := 0; i < c.Intn(5); i++ {
+			for range c.Intn(5) {
 				name := nonEmptyString(c.RandString)
 				group := nonEmptyString(c.RandString)
 				schema := nonEmptyString(c.RandString) + "." + name + "." + group
@@ -72,13 +72,13 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 				})
 			}
 			r.PermissionClaims = nil
-			for i := 0; i < c.Intn(5); i++ {
+			for range c.Intn(5) {
 				group := nonEmptyString(c.RandString)
 				resource := nonEmptyString(c.RandString)
 				identityHash := nonEmptyString(c.RandString)
 				verbs := []string{}
 				numVerbs := c.Intn(5) + 1 // the lower bound is 0, but 0 verbs is not a valid combination
-				for j := 0; j < numVerbs; j++ {
+				for range numVerbs {
 					verbs = append(verbs, nonEmptyString(c.RandString))
 				}
 				r.PermissionClaims = append(r.PermissionClaims, v1alpha2.PermissionClaim{

--- a/sdk/apis/roundtrip_test.go
+++ b/sdk/apis/roundtrip_test.go
@@ -95,7 +95,7 @@ func TestConversion(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			for i := 0; i < *FuzzIters; i++ {
+			for range *FuzzIters {
 				testGenericConversion(t, test.v1.DeepCopyObject, test.v2.DeepCopyObject, test.toV1, test.toV2)
 			}
 		})

--- a/sdk/cmd/help/doc.go
+++ b/sdk/cmd/help/doc.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/component-base/term"
 )
 
-var reEmptyLine = regexp.MustCompile(`(?m)([\w[:punct:]])[ ]*\n([\w[:punct:]])`)
+var reEmptyLine = regexp.MustCompile(`(?m)([\w[:punct:]]) *\n([\w[:punct:]])`)
 
 func Doc(s string) string {
 	s = heredoc.Doc(s)

--- a/sdk/testing/third_party/library-go/crypto/crypto.go
+++ b/sdk/testing/third_party/library-go/crypto/crypto.go
@@ -824,10 +824,10 @@ func (ca *CA) MakeClientCertificate(certFile, keyFile string, u user.Info, expir
 		return nil, err
 	}
 
-	if err = os.WriteFile(certFile, certData, os.FileMode(0644)); err != nil {
+	if err := os.WriteFile(certFile, certData, os.FileMode(0644)); err != nil {
 		return nil, err
 	}
-	if err = os.WriteFile(keyFile, keyData, os.FileMode(0600)); err != nil {
+	if err := os.WriteFile(keyFile, keyData, os.FileMode(0600)); err != nil {
 		return nil, err
 	}
 

--- a/test/e2e/apibinding/default_apibinding_test.go
+++ b/test/e2e/apibinding/default_apibinding_test.go
@@ -111,7 +111,7 @@ func TestDefaultAPIBinding(t *testing.T) {
 			},
 		},
 	}
-	apiExportCreated, err := kcpClusterClient.Cluster(providerPath).ApisV1alpha2().APIExports().Create(ctx, apiExport, metav1.CreateOptions{})
+	_, err = kcpClusterClient.Cluster(providerPath).ApisV1alpha2().APIExports().Create(ctx, apiExport, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	workspaceType := tenancyv1alpha1.WorkspaceType{
@@ -195,7 +195,7 @@ func TestDefaultAPIBinding(t *testing.T) {
 
 	updatedAPIExport := currentAPIExport.DeepCopy()
 
-	updatedAPIExport.Spec.Resources = append(apiExportCreated.Spec.Resources, apisv1alpha2.ResourceSchema{
+	updatedAPIExport.Spec.Resources = append(updatedAPIExport.Spec.Resources, apisv1alpha2.ResourceSchema{
 		Group:  "gateway.networking.k8s.io",
 		Name:   "tlsroutes",
 		Schema: "latest.tlsroutes.gateway.networking.k8s.io",

--- a/test/e2e/audit/audit_log_test.go
+++ b/test/e2e/audit/audit_log_test.go
@@ -62,7 +62,7 @@ func TestAuditLogs(t *testing.T) {
 	_, err = workspaceKubeClient.Cluster(wsPath).CoreV1().ConfigMaps("default").List(ctx, metav1.ListOptions{})
 	require.NoError(t, err, "Error listing configmaps")
 
-	auditLogPath := filepath.Join(artifactDir, "kcp/main/kcp.audit")
+	auditLogPath := filepath.Join(artifactDir, "kcp", "main", "kcp.audit")
 	t.Logf("Reading audit log at %s", auditLogPath)
 	data, err := os.ReadFile(auditLogPath)
 	require.NoError(t, err, "Error reading auditfile")

--- a/test/e2e/conformance/cross_logical_cluster_list_test.go
+++ b/test/e2e/conformance/cross_logical_cluster_list_test.go
@@ -289,7 +289,7 @@ func TestBuiltInCrossLogicalClusterListPartialObjectMetadata(t *testing.T) {
 	kubeClusterClient, err := kcpkubernetesclientset.NewForConfig(cfg)
 	require.NoError(t, err, "error creating kube cluster client")
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		wsPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath, kcptesting.WithRootShard())
 
 		configMapName := fmt.Sprintf("test-cm-%d", i)

--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -25,7 +25,7 @@ import (
 )
 
 // DefaultTokenAuthFile returns the default auth tokens file.
-var DefaultTokenAuthFile = filepath.Join(kcptestinghelpers.RepositoryDir(), "test/e2e/framework/auth-tokens.csv")
+var DefaultTokenAuthFile = filepath.Join(kcptestinghelpers.RepositoryDir(), "test", "e2e", "framework", "auth-tokens.csv")
 
 func init() {
 	var args []string

--- a/test/e2e/garbagecollector/garbagecollector_test.go
+++ b/test/e2e/garbagecollector/garbagecollector_test.go
@@ -153,7 +153,7 @@ func TestGarbageCollectorTypesFromBinding(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test multiple workspaces in parallel
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		t.Run(fmt.Sprintf("tc%d", i), func(t *testing.T) {
 			t.Parallel()
 

--- a/test/e2e/quota/quota_test.go
+++ b/test/e2e/quota/quota_test.go
@@ -70,7 +70,7 @@ func TestKubeQuotaBuiltInCoreV1Types(t *testing.T) {
 
 	// Create more than 1 workspace with the same quota restrictions to validate that after we create the first workspace
 	// and fill its quota to capacity, subsequent workspaces have independent quota.
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		wsPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath, kcptesting.WithName("quota-%d", i))
 
 		ws1Quota := &corev1.ResourceQuota{
@@ -119,7 +119,7 @@ func TestKubeQuotaCoreV1TypesFromBinding(t *testing.T) {
 	t.Cleanup(cancel)
 
 	// Test multiple workspaces in parallel
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		t.Run(fmt.Sprintf("tc%d", i), func(t *testing.T) {
 			t.Parallel()
 
@@ -350,7 +350,7 @@ func TestClusterScopedQuota(t *testing.T) {
 
 	// Create more than 1 workspace with the same quota restrictions to validate that after we create the first workspace
 	// and fill its quota to capacity, subsequent workspaces have independent quota.
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		wsPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath, kcptesting.WithName("quota-%d", i))
 
 		const adminNamespace = "admin"

--- a/test/e2e/virtual/apiexport/virtualworkspace_test.go
+++ b/test/e2e/virtual/apiexport/virtualworkspace_test.go
@@ -1125,9 +1125,11 @@ func newCowboy(namespace, name string) *wildwestv1alpha1.Cowboy {
 }
 
 func createClusterRoleAndBindings(name, subjectName, subjectKind string, verbs []string, resources ...string) (*rbacv1.ClusterRole, *rbacv1.ClusterRoleBinding) {
-	var rules []rbacv1.PolicyRule
+	var total = len(resources) / 3
 
-	for i := range len(resources) / 3 {
+	rules := make([]rbacv1.PolicyRule, total)
+
+	for i := range total {
 		group := resources[i*3]
 		resource := resources[i*3+1]
 		resourceName := resources[i*3+2]
@@ -1142,7 +1144,7 @@ func createClusterRoleAndBindings(name, subjectName, subjectKind string, verbs [
 			r.ResourceNames = []string{resourceName}
 		}
 
-		rules = append(rules, r)
+		rules[i] = r
 	}
 
 	return &rbacv1.ClusterRole{

--- a/test/e2e/virtual/apiexport/virtualworkspace_test.go
+++ b/test/e2e/virtual/apiexport/virtualworkspace_test.go
@@ -1127,7 +1127,7 @@ func newCowboy(namespace, name string) *wildwestv1alpha1.Cowboy {
 func createClusterRoleAndBindings(name, subjectName, subjectKind string, verbs []string, resources ...string) (*rbacv1.ClusterRole, *rbacv1.ClusterRoleBinding) {
 	var rules []rbacv1.PolicyRule
 
-	for i := 0; i < len(resources)/3; i++ {
+	for i := range len(resources) / 3 {
 		group := resources[i*3]
 		resource := resources[i*3+1]
 		resourceName := resources[i*3+2]

--- a/test/e2e/watchcache/watchcache_enabled_test.go
+++ b/test/e2e/watchcache/watchcache_enabled_test.go
@@ -93,7 +93,7 @@ func TestWatchCacheEnabledForCRD(t *testing.T) {
 	})
 
 	t.Log("Getting wildwest.dev.cowboys 10 times from the watch cache")
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		res, err := wildwestClusterClient.Cluster(wsPath).WildwestV1alpha1().Cowboys("default").List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 		require.NoError(t, err)
 		require.Equal(t, 1, len(res.Items), "expected to get exactly one cowboy")
@@ -145,7 +145,7 @@ func TestWatchCacheEnabledForAPIBindings(t *testing.T) {
 		return nil
 	})
 	t.Log("Getting sheriffs.newyork.io 10 times from the watch cache")
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		res, err := dynamicKcpClusterClient.Cluster(wsConsume1aPath).Resource(sheriffsGVR).Namespace("default").List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 		require.NoError(t, err)
 		require.Equal(t, 1, len(res.Items), "expected to get exactly one sheriff")
@@ -194,7 +194,7 @@ func TestWatchCacheEnabledForBuiltinTypes(t *testing.T) {
 
 	// since secrets might be common resources to LIST, try to get them an odd number of times
 	t.Logf("Getting core.secret 115 times from the watch cache for %q cluster", wsPath)
-	for i := 0; i < 115; i++ {
+	for range 115 {
 		res, err := kubeClusterClient.Cluster(wsPath).CoreV1().Secrets("default").List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 		require.NoError(t, err)
 		require.GreaterOrEqual(t, len(res.Items), 1, "expected to get at least one secret")

--- a/test/integration/framework/goleak.go
+++ b/test/integration/framework/goleak.go
@@ -95,7 +95,7 @@ var (
 	// 14s as etcd sets a client request timeout of up to 7 seconds when
 	// shutting down the server and then starts shutting down everything
 	// else.
-	// A shorter timestan d would lead to false positives in the tests.
+	// A shorter timespan d would lead to false positives in the tests.
 	WaitTime = 14 * time.Second
 )
 


### PR DESCRIPTION
## Summary
This PR cleans up the golangci-lint config a bit. Linters that were disabled but actually not trigger on any errors anymore have been removed, some other linters have been enabled and their issues have been fixed (like `intrange`). 95% of this PR is just enabling the filepathJoin linter in gocritic, which I chose to fix simply because it did actually point out a few odd lines that were worth fixing.

## What Type of PR Is This?
/kind cleanup

## Release Notes
```release-note
NONE
```
