### PR TITLE
Move e2e mockoidc to authfixtures

### DIFF
--- a/test/e2e/fixtures/authfixtures/authfixtures.go
+++ b/test/e2e/fixtures/authfixtures/authfixtures.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authfixtures
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	tenancyv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/tenancy/v1alpha1"
+	kcpclientset "github.com/kcp-dev/kcp/sdk/client/clientset/versioned/cluster"
+)
+
+func CreateWorkspaceType(t *testing.T, ctx context.Context, client kcpclientset.ClusterInterface, workspace logicalcluster.Path, name string, authConfigNames ...string) string {
+	configs := []tenancyv1alpha1.AuthenticationConfigurationReference{}
+	for _, name := range authConfigNames {
+		configs = append(configs, tenancyv1alpha1.AuthenticationConfigurationReference{
+			Name: name,
+		})
+	}
+
+	// setup a new workspace auth config that uses mockoidc's server
+	wsType := &tenancyv1alpha1.WorkspaceType{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: tenancyv1alpha1.WorkspaceTypeSpec{
+			AuthenticationConfigurations: configs,
+		},
+	}
+
+	t.Logf("Creating WorkspaceType %s...", name)
+	_, err := client.Cluster(workspace).TenancyV1alpha1().WorkspaceTypes().Create(ctx, wsType, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	return name
+}
+
+func GrantWorkspaceAccess(t *testing.T, ctx context.Context, client kcpkubernetesclientset.ClusterInterface, workspace logicalcluster.Path, name, clusterRole string, subjects []rbacv1.Subject) {
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind: "ClusterRole",
+			Name: clusterRole,
+		},
+		Subjects: subjects,
+	}
+
+	t.Log("Creating ClusterRoleBinding...")
+	_, err := client.Cluster(workspace).RbacV1().ClusterRoleBindings().Create(ctx, crb, metav1.CreateOptions{})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Moves the helpers from `test/e2e/authentication` for OIDC to `test/e2e/fixtures/authfixtures` similar to `test/e2e/fixtures/apifixtures`.

#3513 needs e2e tests that verify that per-workspace users can be authorized to bind an APIExport.

After moving some tests around I feel like it would be overall more coherent to have the OIDC fixtures in a library to use where the core functionality is tested (e.g. APIBinding in test/e2e/apibinding), rather than adding an APIBinding test in test/e2e/authentication.

The package can also later be expanded for more authentication fixtures if need be.

## What Type of PR Is This?

/kind feature

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
