### PR TITLE
Fix APIBinding admission mishandling v1alpha1 API version

### DIFF
--- a/pkg/admission/apibinding/apibinding_interface.go
+++ b/pkg/admission/apibinding/apibinding_interface.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apibinding
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+type apiBinding interface {
+	BindingReference() bindingReference
+	Labels() map[string]string
+	SetLabels(labels map[string]string)
+	Validate() field.ErrorList
+	ValidateUpdate(oldBinding apiBinding) field.ErrorList
+	ToUnstructured() (map[string]interface{}, error)
+}
+
+type bindingReference interface {
+	HasExport() bool
+	ExportName() string
+	ExportPath() string
+	DeepEqual(compare bindingReference) bool
+}
+
+func getAPIBinding(u *unstructured.Unstructured, preferredVersion string) (apiBinding, error) {
+	switch preferredVersion {
+	case "v1alpha1":
+		return getAPIBindingV1alpha1(u)
+
+	case "v1alpha2":
+		return getAPIBindingV1alpha2(u)
+
+	default:
+		return nil, fmt.Errorf("version %q is not supported by this admission plugin", preferredVersion)
+	}
+}

--- a/pkg/admission/apibinding/apibinding_v1alpha1.go
+++ b/pkg/admission/apibinding/apibinding_v1alpha1.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apibinding
+
+import (
+	"fmt"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	apisv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/apis/v1alpha1"
+)
+
+type apiBindingV1alpha1 struct {
+	binding *apisv1alpha1.APIBinding
+}
+
+func getAPIBindingV1alpha1(u *unstructured.Unstructured) (*apiBindingV1alpha1, error) {
+	apiBinding := &apisv1alpha1.APIBinding{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, apiBinding); err != nil {
+		return nil, fmt.Errorf("failed to convert unstructured to APIBinding: %w", err)
+	}
+
+	return &apiBindingV1alpha1{binding: apiBinding}, nil
+}
+
+func (b apiBindingV1alpha1) BindingReference() bindingReference {
+	return bindingReferenceV1alpha1{reference: &b.binding.Spec.Reference}
+}
+
+func (b apiBindingV1alpha1) Labels() map[string]string {
+	return b.binding.Labels
+}
+
+func (b *apiBindingV1alpha1) SetLabels(labels map[string]string) {
+	b.binding.Labels = labels
+}
+
+func (b *apiBindingV1alpha1) Validate() field.ErrorList {
+	return apisv1alpha1.ValidateAPIBinding(b.binding)
+}
+
+func (b apiBindingV1alpha1) ValidateUpdate(oldBinding apiBinding) field.ErrorList {
+	old, ok := oldBinding.(*apiBindingV1alpha1)
+	if !ok {
+		panic("this should not happen")
+	}
+
+	return apisv1alpha1.ValidateAPIBindingUpdate(old.binding, b.binding)
+}
+
+func (b apiBindingV1alpha1) ToUnstructured() (map[string]interface{}, error) {
+	return runtime.DefaultUnstructuredConverter.ToUnstructured(b.binding)
+}
+
+type bindingReferenceV1alpha1 struct {
+	reference *apisv1alpha1.BindingReference
+}
+
+func (r bindingReferenceV1alpha1) HasExport() bool {
+	return r.reference.Export != nil
+}
+
+func (r bindingReferenceV1alpha1) ExportName() string {
+	if r.reference.Export == nil {
+		return ""
+	}
+
+	return r.reference.Export.Name
+}
+
+func (r bindingReferenceV1alpha1) ExportPath() string {
+	if r.reference.Export == nil {
+		return ""
+	}
+
+	return r.reference.Export.Path
+}
+
+func (r bindingReferenceV1alpha1) DeepEqual(compare bindingReference) bool {
+	compareV1alpha1, ok := compare.(bindingReferenceV1alpha1)
+	if !ok {
+		return false
+	}
+
+	return reflect.DeepEqual(r.reference, compareV1alpha1.reference)
+}

