### PR TITLE
Improve authorizer webhook tests

### DIFF
--- a/test/e2e/authorizer/authorizationorder_test.go
+++ b/test/e2e/authorizer/authorizationorder_test.go
@@ -43,8 +43,8 @@ func TestAuthorizationOrder(t *testing.T) {
 		webhookPort := "8080"
 		ctx, cancelFunc := context.WithCancel(context.Background())
 		t.Cleanup(cancelFunc)
-		webhookStop := RunWebhook(ctx, t, webhookPort, "kubernetes:authz:allow")
-		t.Cleanup(webhookStop)
+		webhook1Stop := RunWebhook(ctx, t, webhookPort, "kubernetes:authz:allow")
+		t.Cleanup(webhook1Stop)
 
 		server, kcpClusterClient, kubeClusterClient := setupTest(t, "AlwaysAllowGroups,AlwaysAllowPaths,Webhook,RBAC", "testdata/webhook1.kubeconfig")
 
@@ -53,9 +53,9 @@ func TestAuthorizationOrder(t *testing.T) {
 		require.NoError(t, err)
 
 		// stop the webhook and switch to a deny policy
-		webhookStop()
-		webhookStop = RunWebhook(ctx, t, webhookPort, "kubernetes:authz:deny")
-		t.Cleanup(webhookStop)
+		webhook1Stop()
+		webhook2Stop := RunWebhook(ctx, t, webhookPort, "kubernetes:authz:deny")
+		t.Cleanup(webhook2Stop)
 
 		t.Log("Admin should not be allowed to list ConfigMaps.")
 		_, err = kubeClusterClient.Cluster(logicalcluster.NewPath("root")).CoreV1().ConfigMaps("default").List(ctx, metav1.ListOptions{})
@@ -70,8 +70,8 @@ func TestAuthorizationOrder(t *testing.T) {
 		webhookPort := "8081"
 		ctx, cancelFunc := context.WithCancel(context.Background())
 		t.Cleanup(cancelFunc)
-		webhookStop := RunWebhook(ctx, t, webhookPort, "kubernetes:authz:allow")
-		t.Cleanup(webhookStop)
+		webhook1Stop := RunWebhook(ctx, t, webhookPort, "kubernetes:authz:allow")
+		t.Cleanup(webhook1Stop)
 
 		server, kcpClusterClient, kubeClusterClient := setupTest(t, "Webhook,AlwaysAllowGroups,AlwaysAllowPaths,RBAC", "testdata/webhook2.kubeconfig")
 
@@ -83,9 +83,9 @@ func TestAuthorizationOrder(t *testing.T) {
 		require.NoError(t, err)
 
 		// stop the webhook and switch to a deny policy
-		webhookStop()
-		webhookStop = RunWebhook(ctx, t, webhookPort, "kubernetes:authz:deny")
-		t.Cleanup(webhookStop)
+		webhook1Stop()
+		webhook2Stop := RunWebhook(ctx, t, webhookPort, "kubernetes:authz:deny")
+		t.Cleanup(webhook2Stop)
 
 		t.Log("Admin should not be allowed now to list Logical clusters.")
 		_, err = kcpClusterClient.Cluster(logicalcluster.NewPath("root")).CoreV1alpha1().LogicalClusters().List(ctx, metav1.ListOptions{})

--- a/test/e2e/authorizer/authorizationorder_test.go
+++ b/test/e2e/authorizer/authorizationorder_test.go
@@ -53,7 +53,8 @@ func TestAuthorizationOrder(t *testing.T) {
 
 		// stop the webhook and switch to a deny policy
 		webhookStop()
-		RunWebhook(ctx, t, webhookPort, "kubernetes:authz:deny")
+		webhookStop = RunWebhook(ctx, t, webhookPort, "kubernetes:authz:deny")
+		t.Cleanup(webhookStop)
 
 		t.Log("Admin should not be allowed to list ConfigMaps.")
 		_, err = kubeClusterClient.Cluster(logicalcluster.NewPath("root")).CoreV1().ConfigMaps("default").List(ctx, metav1.ListOptions{})
@@ -82,7 +83,8 @@ func TestAuthorizationOrder(t *testing.T) {
 
 		// stop the webhook and switch to a deny policy
 		webhookStop()
-		RunWebhook(ctx, t, webhookPort, "kubernetes:authz:deny")
+		webhookStop = RunWebhook(ctx, t, webhookPort, "kubernetes:authz:deny")
+		t.Cleanup(webhookStop)
 
 		t.Log("Admin should not be allowed now to list Logical clusters.")
 		_, err = kcpClusterClient.Cluster(logicalcluster.NewPath("root")).CoreV1alpha1().LogicalClusters().List(ctx, metav1.ListOptions{})

--- a/test/e2e/authorizer/utils.go
+++ b/test/e2e/authorizer/utils.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"sync"
 	"testing"
 	"time"
 
@@ -66,11 +67,11 @@ func RunWebhook(ctx context.Context, t *testing.T, port string, response string)
 		return true, ""
 	}, wait.ForeverTestTimeout, time.Millisecond*200)
 
-	return func() {
+	return sync.OnceFunc(func() {
 		t.Log("Stopping webhook...")
 		cancel()
-		if err := cmd.Wait(); err != nil {
-			t.Logf("error waiting for webhook to finish: %v", err)
+		if err := cmd.Wait(); err != nil && err.Error() != "signal: killed" {
+			t.Logf("Error waiting for webhook to finish: %v", err)
 		}
-	}
+	})
 }


### PR DESCRIPTION
## Summary
While refactoring the authorder tests in #3281 we added a small mistake: in each subtest the webhook would get started and its shutdown function registered for cleanup. But then during the test, as intended, we shutdown the webhook and restart it with some other settings. To achieve this, the test manually calls the cancelFunc of the webhook (good) and then starts another webhook (also good).

But for the 2nd instance of the webhook, we do not keep track of its cancellation. Instead when the test finishes, Go will call the cancelFunc for the *1st* webhook *again*, which is pointless at this time.

Additionally, the cancel func for the webhook does not take into account that the webhook will technically *die* because we cancel its context. So the "signal: killed" error that cmd.Wait() returns was printed in the test log, causing slight confusion in me.

If you were to run the tests with `-v`, you'd see this in the logs:

```
fixture.go:119: Waiting for readiness for server at https://127.0.0.1:42123/
metrics.go:66: PROMETHEUS_URL environment variable unset, skipping Prometheus scrape config generation
authorizationorder_test.go:125: Started kcp servers after 30.612133142s
authorizationorder_test.go:50: Admin should be allowed to list Workspaces.
utils.go:70: Stopping webhook...
utils.go:73: error waiting for webhook to finish: signal: killed
utils.go:34: Starting webhook with kubernetes:authz:deny policy...
authorizationorder_test.go:58: Admin should not be allowed to list ConfigMaps.
authorizationorder_test.go:63: Verify that it is allowed to access one of AllowAllPaths endpoints.
authorizationorder_test.go:150: Verifying access to: https://127.0.0.1:42123/healthz
fixture.go:145: Gathering metrics from kcp servers...
fixture.go:150: Gathering metrics for kcp server main
metrics.go:52: error getting metrics for server main: context canceled
fixture.go:269: cleanup: canceling context
fixture.go:273: cleanup: waiting for shutdownComplete
fixture.go:278: cleanup: received shutdownComplete
utils.go:70: Stopping webhook...
utils.go:73: error waiting for webhook to finish: exec: Wait was already called
```

To fix this, this PR makes sure the 2nd webhook also gets its cancel func called. Also, the cancelFunc is now wrapped in sync.OnceFunc(), making it generally much safer to use.

---

Additionally, these tests specifically were failing on my machine. After a lot of debugging, we found the root cause being that these tests are simply too fast. So fast that between kcp's readiness check and us killing it, not enough time passes and kcp freaks out. See #3488 for more information.

Since this weirdness only affects tests that are very, very fast, I chose to work around it by introducing an artificial delay. This delay will only affect the AuthOrder tests and so won't have a noticeable impact on the entire test suite.

## What Type of PR Is This?
/kind flake

## Release Notes
```release-note
NONE
```
