### PR TITLE
Add references on docs landing page to other projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8119/badge)](https://www.bestpractices.dev/projects/8119)
 [![Go Report Card](https://goreportcard.com/badge/github.com/kcp-dev/kcp)](https://goreportcard.com/report/github.com/kcp-dev/kcp)
-[![GitHub](https://img.shields.io/github/license/kcp-dev/kcp)](https://img.shields.io/github/license/kcp-dev/kcp)
-[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/kcp-dev/kcp?sort=semver)](https://img.shields.io/github/v/release/kcp-dev/kcp?sort=semver)
+[![GitHub](https://img.shields.io/github/license/kcp-dev/kcp)](https://github.com/kcp-dev/kcp/blob/main/LICENSE)
+[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/kcp-dev/kcp?sort=semver)](https://github.com/kcp-dev/kcp/releases/latest)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fkcp-dev%2Fkcp.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fkcp-dev%2Fkcp?ref=badge_shield)
 
 ## Overview

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -1,5 +1,14 @@
 # kcp Documentation
 
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8119/badge)](https://www.bestpractices.dev/projects/8119)
+[![Go Report Card](https://goreportcard.com/badge/github.com/kcp-dev/kcp)](https://goreportcard.com/report/github.com/kcp-dev/kcp)
+[![GitHub](https://img.shields.io/github/license/kcp-dev/kcp)](https://github.com/kcp-dev/kcp/blob/main/LICENSE)
+[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/kcp-dev/kcp?sort=semver)](https://github.com/kcp-dev/kcp/releases/latest)
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fkcp-dev%2Fkcp.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fkcp-dev%2Fkcp?ref=badge_shield)
+
+!!! tip ""
+    Looking for other project documentation? Check out: [api-syncagent](https://docs.kcp.io/api-syncagent) | [kcp-operator](https://docs.kcp.io/kcp-operator)
+
 ## Overview
 
 kcp is a Kubernetes-like control plane focusing on:

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -64,6 +64,8 @@ extra:
       link: https://github.com/kcp-dev/kcp
     - icon: fontawesome/brands/slack
       link: https://kubernetes.slack.com/archives/C021U8WSAFK
+    - icon: fontawesome/brands/youtube
+      link: https://www.youtube.com/@kcp-dev
 
 plugins:
   # https://github.com/lukasgeiter/mkdocs-awesome-pages-plugin


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Small docs PR that enriches the docs.kcp.io/kcp landing page with badges and references to the other projects also hosted on docs.kcp.io.

I've looked for a better way to integrate those links but the only thing I found is links in the footer, but those are social links, not cross references. I added YouTube to the footer while I was at it.

This is what the note looks like:

![image](https://github.com/user-attachments/assets/7bbd76a6-9975-42d5-a269-f0526ce6cbe6)


## What Type of PR Is This?

/kind documentation

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
