### PR TITLE
:bug: [release-0.27] Fix virutal workspace OpenAPI v3 endpoint panics

### DIFF
--- a/pkg/virtual/framework/dynamic/apiserver/openapi.go
+++ b/pkg/virtual/framework/dynamic/apiserver/openapi.go
@@ -228,7 +228,9 @@ func (o *openAPIHandler) handleOpenAPIRequest(apiSet apidefinition.APIDefinition
 		}
 
 		groupPath := "apis/" + gv.Group
-		webservices[groupPath] = append(webservices[groupPath], discovery.NewAPIGroupHandler(codecs, apiGroup).WebService())
+		if _, ok := webservices[groupPath]; !ok {
+			webservices[groupPath] = append(webservices[groupPath], discovery.NewAPIGroupHandler(codecs, apiGroup).WebService())
+		}
 	}
 
 	// Build OpenAPI v3 spec for /apis/<group> webservices

--- a/test/e2e/virtual/apiexport/apiresourceschema_cowboys_versions.yaml
+++ b/test/e2e/virtual/apiexport/apiresourceschema_cowboys_versions.yaml
@@ -1,0 +1,81 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIResourceSchema
+metadata:
+  name: today.cowboys.wildwest.dev
+spec:
+  group: wildwest.dev
+  names:
+    kind: Cowboy
+    listKind: CowboyList
+    plural: cowboys
+    singular: cowboy
+  scope: Namespaced
+  conversion:
+    strategy: None
+  versions:
+  - name: v1alpha1
+    schema:
+      description: Cowboy is part of the wild west
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CowboySpec holds the desired state of the Cowboy.
+          properties:
+            intent:
+              type: string
+          type: object
+        status:
+          description: CowboyStatus communicates the observed state of the Cowboy.
+          properties:
+            result:
+              type: string
+          type: object
+      type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - name: v1alpha2
+    schema:
+      description: Cowboy is part of the wild west
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CowboySpec holds the desired state of the Cowboy.
+          properties:
+            intent:
+              type: string
+          type: object
+        status:
+          description: CowboyStatus communicates the observed state of the Cowboy.
+          properties:
+            result:
+              type: string
+          type: object
+      type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}

--- a/test/e2e/virtual/apiexport/openapi_test.go
+++ b/test/e2e/virtual/apiexport/openapi_test.go
@@ -67,7 +67,7 @@ func TestAPIExportOpenAPI(t *testing.T) {
 
 	framework.AdmitWorkspaceAccess(ctx, t, kubeClusterClient, serviceProviderPath, []string{"user-1"}, nil, false)
 
-	setUpServiceProvider(ctx, t, dynamicClusterClient, kcpClients, serviceProviderPath, cfg)
+	setUpServiceProvider(ctx, t, dynamicClusterClient, kcpClients, true, serviceProviderPath, cfg, nil)
 
 	t.Logf("Waiting for APIExport to have a virtual workspace URL for the bound workspace %q", consumerWorkspace.Name)
 	apiExportVWCfg := rest.CopyConfig(cfg)


### PR DESCRIPTION
## Summary

Partial cherry-pick of #3430

Fixes an issue with the virtual workspace OpenAPI v3 endpoint/implementation. If there's a resource with two different versions, it'll cause a panic because we try to register the same GR (GroupResource) twice.

## What Type of PR Is This?

/kind bug

## Release Notes
```release-note
Fix a panic in the OpenAPI v3 endpoint for Virtual Workspaces happening if there's a resource with two or more versions
```

/assign @xrstf @embik 