### PR TITLE
Update to Go 1.24.9

### DIFF
--- a/.github/workflows/docs-gen-and-push.yaml
+++ b/.github/workflows/docs-gen-and-push.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # tag=v6.0.0
         with:
-          go-version: v1.24.8
+          go-version: v1.24.9
           cache: true
 
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c #tag=v6.0.0

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # tag=v6.0.0
         with:
-          go-version: v1.24.8
+          go-version: v1.24.9
 
       - name: Delete non-semver tags
         run: 'git tag -d $(git tag -l | grep -v "^v")'

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.8-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
           command:
             - make
             - verify-boilerplate
@@ -27,7 +27,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.8-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
           command:
             - make
             - verify-codegen
@@ -44,7 +44,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.8-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
           command:
             - make
             - lint
@@ -83,7 +83,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.8-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
           command:
             - make
             - test
@@ -104,7 +104,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.8-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
           command:
             - ./hack/run-with-prow.sh
             - ./hack/run-with-prometheus.sh
@@ -131,7 +131,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.8-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
           command:
             - ./hack/run-with-prow.sh
             - ./hack/run-with-prometheus.sh
@@ -160,7 +160,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.8-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
           command:
             - ./hack/run-with-prow.sh
             - ./hack/run-with-prometheus.sh
@@ -193,7 +193,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.8-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
           command:
             - ./hack/run-with-prow.sh
             - ./hack/run-with-prometheus.sh
@@ -222,7 +222,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.8-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
           command:
             - ./hack/run-with-prow.sh
             - ./hack/run-with-prometheus.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Build the binary
-FROM --platform=${BUILDPLATFORM} docker.io/golang:1.24.8 AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/golang:1.24.9 AS builder
 WORKDIR /workspace
 
 # Install dependencies.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ module github.com/kcp-dev/kcp
 // The script hack/verify-go-versions.sh checks that all version
 // references across the codebase are consistent with the versions
 // maintained here.
-// go-build-version 1.24.8
+// go-build-version 1.24.9
 go 1.24.0
 
 require (


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

We updated to Go 1.24.8 in #3634, but that Go version has a known issue with parsing X509 certificates which caused some K8s upstream issues. Let's bump kcp as well to ensure we don't release a faulty build.

## What Type of PR Is This?

/kind cleanup

## Related Issue(s)

Towards https://github.com/kcp-dev/infra/issues/136

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
kcp is built with Go 1.24.9
```
