### PR TITLE
bump logcheck to 0.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ GOTESTSUM_VER := v1.8.1
 GOTESTSUM_BIN := gotestsum
 GOTESTSUM := $(abspath $(TOOLS_DIR))/$(GOTESTSUM_BIN)-$(GOTESTSUM_VER)
 
-LOGCHECK_VER := v0.8.2
+LOGCHECK_VER := v0.9.0
 LOGCHECK_BIN := logcheck
 LOGCHECK := $(TOOLS_GOBIN_DIR)/$(LOGCHECK_BIN)-$(LOGCHECK_VER)
 export LOGCHECK # so hack scripts can use it


### PR DESCRIPTION
## Summary
There haven't been any relevant changes in 0.9, only a new golangci-lint plugin wrapper. So this PR is just pure maintenance.

## What Type of PR Is This?
/kind cleanup

## Release Notes
```release-note
NONE
```
