### PR TITLE
Update to Go 1.24.8

### DIFF
--- a/.github/workflows/docs-gen-and-push.yaml
+++ b/.github/workflows/docs-gen-and-push.yaml
@@ -34,13 +34,13 @@ jobs:
 
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # tag=v6.0.0
         with:
-          go-version: v1.24.5
+          go-version: v1.24.8
           cache: true
 
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c #tag=v6.0.0
         with:
-          python-version: '3.10'
-          cache: 'pip'
+          python-version: "3.10"
+          cache: "pip"
 
       # mike does not support giving CLI flags for mkdocs, but we also do not
       # want to permanently enable strict mode, so here we enable it just for this

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -3,11 +3,11 @@ name: goreleaser
 on:
   pull_request:
     paths:
-    - .github/workflows/goreleaser.yml
-    - .goreleaser.yaml
+      - .github/workflows/goreleaser.yml
+      - .goreleaser.yaml
   push:
     tags:
-    - 'v*'
+      - "v*"
 
 permissions:
   contents: write
@@ -16,68 +16,68 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-    - name: Free disk space
-      uses: thiagokokada/free-disk-space@9a03d73a373bab1e204b8815f5c7752392482762
-      with:
-        # All of these do save some disk space, but are also somewhat slow to delete.
-        # So we keep them to just speed up the workflow overall.
-        android: false
-        aws-cli: false
-        debug: false
-        docker-images: false
-        google-cloud-sdk: false
-        heroku: false
-        llvm: false
-        opt: false
-        powershell: false
-        python: false
-        ruby: false
-        rust: false
-        tool-cache: false
-        usrlocal: false
-        usrmisc: false
-        varcache: false
+      - name: Free disk space
+        uses: thiagokokada/free-disk-space@9a03d73a373bab1e204b8815f5c7752392482762
+        with:
+          # All of these do save some disk space, but are also somewhat slow to delete.
+          # So we keep them to just speed up the workflow overall.
+          android: false
+          aws-cli: false
+          debug: false
+          docker-images: false
+          google-cloud-sdk: false
+          heroku: false
+          llvm: false
+          opt: false
+          powershell: false
+          python: false
+          ruby: false
+          rust: false
+          tool-cache: false
+          usrlocal: false
+          usrmisc: false
+          varcache: false
 
-    - name: Checkout
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # tag=v5.0.0
-      with:
-        fetch-depth: 0
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # tag=v5.0.0
+        with:
+          fetch-depth: 0
 
-    - name: Setup Go
-      uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # tag=v6.0.0
-      with:
-        go-version: v1.24.5
+      - name: Setup Go
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # tag=v6.0.0
+        with:
+          go-version: v1.24.8
 
-    - name: Delete non-semver tags
-      run: 'git tag -d $(git tag -l | grep -v "^v")'
+      - name: Delete non-semver tags
+        run: 'git tag -d $(git tag -l | grep -v "^v")'
 
-    - name: Set LDFLAGS
-      run: echo LDFLAGS="$(make ldflags)" >> $GITHUB_ENV
+      - name: Set LDFLAGS
+        run: echo LDFLAGS="$(make ldflags)" >> $GITHUB_ENV
 
-    - name: Run GoReleaser on tag
-      if: github.event_name != 'pull_request'
-      uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # tag=v6.4.0
-      with:
-        distribution: goreleaser
-        version: '~> v2'
-        args: release --timeout 60m
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        KREW_GITHUB_TOKEN: ${{ secrets.KREW_GITHUB_TOKEN }}
+      - name: Run GoReleaser on tag
+        if: github.event_name != 'pull_request'
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # tag=v6.4.0
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --timeout 60m
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          KREW_GITHUB_TOKEN: ${{ secrets.KREW_GITHUB_TOKEN }}
 
-    - name: Run GoReleaser on pull request
-      if: github.event_name == 'pull_request'
-      uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # tag=v6.4.0
-      with:
-        distribution: goreleaser
-        version: '~> v2'
-        args: release --timeout 60m --snapshot
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        KREW_GITHUB_TOKEN: ${{ secrets.KREW_GITHUB_TOKEN }}
+      - name: Run GoReleaser on pull request
+        if: github.event_name == 'pull_request'
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # tag=v6.4.0
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --timeout 60m --snapshot
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          KREW_GITHUB_TOKEN: ${{ secrets.KREW_GITHUB_TOKEN }}
 
