### PR TITLE
Fix `create-workspace` on an existing workspace throwing a panic

### DIFF
--- a/cli/pkg/workspace/plugin/create.go
+++ b/cli/pkg/workspace/plugin/create.go
@@ -176,7 +176,7 @@ func (o *CreateWorkspaceOptions) Run(ctx context.Context) error {
 
 	workspaceReference := fmt.Sprintf("Workspace %q (type %s)", o.Name, logicalcluster.NewPath(ws.Spec.Type.Path).Join(string(ws.Spec.Type.Name)).String())
 	if preExisting {
-		if ws.Spec.Type.Name != "" && ws.Spec.Type.Name != structuredWorkspaceType.Name || ws.Spec.Type.Path != structuredWorkspaceType.Path {
+		if structuredWorkspaceType != nil && (ws.Spec.Type.Name != "" && ws.Spec.Type.Name != structuredWorkspaceType.Name || ws.Spec.Type.Path != structuredWorkspaceType.Path) {
 			wsTypeString := logicalcluster.NewPath(ws.Spec.Type.Path).Join(string(ws.Spec.Type.Name)).String()
 			structuredWorkspaceTypeString := logicalcluster.NewPath(structuredWorkspaceType.Path).Join(string(structuredWorkspaceType.Name)).String()
 			return fmt.Errorf("workspace %q cannot be created with type %s, it already exists with different type %s", o.Name, structuredWorkspaceTypeString, wsTypeString)

--- a/cli/pkg/workspace/plugin/create_test.go
+++ b/cli/pkg/workspace/plugin/create_test.go
@@ -47,6 +47,7 @@ func TestCreate(t *testing.T) {
 		config clientcmdapi.Config
 
 		existingWorkspaces []string // existing workspaces
+		skipInitialType    bool
 		markReady          bool
 
 		newWorkspaceName                 string
@@ -101,6 +102,18 @@ func TestCreate(t *testing.T) {
 		},
 		{
 			name: "create, already existing",
+			config: clientcmdapi.Config{CurrentContext: "test",
+				Contexts:  map[string]*clientcmdapi.Context{"test": {Cluster: "test", AuthInfo: "test"}},
+				Clusters:  map[string]*clientcmdapi.Cluster{"test": {Server: "https://test/clusters/root:foo"}},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"test": {Token: "test"}},
+			},
+			existingWorkspaces: []string{"bar"},
+			skipInitialType:    true,
+			newWorkspaceName:   "bar",
+			ignoreExisting:     true,
+		},
+		{
+			name: "create, already existing, use after creation",
 			config: clientcmdapi.Config{CurrentContext: "test",
 				Contexts:  map[string]*clientcmdapi.Context{"test": {Cluster: "test", AuthInfo: "test"}},
 				Clusters:  map[string]*clientcmdapi.Cluster{"test": {Server: "https://test/clusters/root:foo"}},
@@ -234,7 +247,9 @@ func TestCreate(t *testing.T) {
 
 			opts := NewCreateWorkspaceOptions(genericclioptions.NewTestIOStreamsDiscard())
 			opts.Name = tt.newWorkspaceName
-			opts.Type = workspaceType.Path + ":" + string(workspaceType.Name)
+			if !tt.skipInitialType {
+				opts.Type = workspaceType.Path + ":" + string(workspaceType.Name)
+			}
 			opts.IgnoreExisting = tt.ignoreExisting
 			opts.EnterAfterCreate = tt.useAfterCreation
 			opts.ReadyWaitTimeout = time.Second


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

See https://github.com/kcp-dev/kcp/pull/3519

```bash
>    k create-workspace test --ignore-existing
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x8 pc=0x105dfd0d8]

goroutine 1 [running]:
github.com/kcp-dev/kcp/cli/pkg/workspace/plugin.(*CreateWorkspaceOptions).Run(0x1400010e420, {0x106434da8, 0x107231de0})
        /home/runner/work/kcp/kcp/cli/pkg/workspace/plugin/create.go:179 +0x568
github.com/kcp-dev/kcp/cli/pkg/workspace/cmd.NewCreate.func1(0x14000288008, {0x140005214a0, 0x1, 0x2})
        /home/runner/work/kcp/kcp/cli/pkg/workspace/cmd/cmd.go:228 +0x78
github.com/spf13/cobra.(*Command).execute(0x14000288008, {0x1400003a0d0, 0x2, 0x2})
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1015 +0x82c
github.com/spf13/cobra.(*Command).ExecuteC(0x14000288008)
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1148 +0x350
github.com/spf13/cobra.(*Command).Execute(0x14000123f38?)
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1071 +0x1c
main.main()
        /home/runner/work/kcp/kcp/cli/cmd/kubectl-create-workspace/main.go:33 +0x88
zsh: exit 2     k create-workspace test --ignore-existing
```

## What Type of PR Is This?

/kind bug
/kind regression

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Fix `create-workspace` on an existing workspace throwing a panic
```
