### PR TITLE
Add CEL validation to WorkspaceAuthenticationConfiguration

### DIFF
--- a/config/crds/tenancy.kcp.io_workspaceauthenticationconfigurations.yaml
+++ b/config/crds/tenancy.kcp.io_workspaceauthenticationconfigurations.yaml
@@ -68,41 +68,55 @@ spec:
                             for a single prefixed claim or expression.
                           properties:
                             claim:
+                              minLength: 1
                               type: string
                             expression:
+                              minLength: 1
                               type: string
                             prefix:
                               type: string
-                          required:
-                          - claim
                           type: object
+                          x-kubernetes-validations:
+                          - message: either claim or expression must be specified
+                            rule: has(self.claim) || has(self.expression)
+                          - message: claim and expression cannot both be specified
+                            rule: '!(has(self.claim) && has(self.expression))'
+                          - message: prefix can only be specified when claim is specified
+                            rule: '!(has(self.prefix)) || has(self.claim)'
                         uid:
                           description: ClaimOrExpression provides the configuration
                             for a single claim or expression.
                           properties:
                             claim:
+                              minLength: 1
                               type: string
                             expression:
+                              minLength: 1
                               type: string
-                          required:
-                          - claim
                           type: object
+                          x-kubernetes-validations:
+                          - message: claim and expression cannot both be specified
+                            rule: '!(has(self.claim) && has(self.expression))'
                         username:
                           description: PrefixedClaimOrExpression provides the configuration
                             for a single prefixed claim or expression.
                           properties:
                             claim:
+                              minLength: 1
                               type: string
                             expression:
+                              minLength: 1
                               type: string
                             prefix:
                               type: string
-                          required:
-                          - claim
                           type: object
-                      required:
-                      - groups
-                      - username
+                          x-kubernetes-validations:
+                          - message: either claim or expression must be specified
+                            rule: has(self.claim) || has(self.expression)
+                          - message: claim and expression cannot both be specified
+                            rule: '!(has(self.claim) && has(self.expression))'
+                          - message: prefix can only be specified when claim is specified
+                            rule: '!(has(self.prefix)) || has(self.claim)'
                       type: object
                     claimValidationRules:
                       items:
@@ -110,19 +124,31 @@ spec:
                           for a single claim validation rule.
                         properties:
                           claim:
+                            minLength: 1
                             type: string
                           expression:
+                            minLength: 1
                             type: string
                           message:
+                            minLength: 1
                             type: string
                           requiredValue:
+                            minLength: 1
                             type: string
-                        required:
-                        - claim
-                        - expression
-                        - message
-                        - requiredValue
                         type: object
+                        x-kubernetes-validations:
+                        - message: either claim or expression must be specified
+                          rule: has(self.claim) || has(self.expression)
+                        - message: claim and expression cannot both be specified
+                          rule: '!(has(self.claim) && has(self.expression))'
+                        - message: requiredValue can only be specified when claim
+                            is specified
+                          rule: (has(self.expression) && !has(self.requiredValue))
+                            || (has(self.claim) && has(self.requiredValue))
+                        - message: message can only be specified when expression is
+                            specified
+                          rule: (has(self.expression) && has(self.message)) || (has(self.claim)
+                            && !has(self.message))
                       type: array
                     issuer:
                       description: Issuer provides the configuration for an external

--- a/config/root-phase0/apiexport-tenancy.kcp.io.yaml
+++ b/config/root-phase0/apiexport-tenancy.kcp.io.yaml
@@ -9,7 +9,7 @@ spec:
   resources:
   - group: tenancy.kcp.io
     name: workspaceauthenticationconfigurations
-    schema: v250802-1b3cd3d0d.workspaceauthenticationconfigurations.tenancy.kcp.io
+    schema: v250827-717cfea84.workspaceauthenticationconfigurations.tenancy.kcp.io
     storage:
       crd: {}
   - group: tenancy.kcp.io

--- a/config/root-phase0/apiresourceschema-workspaceauthenticationconfigurations.tenancy.kcp.io.yaml
+++ b/config/root-phase0/apiresourceschema-workspaceauthenticationconfigurations.tenancy.kcp.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v250802-1b3cd3d0d.workspaceauthenticationconfigurations.tenancy.kcp.io
+  name: v250827-717cfea84.workspaceauthenticationconfigurations.tenancy.kcp.io
 spec:
   group: tenancy.kcp.io
   names:
