### PR TITLE
Make deletion relationship between workspace and logicalcluster one way

### DIFF
--- a/pkg/reconciler/core/logicalclusterdeletion/logicalcluster_deletion_controller.go
+++ b/pkg/reconciler/core/logicalclusterdeletion/logicalcluster_deletion_controller.go
@@ -262,7 +262,7 @@ func (c *Controller) process(ctx context.Context, key string) error {
 	deleteErr = c.deleter.Delete(ctx, logicalClusterCopy)
 	if deleteErr == nil {
 		logger.V(4).Info("finished deleting logical cluster content", "duration", time.Since(startTime))
-		return c.finalizeWorkspace(ctx, logicalClusterCopy)
+		return c.finalizeLogicalCluster(ctx, logicalClusterCopy)
 	}
 
 	errs := []error{deleteErr}
@@ -276,13 +276,13 @@ func (c *Controller) process(ctx context.Context, key string) error {
 	return utilerrors.NewAggregate(errs)
 }
 
-// finalizeNamespace removes the specified finalizer and finalizes the logical cluster.
-func (c *Controller) finalizeWorkspace(ctx context.Context, ws *corev1alpha1.LogicalCluster) error {
+// finalizeLogicalCluster removes the specified finalizer and finalizes the logical cluster.
+func (c *Controller) finalizeLogicalCluster(ctx context.Context, lc *corev1alpha1.LogicalCluster) error {
 	logger := klog.FromContext(ctx)
-	for i := range ws.Finalizers {
-		if ws.Finalizers[i] == deletion.LogicalClusterDeletionFinalizer {
-			ws.Finalizers = append(ws.Finalizers[:i], ws.Finalizers[i+1:]...)
-			clusterName := logicalcluster.From(ws)
+	for i := range lc.Finalizers {
+		if lc.Finalizers[i] == deletion.LogicalClusterDeletionFinalizer {
+			lc.Finalizers = append(lc.Finalizers[:i], lc.Finalizers[i+1:]...)
+			clusterName := logicalcluster.From(lc)
 
 			// TODO(hasheddan): ClusterRole and ClusterRoleBinding cleanup
 			// should be handled by garbage collection when the controller is
@@ -296,52 +296,52 @@ func (c *Controller) finalizeWorkspace(ctx context.Context, ws *corev1alpha1.Log
 				return fmt.Errorf("could not delete clusterrolebindings for logical cluster %s: %w", clusterName, err)
 			}
 
-			if ws.Spec.Owner != nil {
+			if lc.Spec.Owner != nil {
 				gvr := schema.GroupVersionResource{
-					Resource: ws.Spec.Owner.Resource,
+					Resource: lc.Spec.Owner.Resource,
 				}
-				comps := strings.SplitN(ws.Spec.Owner.APIVersion, "/", 2)
+				comps := strings.SplitN(lc.Spec.Owner.APIVersion, "/", 2)
 				if len(comps) == 2 {
 					gvr.Group = comps[0]
 					gvr.Version = comps[1]
 				} else {
 					gvr.Version = comps[0]
 				}
-				uid := ws.Spec.Owner.UID
-				logger = logger.WithValues("owner.gvr", gvr, "owner.uid", uid, "owner.name", ws.Spec.Owner.Name, "owner.namespace", ws.Spec.Owner.Namespace, "owner.cluster", ws.Spec.Owner.Cluster)
+				uid := lc.Spec.Owner.UID
+				logger = logger.WithValues("owner.gvr", gvr, "owner.uid", uid, "owner.name", lc.Spec.Owner.Name, "owner.namespace", lc.Spec.Owner.Namespace, "owner.cluster", lc.Spec.Owner.Cluster)
 
 				// remove finalizer from owner
 				logger.Info("checking owner for finalizer")
-				clusterPath := logicalcluster.NewPath(ws.Spec.Owner.Cluster)
-				obj, err := c.dynamicFrontProxyClient.Cluster(clusterPath).Resource(gvr).Namespace(ws.Spec.Owner.Namespace).Get(ctx, ws.Spec.Owner.Name, metav1.GetOptions{})
+				clusterPath := logicalcluster.NewPath(lc.Spec.Owner.Cluster)
+				obj, err := c.dynamicFrontProxyClient.Cluster(clusterPath).Resource(gvr).Namespace(lc.Spec.Owner.Namespace).Get(ctx, lc.Spec.Owner.Name, metav1.GetOptions{})
 				if err != nil && !apierrors.IsNotFound(err) {
-					return fmt.Errorf("could not get owner %s %s/%s in cluster %s: %w", gvr, ws.Spec.Owner.Namespace, ws.Spec.Owner.Name, ws.Spec.Owner.Cluster, err)
+					return fmt.Errorf("could not get owner %s %s/%s in cluster %s: %w", gvr, lc.Spec.Owner.Namespace, lc.Spec.Owner.Name, lc.Spec.Owner.Cluster, err)
 				} else if err == nil && obj.GetUID() != uid {
 					logger.Info("owner has changed, skipping finalizer removal")
-					return fmt.Errorf("could not get owner %s %s/%s in cluster %s is of wrong UID: %w", gvr, ws.Spec.Owner.Namespace, ws.Spec.Owner.Name, ws.Spec.Owner.Cluster, err)
+					return fmt.Errorf("could not get owner %s %s/%s in cluster %s is of wrong UID: %w", gvr, lc.Spec.Owner.Namespace, lc.Spec.Owner.Name, lc.Spec.Owner.Cluster, err)
 				} else if err == nil {
 					finalizers := sets.New[string](obj.GetFinalizers()...)
 					if finalizers.Has(corev1alpha1.LogicalClusterFinalizer) {
 						logger.Info("removing finalizer from owner")
 						finalizers.Delete(corev1alpha1.LogicalClusterFinalizer)
 						obj.SetFinalizers(sets.List[string](finalizers))
-						if obj, err = c.dynamicFrontProxyClient.Cluster(clusterPath).Resource(gvr).Namespace(ws.Spec.Owner.Namespace).Update(ctx, obj, metav1.UpdateOptions{}); err != nil {
-							return fmt.Errorf("could not remove finalizer from owner %s %s/%s in cluster %s: %w", gvr, ws.Spec.Owner.Namespace, ws.Spec.Owner.Name, ws.Spec.Owner.Cluster, err)
+						if obj, err = c.dynamicFrontProxyClient.Cluster(clusterPath).Resource(gvr).Namespace(lc.Spec.Owner.Namespace).Update(ctx, obj, metav1.UpdateOptions{}); err != nil {
+							return fmt.Errorf("could not remove finalizer from owner %s %s/%s in cluster %s: %w", gvr, lc.Spec.Owner.Namespace, lc.Spec.Owner.Name, lc.Spec.Owner.Cluster, err)
 						}
 					}
 
 					// delete owner
-					if obj.GetDeletionTimestamp().IsZero() && ws.Spec.DirectlyDeletable {
+					if obj.GetDeletionTimestamp().IsZero() && lc.Spec.DirectlyDeletable {
 						logger.Info("deleting owner")
-						if err := c.dynamicFrontProxyClient.Cluster(clusterPath).Resource(gvr).Namespace(ws.Spec.Owner.Namespace).Delete(ctx, ws.Spec.Owner.Name, metav1.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &uid}}); err != nil && !apierrors.IsNotFound(err) {
-							return fmt.Errorf("could not delete owner %s %s/%s in cluster %s: %w", gvr, ws.Spec.Owner.Namespace, ws.Spec.Owner.Name, ws.Spec.Owner.Cluster, err)
+						if err := c.dynamicFrontProxyClient.Cluster(clusterPath).Resource(gvr).Namespace(lc.Spec.Owner.Namespace).Delete(ctx, lc.Spec.Owner.Name, metav1.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &uid}}); err != nil && !apierrors.IsNotFound(err) {
+							return fmt.Errorf("could not delete owner %s %s/%s in cluster %s: %w", gvr, lc.Spec.Owner.Namespace, lc.Spec.Owner.Name, lc.Spec.Owner.Cluster, err)
 						}
 					}
 				}
 			}
 
 			logger.V(2).Info("removing finalizer from LogicalCluster")
-			_, err := c.kcpClusterClient.CoreV1alpha1().LogicalClusters().Cluster(clusterName.Path()).Update(ctx, ws, metav1.UpdateOptions{})
+			_, err := c.kcpClusterClient.CoreV1alpha1().LogicalClusters().Cluster(clusterName.Path()).Update(ctx, lc, metav1.UpdateOptions{})
 			return err
 		}
 	}

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_deletion.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_deletion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The KCP Authors.
+Copyright 2025 The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_deletion.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_deletion.go
@@ -49,7 +49,7 @@ func (r *deletionReconciler) reconcile(ctx context.Context, workspace *tenancyv1
 		return reconcileStatusContinue, nil
 	}
 
-	if sets.New[string](workspace.Finalizers...).Delete(corev1alpha1.LogicalClusterFinalizer).Len() > 0 {
+	if sets.New(workspace.Finalizers...).Delete(corev1alpha1.LogicalClusterFinalizer).Len() > 0 {
 		return reconcileStatusContinue, nil
 	}
 
@@ -59,9 +59,9 @@ func (r *deletionReconciler) reconcile(ctx context.Context, workspace *tenancyv1
 	if workspace.Status.Phase == corev1alpha1.LogicalClusterPhaseScheduling {
 		a, ok := workspace.Annotations[workspaceClusterAnnotationKey]
 		if !ok {
-			finalizers := sets.New[string](workspace.Finalizers...)
+			finalizers := sets.New(workspace.Finalizers...)
 			finalizers.Delete(corev1alpha1.LogicalClusterFinalizer)
-			workspace.Finalizers = sets.List[string](finalizers)
+			workspace.Finalizers = sets.List(finalizers)
 			return reconcileStatusContinue, nil
 		}
 
@@ -97,10 +97,10 @@ func (r *deletionReconciler) reconcile(ctx context.Context, workspace *tenancyv1
 		// fall-through
 	}
 	if apierrors.IsNotFound(getErr) {
-		finalizers := sets.New[string](workspace.Finalizers...)
+		finalizers := sets.New(workspace.Finalizers...)
 		if finalizers.Has(corev1alpha1.LogicalClusterFinalizer) {
 			logger.Info(fmt.Sprintf("Removing finalizer %s", corev1alpha1.LogicalClusterFinalizer))
-			workspace.Finalizers = sets.List[string](finalizers.Delete(corev1alpha1.LogicalClusterFinalizer))
+			workspace.Finalizers = sets.List(finalizers.Delete(corev1alpha1.LogicalClusterFinalizer))
 			return reconcileStatusStopAndRequeue, nil // spec change
 		}
 		return reconcileStatusContinue, nil

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_deletion.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_deletion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright 2021 The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_deletion_test.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_deletion_test.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workspace
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/google/go-cmp/cmp"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	corev1alpha1 "github.com/kcp-dev/kcp/sdk/apis/core/v1alpha1"
+	tenancyv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/tenancy/v1alpha1"
+	kcpclientset "github.com/kcp-dev/kcp/sdk/client/clientset/versioned/cluster"
+)
+
+type fakeDeletionReconciler struct {
+	clusters map[string]*corev1alpha1.LogicalCluster
+	deletionReconciler
+}
+
+func (f *fakeDeletionReconciler) getLogicalCluster() func(ctx context.Context, cluster logicalcluster.Path) (*corev1alpha1.LogicalCluster, error) {
+	return func(ctx context.Context, cluster logicalcluster.Path) (*corev1alpha1.LogicalCluster, error) {
+		c, ok := f.clusters[cluster.String()]
+		if !ok {
+			return nil, apierrors.NewNotFound(schema.GroupResource{}, cluster.String())
+		}
+		return c, nil
+	}
+}
+
+func (f *fakeDeletionReconciler) deleteLogicalCluster() func(ctx context.Context, cluster logicalcluster.Path) error {
+	return func(ctx context.Context, cluster logicalcluster.Path) error {
+		delete(f.clusters, cluster.String())
+		return nil
+	}
+}
+
+func (f *fakeDeletionReconciler) getShardByHash() func(hash string) (*corev1alpha1.Shard, error) {
+	return func(hash string) (*corev1alpha1.Shard, error) {
+		// for now we can work with a fixed shard
+		s := &corev1alpha1.Shard{}
+		return s, nil
+	}
+}
+
+func (f *fakeDeletionReconciler) kcpLogicalClusterAdminClientFor() func(shard *corev1alpha1.Shard) (kcpclientset.ClusterInterface, error) {
+	return func(shard *corev1alpha1.Shard) (kcpclientset.ClusterInterface, error) {
+		return nil, nil
+	}
+}
+
+func TestReconcile(t *testing.T) {
+	tt := []struct {
+		name               string
+		expStatus          reconcileStatus
+		workspace          *tenancyv1alpha1.Workspace
+		logicalclusters    map[string]*corev1alpha1.LogicalCluster
+		expFinalizers      []string
+		expLogicalClusters map[string]*corev1alpha1.LogicalCluster
+	}{
+		{
+			name:      "no deletion timestamp",
+			expStatus: reconcileStatusContinue,
+			workspace: &tenancyv1alpha1.Workspace{},
+		},
+		{
+			name:      "another finalizer is still set",
+			expStatus: reconcileStatusContinue,
+			workspace: &tenancyv1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: ptr.To(metav1.Now()),
+					Finalizers: []string{
+						corev1alpha1.LogicalClusterFinalizer,
+						"other-finalizer",
+					},
+				},
+			},
+			expFinalizers: []string{
+				corev1alpha1.LogicalClusterFinalizer,
+				"other-finalizer",
+			},
+		},
+		{
+			name:      "workspace is still initializing, no logicalcluster exists",
+			expStatus: reconcileStatusContinue,
+			workspace: &tenancyv1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: ptr.To(metav1.Now()),
+					Finalizers: []string{
+						corev1alpha1.LogicalClusterFinalizer,
+					},
+				},
+				Status: tenancyv1alpha1.WorkspaceStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseScheduling,
+				},
+			},
+			// we expect no finalizers here, as we can take a shortcut and directly
+			// delete the workspace without needing to delete the logicalcluster first
+			expFinalizers: []string{},
+		},
+		{
+			name:      "workspace is still initializing, logicalcluster not marked for deletion yet",
+			expStatus: reconcileStatusContinue,
+			workspace: &tenancyv1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: ptr.To(metav1.Now()),
+					Finalizers: []string{
+						corev1alpha1.LogicalClusterFinalizer,
+					},
+					Annotations: map[string]string{
+						workspaceClusterAnnotationKey: "test",
+					},
+				},
+				Status: tenancyv1alpha1.WorkspaceStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseScheduling,
+				},
+			},
+			logicalclusters: map[string]*corev1alpha1.LogicalCluster{
+				"test": {},
+			},
+			// we do not remove our finalizers in this case, as we wait
+			// for another reconciliation loop
+			expFinalizers: []string{
+				corev1alpha1.LogicalClusterFinalizer,
+			},
+			// we do expect our logicalCluster to be removed
+			expLogicalClusters: map[string]*corev1alpha1.LogicalCluster{},
+		},
+		{
+			name:      "workspace is marked for deletion, logicalcluster is already deleted",
+			expStatus: reconcileStatusStopAndRequeue,
+			workspace: &tenancyv1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: ptr.To(metav1.Now()),
+					Finalizers: []string{
+						corev1alpha1.LogicalClusterFinalizer,
+					},
+				},
+			},
+			// finalizer should be removed
+			expFinalizers: []string{},
+		},
+		{
+			name:      "workspace is marked for deletion, finalizer is already removed (edge case)",
+			expStatus: reconcileStatusContinue,
+			workspace: &tenancyv1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: ptr.To(metav1.Now()),
+				},
+			},
+		},
+	}
+
+	// swallow any log output, so we don't pollute test results
+	ctx := logr.NewContext(context.Background(), logr.Discard())
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			fdr := fakeDeletionReconciler{
+				clusters: tc.logicalclusters,
+			}
+			fdr.deletionReconciler.getLogicalCluster = fdr.getLogicalCluster()
+			fdr.deletionReconciler.deleteLogicalCluster = fdr.deleteLogicalCluster()
+			fdr.deletionReconciler.getShardByHash = fdr.getShardByHash()
+			fdr.deletionReconciler.kcpLogicalClusterAdminClientFor = fdr.kcpLogicalClusterAdminClientFor()
+
+			status, err := fdr.deletionReconciler.reconcile(ctx, tc.workspace)
+
+			if status != tc.expStatus {
+				t.Errorf("Exp status %v, got %v", tc.expStatus, status)
+			}
+
+			if !slices.Equal(tc.expFinalizers, tc.workspace.Finalizers) {
+				t.Errorf("Exp finalizers %v, got %v", tc.expFinalizers, tc.workspace.Finalizers)
+			}
+
+			if diff := cmp.Diff(tc.expLogicalClusters, tc.logicalclusters); diff != "" {
+				t.Errorf("logicalcluster mismatch: %s", diff)
+			}
+
+			if err != nil {
+				t.Errorf("did not expect an error, but got %b", err)
+			}
+		})
+	}
+}

