### PR TITLE
Rely on user-installed tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .kcp*
 contrib/demo/clusters/kind/*.yaml
 contrib/demo/clusters/kind/*.kubeconfig
+contrib/tilt/kcp-helm-charts/
 *.log
 coverage.*
 tools

--- a/contrib/tilt/kind.sh
+++ b/contrib/tilt/kind.sh
@@ -16,28 +16,20 @@
 
 set -e
 
-ARCH=""
-case $(uname -m) in
-    i386)   ARCH="386" ;;
-    i686)   ARCH="386" ;;
-    x86_64) ARCH="amd64" ;;
-    arm)    dpkg --print-architecture | grep -q "arm64" && ARCH="arm64" || ARCH="arm" ;;
-esac
-
-if [ ! -f "/usr/local/bin/kind" ]; then
- echo "Installing KIND"
- curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-linux-$ARCH
- chmod +x ./kind
- sudo mv ./kind /usr/local/bin/kind
-else
-    echo "KIND already installed"
+if ! command -v kind &> /dev/null; then
+  echo "kind not found, exiting"
+  exit 1
 fi
 
-if [ ! -f "$HOME/.local/bin/tilt" ]; then
- echo "Installing TILT"
- curl -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.sh | bash
-else
-    echo "TILT already installed"
+if ! command -v helm &> /dev/null; then
+  echo "helm not found, exiting"
+  exit 1
+fi
+
+if ! command -v tilt &> /dev/null; then
+  echo "tilt not found, exiting"
+  echo "please follow the instructions at https://github.com/tilt-dev/tilt#install-tilt"
+  exit 1
 fi
 
 CLUSTER_NAME=${CLUSTER_NAME:-kcp}


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

I had already done these changes a while ago - I don't think a dev script should install tools into non-user directories.
On top if the user has any of the tools installed the current script would still install (and then maybe not use) them.
I think we can assume that `kind` and `helm` are present and that someone wanting to use `tilt` can install it themselves.

## What Type of PR Is This?

/kind cleanup

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
