### PR TITLE
Update reference to renamed kcp-dev channel (now kcp-users)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This community has a [Code of Conduct](./code-of-conduct.md). Please make sure t
 
 There are several ways to communicate with us:
 
-- The [`#kcp-dev` channel](https://app.slack.com/client/T09NY5SBT/C021U8WSAFK) in the [Kubernetes Slack workspace](https://slack.k8s.io).
+- The [`#kcp-users` channel](https://app.slack.com/client/T09NY5SBT/C021U8WSAFK) in the [Kubernetes Slack workspace](https://slack.k8s.io).
 - Our mailing lists:
     - [kcp-dev](https://groups.google.com/g/kcp-dev) for development discussions.
     - [kcp-users](https://groups.google.com/g/kcp-users) for discussions among users and potential users.

--- a/docs/content/contributing/guides/publishing-a-new-kcp-release.md
+++ b/docs/content/contributing/guides/publishing-a-new-kcp-release.md
@@ -128,4 +128,4 @@ Documentation for the respective release branch needs to be triggered manually a
    1. Subject: `[release] <version>` e.g. `[release] v0.8.0`
    2. In the body, include noteworthy changes
    3. Provide a link to the release in GitHub for the full release notes
-2. Post a message in the [#kcp-dev](https://kubernetes.slack.com/archives/C021U8WSAFK) Slack channel
+2. Post a message in the [#kcp-users](https://kubernetes.slack.com/archives/C021U8WSAFK) Slack channel

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -37,7 +37,7 @@ guide.
 
 There are several ways to communicate with us:
 
-- The [`#kcp-dev` channel](https://app.slack.com/client/T09NY5SBT/C021U8WSAFK) in the [Kubernetes Slack workspace](https://slack.k8s.io).
+- The [`#kcp-users` channel](https://app.slack.com/client/T09NY5SBT/C021U8WSAFK) in the [Kubernetes Slack workspace](https://slack.k8s.io).
 - Our mailing lists:
     - [kcp-dev](https://groups.google.com/g/kcp-dev) for development discussions.
     - [kcp-users](https://groups.google.com/g/kcp-users) for discussions among users and potential users.


### PR DESCRIPTION
On-behalf-of: SAP <marvin.beckers@sap.com>

<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

The `#kcp-dev` channel has been renamed to `#kcp-users` (reference: https://github.com/kubernetes/community/pull/8527). Therefore we should update the channel name across our docs (the channel ID has stayed the same).

## What Type of PR Is This?
/kind documentation

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