@@ -65,41 +65,55 @@ spec:
                           for a single prefixed claim or expression.
                         properties:
                           claim:
+                            minLength: 1
                             type: string
                           expression:
+                            minLength: 1
                             type: string
                           prefix:
                             type: string
-                        required:
-                        - claim
                         type: object
+                        x-kubernetes-validations:
+                        - message: either claim or expression must be specified
+                          rule: has(self.claim) || has(self.expression)
+                        - message: claim and expression cannot both be specified
+                          rule: '!(has(self.claim) && has(self.expression))'
+                        - message: prefix can only be specified when claim is specified
+                          rule: '!(has(self.prefix)) || has(self.claim)'
                       uid:
                         description: ClaimOrExpression provides the configuration
                           for a single claim or expression.
                         properties:
                           claim:
+                            minLength: 1
                             type: string
                           expression:
+                            minLength: 1
                             type: string
-                        required:
-                        - claim
                         type: object
+                        x-kubernetes-validations:
+                        - message: claim and expression cannot both be specified
+                          rule: '!(has(self.claim) && has(self.expression))'
                       username:
                         description: PrefixedClaimOrExpression provides the configuration
                           for a single prefixed claim or expression.
                         properties:
                           claim:
+                            minLength: 1
                             type: string
                           expression:
+                            minLength: 1
                             type: string
                           prefix:
                             type: string
-                        required:
-                        - claim
                         type: object
-                    required:
-                    - groups
-                    - username
+                        x-kubernetes-validations:
+                        - message: either claim or expression must be specified
+                          rule: has(self.claim) || has(self.expression)
+                        - message: claim and expression cannot both be specified
+                          rule: '!(has(self.claim) && has(self.expression))'
+                        - message: prefix can only be specified when claim is specified
+                          rule: '!(has(self.prefix)) || has(self.claim)'
                     type: object
                   claimValidationRules:
                     items:
@@ -107,19 +121,31 @@ spec:
                         for a single claim validation rule.
                       properties:
                         claim:
+                          minLength: 1
                           type: string
                         expression:
+                          minLength: 1
                           type: string
                         message:
+                          minLength: 1
                           type: string
                         requiredValue:
+                          minLength: 1
                           type: string
-                      required:
-                      - claim
-                      - expression
-                      - message
-                      - requiredValue
                       type: object
+                      x-kubernetes-validations:
+                      - message: either claim or expression must be specified
+                        rule: has(self.claim) || has(self.expression)
+                      - message: claim and expression cannot both be specified
+                        rule: '!(has(self.claim) && has(self.expression))'
+                      - message: requiredValue can only be specified when claim is
+                          specified
+                        rule: (has(self.expression) && !has(self.requiredValue)) ||
+                          (has(self.claim) && has(self.requiredValue))
+                      - message: message can only be specified when expression is
+                          specified
+                        rule: (has(self.expression) && has(self.message)) || (has(self.claim)
+                          && !has(self.message))
                     type: array
                   issuer:
                     description: Issuer provides the configuration for an external

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -4074,7 +4074,6 @@ func schema_sdk_apis_tenancy_v1alpha1_ClaimMappings(ref common.ReferenceCallback
 						},
 					},
 				},
-				Required: []string{"username", "groups"},
 			},
 		},
 		Dependencies: []string{
@@ -4091,9 +4090,8 @@ func schema_sdk_apis_tenancy_v1alpha1_ClaimOrExpression(ref common.ReferenceCall
 				Properties: map[string]spec.Schema{
 					"claim": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"expression": {
@@ -4103,7 +4101,6 @@ func schema_sdk_apis_tenancy_v1alpha1_ClaimOrExpression(ref common.ReferenceCall
 						},
 					},
 				},
-				Required: []string{"claim"},
 			},
 		},
 	}
@@ -4118,34 +4115,29 @@ func schema_sdk_apis_tenancy_v1alpha1_ClaimValidationRule(ref common.ReferenceCa
 				Properties: map[string]spec.Schema{
 					"claim": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"requiredValue": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"expression": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"message": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 				},
-				Required: []string{"claim", "requiredValue", "expression", "message"},
 			},
 		},
 	}