--- a/pkg/admission/apibinding/apibinding_v1alpha2.go
+++ b/pkg/admission/apibinding/apibinding_v1alpha2.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apibinding
+
+import (
+	"fmt"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	apisv1alpha2 "github.com/kcp-dev/kcp/sdk/apis/apis/v1alpha2"
+)
+
+type apiBindingV1alpha2 struct {
+	binding *apisv1alpha2.APIBinding
+}
+
+func getAPIBindingV1alpha2(u *unstructured.Unstructured) (*apiBindingV1alpha2, error) {
+	apiBinding := &apisv1alpha2.APIBinding{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, apiBinding); err != nil {
+		return nil, fmt.Errorf("failed to convert unstructured to APIBinding: %w", err)
+	}
+
+	return &apiBindingV1alpha2{binding: apiBinding}, nil
+}
+
+func (b apiBindingV1alpha2) BindingReference() bindingReference {
+	return bindingReferenceV1alpha2{reference: &b.binding.Spec.Reference}
+}
+
+func (b apiBindingV1alpha2) Labels() map[string]string {
+	return b.binding.Labels
+}
+
+func (b *apiBindingV1alpha2) SetLabels(labels map[string]string) {
+	b.binding.Labels = labels
+}
+
+func (b apiBindingV1alpha2) Validate() field.ErrorList {
+	return apisv1alpha2.ValidateAPIBinding(b.binding)
+}
+
+func (b apiBindingV1alpha2) ValidateUpdate(oldBinding apiBinding) field.ErrorList {
+	old, ok := oldBinding.(*apiBindingV1alpha2)
+	if !ok {
+		panic("this should not happen")
+	}
+
+	return apisv1alpha2.ValidateAPIBindingUpdate(old.binding, b.binding)
+}
+
+func (b apiBindingV1alpha2) ToUnstructured() (map[string]interface{}, error) {
+	return runtime.DefaultUnstructuredConverter.ToUnstructured(b.binding)
+}
+
+type bindingReferenceV1alpha2 struct {
+	reference *apisv1alpha2.BindingReference
+}
+
+func (r bindingReferenceV1alpha2) HasExport() bool {
+	return r.reference.Export != nil
+}
+
+func (r bindingReferenceV1alpha2) ExportName() string {
+	return r.reference.Export.Name
+}
+
+func (r bindingReferenceV1alpha2) ExportPath() string {
+	return r.reference.Export.Path
+}
+
+func (r bindingReferenceV1alpha2) DeepEqual(compare bindingReference) bool {
+	compareV1alpha2, ok := compare.(bindingReferenceV1alpha2)
+	if !ok {
+		return false
+	}
+
+	return reflect.DeepEqual(r.reference, compareV1alpha2.reference)
+}

--- a/sdk/apis/apis/v1alpha1/validation.go
+++ b/sdk/apis/apis/v1alpha1/validation.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// ValidateAPIBinding validates an APIBinding.
+func ValidateAPIBinding(apiBinding *APIBinding) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, ValidateAPIBindingReference(apiBinding.Spec.Reference, field.NewPath("spec", "reference"))...)
+
+	return allErrs
+}
+
+// ValidateAPIBindingUpdate validates an updated APIBinding.
+func ValidateAPIBindingUpdate(oldBinding, newBinding *APIBinding) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, ValidateAPIBinding(newBinding)...)
+
+	if oldBinding.Status.Phase != "" && newBinding.Status.Phase == "" {
+		allErrs = append(allErrs,
+			field.Forbidden(
+				field.NewPath("status", "phase"),
+				fmt.Sprintf("cannot transition from %q to %q", oldBinding.Status.Phase, newBinding.Status.Phase),
+			),
+		)
+	}
+
+	return allErrs
+}
+
+// ValidateAPIBindingReference validates an APIBinding's BindingReference.
+func ValidateAPIBindingReference(reference BindingReference, path *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if reference.Export == nil {
+		allErrs = append(allErrs, field.Required(path.Child("export"), ""))
+	} else if reference.Export.Name == "" {
+		allErrs = append(allErrs, field.Required(path.Child("export").Child("name"), ""))
+	}
+
+	return allErrs
+}

