### PR TITLE
Publish PR images (again)

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -64,9 +64,6 @@ presubmits:
         - image: quay.io/containers/buildah:v1.38.0
           command:
             - hack/build-image.sh
-          env:
-            - name: DRY_RUN
-              value: "1"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

We lost track of publishing PR-based images somehow. This happened ~6months ago. 
Dry run is not needed as we replace tag. See:
https://public-prow.kcp.k8c.io/view/s3/prow-public-data/pr-logs/pull/kcp-dev_kcp/3641/pull-kcp-build-image/1976178423046868992 :
```
Successfully tagged ghcr.io/kcp-dev/kcp-prs:pr-3641-fd948d985-arm64
950eb743ddf77dc2d9e63e07b536e7a09b9bd5900a05c874874895df70f070f9
Creating manifest ghcr.io/kcp-dev/kcp-prs:pr-3641-fd948d985 ...
806b61f329b84ef929a0f139ca1b5de7f42db777a5603b0225f52b31117c9d1f
806b61f329b84ef929a0f139ca1b5de7f42db777a5603b0225f52b31117c9d1f: sha256:b75dfc6dba9a607f1457d93319c9ca6f735dbf017b92f80175353d0d1c2e2691
806b61f329b84ef929a0f139ca1b5de7f42db777a5603b0225f52b31117c9d1f: sha256:adb4a631bf8cdca1bee6e4e7dc287231972bce9af86235e1210027ca78fd94ac
Not pushing images because $DRY_RUN is set.
Done.
```

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
