### PR TITLE
Add admission plugin for CachedResources

### DIFF
--- a/pkg/admission/cachedresource/admission.go
+++ b/pkg/admission/cachedresource/admission.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cachedresource
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/admission"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	"github.com/kcp-dev/kcp/pkg/indexers"
+	cachedresourcesreconciler "github.com/kcp-dev/kcp/pkg/reconciler/cache/cachedresources"
+	cachev1alpha1 "github.com/kcp-dev/kcp/sdk/apis/cache/v1alpha1"
+	kcpinformers "github.com/kcp-dev/kcp/sdk/client/informers/externalversions"
+)
+
+// PluginName is the name used to identify this admission webhook.
+const PluginName = "apis.kcp.io/CachedResource"
+
+// Ensure that the required admission interfaces are implemented.
+var (
+	_ = admission.ValidationInterface(&CachedResourceAdmission{})
+	_ = admission.InitializationValidator(&CachedResourceAdmission{})
+)
+
+// Register registers the reserved name admission webhook.
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName,
+		func(_ io.Reader) (admission.Interface, error) {
+			p := &CachedResourceAdmission{
+				Handler: admission.NewHandler(admission.Create),
+			}
+			p.listCachedResourcesByGVR = func(cluster logicalcluster.Name, gvr schema.GroupVersionResource) ([]*cachev1alpha1.CachedResource, error) {
+				return indexers.ByIndex[*cachev1alpha1.CachedResource](
+					p.localCachedResourcesIndexer,
+					cachedresourcesreconciler.ByGVRAndLogicalCluster,
+					cachedresourcesreconciler.GVRAndLogicalClusterKey(gvr, cluster),
+				)
+			}
+
+			return p, nil
+		})
+}
+
+// CachedResourceAdmission is an admission plugin for checking APIExport validity.
+type CachedResourceAdmission struct {
+	*admission.Handler
+
+	listCachedResourcesByGVR    func(cluster logicalcluster.Name, gvr schema.GroupVersionResource) ([]*cachev1alpha1.CachedResource, error)
+	localCachedResourcesIndexer cache.Indexer
+}
+
+func (adm *CachedResourceAdmission) SetKcpInformers(local, global kcpinformers.SharedInformerFactory) {
+	adm.SetReadyFunc(func() bool {
+		return local.Cache().V1alpha1().CachedResources().Informer().HasSynced()
+	})
+	adm.localCachedResourcesIndexer = local.Cache().V1alpha1().CachedResources().Informer().GetIndexer()
+
+	indexers.AddIfNotPresentOrDie(local.Cache().V1alpha1().CachedResources().Informer().GetIndexer(), cache.Indexers{
+		cachedresourcesreconciler.ByGVRAndLogicalCluster: cachedresourcesreconciler.IndexByGVRAndLogicalCluster,
+	})
+}
+
+// ValidateInitialization ensures the required injected fields are set.
+func (adm *CachedResourceAdmission) ValidateInitialization() error {
+	if adm.localCachedResourcesIndexer == nil {
+		return fmt.Errorf(PluginName + " plugin needs a CachedResource indexer")
+	}
+	return nil
+}
+
+// Validate ensures that the APIExport is valid.
+func (adm *CachedResourceAdmission) Validate(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
+	if a.GetResource().GroupResource() != cachev1alpha1.Resource("cachedresources") || a.GetKind().GroupKind() != cachev1alpha1.Kind("CachedResource") {
+		return nil
+	}
+	if a.GetOperation() != admission.Create {
+		return nil
+	}
+
+	u, ok := a.GetObject().(*unstructured.Unstructured)
+	if !ok {
+		return fmt.Errorf("unexpected type %T", a.GetObject())
+	}
+
+	cachedResource := &cachev1alpha1.CachedResource{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, cachedResource); err != nil {
+		return fmt.Errorf("failed to convert unstructured to CachedResource: %w", err)
+	}
+
+	return adm.validateV1alpha1(ctx, a, cachedResource)
+}
+
+func (adm *CachedResourceAdmission) validateV1alpha1(ctx context.Context, a admission.Attributes, cachedResource *cachev1alpha1.CachedResource) error {
+	clusterName, err := genericapirequest.ClusterNameFrom(ctx)
+	if err != nil {
+		return apierrors.NewInternalError(err)
+	}
+
+	gvr := schema.GroupVersionResource(cachedResource.Spec.GroupVersionResource)
+	existing, err := adm.listCachedResourcesByGVR(clusterName, gvr)
+	if err != nil {
+		return err
+	}
+
+	// Make sure there is at most one CachedResource per GVR.
+	if len(existing) > 0 {
+		return admission.NewForbidden(a,
+			field.Invalid(
+				field.NewPath("spec"),
+				fmt.Sprintf("%s.%s.%s", gvr.Group, gvr.Version, gvr.Resource),
+				fmt.Sprintf("CachedResource with this GVR already exists in the %q workspace", clusterName)),
+		)
+	}
+
+	return nil
+}

