### PR TITLE
don't assume sed revision based on OS

### DIFF
--- a/hack/gen-patch-defaultrestmapper.sh
+++ b/hack/gen-patch-defaultrestmapper.sh
@@ -55,12 +55,7 @@ touch "${DEFAULTRESTMAPPER_PATCH_FILEPATH}"
 # paste upstream's defaultrestmapper.go contents, starting right
 # after its `package meta` declaration.
 
-cat "${REPO_ROOT}/hack/boilerplate/boilerplate.go.txt" > "${DEFAULTRESTMAPPER_PATCH_FILEPATH}"
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  sed -i '' "s/YEAR/$(date +'%Y')/" "${DEFAULTRESTMAPPER_PATCH_FILEPATH}"
-else
-  sed -i "s/YEAR/$(date +'%Y')/" "${DEFAULTRESTMAPPER_PATCH_FILEPATH}"
-fi
+sed "s/YEAR/$(date +'%Y')/" "${REPO_ROOT}/hack/boilerplate/boilerplate.go.txt" > "${DEFAULTRESTMAPPER_PATCH_FILEPATH}"
 cat >> "${DEFAULTRESTMAPPER_PATCH_FILEPATH}" << Header_EOF
 
 package dynamicrestmapper


### PR DESCRIPTION

<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

We should not assume the sed revision based on the Operating system. For example on my Mac, I am using gnu sed, which causes the script to fail. I think in this case the fix is rather straightforward, but if you ever run into this in a more complicated setting you can make use of is_gnu_sed snippet https://github.com/kcp-dev/kcp/blob/e3c2d234c1e93f7e643ae600276090aaaeb7d7eb/hack/verify-contextual-logging.sh#L40-L45

## What Type of PR Is This?
/kind bug
<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
