### PR TITLE
Add kcp_indexed_logicalclusters metric

### DIFF
--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -155,6 +155,8 @@ func (c *State) UpsertWorkspace(shard string, ws *tenancyv1alpha1.Workspace) {
 			c.shardClusterWorkspaceMount[shard][clusterName][ws.Name] = ws.Spec
 		}
 	}
+
+	clustersOnShard.WithLabelValues(shard).Set(float64(len(c.shardClusterWorkspaceName[shard])))
 }
 
 func (c *State) DeleteWorkspace(shard string, ws *tenancyv1alpha1.Workspace) {
@@ -211,6 +213,8 @@ func (c *State) DeleteWorkspace(shard string, ws *tenancyv1alpha1.Workspace) {
 			delete(c.shardClusterWorkspaceNameErrorCode, shard)
 		}
 	}
+
+	clustersOnShard.WithLabelValues(shard).Set(float64(len(c.shardClusterWorkspaceName[shard])))
 }
 
 func (c *State) UpsertLogicalCluster(shard string, logicalCluster *corev1alpha1.LogicalCluster) {
@@ -283,6 +287,8 @@ func (c *State) DeleteShard(shardName string) {
 	delete(c.shardClusterWorkspaceType, shardName)
 	delete(c.shardClusterParentCluster, shardName)
 	delete(c.shardClusterWorkspaceNameErrorCode, shardName)
+
+	clustersOnShard.DeleteLabelValues(shardName)
 }
 
 func (c *State) Lookup(path logicalcluster.Path) (Result, bool) {

--- a/pkg/index/metrics.go
+++ b/pkg/index/metrics.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package index
+
+import (
+	"sync"
+
+	compbasemetrics "k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+var (
+	clustersOnShard = compbasemetrics.NewGaugeVec(
+		&compbasemetrics.GaugeOpts{
+			Namespace:      "kcp",
+			Name:           "indexed_logicalclusters",
+			Help:           "Number of logicalclusters indexed by kcp-front-proxy or embedded localproxy per shard.",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"shard"},
+	)
+)
+
+var registerMetrics sync.Once
+
+// Register metrics.
+func Register() {
+	registerMetrics.Do(func() {
+		legacyregistry.MustRegister(clustersOnShard)
+	})
+}
+
+func init() {
+	Register()
+}


### PR DESCRIPTION
## Summary
This PR adds a new metric to the cluster index that reports the number of known logicalclusters per shard.

## What Type of PR Is This?
/kind feature

## Release Notes
```release-note
Add new `kcp_indexed_logicalclusters` metric that contains the number of known logicalclusters per shard (metric has a `shard` label).
```
