### PR TITLE
 Fix sdk/testing panicking when used outside of a kcp clone 

### DIFF
--- a/cmd/sharded-test-server/cache.go
+++ b/cmd/sharded-test-server/cache.go
@@ -52,7 +52,7 @@ func startCacheServer(ctx context.Context, logDirPath, workingDir, hostIP string
 	)
 	cacheWorkingDir := filepath.Join(workingDir, ".kcp-cache")
 	cachePort := 8012
-	commandLine := kcptestingserver.Command("cache-server", "cache")
+	workdir, commandLine := kcptestingserver.Command("cache-server", "cache")
 	commandLine = append(
 		commandLine,
 		fmt.Sprintf("--root-directory=%s", cacheWorkingDir),
@@ -64,6 +64,7 @@ func startCacheServer(ctx context.Context, logDirPath, workingDir, hostIP string
 	)
 	fmt.Fprintf(out, "running: %v\n", strings.Join(commandLine, " "))
 	cmd := exec.CommandContext(ctx, commandLine[0], commandLine[1:]...) //nolint:gosec
+	cmd.Dir = workdir
 
 	logFilePath := filepath.Join(".kcp-cache", "kcp.log")
 	if logDirPath != "" {

--- a/cmd/sharded-test-server/frontproxy.go
+++ b/cmd/sharded-test-server/frontproxy.go
@@ -131,7 +131,8 @@ func startFrontProxy(
 	}
 
 	// run front-proxy command
-	commandLine := append(kcptestingserver.Command("kcp-front-proxy", "front-proxy"),
+	workdir, commandLine := kcptestingserver.Command("kcp-front-proxy", "front-proxy")
+	commandLine = append(commandLine,
 		"--bind-address="+hostIP,
 		fmt.Sprintf("--mapping-file=%s", filepath.Join(workDirPath, ".kcp-front-proxy", "mapping.yaml")),
 		fmt.Sprintf("--root-directory=%s", filepath.Join(workDirPath, ".kcp-front-proxy")),
@@ -147,6 +148,7 @@ func startFrontProxy(
 	fmt.Fprintf(out, "running: %v\n", strings.Join(commandLine, " "))
 
 	cmd := exec.CommandContext(ctx, commandLine[0], commandLine[1:]...) //nolint:gosec
+	cmd.Dir = workdir
 
 	logFilePath := filepath.Join(workDirPath, ".kcp-front-proxy", "proxy.log")
 	if logDirPath != "" {

--- a/cmd/sharded-test-server/virtual.go
+++ b/cmd/sharded-test-server/virtual.go
@@ -188,7 +188,7 @@ func (v *VirtualWorkspace) start(ctx context.Context) error {
 		auditFilePath = filepath.Join(v.logDirPath, fmt.Sprintf("kcp-virtual-workspaces-%d-audit.log", v.index))
 	}
 
-	commandLine := kcptestingserver.Command("virtual-workspaces", strings.ToLower(prefix))
+	workdir, commandLine := kcptestingserver.Command("virtual-workspaces", strings.ToLower(prefix))
 	commandLine = append(commandLine, v.args...)
 	commandLine = append(
 		commandLine,
@@ -202,6 +202,7 @@ func (v *VirtualWorkspace) start(ctx context.Context) error {
 	fmt.Fprintf(out, "running: %v\n", strings.Join(commandLine, " "))
 
 	cmd := exec.CommandContext(ctx, commandLine[0], commandLine[1:]...) //nolint:gosec
+	cmd.Dir = workdir
 
 	if err := os.MkdirAll(filepath.Dir(logFilePath), 0755); err != nil {
 		return err

--- a/cmd/test-server/kcp/shard.go
+++ b/cmd/test-server/kcp/shard.go
@@ -94,8 +94,7 @@ func (s *Shard) Start(ctx context.Context, quiet bool) error {
 	}
 
 	// setup command
-	var commandLine []string
-	commandLine = append(commandLine, kcptestingserver.StartKcpCommand(s.name)...)
+	workdir, commandLine := kcptestingserver.StartKcpCommand(s.name)
 	commandLine = append(commandLine, s.args...)
 	commandLine = append(commandLine,
 		"--root-directory", s.runtimeDir,
@@ -114,6 +113,7 @@ func (s *Shard) Start(ctx context.Context, quiet bool) error {
 	fmt.Fprintf(out, "running: %v\n", strings.Join(commandLine, " "))
 
 	cmd := exec.CommandContext(ctx, commandLine[0], commandLine[1:]...) //nolint:gosec
+	cmd.Dir = workdir
 	if err := os.MkdirAll(filepath.Dir(s.logFilePath), 0755); err != nil {
 		return err
 	}

--- a/sdk/testing/server/metrics.go
+++ b/sdk/testing/server/metrics.go
@@ -74,7 +74,9 @@ func scrapeMetricsForServer(t TestingT, srv RunningServer) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), wait.ForeverTestTimeout)
 	defer cancel()
-	require.NoError(t, ScrapeMetrics(ctx, srv.RootShardSystemMasterBaseConfig(t), promUrl, kcptestinghelpers.RepositoryDir(), jobName, filepath.Join(srv.CADirectory(), "apiserver.crt"), labels))
+	repoDir, err := kcptestinghelpers.RepositoryDir()
+	require.NoError(t, err)
+	require.NoError(t, ScrapeMetrics(ctx, srv.RootShardSystemMasterBaseConfig(t), promUrl, repoDir, jobName, filepath.Join(srv.CADirectory(), "apiserver.crt"), labels))
 }
 
 func ScrapeMetrics(ctx context.Context, cfg *rest.Config, promUrl, promCfgDir, jobName, caFile string, labels map[string]string) error {

--- a/test/e2e/framework/flags.go
+++ b/test/e2e/framework/flags.go
@@ -41,7 +41,11 @@ func complete() {
 		panic(errors.New("only one of --use-default-kcp-server and --kcp-kubeconfig should be set"))
 	}
 	if testConfig.useDefaultKCPServer {
-		testConfig.kcpKubeconfig = filepath.Join(kcptestinghelpers.RepositoryDir(), ".kcp", "admin.kubeconfig")
+		repo, err := kcptestinghelpers.RepositoryDir()
+		if err != nil {
+			panic(err)
+		}
+		testConfig.kcpKubeconfig = filepath.Join(repo, ".kcp", "admin.kubeconfig")
 	}
 	if len(testConfig.kcpKubeconfig) > 0 && len(testConfig.shardKubeconfigs) == 0 {
 		testConfig.shardKubeconfigs = map[string]string{corev1alpha1.RootShard: testConfig.kcpKubeconfig}

--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -25,9 +25,16 @@ import (
 )
 
 // DefaultTokenAuthFile returns the default auth tokens file.
-var DefaultTokenAuthFile = filepath.Join(kcptestinghelpers.RepositoryDir(), "test", "e2e", "framework", "auth-tokens.csv")
+var DefaultTokenAuthFile string
 
 func init() {
+	repo, err := kcptestinghelpers.RepositoryDir()
+	if err != nil {
+		panic(err)
+	}
+
+	DefaultTokenAuthFile = filepath.Join(repo, "test", "e2e", "framework", "auth-tokens.csv")
+
 	var args []string
 	args = append(args, "--token-auth-file", DefaultTokenAuthFile) //nolint:gocritic // no.
 	args = append(args, "--feature-gates=WorkspaceMounts=true,CacheAPIs=true,WorkspaceAuthentication=true")

--- a/test/e2e/framework/kubectl.go
+++ b/test/e2e/framework/kubectl.go
@@ -40,7 +40,11 @@ func KcpCliPluginCommand() []string {
 	if env.NoGoRunEnvSet() {
 		return []string{"kubectl", "kcp"}
 	} else {
-		cmdPath := filepath.Join(kcptestinghelpers.RepositoryDir(), "cmd", "kubectl-kcp")
+		repo, err := kcptestinghelpers.RepositoryDir()
+		if err != nil {
+			panic(err)
+		}
+		cmdPath := filepath.Join(repo, "cmd", "kubectl-kcp")
 		return []string{"go", "run", cmdPath}
 	}
 }


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

When using `sdk/testing` outside of the kcp repository this happens:

```

goroutine 127 [running]:
testing.(*M).startAlarm.func1()
        /opt/homebrew/Cellar/go/1.25.1/libexec/src/testing/testing.go:2682 +0x490
created by time.goFunc
        /opt/homebrew/Cellar/go/1.25.1/libexec/src/time/sleep.go:215 +0x44

goroutine 1 [chan receive, 10 minutes]:
testing.(*T).Run(0xc0008b0a80, {0x105381641, 0x12}, 0x10626b7f0)
        /opt/homebrew/Cellar/go/1.25.1/libexec/src/testing/testing.go:2005 +0x700
testing.runTests.func1(0xc0008b0a80)
        /opt/homebrew/Cellar/go/1.25.1/libexec/src/testing/testing.go:2477 +0x78
testing.tRunner(0xc0008b0a80, 0xc000071ad8)
        /opt/homebrew/Cellar/go/1.25.1/libexec/src/testing/testing.go:1934 +0x168
testing.runTests(0xc0002439f8, {0x107f78950, 0x1, 0x1}, {0x5e6752d3e2f4c05b?, 0x0?, 0x107feaf40?})
        /opt/homebrew/Cellar/go/1.25.1/libexec/src/testing/testing.go:2475 +0x738
testing.(*M).Run(0xc000033400)
        /opt/homebrew/Cellar/go/1.25.1/libexec/src/testing/testing.go:2337 +0xaf8
main.main()
        _testmain.go:45 +0x104

goroutine 137 [select]:
k8s.io/klog/v2.(*flushDaemon).run.func1()
        /Users/I567861/SAPDevelop/golang/pkg/mod/k8s.io/klog/v2@v2.130.1/klog.go:1141 +0x164
created by k8s.io/klog/v2.(*flushDaemon).run in goroutine 1
        /Users/I567861/SAPDevelop/golang/pkg/mod/k8s.io/klog/v2@v2.130.1/klog.go:1137 +0x1ec

goroutine 138 [runnable]:
path/filepath.Abs({0xc000e00b18, 0x1})
        /opt/homebrew/Cellar/go/1.25.1/libexec/src/path/filepath/path.go:161 +0x70
github.com/kcp-dev/kcp/sdk/testing/helpers.RepositoryDir()
        /Users/I567861/SAPDevelop/golang/pkg/mod/github.com/kcp-dev/kcp/sdk@v0.28.1/testing/helpers/repo.go:38 +0x104
github.com/kcp-dev/kcp/sdk/testing/server.Command({0x10536796b, 0x3}, {0x105367a4f, 0x3})
        /Users/I567861/SAPDevelop/golang/pkg/mod/github.com/kcp-dev/kcp/sdk@v0.28.1/testing/server/fixture.go:211 +0x2bc
github.com/kcp-dev/kcp/sdk/testing/server.StartKcpCommand(...)
        /Users/I567861/SAPDevelop/golang/pkg/mod/github.com/kcp-dev/kcp/sdk@v0.28.1/testing/server/fixture.go:197
github.com/kcp-dev/kcp/sdk/testing/server.runExternal({0x1062bef68, 0xc0006839a0}, {0x1062d8ef0, 0xc0008b0c40}, {{0x10536a4ef, 0x6}, {0xc000b01180, 0x4, 0x4}, {0xc0001aa8c0, ...}, ...})
        /Users/I567861/SAPDevelop/golang/pkg/mod/github.com/kcp-dev/kcp/sdk@v0.28.1/testing/server/fixture.go:304 +0x130
github.com/kcp-dev/kcp/sdk/testing/server.(*kcpServer).Run(0xc0000339a0, {0x1062d8ef0, 0xc0008b0c40})
        /Users/I567861/SAPDevelop/golang/pkg/mod/github.com/kcp-dev/kcp/sdk@v0.28.1/testing/server/fixture.go:262 +0x198
github.com/kcp-dev/kcp/sdk/testing/server.NewFixture({0x1062d8ef0, 0xc0008b0c40}, {0xc000602310, 0x1, 0x1})
        /Users/I567861/SAPDevelop/golang/pkg/mod/github.com/kcp-dev/kcp/sdk@v0.28.1/testing/server/fixture.go:105 +0x4a4
github.com/kcp-dev/kcp/sdk/testing.SharedKcpServer({0x1062d8e78, 0xc0008b0c40})
        /Users/I567861/SAPDevelop/golang/pkg/mod/github.com/kcp-dev/kcp/sdk@v0.28.1/testing/kcp.go:122 +0x588
github.com/kube-bind/kube-bind/kcp/test/e2e.TestKCPIntegration(0xc0008b0c40)
        /Users/I567861/SAPDevelop/code/kube-bind/contrib/kcp/test/e2e/kcp_test.go:228 +0x3c
testing.tRunner(0xc0008b0c40, 0x10626b7f0)
        /opt/homebrew/Cellar/go/1.25.1/libexec/src/testing/testing.go:1934 +0x168
created by testing.(*T).Run in goroutine 1
        /opt/homebrew/Cellar/go/1.25.1/libexec/src/testing/testing.go:1997 +0x6e4
FAIL    github.com/kube-bind/kube-bind/kcp/test/e2e     600.667s
```

vs what I expected when used with a local replace:

```
    kcp_test.go:228: Starting kcp servers...
    fixture.go:308: running: go run ./cmd/kcp start --root-directory /var/folders/g8/823sprmj67963tncc3h_fh9w0000gn/T/tmp.XqQC1Z0SUR/TestKCPIntegration1825569687/002/kcp/shared --secure-port=60672 --embedded-etcd-client-port=60673 --embedded-etcd-peer-port=60674 --embedded-etcd-wal-size-bytes=5000 --kubeconfig-path=/var/folders/g8/823sprmj67963tncc3h_fh9w0000gn/T/tmp.XqQC1Z0SUR/TestKCPIntegration1825569687/002/kcp/shared/admin.kubeconfig --audit-log-path /var/folders/g8/823sprmj67963tncc3h_fh9w0000gn/T/tmp.XqQC1Z0SUR/TestKCPIntegration1825569687/001/TestKCPIntegration/2839004668/test-kcpintegration/kcp/shared/kcp.audit --v=4 --feature-gates= --bind-address=127.0.0.1 --audit-policy-file /var/folders/g8/823sprmj67963tncc3h_fh9w0000gn/T/tmp.XqQC1Z0SUR/TestKCPIntegration1825569687/003/audit-policy.yaml --client-ca-file /var/folders/g8/823sprmj67963tncc3h_fh9w0000gn/T/tmp.XqQC1Z0SUR/TestKCPIntegration1825569687/004/client-ca.crt
    fixture.go:119: Waiting for readiness for server at https://127.0.0.1:60672
```

vs what I expected when used as a module:

```
    kcp_test.go:228: Starting kcp servers...
    fixture.go:308: running: kcp start --root-directory /var/folders/g8/823sprmj67963tncc3h_fh9w0000gn/T/tmp.nkeBvYVlDS/TestKCPIntegration4171701229/002/kcp/shared --secure-port=61016 --embedded-etcd-client-port=61017 --embedded-etcd-peer-port=61018 --embedded-etcd-wal-size-bytes=5000 --kubeconfig-path=/var/folders/g8/823sprmj67963tncc3h_fh9w0000gn/T/tmp.nkeBvYVlDS/TestKCPIntegration4171701229/002/kcp/shared/admin.kubeconfig --audit-log-path /var/folders/g8/823sprmj67963tncc3h_fh9w0000gn/T/tmp.nkeBvYVlDS/TestKCPIntegration4171701229/001/TestKCPIntegration/116647650/test-kcpintegration/kcp/shared/kcp.audit --v=4 --feature-gates= --bind-address=127.0.0.1 --audit-policy-file /var/folders/g8/823sprmj67963tncc3h_fh9w0000gn/T/tmp.nkeBvYVlDS/TestKCPIntegration4171701229/003/audit-policy.yaml --client-ca-file /var/folders/g8/823sprmj67963tncc3h_fh9w0000gn/T/tmp.nkeBvYVlDS/TestKCPIntegration4171701229/004/client-ca.crt
    fixture.go:119: Waiting for readiness for server at https://127.0.0.1:61016
```

## What Type of PR Is This?

/kind bug

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
