### PR TITLE
Allow docker image to run without mounting `/.kcp`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,12 +52,19 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     make OS=${TARGETOS} ARCH=${TARGETARCH}
 
+# distroless doesn't have coreutils, so we need to create a directory
+# for kcp here and copy it over. Any directory would do.
+# It would be better to set WORKDIR to the home directory /home/nonroot,
+# but that would break for existing users.
+RUN mkdir /.kcp
+
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:debug
 
 # Copy wget so we can do basic healthchecks in the final image.
 COPY --from=builder /usr/bin/wget /usr/bin/wget
+COPY --from=builder --chown=65532:65532 /.kcp /.kcp
 
 WORKDIR /
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Currently:

```
>docker run -it --rm ghcr.io/kcp-dev/kcp:main
I0703 14:20:21.146754       1 generic.go:91] "creating root directory" dir="/.kcp"
Error: mkdir /.kcp: permission denied
zsh: exit 1     docker run -it --rm ghcr.io/kcp-dev/kcp:main
```

Expected:
```
>docker run -it --rm kcp:dev
I0703 14:19:10.003794       1 generic.go:107] "using root directory" dir="/.kcp"
I0703 14:19:10.003870       1 controllers.go:84] "generating service account key file" file="/.kcp/sa.key"
W0703 14:19:11.188983       1 registry.go:345] setting componentGlobalsRegistry in SetFallback. We recommend calling componentGlobalsRegistry.Set() right after parsing flags to avoid using feature gates before their final values are set by the flags.
[...]
```

A simpler change would've been to set `WORKDIR` to /home/nonroot, but that would break any existing users that mount their kcp storage into `/.kcp`.

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind bug

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