--- a/pkg/admission/cachedresource/admission_test.go
+++ b/pkg/admission/cachedresource/admission_test.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cachedresource
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/authentication/user"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	"github.com/kcp-dev/kcp/pkg/admission/helpers"
+	cachev1alpha1 "github.com/kcp-dev/kcp/sdk/apis/cache/v1alpha1"
+)
+
+func createAttr(cachedResource *cachev1alpha1.CachedResource) admission.Attributes {
+	return admission.NewAttributesRecord(
+		helpers.ToUnstructuredOrDie(cachedResource),
+		nil,
+		cachev1alpha1.Kind("CachedResource").WithVersion("v1alpha1"),
+		"",
+		cachedResource.Name,
+		cachev1alpha1.Resource("cachedresources").WithVersion("v1alpha1"),
+		"",
+		admission.Create,
+		&metav1.CreateOptions{},
+		false,
+		&user.DefaultInfo{},
+	)
+}
+
+func updateAttr(cachedResource *cachev1alpha1.CachedResource) admission.Attributes {
+	return admission.NewAttributesRecord(
+		helpers.ToUnstructuredOrDie(cachedResource),
+		nil,
+		cachev1alpha1.Kind("CachedResource").WithVersion("v1alpha1"),
+		"",
+		cachedResource.Name,
+		cachev1alpha1.Resource("cachedresources").WithVersion("v1alpha1"),
+		"",
+		admission.Update,
+		&metav1.UpdateOptions{},
+		false,
+		&user.DefaultInfo{},
+	)
+}
+
+func createCachedResource(name string, gvr schema.GroupVersionResource) *cachev1alpha1.CachedResource {
+	return &cachev1alpha1.CachedResource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: cachev1alpha1.CachedResourceSpec{
+			GroupVersionResource: cachev1alpha1.GroupVersionResource{
+				Group:    gvr.Group,
+				Version:  gvr.Version,
+				Resource: gvr.Resource,
+			},
+		},
+	}
+}
+
+func TestAdmission(t *testing.T) {
+	cases := map[string]struct {
+		attr    admission.Attributes
+		index   map[logicalcluster.Name]map[schema.GroupVersionResource][]*cachev1alpha1.CachedResource
+		cluster logicalcluster.Name
+		gvr     schema.GroupVersionResource
+		wantErr error
+	}{
+		"Empty": {
+			attr: createAttr(createCachedResource("wohoo", schema.GroupVersionResource{
+				Group:    "example.org",
+				Version:  "v1",
+				Resource: "objects",
+			})),
+			index:   map[logicalcluster.Name]map[schema.GroupVersionResource][]*cachev1alpha1.CachedResource{},
+			cluster: logicalcluster.Name("cluster-1"),
+		},
+		"New": {
+			attr: createAttr(createCachedResource("wohoo", schema.GroupVersionResource{
+				Group:    "example.org",
+				Version:  "v1",
+				Resource: "objects",
+			})),
+			index: map[logicalcluster.Name]map[schema.GroupVersionResource][]*cachev1alpha1.CachedResource{
+				"cluster-2": {
+					schema.GroupVersionResource{
+						Group:    "example.org",
+						Version:  "v1",
+						Resource: "objects",
+					}: []*cachev1alpha1.CachedResource{
+						createCachedResource("cluster-2-example-org-v1-objects", schema.GroupVersionResource{
+							Group:    "example.org",
+							Version:  "v1",
+							Resource: "objects",
+						}),
+					},
+				},
+			},
+			cluster: logicalcluster.Name("cluster-1"),
+		},
+		"AlreadyExists": {
+			attr: createAttr(createCachedResource("wohoo", schema.GroupVersionResource{
+				Group:    "example.org",
+				Version:  "v1",
+				Resource: "objects",
+			})),
+			index: map[logicalcluster.Name]map[schema.GroupVersionResource][]*cachev1alpha1.CachedResource{
+				"cluster-2": {
+					schema.GroupVersionResource{
+						Group:    "example.org",
+						Version:  "v1",
+						Resource: "objects",
+					}: []*cachev1alpha1.CachedResource{
+						createCachedResource("cluster-2-example-org-v1-objects", schema.GroupVersionResource{
+							Group:    "example.org",
+							Version:  "v1",
+							Resource: "objects",
+						}),
+					},
+				},
+			},
+			wantErr: admission.NewForbidden(createAttr(createCachedResource("wohoo", schema.GroupVersionResource{
+				Group:    "example.org",
+				Version:  "v1",
+				Resource: "objects",
+			})),
+				field.Invalid(
+					field.NewPath("spec"),
+					"example.org.v1.objects",
+					"CachedResource with this GVR already exists in the \"cluster-2\" workspace"),
+			),
+			cluster: logicalcluster.Name("cluster-2"),
+		},
+		"IgnoreIfNotCreate": {
+			attr: updateAttr(createCachedResource("wohoo", schema.GroupVersionResource{
+				Group:    "example.org",
+				Version:  "v1",
+				Resource: "objects",
+			})),
+			index: map[logicalcluster.Name]map[schema.GroupVersionResource][]*cachev1alpha1.CachedResource{
+				"cluster-1": {
+					schema.GroupVersionResource{
+						Group:    "example.org",
+						Version:  "v1",
+						Resource: "objects",
+					}: []*cachev1alpha1.CachedResource{
+						createCachedResource("cluster-1-example-org-v1-objects", schema.GroupVersionResource{
+							Group:    "example.org",
+							Version:  "v1",
+							Resource: "objects",
+						}),
+					},
+				},
+			},
+			wantErr: nil,
+			cluster: logicalcluster.Name("cluster-1"),
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx := genericapirequest.WithCluster(context.Background(), genericapirequest.Cluster{Name: tc.cluster})
+			plugin := CachedResourceAdmission{
+				listCachedResourcesByGVR: func(cluster logicalcluster.Name, gvr schema.GroupVersionResource) ([]*cachev1alpha1.CachedResource, error) {
+					return tc.index[cluster][gvr], nil
+				},
+			}
+
+			err := plugin.Validate(ctx, tc.attr, nil)
+			if tc.wantErr == nil {
+				require.NoError(t, err, "Validate should succeed")
+			} else {
+				require.Equal(t, tc.wantErr, err, "Validate returned an unexpected error")
+			}
+		})
+	}
+}

