### PR TITLE
[release-0.28] Address GitHub runner reduced disk space in goreleaser action

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -25,6 +25,17 @@ jobs:
       with:
         go-version: v1.23.10
 
+    - name: Download go modules
+      run: |
+        echo "Downloading modules for go.mod"
+        go mod download
+        for gomod in **/go.mod; do
+          echo "Downloading modules for $gomod"
+          cd $(dirname $gomod)
+          go mod download
+          cd -
+        done
+
     - name: Delete non-semver tags
       run: 'git tag -d $(git tag -l | grep -v "^v")'
 


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Cherry-pick of two commits from #3511 that fixed the goreleaser action, unfortunately we forgot to backport them to `release-0.28`, resulting in build failures for v0.28.2: https://github.com/kcp-dev/kcp/actions/runs/18009582545/job/51240580436

## What Type of PR Is This?

/kind cleanup

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