--- a/test/e2e/workspace/deletion_test.go
+++ b/test/e2e/workspace/deletion_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workspace
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	logicalclusterdeletion "github.com/kcp-dev/kcp/pkg/reconciler/core/logicalclusterdeletion/deletion"
+	"github.com/kcp-dev/kcp/sdk/apis/core"
+	corev1alpha1 "github.com/kcp-dev/kcp/sdk/apis/core/v1alpha1"
+	kcpclientset "github.com/kcp-dev/kcp/sdk/client/clientset/versioned/cluster"
+	kcptesting "github.com/kcp-dev/kcp/sdk/testing"
+	kcptestinghelpers "github.com/kcp-dev/kcp/sdk/testing/helpers"
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+)
+
+// TestWorkspaceLogicalclusterRelationship tests that a workspace gets not
+// deleted prematurely if its LogicalCluster has not yet been deleted.
+func TestWorkspaceLogicalclusterRelationship(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "control-plane")
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	t.Cleanup(cancelFunc)
+
+	server := kcptesting.SharedKcpServer(t)
+	cfg := server.BaseConfig(t)
+
+	// This will create structure as below for testing:
+	// └── root
+	//   └── e2e-workspace-n784f
+	//    └── test
+	wsName := "test"
+	fixtureRoot, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path())
+	testPath, _ := kcptesting.NewWorkspaceFixture(t, server, fixtureRoot, kcptesting.WithName(wsName))
+
+	clientset, err := kcpclientset.NewForConfig(cfg)
+	require.NoError(t, err, "error creating kube cluster client set")
+
+	lc, err := clientset.Cluster(testPath).CoreV1alpha1().LogicalClusters().Get(ctx, corev1alpha1.LogicalClusterName, v1.GetOptions{})
+	require.NoError(t, err, "error getting logicalcluster")
+
+	// add a finalizer to the cluster, mimicking an external finalizer
+	customFinalizer := "example.com/test"
+	lcsUpd := lc.DeepCopy()
+	lcsUpd.Finalizers = append(lcsUpd.Finalizers, customFinalizer)
+	_, err = clientset.Cluster(testPath).CoreV1alpha1().LogicalClusters().Update(ctx, lcsUpd, v1.UpdateOptions{})
+	require.NoError(t, err, "error updating logicalcluster")
+
+	// delete the workspace
+	err = clientset.Cluster(fixtureRoot).TenancyV1alpha1().Workspaces().Delete(ctx, wsName, v1.DeleteOptions{})
+	require.NoError(t, err, "error deleting workspace")
+
+	// ensure that the deletion has propagated to the logicalcluster, meaning:
+	// - it should have a deletion timestamp
+	// - it should have the custom finalizer
+	// - it should not have its own deletion finalizer anymore
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		lc, err := clientset.Cluster(testPath).CoreV1alpha1().LogicalClusters().Get(ctx, corev1alpha1.LogicalClusterName, v1.GetOptions{})
+		require.NoError(c, err, "error getting logicalcluster")
+		require.NotEqual(c, nil, lc.DeletionTimestamp)
+		require.Contains(c, lc.Finalizers, customFinalizer)
+		require.NotContains(c, lc.Finalizers, logicalclusterdeletion.LogicalClusterDeletionFinalizer)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "waiting for logicalcluster to be marked for deletion")
+
+	// ensure that the workspace has a deletionTimestamp, but still has the
+	// logicalcluster finalizer
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		ws, err := clientset.Cluster(fixtureRoot).TenancyV1alpha1().Workspaces().Get(ctx, wsName, v1.GetOptions{})
+		require.NoError(c, err, "error getting workspace")
+		require.NotEqual(c, nil, ws.DeletionTimestamp)
+		require.Contains(c, ws.Finalizers, corev1alpha1.LogicalClusterFinalizer)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "waiting for workspace to be marked for deletion")
+
+	// remove the custom finalizer from the logicalcluster object
+	lc, err = clientset.Cluster(testPath).CoreV1alpha1().LogicalClusters().Get(ctx, corev1alpha1.LogicalClusterName, v1.GetOptions{})
+	require.NoError(t, err, "error getting logicalcluster")
+	lcsUpd = lc.DeepCopy()
+	lcsUpd.Finalizers = removeByValue(lcsUpd.Finalizers, customFinalizer)
+	_, err = clientset.Cluster(testPath).CoreV1alpha1().LogicalClusters().Update(ctx, lcsUpd, v1.UpdateOptions{})
+	require.NoError(t, err, "error updating logicalcluster")
+
+	// the logicalcluster should now be cleaned up successfully
+	kcptestinghelpers.Eventually(t, func() (success bool, reason string) {
+		_, err := clientset.Cluster(testPath).CoreV1alpha1().LogicalClusters().Get(ctx, corev1alpha1.LogicalClusterName, v1.GetOptions{})
+		if apierrors.IsForbidden(err) {
+			return true, ""
+		}
+		return false, "logicalcluster still exists"
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "waiting for logicalcluster to be deleted")
+
+	// the workspace should now be cleaned up successfully
+	kcptestinghelpers.Eventually(t, func() (success bool, reason string) {
+		_, err := clientset.Cluster(fixtureRoot).TenancyV1alpha1().Workspaces().Get(ctx, wsName, v1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return true, ""
+		}
+		return false, "workspace still exists"
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "waiting for workspace to be deleted")
+}
+
+func removeByValue[T comparable](l []T, item T) []T {
+	for i, other := range l {
+		if other == item {
+			return append(l[:i], l[i+1:]...)
+		}
+	}
+	return l
+}

--- a/test/e2e/workspace/deletion_test.go
+++ b/test/e2e/workspace/deletion_test.go
@@ -70,8 +70,10 @@ func TestWorkspaceLogicalClusterRelationship(t *testing.T) {
 		lcsUpd.Finalizers = append(lcsUpd.Finalizers, customFinalizer)
 		_, err = clientset.Cluster(testPath).CoreV1alpha1().LogicalClusters().Update(ctx, lcsUpd, v1.UpdateOptions{})
 		require.NoError(c, err, "error updating logicalcluster")
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "waiting for finalizer to be applied and workspace to be deleted")
 
-		// delete the workspace
+	// delete the workspace
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		err = clientset.Cluster(fixtureRoot).TenancyV1alpha1().Workspaces().Delete(ctx, wsName, v1.DeleteOptions{})
 		require.NoError(c, err, "error deleting workspace")
 	}, wait.ForeverTestTimeout, 100*time.Millisecond, "waiting for finalizer to be applied and workspace to be deleted")


### PR DESCRIPTION
## Summary

This PR changes the deletion relationship between workspaces and logicalclusters to be one way. This means that the workspace will remain as the parent object of a logicalcluster and does not get deleted until the logicalcluster object is completely done. Prior to this, it was possible for a workspace object to be completely removed, even if it still had a logicalcluster (see the issue linked below for more info).

This PR also introduces an E2E test to verify the behavior. Commits are ordered accordingly: If you run the E2E test against the old code, it will fail; with the new code it will pass.

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind bug

## Related Issue(s)

Fixes #3490 

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