--- a/pkg/admission/plugins.go
+++ b/pkg/admission/plugins.go
@@ -47,6 +47,7 @@ import (
 	"github.com/kcp-dev/kcp/pkg/admission/apiexport"
 	"github.com/kcp-dev/kcp/pkg/admission/apiexportendpointslice"
 	"github.com/kcp-dev/kcp/pkg/admission/apiresourceschema"
+	"github.com/kcp-dev/kcp/pkg/admission/cachedresource"
 	"github.com/kcp-dev/kcp/pkg/admission/crdnooverlappinggvr"
 	"github.com/kcp-dev/kcp/pkg/admission/kubequota"
 	"github.com/kcp-dev/kcp/pkg/admission/logicalcluster"
@@ -93,6 +94,7 @@ var AllOrderedPlugins = beforeWebhooks(kubeapiserveroptions.AllOrderedPlugins,
 	pathannotation.PluginName,
 	kubequota.PluginName,
 	mutatingadmissionpolicy.PluginName,
+	cachedresource.PluginName,
 )
 
 func beforeWebhooks(recommended []string, plugins ...string) []string {
@@ -132,6 +134,7 @@ func RegisterAllKcpAdmissionPlugins(plugins *admission.Plugins) {
 	permissionclaims.Register(plugins)
 	pathannotation.Register(plugins)
 	kubequota.Register(plugins)
+	cachedresource.Register(plugins)
 }
 
 var defaultOnPluginsInKcp = sets.New[string](
@@ -161,6 +164,7 @@ var defaultOnPluginsInKcp = sets.New[string](
 	permissionclaims.PluginName,
 	pathannotation.PluginName,
 	kubequota.PluginName,
+	cachedresource.PluginName,
 )
 
 // defaultOnKubePluginsInKube is a copy of kubeapiserveroptions.defaultOnKubePlugins.

--- a/pkg/reconciler/cache/cachedresources/indexers.go
+++ b/pkg/reconciler/cache/cachedresources/indexers.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cachedresources
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	cachev1alpha1 "github.com/kcp-dev/kcp/sdk/apis/cache/v1alpha1"
+)
+
+const (
+	// ByGVRAndLogicalCluster is the name for the index that indexes by an object's gvr and logical cluster.
+	ByGVRAndLogicalCluster = "kcp-byGVRAndLogicalCluster"
+)
+
+// IndexByShardAndLogicalClusterAndNamespace is an index function that indexes by an object's gvr and logical cluster.
+func IndexByGVRAndLogicalCluster(obj interface{}) ([]string, error) {
+	cachedResource := obj.(*cachev1alpha1.CachedResource)
+	return []string{
+		GVRAndLogicalClusterKey(
+			schema.GroupVersionResource(cachedResource.Spec.GroupVersionResource),
+			logicalcluster.From(cachedResource),
+		),
+	}, nil
+}
+
+// GVRAndShardAndLogicalClusterAndNamespaceKey creates an index key from the given parameters.
+// Key will be in the form of version.resource.group|cluster.
+func GVRAndLogicalClusterKey(gvr schema.GroupVersionResource, cluster logicalcluster.Name) string {
+	var key string
+	if gvr.Group == "" {
+		gvr.Group = "core"
+	}
+	key += gvr.Version + "." + gvr.Resource + "." + gvr.Group
+	if !cluster.Empty() {
+		key += "|" + cluster.String()
+	}
+	return key
+}

--- a/pkg/virtual/framework/transforming/transformer_test.go
+++ b/pkg/virtual/framework/transforming/transformer_test.go
@@ -165,8 +165,15 @@ func (c *resourceClient) RawDelete(ctx context.Context, name string, opts metav1
 	return bytes, 0, err
 }
 
+func titleASCII(s string) string {
+	if s == "" {
+		return ""
+	}
+	return strings.ToUpper(s[0:1]) + s[1:]
+}
+
 func (c *resourceClient) RawDeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOptions metav1.ListOptions) ([]byte, int, error) {
-	gvk := c.resource.GroupVersion().WithKind(strings.TrimRight(strings.Title(c.resource.Resource), "s")) //nolint:staticcheck
+	gvk := c.resource.GroupVersion().WithKind(strings.TrimRight(titleASCII(c.resource.Resource), "s"))
 	objs, _ := c.client.Tracker().List(c.resource, gvk, c.namespace)
 	list := objs.(*unstructured.UnstructuredList)
 	list.SetGroupVersionKind(schema.GroupVersionKind{Group: gvk.Group, Version: gvk.Version, Kind: gvk.Kind + "List"})


### PR DESCRIPTION
## Summary

The admission plugin validates CachedResources creation, and ensures that there is no other such CachedResource in the cluster that acts on the same GVR.

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind bug

## Related Issue(s)

Fixes https://github.com/kcp-dev/kcp/issues/3469

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Make CachedResources GVR immutable and unique in the logicalcluster 
```
