### PR TITLE
test/e2e/fixtures/wildwest/client: sherifves -> sheriffs

### DIFF
--- a/test/e2e/fixtures/wildwest/client/clientset/versioned/cluster/typed/wildwest/v1alpha1/fake/sheriff.go
+++ b/test/e2e/fixtures/wildwest/client/clientset/versioned/cluster/typed/wildwest/v1alpha1/fake/sheriff.go
@@ -39,7 +39,7 @@ func newFakeSheriffClusterClient(fake *WildwestV1alpha1ClusterClient) typedkcpwi
 	return &sheriffClusterClient{
 		kcpgentype.NewFakeClusterClientWithList[*wildwestv1alpha1.Sheriff, *wildwestv1alpha1.SheriffList](
 			fake.Fake,
-			wildwestv1alpha1.SchemeGroupVersion.WithResource("sherifves"),
+			wildwestv1alpha1.SchemeGroupVersion.WithResource("sheriffs"),
 			wildwestv1alpha1.SchemeGroupVersion.WithKind("Sheriff"),
 			func() *wildwestv1alpha1.Sheriff { return &wildwestv1alpha1.Sheriff{} },
 			func() *wildwestv1alpha1.SheriffList { return &wildwestv1alpha1.SheriffList{} },
@@ -72,7 +72,7 @@ func newFakeSheriffClient(fake *kcptesting.Fake, clusterPath logicalcluster.Path
 			fake,
 			clusterPath,
 			"",
-			wildwestv1alpha1.SchemeGroupVersion.WithResource("sherifves"),
+			wildwestv1alpha1.SchemeGroupVersion.WithResource("sheriffs"),
 			wildwestv1alpha1.SchemeGroupVersion.WithKind("Sheriff"),
 			func() *wildwestv1alpha1.Sheriff { return &wildwestv1alpha1.Sheriff{} },
 			func() *wildwestv1alpha1.SheriffList { return &wildwestv1alpha1.SheriffList{} },

--- a/test/e2e/fixtures/wildwest/client/clientset/versioned/cluster/typed/wildwest/v1alpha1/fake/wildwest_client.go
+++ b/test/e2e/fixtures/wildwest/client/clientset/versioned/cluster/typed/wildwest/v1alpha1/fake/wildwest_client.go
@@ -45,7 +45,7 @@ func (c *WildwestV1alpha1ClusterClient) Cowboys() kcpwildwestv1alpha1.CowboyClus
 	return newFakeCowboyClusterClient(c)
 }
 
-func (c *WildwestV1alpha1ClusterClient) Sherifves() kcpwildwestv1alpha1.SheriffClusterInterface {
+func (c *WildwestV1alpha1ClusterClient) Sheriffs() kcpwildwestv1alpha1.SheriffClusterInterface {
 	return newFakeSheriffClusterClient(c)
 }
 
@@ -58,7 +58,7 @@ func (c *WildwestV1alpha1Client) Cowboys(namespace string) wildwestv1alpha1.Cowb
 	return newFakeCowboyClient(c.Fake, namespace, c.ClusterPath)
 }
 
-func (c *WildwestV1alpha1Client) Sherifves() wildwestv1alpha1.SheriffInterface {
+func (c *WildwestV1alpha1Client) Sheriffs() wildwestv1alpha1.SheriffInterface {
 	return newFakeSheriffClient(c.Fake, c.ClusterPath)
 }
 

--- a/test/e2e/fixtures/wildwest/client/clientset/versioned/cluster/typed/wildwest/v1alpha1/sheriff.go
+++ b/test/e2e/fixtures/wildwest/client/clientset/versioned/cluster/typed/wildwest/v1alpha1/sheriff.go
@@ -31,13 +31,13 @@ import (
 	kcpv1alpha1 "github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/client/clientset/versioned/typed/wildwest/v1alpha1"
 )
 
-// SherifvesClusterGetter has a method to return a SheriffClusterInterface.
+// SheriffsClusterGetter has a method to return a SheriffClusterInterface.
 // A group's cluster client should implement this interface.
-type SherifvesClusterGetter interface {
-	Sherifves() SheriffClusterInterface
+type SheriffsClusterGetter interface {
+	Sheriffs() SheriffClusterInterface
 }
 
-// SheriffClusterInterface can operate on Sherifves across all clusters,
+// SheriffClusterInterface can operate on Sheriffs across all clusters,
 // or scope down to one cluster and return a kcpv1alpha1.SheriffInterface.
 type SheriffClusterInterface interface {
 	Cluster(logicalcluster.Path) kcpv1alpha1.SheriffInterface
@@ -46,25 +46,25 @@ type SheriffClusterInterface interface {
 	SheriffClusterExpansion
 }
 
-type sherifvesClusterInterface struct {
+type sheriffsClusterInterface struct {
 	clientCache kcpclient.Cache[*kcpv1alpha1.WildwestV1alpha1Client]
 }
 
 // Cluster scopes the client down to a particular cluster.
-func (c *sherifvesClusterInterface) Cluster(clusterPath logicalcluster.Path) kcpv1alpha1.SheriffInterface {
+func (c *sheriffsClusterInterface) Cluster(clusterPath logicalcluster.Path) kcpv1alpha1.SheriffInterface {
 	if clusterPath == logicalcluster.Wildcard {
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 
-	return c.clientCache.ClusterOrDie(clusterPath).Sherifves()
+	return c.clientCache.ClusterOrDie(clusterPath).Sheriffs()
 }
 
-// List returns the entire collection of all Sherifves across all clusters.
-func (c *sherifvesClusterInterface) List(ctx context.Context, opts v1.ListOptions) (*kcpwildwestv1alpha1.SheriffList, error) {
-	return c.clientCache.ClusterOrDie(logicalcluster.Wildcard).Sherifves().List(ctx, opts)
+// List returns the entire collection of all Sheriffs across all clusters.
+func (c *sheriffsClusterInterface) List(ctx context.Context, opts v1.ListOptions) (*kcpwildwestv1alpha1.SheriffList, error) {
+	return c.clientCache.ClusterOrDie(logicalcluster.Wildcard).Sheriffs().List(ctx, opts)
 }
 
-// Watch begins to watch all Sherifves across all clusters.
-func (c *sherifvesClusterInterface) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
-	return c.clientCache.ClusterOrDie(logicalcluster.Wildcard).Sherifves().Watch(ctx, opts)
+// Watch begins to watch all Sheriffs across all clusters.
+func (c *sheriffsClusterInterface) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
+	return c.clientCache.ClusterOrDie(logicalcluster.Wildcard).Sheriffs().Watch(ctx, opts)
 }

--- a/test/e2e/fixtures/wildwest/client/clientset/versioned/cluster/typed/wildwest/v1alpha1/wildwest_client.go
+++ b/test/e2e/fixtures/wildwest/client/clientset/versioned/cluster/typed/wildwest/v1alpha1/wildwest_client.go
@@ -34,7 +34,7 @@ import (
 type WildwestV1alpha1ClusterInterface interface {
 	WildwestV1alpha1ClusterScoper
 	CowboysClusterGetter
-	SherifvesClusterGetter
+	SheriffsClusterGetter
 }
 
 type WildwestV1alpha1ClusterScoper interface {
@@ -57,8 +57,8 @@ func (c *WildwestV1alpha1ClusterClient) Cowboys() CowboyClusterInterface {
 	return &cowboysClusterInterface{clientCache: c.clientCache}
 }
 
-func (c *WildwestV1alpha1ClusterClient) Sherifves() SheriffClusterInterface {
-	return &sherifvesClusterInterface{clientCache: c.clientCache}
+func (c *WildwestV1alpha1ClusterClient) Sheriffs() SheriffClusterInterface {
+	return &sheriffsClusterInterface{clientCache: c.clientCache}
 }
 
 // NewForConfig creates a new WildwestV1alpha1ClusterClient for the given config.

--- a/test/e2e/fixtures/wildwest/client/clientset/versioned/typed/wildwest/v1alpha1/fake/fake_sheriff.go
+++ b/test/e2e/fixtures/wildwest/client/clientset/versioned/typed/wildwest/v1alpha1/fake/fake_sheriff.go
@@ -26,18 +26,18 @@ import (
 	typedwildwestv1alpha1 "github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/client/clientset/versioned/typed/wildwest/v1alpha1"
 )
 
-// fakeSherifves implements SheriffInterface
-type fakeSherifves struct {
+// fakeSheriffs implements SheriffInterface
+type fakeSheriffs struct {
 	*gentype.FakeClientWithListAndApply[*v1alpha1.Sheriff, *v1alpha1.SheriffList, *wildwestv1alpha1.SheriffApplyConfiguration]
 	Fake *FakeWildwestV1alpha1
 }
 
-func newFakeSherifves(fake *FakeWildwestV1alpha1) typedwildwestv1alpha1.SheriffInterface {
-	return &fakeSherifves{
+func newFakeSheriffs(fake *FakeWildwestV1alpha1) typedwildwestv1alpha1.SheriffInterface {
+	return &fakeSheriffs{
 		gentype.NewFakeClientWithListAndApply[*v1alpha1.Sheriff, *v1alpha1.SheriffList, *wildwestv1alpha1.SheriffApplyConfiguration](
 			fake.Fake,
 			"",
-			v1alpha1.SchemeGroupVersion.WithResource("sherifves"),
+			v1alpha1.SchemeGroupVersion.WithResource("sheriffs"),
 			v1alpha1.SchemeGroupVersion.WithKind("Sheriff"),
 			func() *v1alpha1.Sheriff { return &v1alpha1.Sheriff{} },
 			func() *v1alpha1.SheriffList { return &v1alpha1.SheriffList{} },

--- a/test/e2e/fixtures/wildwest/client/clientset/versioned/typed/wildwest/v1alpha1/fake/fake_wildwest_client.go
+++ b/test/e2e/fixtures/wildwest/client/clientset/versioned/typed/wildwest/v1alpha1/fake/fake_wildwest_client.go
@@ -33,8 +33,8 @@ func (c *FakeWildwestV1alpha1) Cowboys(namespace string) v1alpha1.CowboyInterfac
 	return newFakeCowboys(c, namespace)
 }
 
-func (c *FakeWildwestV1alpha1) Sherifves() v1alpha1.SheriffInterface {
-	return newFakeSherifves(c)
+func (c *FakeWildwestV1alpha1) Sheriffs() v1alpha1.SheriffInterface {
+	return newFakeSheriffs(c)
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/test/e2e/fixtures/wildwest/client/clientset/versioned/typed/wildwest/v1alpha1/sheriff.go
+++ b/test/e2e/fixtures/wildwest/client/clientset/versioned/typed/wildwest/v1alpha1/sheriff.go
@@ -31,10 +31,10 @@ import (
 	scheme "github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/client/clientset/versioned/scheme"
 )
 
-// SherifvesGetter has a method to return a SheriffInterface.
+// SheriffsGetter has a method to return a SheriffInterface.
 // A group's client should implement this interface.
-type SherifvesGetter interface {
-	Sherifves() SheriffInterface
+type SheriffsGetter interface {
+	Sheriffs() SheriffInterface
 }
 
 // SheriffInterface has methods to work with Sheriff resources.
@@ -55,16 +55,16 @@ type SheriffInterface interface {
 	SheriffExpansion
 }
 
-// sherifves implements SheriffInterface
-type sherifves struct {
+// sheriffs implements SheriffInterface
+type sheriffs struct {
 	*gentype.ClientWithListAndApply[*wildwestv1alpha1.Sheriff, *wildwestv1alpha1.SheriffList, *applyconfigurationwildwestv1alpha1.SheriffApplyConfiguration]
 }
 
-// newSherifves returns a Sherifves
-func newSherifves(c *WildwestV1alpha1Client) *sherifves {
-	return &sherifves{
+// newSheriffs returns a Sheriffs
+func newSheriffs(c *WildwestV1alpha1Client) *sheriffs {
+	return &sheriffs{
 		gentype.NewClientWithListAndApply[*wildwestv1alpha1.Sheriff, *wildwestv1alpha1.SheriffList, *applyconfigurationwildwestv1alpha1.SheriffApplyConfiguration](
-			"sherifves",
+			"sheriffs",
 			c.RESTClient(),
 			scheme.ParameterCodec,
 			"",

--- a/test/e2e/fixtures/wildwest/client/clientset/versioned/typed/wildwest/v1alpha1/wildwest_client.go
+++ b/test/e2e/fixtures/wildwest/client/clientset/versioned/typed/wildwest/v1alpha1/wildwest_client.go
@@ -30,7 +30,7 @@ import (
 type WildwestV1alpha1Interface interface {
 	RESTClient() rest.Interface
 	CowboysGetter
-	SherifvesGetter
+	SheriffsGetter
 }
 
 // WildwestV1alpha1Client is used to interact with features provided by the wildwest.dev group.
@@ -42,8 +42,8 @@ func (c *WildwestV1alpha1Client) Cowboys(namespace string) CowboyInterface {
 	return newCowboys(c, namespace)
 }
 
-func (c *WildwestV1alpha1Client) Sherifves() SheriffInterface {
-	return newSherifves(c)
+func (c *WildwestV1alpha1Client) Sheriffs() SheriffInterface {
+	return newSheriffs(c)
 }
 
 // NewForConfig creates a new WildwestV1alpha1Client for the given config.

--- a/test/e2e/fixtures/wildwest/client/informers/externalversions/generic.go
+++ b/test/e2e/fixtures/wildwest/client/informers/externalversions/generic.go
@@ -97,8 +97,8 @@ func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource
 	// Group=wildwest.dev, Version=v1alpha1
 	case kcpv1alpha1.SchemeGroupVersion.WithResource("cowboys"):
 		return &genericClusterInformer{resource: resource.GroupResource(), informer: f.Wildwest().V1alpha1().Cowboys().Informer()}, nil
-	case kcpv1alpha1.SchemeGroupVersion.WithResource("sherifves"):
-		return &genericClusterInformer{resource: resource.GroupResource(), informer: f.Wildwest().V1alpha1().Sherifves().Informer()}, nil
+	case kcpv1alpha1.SchemeGroupVersion.WithResource("sheriffs"):
+		return &genericClusterInformer{resource: resource.GroupResource(), informer: f.Wildwest().V1alpha1().Sheriffs().Informer()}, nil
 
 	}
 
@@ -113,8 +113,8 @@ func (f *sharedScopedInformerFactory) ForResource(resource schema.GroupVersionRe
 	case kcpv1alpha1.SchemeGroupVersion.WithResource("cowboys"):
 		informer := f.Wildwest().V1alpha1().Cowboys().Informer()
 		return &genericInformer{lister: cache.NewGenericLister(informer.GetIndexer(), resource.GroupResource()), informer: informer}, nil
-	case kcpv1alpha1.SchemeGroupVersion.WithResource("sherifves"):
-		informer := f.Wildwest().V1alpha1().Sherifves().Informer()
+	case kcpv1alpha1.SchemeGroupVersion.WithResource("sheriffs"):
+		informer := f.Wildwest().V1alpha1().Sheriffs().Informer()
 		return &genericInformer{lister: cache.NewGenericLister(informer.GetIndexer(), resource.GroupResource()), informer: informer}, nil
 
 	}

--- a/test/e2e/fixtures/wildwest/client/informers/externalversions/wildwest/v1alpha1/interface.go
+++ b/test/e2e/fixtures/wildwest/client/informers/externalversions/wildwest/v1alpha1/interface.go
@@ -25,8 +25,8 @@ import (
 type ClusterInterface interface {
 	// Cowboys returns a CowboyClusterInformer.
 	Cowboys() CowboyClusterInformer
-	// Sherifves returns a SheriffClusterInformer.
-	Sherifves() SheriffClusterInformer
+	// Sheriffs returns a SheriffClusterInformer.
+	Sheriffs() SheriffClusterInformer
 }
 
 type version struct {
@@ -44,16 +44,16 @@ func (v *version) Cowboys() CowboyClusterInformer {
 	return &cowboyClusterInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
-// Sherifves returns a SheriffClusterInformer.
-func (v *version) Sherifves() SheriffClusterInformer {
+// Sheriffs returns a SheriffClusterInformer.
+func (v *version) Sheriffs() SheriffClusterInformer {
 	return &sheriffClusterInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
 type Interface interface {
 	// Cowboys returns a CowboyInformer.
 	Cowboys() CowboyInformer
-	// Sherifves returns a SheriffInformer.
-	Sherifves() SheriffInformer
+	// Sheriffs returns a SheriffInformer.
+	Sheriffs() SheriffInformer
 }
 
 type scopedVersion struct {
@@ -72,7 +72,7 @@ func (v *scopedVersion) Cowboys() CowboyInformer {
 	return &cowboyScopedInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// Sherifves returns a SheriffInformer.
-func (v *scopedVersion) Sherifves() SheriffInformer {
+// Sheriffs returns a SheriffInformer.
+func (v *scopedVersion) Sheriffs() SheriffInformer {
 	return &sheriffScopedInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/test/e2e/fixtures/wildwest/client/informers/externalversions/wildwest/v1alpha1/sheriff.go
+++ b/test/e2e/fixtures/wildwest/client/informers/externalversions/wildwest/v1alpha1/sheriff.go
@@ -39,7 +39,7 @@ import (
 )
 
 // SheriffClusterInformer provides access to a shared informer and lister for
-// Sherifves.
+// Sheriffs.
 type SheriffClusterInformer interface {
 	Cluster(logicalcluster.Name) SheriffInformer
 	ClusterWithContext(context.Context, logicalcluster.Name) SheriffInformer
@@ -69,13 +69,13 @@ func NewFilteredSheriffClusterInformer(client kcpcluster.ClusterInterface, resyn
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.WildwestV1alpha1().Sherifves().List(context.Background(), options)
+				return client.WildwestV1alpha1().Sheriffs().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.WildwestV1alpha1().Sherifves().Watch(context.Background(), options)
+				return client.WildwestV1alpha1().Sheriffs().Watch(context.Background(), options)
 			},
 		},
 		&kcpwildwestv1alpha1.Sheriff{},
@@ -127,7 +127,7 @@ func (i *sheriffInformer) Lister() kcpv1alpha1.SheriffLister {
 }
 
 // SheriffInformer provides access to a shared informer and lister for
-// Sherifves.
+// Sheriffs.
 type SheriffInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() kcpv1alpha1.SheriffLister
@@ -155,13 +155,13 @@ func NewFilteredSheriffInformer(client kcpversioned.Interface, resyncPeriod time
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.WildwestV1alpha1().Sherifves().List(context.Background(), options)
+				return client.WildwestV1alpha1().Sheriffs().List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.WildwestV1alpha1().Sherifves().Watch(context.Background(), options)
+				return client.WildwestV1alpha1().Sheriffs().Watch(context.Background(), options)
 			},
 		},
 		&kcpwildwestv1alpha1.Sheriff{},

--- a/test/e2e/fixtures/wildwest/client/listers/wildwest/v1alpha1/sheriff.go
+++ b/test/e2e/fixtures/wildwest/client/listers/wildwest/v1alpha1/sheriff.go
@@ -28,14 +28,14 @@ import (
 	kcpv1alpha1 "github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/apis/wildwest/v1alpha1"
 )
 
-// SheriffClusterLister helps list Sherifves across all workspaces,
+// SheriffClusterLister helps list Sheriffs across all workspaces,
 // or scope down to a SheriffLister for one workspace.
 // All objects returned here must be treated as read-only.
 type SheriffClusterLister interface {
-	// List lists all Sherifves in the indexer.
+	// List lists all Sheriffs in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*kcpv1alpha1.Sheriff, err error)
-	// Cluster returns a lister that can list and get Sherifves in one workspace.
+	// Cluster returns a lister that can list and get Sheriffs in one workspace.
 	Cluster(clusterName logicalcluster.Name) SheriffLister
 	SheriffClusterListerExpansion
 }
@@ -58,14 +58,14 @@ func NewSheriffClusterLister(indexer cache.Indexer) SheriffClusterLister {
 	}
 }
 
-// Cluster scopes the lister to one workspace, allowing users to list and get Sherifves.
+// Cluster scopes the lister to one workspace, allowing users to list and get Sheriffs.
 func (l *sheriffClusterLister) Cluster(clusterName logicalcluster.Name) SheriffLister {
 	return &sheriffLister{
 		l.ResourceClusterIndexer.WithCluster(clusterName),
 	}
 }
 
-// sheriffLister can list all Sherifves inside a workspace
+// sheriffLister can list all Sheriffs inside a workspace
 // or scope down to a SheriffNamespaceLister for one namespace.
 type sheriffLister struct {
 	kcplisters.ResourceIndexer[*kcpv1alpha1.Sheriff]
@@ -73,10 +73,10 @@ type sheriffLister struct {
 
 var _ SheriffLister = new(sheriffLister)
 
-// SheriffLister can list all Sherifves, or get one in particular.
+// SheriffLister can list all Sheriffs, or get one in particular.
 // All objects returned here must be treated as read-only.
 type SheriffLister interface {
-	// List lists all Sherifves in the indexer.
+	// List lists all Sheriffs in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*kcpv1alpha1.Sheriff, err error)
 	// Get retrieves the Sheriff from the indexer for a given workspace and name.
@@ -96,7 +96,7 @@ func NewSheriffLister(indexer cache.Indexer) SheriffLister {
 	}
 }
 
-// sheriffScopedLister can list all Sherifves inside a workspace
+// sheriffScopedLister can list all Sheriffs inside a workspace
 // or scope down to a SheriffNamespaceLister.
 type sheriffScopedLister struct {
 	kcplisters.ResourceIndexer[*kcpv1alpha1.Sheriff]


### PR DESCRIPTION

<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Fixes a typo in e2e test fixtures: it should be `sheriffs` instead of `sherifves`. It made the wildwest.dev client fail with unknown resource.

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind cleanup

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
