### PR TITLE
Add `system:cluster:<logical-cluster>` group to effective users to enhance cross-workspace authz

### DIFF
--- a/docs/content/concepts/authorization/authorizers.md
+++ b/docs/content/concepts/authorization/authorizers.md
@@ -127,6 +127,8 @@ roleRef:
 
 ##### Cross-Workspace
 
+Users from other workspaces can be authorized to peform actions using RBAC, e.g. to `bind` and APIExport.
+
 ###### Service Accounts
 
 A service-account defined in a workspace implicitly is granted access to it.

--- a/docs/content/concepts/authorization/authorizers.md
+++ b/docs/content/concepts/authorization/authorizers.md
@@ -144,7 +144,7 @@ A service-account defined in a different workspace is NOT given access to it.
 
 Users can either be global kcp users or users that originate from a specific workspace, e.g. through an OIDC provider configured for that workspace.
 
-Users that do not originate from the workspace the request is being made to and are not global kcp users are only visible as `system:anonymous`
+Users that do not originate from the workspace the request is being made to and are not global kcp users are only visible as user `system:anonymous`
 with groups `system:authenticated` and `system:cluster:<logical-cluster>`, where `<logical-cluster>` is the name of the logical cluster backing
 the workspace they originated from.
 

--- a/test/e2e/apibinding/cross_workspace_auth_test.go
+++ b/test/e2e/apibinding/cross_workspace_auth_test.go
@@ -1,0 +1,770 @@
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apibinding
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+	rbacregistryvalidation "k8s.io/kubernetes/pkg/registry/rbac/validation"
+
+	kcpdynamic "github.com/kcp-dev/client-go/dynamic"
+	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	"github.com/kcp-dev/kcp/config/helpers"
+	apisv1alpha2 "github.com/kcp-dev/kcp/sdk/apis/apis/v1alpha2"
+	tenancyv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/tenancy/v1alpha1"
+	kcpclientset "github.com/kcp-dev/kcp/sdk/client/clientset/versioned/cluster"
+	kcptesting "github.com/kcp-dev/kcp/sdk/testing"
+	kcptestinghelpers "github.com/kcp-dev/kcp/sdk/testing/helpers"
+	"github.com/kcp-dev/kcp/test/e2e/fixtures/authfixtures"
+	"github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/apis/wildwest"
+	wildwestv1alpha1 "github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/apis/wildwest/v1alpha1"
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+)
+
+// TestWorkspaceAuth tests that a user from the consumer workspace can
+// bind an APIExport from the provider workspace.
+//  1. The user is authenticated via OIDC against the consumer workspace
+//     using a method that is only available in the consumer workspace
+//  2. The user can manage APIBindings in the consumer workspace
+//  3. The provider workspace allows the binding of APIExports for users
+//     coming from the consumer workspace through the
+//     system:cluster:<consumer-cluster> group
+func TestWorkspaceAuth(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "control-plane")
+
+	server := kcptesting.SharedKcpServer(t)
+	baseWsPath, _ := kcptesting.NewWorkspaceFixture(t, server, logicalcluster.NewPath("root"), kcptesting.WithNamePrefix("apibinding-serviceaccount"))
+
+	kcpConfig := server.BaseConfig(t)
+	kubeClusterClient, err := kcpkubernetesclientset.NewForConfig(kcpConfig)
+	require.NoError(t, err)
+	kcpClusterClient, err := kcpclientset.NewForConfig(kcpConfig)
+	require.NoError(t, err)
+	dynamicClusterClient, err := kcpdynamic.NewForConfig(kcpConfig)
+	require.NoError(t, err)
+
+	t.Log("Create consumer workspace with OIDC")
+	mockOidc, ca := authfixtures.StartMockOIDC(t, server)
+	authConfig := authfixtures.CreateWorkspaceOIDCAuthentication(t, t.Context(), kcpClusterClient, baseWsPath, mockOidc, ca, nil)
+	wsOidcType := authfixtures.CreateWorkspaceType(t, t.Context(), kcpClusterClient, baseWsPath, "with-oidc", authConfig)
+	consumerPath, consumerWS := kcptesting.NewWorkspaceFixture(t, server, baseWsPath, kcptesting.WithName("consumer"), kcptesting.WithType(baseWsPath, tenancyv1alpha1.WorkspaceTypeName(wsOidcType)))
+
+	t.Log("Create an oidc client")
+	token := authfixtures.CreateOIDCToken(t, mockOidc, "test-oidc-user", "testuser@example.com", nil)
+	oidcKcpClient, err := kcpclientset.NewForConfig(framework.ConfigWithToken(token, kcpConfig))
+	require.NoError(t, err)
+
+	t.Log("Create provider workspace")
+	providerPath, _ := kcptesting.NewWorkspaceFixture(t, server, baseWsPath, kcptesting.WithName("provider"))
+
+	t.Log("Create APIExport in provider")
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(kubeClusterClient.Cluster(providerPath).Discovery()))
+	err = helpers.CreateResourceFromFS(t.Context(), dynamicClusterClient.Cluster(providerPath), mapper, nil, "apiresourceschema_cowboys.yaml", testFiles)
+	require.NoError(t, err)
+
+	cowboysAPIExport := &apisv1alpha2.APIExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "today-cowboys",
+		},
+		Spec: apisv1alpha2.APIExportSpec{
+			Resources: []apisv1alpha2.ResourceSchema{
+				{
+					Name:   "cowboys",
+					Group:  "wildwest.dev",
+					Schema: "today.cowboys.wildwest.dev",
+					Storage: apisv1alpha2.ResourceSchemaStorage{
+						CRD: &apisv1alpha2.ResourceSchemaStorageCRD{},
+					},
+				},
+			},
+		},
+	}
+	_, err = kcpClusterClient.Cluster(providerPath).ApisV1alpha2().APIExports().Create(t.Context(), cowboysAPIExport, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("Allow users from consumer to bind APIExports through group system:cluster:%s", consumerWS.Spec.Cluster)
+	providerCR := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "bind-apiexport",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				Verbs:         []string{"bind"},
+				APIGroups:     []string{"apis.kcp.io"},
+				Resources:     []string{"apiexports"},
+				ResourceNames: []string{cowboysAPIExport.Name},
+			},
+		},
+	}
+	_, err = kubeClusterClient.Cluster(providerPath).RbacV1().ClusterRoles().Create(t.Context(), providerCR, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	providerCRB := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "bind-apiexport",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind: "Group",
+				Name: "system:cluster:" + consumerWS.Spec.Cluster,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.SchemeGroupVersion.Group,
+			Kind:     "ClusterRole",
+			Name:     providerCR.Name,
+		},
+	}
+	_, err = kubeClusterClient.Cluster(providerPath).RbacV1().ClusterRoleBindings().Create(t.Context(), providerCRB, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Log("Allow authenticated users to manage APIBindings in consumer")
+
+	consumerCR := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "manage-apibindings",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				Verbs:     []string{"*"},
+				APIGroups: []string{"apis.kcp.io"},
+				Resources: []string{"apibindings"},
+			},
+			{
+				Verbs:           []string{"*"},
+				NonResourceURLs: []string{"*"},
+			},
+		},
+	}
+	_, err = kubeClusterClient.Cluster(consumerPath).RbacV1().ClusterRoles().Create(t.Context(), consumerCR, metav1.CreateOptions{})
+	require.NoError(t, err)
+	consumerCRB := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "authenticated-manage-apibindings",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind: "Group",
+				Name: "system:authenticated",
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.SchemeGroupVersion.Group,
+			Kind:     "ClusterRole",
+			Name:     consumerCR.Name,
+		},
+	}
+	_, err = kubeClusterClient.Cluster(consumerPath).RbacV1().ClusterRoleBindings().Create(t.Context(), consumerCRB, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Log("Bind APIExport in consumer using the oidc client")
+	cowboysAPIBinding := &apisv1alpha2.APIBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "today-cowboys",
+		},
+		Spec: apisv1alpha2.APIBindingSpec{
+			Reference: apisv1alpha2.BindingReference{
+				Export: &apisv1alpha2.ExportBindingReference{
+					Path: providerPath.String(),
+					Name: cowboysAPIExport.Name,
+				},
+			},
+		},
+	}
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		_, err = oidcKcpClient.Cluster(consumerPath).ApisV1alpha2().APIBindings().Create(t.Context(), cowboysAPIBinding, metav1.CreateOptions{})
+		return err == nil, fmt.Sprintf("Error creating APIBinding: %v", err)
+	}, wait.ForeverTestTimeout, time.Millisecond*100)
+
+	t.Logf("Make sure %q API group shows up in consumer workspace %q group discovery", wildwest.GroupName, consumerPath)
+	err = wait.PollUntilContextTimeout(t.Context(), 100*time.Millisecond, wait.ForeverTestTimeout, true, func(c context.Context) (done bool, err error) {
+		groups, err := oidcKcpClient.Cluster(consumerPath).Discovery().ServerGroups()
+		if err != nil {
+			return false, fmt.Errorf("error retrieving consumer workspace %q group discovery: %w", consumerPath, err)
+		}
+		return groupExists(groups, wildwest.GroupName), nil
+	})
+	require.NoError(t, err)
+	t.Logf("Make sure cowboys API resource shows up in consumer workspace %q group version discovery", consumerPath)
+	resources, err := kubeClusterClient.Cluster(consumerPath).Discovery().ServerResourcesForGroupVersion(wildwestv1alpha1.SchemeGroupVersion.String())
+	require.NoError(t, err, "error retrieving consumer workspace %q API discovery", consumerPath)
+	require.True(t, resourceExists(resources, "cowboys"), "consumer workspace %q discovery is missing cowboys resource", consumerPath)
+}
+
+// TestServiceAccount tests that a Service Account from the consumer workspace can
+// bind an APIExport from the provider workspace.
+//  1. The Service Account can manage APIBindings in the consumer workspace
+//  2. The provider workspace allows the binding of APIExports for users
+//     coming from the consumer workspace through the
+//     system:cluster:<consumer-cluster> group
+//
+// This test is functionally equivalent to TestWorkspaceAuth, but uses
+// a Service Account instead of a "real" user authenticated via OIDC.
+// Background is that in KCP Service Accounts are sometimes handled
+// differently to users and go through a different code path when
+// effective users are computed.
+func TestServiceAccount(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "control-plane")
+
+	server := kcptesting.SharedKcpServer(t)
+	baseWsPath, _ := kcptesting.NewWorkspaceFixture(t, server, logicalcluster.NewPath("root"), kcptesting.WithNamePrefix("apibinding-oidc"))
+
+	kcpConfig := server.BaseConfig(t)
+	kubeClusterClient, err := kcpkubernetesclientset.NewForConfig(kcpConfig)
+	require.NoError(t, err)
+	kcpClusterClient, err := kcpclientset.NewForConfig(kcpConfig)
+	require.NoError(t, err)
+	dynamicClusterClient, err := kcpdynamic.NewForConfig(kcpConfig)
+	require.NoError(t, err)
+
+	t.Log("Create consumer workspace")
+	consumerPath, consumerWS := kcptesting.NewWorkspaceFixture(t, server, baseWsPath, kcptesting.WithName("consumer"))
+
+	t.Log("Create a service account in the consumer workspace")
+	_, tokenSecret := authfixtures.CreateServiceAccount(t, kubeClusterClient, consumerPath, "default", "test-sa-")
+	saClient, err := kcpclientset.NewForConfig(framework.ConfigWithToken(string(tokenSecret.Data["token"]), kcpConfig))
+	require.NoError(t, err)
+
+	t.Log("Create provider workspace")
+	providerPath, _ := kcptesting.NewWorkspaceFixture(t, server, baseWsPath, kcptesting.WithName("provider"))
+
+	t.Log("Create APIExport in provider")
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(kubeClusterClient.Cluster(providerPath).Discovery()))
+	err = helpers.CreateResourceFromFS(t.Context(), dynamicClusterClient.Cluster(providerPath), mapper, nil, "apiresourceschema_cowboys.yaml", testFiles)
+	require.NoError(t, err)
+
+	cowboysAPIExport := &apisv1alpha2.APIExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "today-cowboys",
+		},
+		Spec: apisv1alpha2.APIExportSpec{
+			Resources: []apisv1alpha2.ResourceSchema{
+				{
+					Name:   "cowboys",
+					Group:  "wildwest.dev",
+					Schema: "today.cowboys.wildwest.dev",
+					Storage: apisv1alpha2.ResourceSchemaStorage{
+						CRD: &apisv1alpha2.ResourceSchemaStorageCRD{},
+					},
+				},
+			},
+		},
+	}
+	_, err = kcpClusterClient.Cluster(providerPath).ApisV1alpha2().APIExports().Create(t.Context(), cowboysAPIExport, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("Allow users from consumer to bind APIExports through group system:cluster:%s", consumerWS.Spec.Cluster)
+	providerCR := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "bind-apiexport",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				Verbs:         []string{"bind"},
+				APIGroups:     []string{"apis.kcp.io"},
+				Resources:     []string{"apiexports"},
+				ResourceNames: []string{cowboysAPIExport.Name},
+			},
+		},
+	}
+	_, err = kubeClusterClient.Cluster(providerPath).RbacV1().ClusterRoles().Create(t.Context(), providerCR, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	providerCRB := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "bind-apiexport",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind: "Group",
+				Name: "system:cluster:" + consumerWS.Spec.Cluster,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.SchemeGroupVersion.Group,
+			Kind:     "ClusterRole",
+			Name:     providerCR.Name,
+		},
+	}
+	_, err = kubeClusterClient.Cluster(providerPath).RbacV1().ClusterRoleBindings().Create(t.Context(), providerCRB, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Log("Allow authenticated users to manage APIBindings in consumer")
+
+	consumerCR := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "manage-apibindings",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				Verbs:     []string{"*"},
+				APIGroups: []string{"apis.kcp.io"},
+				Resources: []string{"apibindings"},
+			},
+			{
+				Verbs:           []string{"*"},
+				NonResourceURLs: []string{"*"},
+			},
+		},
+	}
+	_, err = kubeClusterClient.Cluster(consumerPath).RbacV1().ClusterRoles().Create(t.Context(), consumerCR, metav1.CreateOptions{})
+	require.NoError(t, err)
+	consumerCRB := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "authenticated-manage-apibindings",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind: "Group",
+				Name: "system:authenticated",
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.SchemeGroupVersion.Group,
+			Kind:     "ClusterRole",
+			Name:     consumerCR.Name,
+		},
+	}
+	_, err = kubeClusterClient.Cluster(consumerPath).RbacV1().ClusterRoleBindings().Create(t.Context(), consumerCRB, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Log("Bind APIExport in consumer using the service account client")
+	cowboysAPIBinding := &apisv1alpha2.APIBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "today-cowboys",
+		},
+		Spec: apisv1alpha2.APIBindingSpec{
+			Reference: apisv1alpha2.BindingReference{
+				Export: &apisv1alpha2.ExportBindingReference{
+					Path: providerPath.String(),
+					Name: cowboysAPIExport.Name,
+				},
+			},
+		},
+	}
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		_, err = saClient.Cluster(consumerPath).ApisV1alpha2().APIBindings().Create(t.Context(), cowboysAPIBinding, metav1.CreateOptions{})
+		return err == nil, fmt.Sprintf("Error creating APIBinding: %v", err)
+	}, wait.ForeverTestTimeout, time.Millisecond*100)
+
+	t.Logf("Make sure %q API group shows up in consumer workspace %q group discovery", wildwest.GroupName, consumerPath)
+	err = wait.PollUntilContextTimeout(t.Context(), 100*time.Millisecond, wait.ForeverTestTimeout, true, func(c context.Context) (done bool, err error) {
+		groups, err := saClient.Cluster(consumerPath).Discovery().ServerGroups()
+		if err != nil {
+			return false, fmt.Errorf("error retrieving consumer workspace %q group discovery: %w", consumerPath, err)
+		}
+		return groupExists(groups, wildwest.GroupName), nil
+	})
+	require.NoError(t, err)
+	t.Logf("Make sure cowboys API resource shows up in consumer workspace %q group version discovery", consumerPath)
+	resources, err := kubeClusterClient.Cluster(consumerPath).Discovery().ServerResourcesForGroupVersion(wildwestv1alpha1.SchemeGroupVersion.String())
+	require.NoError(t, err, "error retrieving consumer workspace %q API discovery", consumerPath)
+	require.True(t, resourceExists(resources, "cowboys"), "consumer workspace %q discovery is missing cowboys resource", consumerPath)
+}
+
+// TestScopedUser tests that a user restricted to the consumer workspace
+// by scopes can bind an APIExport from the provider workspace.
+//  1. The user is a global KCP user but is restricted by scopes to
+//     the consumer workspace
+//  2. The user can manage APIBindings in the consumer workspace
+//  3. The provider workspace allows the binding of APIExports for users
+//     coming from the consumer workspace through the
+//     system:cluster:<consumer-cluster> group
+//
+// This test is functionally equivalent to TestWorkspaceAuth, but
+// impersonates a global user with scopes instead of using
+// a per-workspace user.
+func TestScopedUser(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "control-plane")
+
+	server := kcptesting.SharedKcpServer(t)
+	baseWsPath, _ := kcptesting.NewWorkspaceFixture(t, server, logicalcluster.NewPath("root"), kcptesting.WithNamePrefix("apibinding-scoped"))
+
+	kcpConfig := server.BaseConfig(t)
+	kubeClusterClient, err := kcpkubernetesclientset.NewForConfig(kcpConfig)
+	require.NoError(t, err)
+	kcpClusterClient, err := kcpclientset.NewForConfig(kcpConfig)
+	require.NoError(t, err)
+	dynamicClusterClient, err := kcpdynamic.NewForConfig(kcpConfig)
+	require.NoError(t, err)
+
+	t.Log("Create consumer workspace")
+	consumerPath, consumerWS := kcptesting.NewWorkspaceFixture(t, server, baseWsPath, kcptesting.WithName("consumer"))
+
+	t.Log("Impersonate an authenticated user restricted to the consumer workspace with scopes")
+
+	t.Log("Admit user-1 as admin to the consumer workspace")
+	testUser := "user-1"
+	framework.AdmitWorkspaceAccess(t.Context(), t, kubeClusterClient, consumerPath, []string{testUser}, nil, true)
+
+	t.Log("Admit user-2 as a normal user to the consumer workspace")
+	impersonateUser := "user-2"
+	framework.AdmitWorkspaceAccess(t.Context(), t, kubeClusterClient, consumerPath, []string{impersonateUser}, nil, false)
+
+	t.Log("Use user-1 to impersonate user-2 with a scope")
+	userCfg := framework.StaticTokenUserConfig(testUser, kcpConfig)
+	userCfg.Impersonate = rest.ImpersonationConfig{
+		UserName: impersonateUser,
+		Extra: map[string][]string{
+			rbacregistryvalidation.ScopeExtraKey: {"cluster:" + consumerWS.Spec.Cluster},
+		},
+	}
+	userClient, err := kcpclientset.NewForConfig(userCfg)
+	require.NoError(t, err)
+
+	t.Log("Create provider workspace")
+	providerPath, _ := kcptesting.NewWorkspaceFixture(t, server, baseWsPath, kcptesting.WithName("provider"))
+
+	t.Log("Create APIExport in provider")
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(kubeClusterClient.Cluster(providerPath).Discovery()))
+	err = helpers.CreateResourceFromFS(t.Context(), dynamicClusterClient.Cluster(providerPath), mapper, nil, "apiresourceschema_cowboys.yaml", testFiles)
+	require.NoError(t, err)
+
+	cowboysAPIExport := &apisv1alpha2.APIExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "today-cowboys",
+		},
+		Spec: apisv1alpha2.APIExportSpec{
+			Resources: []apisv1alpha2.ResourceSchema{
+				{
+					Name:   "cowboys",
+					Group:  "wildwest.dev",
+					Schema: "today.cowboys.wildwest.dev",
+					Storage: apisv1alpha2.ResourceSchemaStorage{
+						CRD: &apisv1alpha2.ResourceSchemaStorageCRD{},
+					},
+				},
+			},
+		},
+	}
+	_, err = kcpClusterClient.Cluster(providerPath).ApisV1alpha2().APIExports().Create(t.Context(), cowboysAPIExport, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("Allow users from consumer to bind APIExports through group system:cluster:%s", consumerWS.Spec.Cluster)
+	providerCR := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "bind-apiexport",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				Verbs:         []string{"bind"},
+				APIGroups:     []string{"apis.kcp.io"},
+				Resources:     []string{"apiexports"},
+				ResourceNames: []string{cowboysAPIExport.Name},
+			},
+		},
+	}
+	_, err = kubeClusterClient.Cluster(providerPath).RbacV1().ClusterRoles().Create(t.Context(), providerCR, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	providerCRB := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "bind-apiexport",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind: "Group",
+				Name: "system:cluster:" + consumerWS.Spec.Cluster,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.SchemeGroupVersion.Group,
+			Kind:     "ClusterRole",
+			Name:     providerCR.Name,
+		},
+	}
+	_, err = kubeClusterClient.Cluster(providerPath).RbacV1().ClusterRoleBindings().Create(t.Context(), providerCRB, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Log("Allow authenticated users to manage APIBindings in consumer")
+
+	consumerCR := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "manage-apibindings",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				Verbs:     []string{"*"},
+				APIGroups: []string{"apis.kcp.io"},
+				Resources: []string{"apibindings"},
+			},
+			{
+				Verbs:           []string{"*"},
+				NonResourceURLs: []string{"*"},
+			},
+		},
+	}
+	_, err = kubeClusterClient.Cluster(consumerPath).RbacV1().ClusterRoles().Create(t.Context(), consumerCR, metav1.CreateOptions{})
+	require.NoError(t, err)
+	consumerCRB := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "authenticated-manage-apibindings",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind: "Group",
+				Name: "system:authenticated",
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.SchemeGroupVersion.Group,
+			Kind:     "ClusterRole",
+			Name:     consumerCR.Name,
+		},
+	}
+	_, err = kubeClusterClient.Cluster(consumerPath).RbacV1().ClusterRoleBindings().Create(t.Context(), consumerCRB, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Log("Bind APIExport in consumer using the user client")
+	cowboysAPIBinding := &apisv1alpha2.APIBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "today-cowboys",
+		},
+		Spec: apisv1alpha2.APIBindingSpec{
+			Reference: apisv1alpha2.BindingReference{
+				Export: &apisv1alpha2.ExportBindingReference{
+					Path: providerPath.String(),
+					Name: cowboysAPIExport.Name,
+				},
+			},
+		},
+	}
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		_, err = userClient.Cluster(consumerPath).ApisV1alpha2().APIBindings().Create(t.Context(), cowboysAPIBinding, metav1.CreateOptions{})
+		return err == nil, fmt.Sprintf("Error creating APIBinding: %v", err)
+	}, wait.ForeverTestTimeout, time.Millisecond*100)
+
+	t.Logf("Make sure %q API group shows up in consumer workspace %q group discovery", wildwest.GroupName, consumerPath)
+	err = wait.PollUntilContextTimeout(t.Context(), 100*time.Millisecond, wait.ForeverTestTimeout, true, func(c context.Context) (done bool, err error) {
+		groups, err := userClient.Cluster(consumerPath).Discovery().ServerGroups()
+		if err != nil {
+			return false, fmt.Errorf("error retrieving consumer workspace %q group discovery: %w", consumerPath, err)
+		}
+		return groupExists(groups, wildwest.GroupName), nil
+	})
+	require.NoError(t, err)
+	t.Logf("Make sure cowboys API resource shows up in consumer workspace %q group version discovery", consumerPath)
+	resources, err := kubeClusterClient.Cluster(consumerPath).Discovery().ServerResourcesForGroupVersion(wildwestv1alpha1.SchemeGroupVersion.String())
+	require.NoError(t, err, "error retrieving consumer workspace %q API discovery", consumerPath)
+	require.True(t, resourceExists(resources, "cowboys"), "consumer workspace %q discovery is missing cowboys resource", consumerPath)
+}
+
+// TestUserWithWarrants tests that a user with a warrant for another
+// user in the workspace can bind an APIExport from the provider
+// workspace.
+//  1. The user is a global KCP user but can act as another user
+//     in consumer workspace through a warrant.
+//  2. The user can manage APIBindings in the consumer workspace
+//  3. The provider workspace allows the binding of APIExports for users
+//     coming from the consumer workspace through the
+//     system:cluster:<consumer-cluster> group
+//
+// This test is functionally equivalent to TestWorkspaceAuth, but
+// uses a global user using warrants to act as a scoped user
+// a per-workspace user.
+func TestUserWithWarrants(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "control-plane")
+
+	server := kcptesting.SharedKcpServer(t)
+	baseWsPath, _ := kcptesting.NewWorkspaceFixture(t, server, logicalcluster.NewPath("root"), kcptesting.WithNamePrefix("apibinding-warrants"))
+
+	kcpConfig := server.BaseConfig(t)
+	kubeClusterClient, err := kcpkubernetesclientset.NewForConfig(kcpConfig)
+	require.NoError(t, err)
+	kcpClusterClient, err := kcpclientset.NewForConfig(kcpConfig)
+	require.NoError(t, err)
+	dynamicClusterClient, err := kcpdynamic.NewForConfig(kcpConfig)
+	require.NoError(t, err)
+
+	t.Log("Create consumer workspace")
+	consumerPath, consumerWS := kcptesting.NewWorkspaceFixture(t, server, baseWsPath, kcptesting.WithName("consumer"))
+
+	t.Log("Impersonate an authenticated user restricted to the consumer workspace with scopes")
+
+	t.Log("Admit user-1 as admin to the consumer workspace")
+	testUser := "user-1"
+	framework.AdmitWorkspaceAccess(t.Context(), t, kubeClusterClient, consumerPath, []string{testUser}, nil, true)
+
+	t.Log("Admit user-2 as a normal user to the consumer workspace")
+	impersonateUser := "user-2"
+	framework.AdmitWorkspaceAccess(t.Context(), t, kubeClusterClient, consumerPath, []string{impersonateUser}, nil, false)
+
+	t.Log("Use user-1 to impersonate itself with a warrant for user-2 with a scope")
+	userCfg := framework.StaticTokenUserConfig(testUser, kcpConfig)
+	userCfg.Impersonate = rest.ImpersonationConfig{
+		UserName: testUser,
+		Extra: map[string][]string{
+			rbacregistryvalidation.WarrantExtraKey: {`{"user":"` + impersonateUser + `","extra":{"authentication.kcp.io/scopes": ["cluster:` + consumerWS.Spec.Cluster + `"]}}`},
+		},
+	}
+	t.Log("user-1 extra", "extra", userCfg.Impersonate.Extra)
+	userClient, err := kcpclientset.NewForConfig(userCfg)
+	require.NoError(t, err)
+
+	t.Log("Create provider workspace")
+	providerPath, _ := kcptesting.NewWorkspaceFixture(t, server, baseWsPath, kcptesting.WithName("provider"))
+
+	t.Log("Create APIExport in provider")
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(kubeClusterClient.Cluster(providerPath).Discovery()))
+	err = helpers.CreateResourceFromFS(t.Context(), dynamicClusterClient.Cluster(providerPath), mapper, nil, "apiresourceschema_cowboys.yaml", testFiles)
+	require.NoError(t, err)
+
+	cowboysAPIExport := &apisv1alpha2.APIExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "today-cowboys",
+		},
+		Spec: apisv1alpha2.APIExportSpec{
+			Resources: []apisv1alpha2.ResourceSchema{
+				{
+					Name:   "cowboys",
+					Group:  "wildwest.dev",
+					Schema: "today.cowboys.wildwest.dev",
+					Storage: apisv1alpha2.ResourceSchemaStorage{
+						CRD: &apisv1alpha2.ResourceSchemaStorageCRD{},
+					},
+				},
+			},
+		},
+	}
+	_, err = kcpClusterClient.Cluster(providerPath).ApisV1alpha2().APIExports().Create(t.Context(), cowboysAPIExport, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("Allow users from consumer to bind APIExports through group system:cluster:%s", consumerWS.Spec.Cluster)
+	providerCR := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "bind-apiexport",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				Verbs:         []string{"bind"},
+				APIGroups:     []string{"apis.kcp.io"},
+				Resources:     []string{"apiexports"},
+				ResourceNames: []string{cowboysAPIExport.Name},
+			},
+		},
+	}
+	_, err = kubeClusterClient.Cluster(providerPath).RbacV1().ClusterRoles().Create(t.Context(), providerCR, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	providerCRB := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "bind-apiexport",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind: "Group",
+				Name: "system:cluster:" + consumerWS.Spec.Cluster,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.SchemeGroupVersion.Group,
+			Kind:     "ClusterRole",
+			Name:     providerCR.Name,
+		},
+	}
+	_, err = kubeClusterClient.Cluster(providerPath).RbacV1().ClusterRoleBindings().Create(t.Context(), providerCRB, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Log("Allow authenticated users to manage APIBindings in consumer")
+
+	consumerCR := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "manage-apibindings",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				Verbs:     []string{"*"},
+				APIGroups: []string{"apis.kcp.io"},
+				Resources: []string{"apibindings"},
+			},
+			{
+				Verbs:           []string{"*"},
+				NonResourceURLs: []string{"*"},
+			},
+		},
+	}
+	_, err = kubeClusterClient.Cluster(consumerPath).RbacV1().ClusterRoles().Create(t.Context(), consumerCR, metav1.CreateOptions{})
+	require.NoError(t, err)
+	consumerCRB := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "authenticated-manage-apibindings",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind: "Group",
+				Name: "system:authenticated",
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.SchemeGroupVersion.Group,
+			Kind:     "ClusterRole",
+			Name:     consumerCR.Name,
+		},
+	}
+	_, err = kubeClusterClient.Cluster(consumerPath).RbacV1().ClusterRoleBindings().Create(t.Context(), consumerCRB, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Log("Bind APIExport in consumer using the user client")
+	cowboysAPIBinding := &apisv1alpha2.APIBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "today-cowboys",
+		},
+		Spec: apisv1alpha2.APIBindingSpec{
+			Reference: apisv1alpha2.BindingReference{
+				Export: &apisv1alpha2.ExportBindingReference{
+					Path: providerPath.String(),
+					Name: cowboysAPIExport.Name,
+				},
+			},
+		},
+	}
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		_, err = userClient.Cluster(consumerPath).ApisV1alpha2().APIBindings().Create(t.Context(), cowboysAPIBinding, metav1.CreateOptions{})
+		return err == nil, fmt.Sprintf("Error creating APIBinding: %v", err)
+	}, wait.ForeverTestTimeout, time.Millisecond*100)
+
+	t.Logf("Make sure %q API group shows up in consumer workspace %q group discovery", wildwest.GroupName, consumerPath)
+	err = wait.PollUntilContextTimeout(t.Context(), 100*time.Millisecond, wait.ForeverTestTimeout, true, func(c context.Context) (done bool, err error) {
+		groups, err := userClient.Cluster(consumerPath).Discovery().ServerGroups()
+		if err != nil {
+			return false, fmt.Errorf("error retrieving consumer workspace %q group discovery: %w", consumerPath, err)
+		}
+		return groupExists(groups, wildwest.GroupName), nil
+	})
+	require.NoError(t, err)
+	t.Logf("Make sure cowboys API resource shows up in consumer workspace %q group version discovery", consumerPath)
+	resources, err := kubeClusterClient.Cluster(consumerPath).Discovery().ServerResourcesForGroupVersion(wildwestv1alpha1.SchemeGroupVersion.String())
+	require.NoError(t, err, "error retrieving consumer workspace %q API discovery", consumerPath)
+	require.True(t, resourceExists(resources, "cowboys"), "consumer workspace %q discovery is missing cowboys resource", consumerPath)
+}

