### PR TITLE
fix bug when running ws command with kubeconfig flags

### DIFF
--- a/cli/pkg/base/options.go
+++ b/cli/pkg/base/options.go
@@ -75,12 +75,7 @@ func (o *Options) Complete() error {
 		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 		loadingRules.ExplicitPath = o.Kubeconfig
 
-		startingConfig, err := loadingRules.GetStartingConfig()
-		if err != nil {
-			return err
-		}
-
-		o.ClientConfig = clientcmd.NewDefaultClientConfig(*startingConfig, o.KubectlOverrides)
+		o.ClientConfig = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, o.KubectlOverrides)
 	}
 
 	return nil


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary
```
change fixes bug when rrunning workspace commands with 
either kubeconfig flag or environment variable
```

## What Type of PR Is This?
/kind bug
<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #
https://github.com/kcp-dev/kcp/issues/3594

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