@@ -4363,9 +4355,8 @@ func schema_sdk_apis_tenancy_v1alpha1_PrefixedClaimOrExpression(ref common.Refer
 				Properties: map[string]spec.Schema{
 					"claim": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"prefix": {
@@ -4381,7 +4372,6 @@ func schema_sdk_apis_tenancy_v1alpha1_PrefixedClaimOrExpression(ref common.Refer
 						},
 					},
 				},
-				Required: []string{"claim"},
 			},
 		},
 	}

--- a/sdk/apis/tenancy/v1alpha1/types_workspaceauthentication.go
+++ b/sdk/apis/tenancy/v1alpha1/types_workspaceauthentication.go
@@ -102,18 +102,30 @@ const (
 )
 
 // ClaimValidationRule provides the configuration for a single claim validation rule.
+// +kubebuilder:validation:XValidation:rule="has(self.claim) || has(self.expression)",message="either claim or expression must be specified"
+// +kubebuilder:validation:XValidation:rule="!(has(self.claim) && has(self.expression))",message="claim and expression cannot both be specified"
+// +kubebuilder:validation:XValidation:rule="(has(self.expression) && !has(self.requiredValue)) || (has(self.claim) && has(self.requiredValue))",message="requiredValue can only be specified when claim is specified"
+// +kubebuilder:validation:XValidation:rule="(has(self.expression) && has(self.message)) || (has(self.claim) && !has(self.message))",message="message can only be specified when expression is specified"
 type ClaimValidationRule struct {
-	Claim         string `json:"claim"`
-	RequiredValue string `json:"requiredValue"`
+	// +optional
+	// +kubebuilder:validation:MinLength=1
+	Claim string `json:"claim,omitempty"`
+	// +optional
+	// +kubebuilder:validation:MinLength=1
+	RequiredValue string `json:"requiredValue,omitempty"`
 
-	Expression string `json:"expression"`
-	Message    string `json:"message"`
+	// +optional
+	// +kubebuilder:validation:MinLength=1
+	Expression string `json:"expression,omitempty"`
+	// +optional
+	// +kubebuilder:validation:MinLength=1
+	Message string `json:"message,omitempty"`
 }
 
 // ClaimMappings provides the configuration for claim mapping.
 type ClaimMappings struct {
-	Username PrefixedClaimOrExpression `json:"username"`
-	Groups   PrefixedClaimOrExpression `json:"groups"`
+	Username PrefixedClaimOrExpression `json:"username,omitempty"`
+	Groups   PrefixedClaimOrExpression `json:"groups,omitempty"`
 	// +optional
 	UID ClaimOrExpression `json:"uid,omitempty"`
 	// +optional
@@ -121,18 +133,28 @@ type ClaimMappings struct {
 }
 
 // PrefixedClaimOrExpression provides the configuration for a single prefixed claim or expression.
+// +kubebuilder:validation:XValidation:rule="has(self.claim) || has(self.expression)",message="either claim or expression must be specified"
+// +kubebuilder:validation:XValidation:rule="!(has(self.claim) && has(self.expression))",message="claim and expression cannot both be specified"
+// +kubebuilder:validation:XValidation:rule="!(has(self.prefix)) || has(self.claim)",message="prefix can only be specified when claim is specified"
 type PrefixedClaimOrExpression struct {
-	Claim string `json:"claim"`
+	// +optional
+	// +kubebuilder:validation:MinLength=1
+	Claim string `json:"claim,omitempty"`
 	// +optional
 	Prefix *string `json:"prefix,omitempty"`
 	// +optional
+	// +kubebuilder:validation:MinLength=1
 	Expression string `json:"expression,omitempty"`
 }
 
 // ClaimOrExpression provides the configuration for a single claim or expression.
+// +kubebuilder:validation:XValidation:rule="!(has(self.claim) && has(self.expression))",message="claim and expression cannot both be specified"
 type ClaimOrExpression struct {
-	Claim string `json:"claim"`
 	// +optional
+	// +kubebuilder:validation:MinLength=1
+	Claim string `json:"claim,omitempty"`
+	// +optional
+	// +kubebuilder:validation:MinLength=1
 	Expression string `json:"expression,omitempty"`
 }
 


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Add CEL validation mimicking the custom validation from upstream:

https://github.com/kubernetes/kubernetes/blob/091f87c10bc3532041b77a783a5f832de5506dc8/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation.go

It's currently not possible to define claimValidationRules as the generated spec expects all fields to be set.

## What Type of PR Is This?

/kind bug

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
