### PR TITLE
Remove additional printing column 'Ready' from APIExport

### DIFF
--- a/config/crds/apis.kcp.io_apiexports.yaml
+++ b/config/crds/apis.kcp.io_apiexports.yaml
@@ -292,9 +292,6 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    - jsonPath: .status.conditions[?(@.type=="VirtualWorkspaceURLsReady")].status
-      name: Ready
-      type: string
     name: v1alpha2
     schema:
       openAPIV3Schema:
@@ -550,8 +547,11 @@ spec:
               virtualWorkspaces:
                 description: |-
                   virtualWorkspaces contains all APIExport virtual workspace URLs.
+                  this field is empty unless kcp has been started with the
+                  'EnableDeprecatedAPIExportVirtualWorkspacesUrls' feature gate.
 
-                  Deprecated: use APIExportEndpointSlice.status.endpoints instead
+                  Deprecated: use APIExportEndpointSlice.status.endpoints instead. This
+                  field will be removed in an upcoming API version.
                 items:
                   properties:
                     url:

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -2300,7 +2300,7 @@ func schema_sdk_apis_apis_v1alpha2_APIExportStatus(ref common.ReferenceCallback)
 					},
 					"virtualWorkspaces": {
 						SchemaProps: spec.SchemaProps{
-							Description: "virtualWorkspaces contains all APIExport virtual workspace URLs.\n\nDeprecated: use APIExportEndpointSlice.status.endpoints instead",
+							Description: "virtualWorkspaces contains all APIExport virtual workspace URLs. this field is empty unless kcp has been started with the 'EnableDeprecatedAPIExportVirtualWorkspacesUrls' feature gate.\n\nDeprecated: use APIExportEndpointSlice.status.endpoints instead. This field will be removed in an upcoming API version.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/sdk/apis/apis/v1alpha2/types_apiexport.go
+++ b/sdk/apis/apis/v1alpha2/types_apiexport.go
@@ -56,7 +56,6 @@ const (
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,categories=kcp
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=`.status.conditions[?(@.type=="VirtualWorkspaceURLsReady")].status`
 type APIExport struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional
@@ -323,8 +322,11 @@ type APIExportStatus struct {
 	Conditions conditionsv1alpha1.Conditions `json:"conditions,omitempty"`
 
 	// virtualWorkspaces contains all APIExport virtual workspace URLs.
+	// this field is empty unless kcp has been started with the
+	// 'EnableDeprecatedAPIExportVirtualWorkspacesUrls' feature gate.
 	//
-	// Deprecated: use APIExportEndpointSlice.status.endpoints instead
+	// Deprecated: use APIExportEndpointSlice.status.endpoints instead. This
+	// field will be removed in an upcoming API version.
 	//
 	// +optional
 	VirtualWorkspaces []VirtualWorkspace `json:"virtualWorkspaces,omitempty"`


### PR DESCRIPTION


<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

This removes an additional printing column from APIExports that is going to be always empty unless the feature gate to keep virtual workspace URLs alive is set.

In addition, this clarifies that the virtual workspace URL field on APIExports is no longer populated unless the feature gate is set.

## What Type of PR Is This?

/kind cleanup
/kind api-change

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Stop printing Ready column for `APIExports` as virtual workspace URLs are no longer populated by default
```