--- a/sdk/apis/apis/v1alpha2/validation.go
+++ b/sdk/apis/apis/v1alpha2/validation.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The KCP Authors.
+Copyright 2025 The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,18 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package apibinding
+package v1alpha2
 
 import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-
-	apisv1alpha2 "github.com/kcp-dev/kcp/sdk/apis/apis/v1alpha2"
 )
 
 // ValidateAPIBinding validates an APIBinding.
-func ValidateAPIBinding(apiBinding *apisv1alpha2.APIBinding) field.ErrorList {
+func ValidateAPIBinding(apiBinding *APIBinding) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, ValidateAPIBindingReference(apiBinding.Spec.Reference, field.NewPath("spec", "reference"))...)
@@ -34,7 +32,7 @@ func ValidateAPIBinding(apiBinding *apisv1alpha2.APIBinding) field.ErrorList {
 }
 
 // ValidateAPIBindingUpdate validates an updated APIBinding.
-func ValidateAPIBindingUpdate(oldBinding, newBinding *apisv1alpha2.APIBinding) field.ErrorList {
+func ValidateAPIBindingUpdate(oldBinding, newBinding *APIBinding) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, ValidateAPIBinding(newBinding)...)
@@ -52,7 +50,7 @@ func ValidateAPIBindingUpdate(oldBinding, newBinding *apisv1alpha2.APIBinding) f
 }
 
 // ValidateAPIBindingReference validates an APIBinding's BindingReference.
-func ValidateAPIBindingReference(reference apisv1alpha2.BindingReference, path *field.Path) field.ErrorList {
+func ValidateAPIBindingReference(reference BindingReference, path *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if reference.Export == nil {


### PR DESCRIPTION
## Summary

As of v0.28.0, it became impossible to apply v1alpha1 APIBindings. The error would look like this:

```
The APIBinding "foo" is invalid:
* spec.permissionClaims[0]: Invalid value: "object": either "all" or "resourceSelector" must be set
* spec.permissionClaims[1]: Invalid value: "object": either "all" or "resourceSelector" must be set
* spec.permissionClaims[2]: Invalid value: "object": either "all" or "resourceSelector" must be set
```

We found out that this is happening because the APIBinding admission is mishandling the v1alpha1 API version. The admission plugin would receive the v1alpha1 version of the object, but it would unpack it into the v1alpha2 struct leading to data loss. At the end, the admission plugin would write back the v1alpha2 object, causing further issues in addition to the data loss.

This PR modifies the admission plugin to be able to handle both v1alpha1 and v1alpha2 API versions. The implementation is based on #3539, i.e. I implemented an interface for APIBindings with functions needed by the admission plugin, then there are two implementations of that interface, for v1alpha1 and v1alpha2. I also added some simple unit tests to the APIBindings admission plugin to make sure we test this scenario in the CI.

Alternative considered was that we do conversion inside the APIBindings admission plugin, that would:
- Add some unnecessary load (convert v1alpha1 to v1alpha2, eventually convert old object to v1alpha2 in case of updates, then convert both back to v1alpha1)
- Introduce some more edge cases (conversion expects already valid object, however CEL validation happens in validating admission, so after mutating admission is done, which is too late in this case)

This is technically a workaround for not having internal types, which should be our goal for the future. I'll create a ticket to track that.

This will need to be cherry-picked to v0.28.

## What Type of PR Is This?

/kind bug
/kind regression

## Related Issue(s)

Fixes #3527 

## Release Notes
```release-note
Fix APIBinding admission mishandling v1alpha1 API version. This fixes the bug where it was impossible to apply v1alpha1 APIBindings
```

/assign @xrstf @embik @mjudeikis 