-    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag=v4.6.2
-      if: ${{ always() }}
-      with:
-        name: binaries
-        path: dist/*.tar.gz
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag=v4.6.2
+        if: ${{ always() }}
+        with:
+          name: binaries
+          path: dist/*.tar.gz

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.5-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.8-1
           command:
             - make
             - verify-boilerplate
@@ -27,7 +27,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.5-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.8-1
           command:
             - make
             - verify-codegen
@@ -44,7 +44,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.5-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.8-1
           command:
             - make
             - lint
@@ -66,7 +66,7 @@ presubmits:
             - hack/build-image.sh
           env:
             - name: DRY_RUN
-              value: '1'
+              value: "1"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -83,13 +83,13 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.5-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.8-1
           command:
             - make
             - test
           env:
             - name: USE_GOTESTSUM
-              value: '1'
+              value: "1"
           resources:
             requests:
               memory: 4Gi
@@ -104,7 +104,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.5-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.8-1
           command:
             - ./hack/run-with-prow.sh
             - ./hack/run-with-prometheus.sh
@@ -112,11 +112,11 @@ presubmits:
             - test-integration
           env:
             - name: USE_GOTESTSUM
-              value: '1'
+              value: "1"
             - name: KUBE_CACHE_MUTATION_DETECTOR
-              value: '1'
+              value: "1"
             - name: E2E_PARALLELISM
-              value: '3'
+              value: "3"
           resources:
             requests:
               memory: 6Gi
@@ -131,7 +131,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.5-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.8-1
           command:
             - ./hack/run-with-prow.sh
             - ./hack/run-with-prometheus.sh
@@ -141,11 +141,11 @@ presubmits:
             - name: SUITES
               value: control-plane
             - name: USE_GOTESTSUM
-              value: '1'
+              value: "1"
             - name: KUBE_CACHE_MUTATION_DETECTOR
-              value: '1'
+              value: "1"
             - name: E2E_PARALLELISM
-              value: '3'
+              value: "3"
           resources:
             requests:
               memory: 6Gi
@@ -160,7 +160,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.5-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.8-1
           command:
             - ./hack/run-with-prow.sh
             - ./hack/run-with-prometheus.sh
@@ -170,15 +170,15 @@ presubmits:
             - name: SUITES
               value: control-plane
             - name: USE_GOTESTSUM
-              value: '1'
+              value: "1"
             - name: KUBE_CACHE_MUTATION_DETECTOR
-              value: '1'
+              value: "1"
             - name: COUNT
-              value: '2'
+              value: "2"
             - name: E2E_PARALLELISM
-              value: '3'
+              value: "3"
             - name: TEST_ARGS
-              value: '-timeout 20m'
+              value: "-timeout 20m"
           resources:
             requests:
               memory: 6Gi
@@ -193,7 +193,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.5-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.8-1
           command:
             - ./hack/run-with-prow.sh
             - ./hack/run-with-prometheus.sh
@@ -203,11 +203,11 @@ presubmits:
             - name: SUITES
               value: control-plane
             - name: USE_GOTESTSUM
-              value: '1'
+              value: "1"
             - name: KUBE_CACHE_MUTATION_DETECTOR
-              value: '1'
+              value: "1"
             - name: E2E_PARALLELISM
-              value: '3'
+              value: "3"
           resources:
             requests:
               memory: 6Gi
@@ -222,7 +222,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.5-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.8-1
           command:
             - ./hack/run-with-prow.sh
             - ./hack/run-with-prometheus.sh
@@ -232,11 +232,11 @@ presubmits:
             - name: SUITES
               value: control-plane
             - name: USE_GOTESTSUM
-              value: '1'
+              value: "1"
             - name: KUBE_CACHE_MUTATION_DETECTOR
-              value: '1'
+              value: "1"
             - name: E2E_PARALLELISM
-              value: '3'
+              value: "3"
           resources:
             requests:
               memory: 6Gi

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Build the binary
-FROM --platform=${BUILDPLATFORM} docker.io/golang:1.24.5 AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/golang:1.24.8 AS builder
 WORKDIR /workspace
 
 # Install dependencies.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ module github.com/kcp-dev/kcp
 // The script hack/verify-go-versions.sh checks that all version
 // references across the codebase are consistent with the versions
 // maintained here.
-// go-build-version 1.24.5
+// go-build-version 1.24.8
 go 1.24.0
 
 require (


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Updates our Go version to the latest 1.24 release. The GitHub workflows got automatically formatted by my editor, sorry about that.

## What Type of PR Is This?

/kind cleanup

## Related Issue(s)

Towards https://github.com/kcp-dev/infra/issues/136

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
kcp is built with Go 1.24.8
```
