### PR TITLE
Docs: added a note in kubectl-plugin docs to guide users when to use kubectl create workspace

### DIFF
--- a/docs/content/setup/kubectl-plugin.md
+++ b/docs/content/setup/kubectl-plugin.md
@@ -22,8 +22,7 @@ $ kubectl krew install kcp-dev/ws
 $ kubectl krew install kcp-dev/create-workspace
 ```
 !!! Note
-    When Installed directly from the repo we use `kubectl create workspace`
-    instead of `kubectl create-workspace`
+    When installed directly from the git repository `kubectl create workspace` should be used instead of `kubectl create-workspace`.
 
 The plugins will be [automatically discovered by your current `kubectl` binary](https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/):
 

--- a/docs/content/setup/kubectl-plugin.md
+++ b/docs/content/setup/kubectl-plugin.md
@@ -21,6 +21,9 @@ $ kubectl krew install kcp-dev/kcp
 $ kubectl krew install kcp-dev/ws
 $ kubectl krew install kcp-dev/create-workspace
 ```
+!!! Note
+    When Installed directly from the repo we use `kubectl create workspace`
+    instead of `kubectl create-workspace`
 
 The plugins will be [automatically discovered by your current `kubectl` binary](https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/):
 


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary
added a note in kubectl-plugin docs to guide users when to use `kubectl create workspace` instead of `kubectl create-workspace`
## What Type of PR Is This?
/kind documentation
<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #3559 

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