--- a/test/e2e/authorizer/scopes_test.go
+++ b/test/e2e/authorizer/scopes_test.go
@@ -104,6 +104,16 @@ func TestSubjectAccessReview(t *testing.T) {
 			wantAllowed: false,
 		},
 		{
+			name:   "out-of-scoped users with warrant",
+			user:   "user",
+			groups: []string{},
+			extra: map[string]authorizationv1.ExtraValue{
+				serviceaccount.ClusterNameKey:          {"other"},
+				rbacregistryvalidation.WarrantExtraKey: {`{"user":"user2","groups":["system:kcp:admin"]}`},
+			},
+			wantAllowed: true,
+		},
+		{
 			name:        "service account",
 			user:        "system:serviceaccount:default:default",
 			groups:      []string{"system:kcp:admin"},
@@ -128,12 +138,15 @@ func TestSubjectAccessReview(t *testing.T) {
 			wantAllowed: false,
 		},
 		{
-			name: "service account with other cluster and warrant",
-			user: "system:serviceaccount:default:default", groups: []string{"system:kcp:admin"}, extra: map[string]authorizationv1.ExtraValue{
+			name:   "service account with other cluster and warrant",
+			user:   "system:serviceaccount:default:default",
+			groups: []string{},
+			extra: map[string]authorizationv1.ExtraValue{
 				serviceaccount.ClusterNameKey:          {"other"},
 				rbacregistryvalidation.WarrantExtraKey: {`{"user":"user","groups":["system:kcp:admin"]}`},
 			},
-			wantAllowed: true},
+			wantAllowed: true,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())

--- a/test/e2e/fixtures/authfixtures/serviceAccount.go
+++ b/test/e2e/fixtures/authfixtures/serviceAccount.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authfixtures
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	kcptestinghelpers "github.com/kcp-dev/kcp/sdk/testing/helpers"
+)
+
+func CreateServiceAccount(t *testing.T, client kcpkubernetesclientset.ClusterInterface, workspace logicalcluster.Path, namespace string, generateName string) (*corev1.ServiceAccount, *corev1.Secret) {
+	t.Helper()
+
+	t.Log("Create a service account")
+	sa, err := client.Cluster(workspace).CoreV1().ServiceAccounts(namespace).Create(
+		t.Context(),
+		&corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: generateName,
+			},
+		},
+		metav1.CreateOptions{},
+	)
+	require.NoError(t, err)
+
+	t.Log("Creating the service account secret")
+	saSecret, err := client.Cluster(workspace).CoreV1().Secrets(namespace).Create(
+		t.Context(),
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: sa.Name + "-token",
+				Annotations: map[string]string{
+					corev1.ServiceAccountNameKey: sa.Name,
+				},
+			},
+			Type: corev1.SecretTypeServiceAccountToken,
+		},
+		metav1.CreateOptions{},
+	)
+	require.NoError(t, err, "failed to create service account secret")
+
+	t.Log("Waiting for service account secret to be filled")
+	var tokenSecret *corev1.Secret
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		var err error
+		tokenSecret, err = client.Cluster(workspace).CoreV1().Secrets(namespace).Get(t.Context(), saSecret.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, fmt.Sprintf("Error getting service account secret: %v", err)
+		}
+		return len(tokenSecret.Data) > 0, ""
+	}, wait.ForeverTestTimeout, time.Millisecond*100)
+
+	return sa, tokenSecret
+}


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Needs https://github.com/kcp-dev/kubernetes/pull/176

This adds tests ensuring that global users (with scopes and with warrants), service accounts and per-workspace users can bind APIExports of another workspace when said workspace allows binding from the source workspace through the `system:cluster:<logical-cluster>` group, where `<logical-cluster>` is the name of the logical cluster backing the source workspace.
This is representative of other cross-workspace requests and should work for any cross-workspace authorization check.

Caveat:

Global users without scopes or warrants are not considered at the moment (though could be covered by simply adding the `system:cluster:..` group to the request when creating an APIBinding - but that would only work for APIBinding/-Exports). They will still be bound by the usual authorization methods.

## What Type of PR Is This?

/kind feature

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #3513 

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Users from other workspaces can be authorized by granting permission to the `system:cluster:<clusterid>` group
Authorization webhooks now get a payload with the target cluster in the `authorization.kcp.io/cluster-name` extra. The `authorization.kubernetes.io/cluster-name` extra is deprecated and will be removed in a future release
```
