### PR TITLE
fix flakiness in TestAPIExportBindingAuthorizer

### DIFF
--- a/test/e2e/virtual/apiexport/authorizer_test.go
+++ b/test/e2e/virtual/apiexport/authorizer_test.go
@@ -631,7 +631,8 @@ func TestAPIExportBindingAuthorizer(t *testing.T) {
 
 	// Bind to second tenant workspace so url pops up. So we use this to check tenant1 access.
 	for _, shard := range shards.Items {
-		tenant2Path, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath, kcptesting.WithName(shard.Name+"-tenant-2"))
+		tenant2Path, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath, kcptesting.WithName(shard.Name+"-tenant-2"), kcptesting.WithShard(shard.Name))
+
 		kcptestinghelpers.Eventually(t, func() (bool, string) {
 			_, err = kcpClient.Cluster(tenant2Path).ApisV1alpha2().APIBindings().Create(ctx, apiBinding, metav1.CreateOptions{})
 			return err == nil, fmt.Sprintf("Error creating APIBinding: %v", err)


### PR DESCRIPTION
## Summary
The test's intention is to ensure there is 1 consumer per shard for the wildwest API. To achieve this it creates 1 workspace for each shard and then binds to the APIExport from within there. However the code failed to ensure that the logicalclusters for these workspaces are actually at least evenly distributed to every shard (it doesn't matter if `root-tenant-2` is scheduled onto `shard-1`, as long as `shard-1-tenant-2` is then scheduled onto the root shard).

This lead to flakiness as sometimes both logicalclusters were scheduled onto the same shard, and suddenly there was only one consumer shard and so the test failed.

## What Type of PR Is This?
/kind flake

## Related Issue(s)
Fixes #3444

## Release Notes
```release-note
NONE
```
