### PR TITLE
add original rv and uid to object annotation

### DIFF
--- a/pkg/reconciler/cache/cachedresources/replication/replication_reconcile_unstructured.go
+++ b/pkg/reconciler/cache/cachedresources/replication/replication_reconcile_unstructured.go
@@ -74,7 +74,22 @@ func ensureMeta(cacheObject *unstructured.Unstructured, localObject *unstructure
 				}
 			}()
 		}
-		// TODO: in the future the original RV will be stored in an annotation
+		if originalRV, hasOriginalRV := cacheObjAnnotations[AnnotationKeyOriginalResourceVersion]; hasOriginalRV {
+			unstructured.RemoveNestedField(cacheObjAnnotations, AnnotationKeyOriginalResourceVersion)
+			defer func() {
+				if err == nil {
+					err = unstructured.SetNestedField(cacheObject.Object, originalRV, "metadata", "annotations", AnnotationKeyOriginalResourceVersion)
+				}
+			}()
+		}
+		if originalUID, hasOriginalUID := cacheObjAnnotations[AnnotationKeyOriginalResourceUID]; hasOriginalUID {
+			unstructured.RemoveNestedField(cacheObjAnnotations, AnnotationKeyOriginalResourceUID)
+			defer func() {
+				if err == nil {
+					err = unstructured.SetNestedField(cacheObject.Object, originalUID, "metadata", "annotations", AnnotationKeyOriginalResourceUID)
+				}
+			}()
+		}
 	}
 
 	// before we can compare with the local object we need to

--- a/pkg/reconciler/cache/replication/replication_reconcile_unstructured.go
+++ b/pkg/reconciler/cache/replication/replication_reconcile_unstructured.go
@@ -82,7 +82,22 @@ func ensureMeta(cacheObject *unstructured.Unstructured, localObject *unstructure
 				}
 			}()
 		}
-		// TODO: in the future the original RV will be stored in an annotation
+		if originalRV, hasOriginalRV := cacheObjAnnotations[AnnotationKeyOriginalResourceVersion]; hasOriginalRV {
+			unstructured.RemoveNestedField(cacheObjAnnotations, AnnotationKeyOriginalResourceVersion)
+			defer func() {
+				if err == nil {
+					err = unstructured.SetNestedField(cacheObject.Object, originalRV, "metadata", "annotations", AnnotationKeyOriginalResourceVersion)
+				}
+			}()
+		}
+		if originalUID, hasOriginalUID := cacheObjAnnotations[AnnotationKeyOriginalResourceUID]; hasOriginalUID {
+			unstructured.RemoveNestedField(cacheObjAnnotations, AnnotationKeyOriginalResourceUID)
+			defer func() {
+				if err == nil {
+					err = unstructured.SetNestedField(cacheObject.Object, originalUID, "metadata", "annotations", AnnotationKeyOriginalResourceUID)
+				}
+			}()
+		}
 	}
 
 	// before we can compare with the local object we need to


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary
```
change adds original resource version and UID to object before storing in the cache server
```

## What Type of PR Is This?
/kind feature
<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #
https://github.com/kcp-dev/kcp/issues/3631

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Adds resource version and UID to object's annotation before persisting to the cache server
```
