### PR TITLE
Fix bind cli

### DIFF
--- a/cli/pkg/bind/plugin/bind.go
+++ b/cli/pkg/bind/plugin/bind.go
@@ -236,6 +236,7 @@ func (b *BindOptions) parsePermissionClaim(claim string, accepted bool) error {
 	}
 	// TODO(mjudeikis): Once we add support for selectors/
 	parsedClaim.Selector = apisv1alpha2.PermissionClaimSelector{MatchAll: true}
+	parsedClaim.Verbs = []string{"*"}
 
 	if accepted {
 		b.acceptedPermissionClaims = append(b.acceptedPermissionClaims, parsedClaim)


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

## What Type of PR Is This?

`kubectl kcp bind` stopped working. 

/kind bug

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Fix `kubectl kcp bind` command after verbs permission claims migration
```
