### PR TITLE
Add GitHub Admin Team to governance

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -64,6 +64,27 @@ the project succeed.
 The collective team of all Maintainers is known as the Maintainer Council, which
 is the governing body for the project.
 
+### Security Response Team
+
+The Maintainers will appoint a Security Response Team to handle security reports.
+This committee may simply consist of the Maintainer Council themselves. If this
+responsibility is delegated, the Maintainers will appoint a team of at least two
+contributors to handle it. The Maintainers will review who is assigned to this
+at least once a year.
+
+The Security Response Team is responsible for handling all reports of security
+holes and breaches according to the [security policy](./SECURITY.md).
+
+The members of the Security Response Team are documented in [MAINTAINERS.md](./MAINTAINERS.md).
+
+### GitHub Admin Team
+
+The maintainers will appoint a GitHub Admin Team to handle ownership of the GitHub organization(s) owned by the kcp project. Members of the GitHub Admin Team need to be extremely trustworthy individuals with a long-standing trusted relationship to the project.
+
+The team's responsibility is being administrators for the GitHub organization(s). This would include managing organization-wide permissions, creating new repositories, configuring the organization, etc. The GitHub Admin Team is an executive organ of the full Maintainer Council with the goal to reduce broad permissions, but members of the team are bound by Maintainer Council decisions. Members of the GitHub Admin Team must not be from a single employer/organization.
+
+The members of the GitHub Admin Team are documented in [MAINTAINERS.md](./MAINTAINERS.md).
+
 ## Becoming a Maintainer
 
 <!-- If you have full Contributor Ladder documentation that covers becoming
@@ -133,18 +154,6 @@ Code of Conduct violations happen through the [CNCF Code of Conduct committee](.
 and kcp maintainers pledge to work with the committee to resolve any incidents
 occurring in the kcp community.
 
-## Security Response Team
-
-The Maintainers will appoint a Security Response Team to handle security reports.
-This committee may simply consist of the Maintainer Council themselves. If this
-responsibility is delegated, the Maintainers will appoint a team of at least two
-contributors to handle it. The Maintainers will review who is assigned to this
-at least once a year.
-
-The Security Response Team is responsible for handling all reports of security
-holes and breaches according to the [security policy](./SECURITY.md).
-
-The members of the Security Response Team are documented in [MAINTAINERS.md](./MAINTAINERS.md).
 
 ## Voting
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -23,3 +23,9 @@ The following maintainers are members of the security response team and enact th
 - Dr. Stefan Schimanski
 - Mangirdas Judeikis
 - Marvin Beckers
+
+## GitHub Admin Team
+
+The following maintainers are members of the GitHub Admin Team and manage the GitHub organizations:
+
+- TBD


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

We should codify GitHub admin responsibilities in our governance document to make clear who should have full, unrestricted access to the GitHub org(s) we own.

This PR does not include any names for the team, as I would like to put a vote on the mailing list after merging this governance change.

This is a governance change and therefore requires a 2/3 vote from the maintainers.

## What Type of PR Is This?

/kind documentation

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
