### PR TITLE
Fix GenCachedObjectName in CachedResource replication reconciler

### DIFF
--- a/pkg/reconciler/cache/cachedresources/replication/replication_reconcile.go
+++ b/pkg/reconciler/cache/cachedresources/replication/replication_reconcile.go
@@ -59,7 +59,7 @@ func GenCachedObjectName(gvr schema.GroupVersionResource, namespace, name string
 	buf.WriteString(namespace)
 	buf.WriteString(name)
 
-	hash := sha256.Sum256([]byte(name))
+	hash := sha256.Sum256(buf.Bytes())
 	base36hash := strings.ToLower(base36.EncodeBytes(hash[:]))
 
 	return base36hash

--- a/pkg/reconciler/cache/cachedresources/replication/replication_reconcile_test.go
+++ b/pkg/reconciler/cache/cachedresources/replication/replication_reconcile_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package replication
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestGenCachedObjectName(t *testing.T) {
+	tests := map[string]struct {
+		gvr       schema.GroupVersionResource
+		namespace string
+		name      string
+		want      string
+	}{
+		"matching": {
+			gvr: schema.GroupVersionResource{
+				Group:    "group-1",
+				Version:  "v1",
+				Resource: "resource-1",
+			},
+			namespace: "",
+			name:      "a-resource",
+			want:      "6dgup41jy1ta41gc4q4hb1hdnmrdgl4rdn5ux0t8ya9nhk3jo6",
+		},
+	}
+	for tname, tt := range tests {
+		t.Run(tname, func(t *testing.T) {
+			objName := GenCachedObjectName(tt.gvr, tt.namespace, tt.name)
+			require.Equal(t, tt.want, objName, "GenCachedObjectName returned an unexpected object name")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

GenCachedObjectName generated an object name just from the "name" arg. This PR fixes that and adds a unit test.

## What Type of PR Is This?

/kind bug

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
