### PR TITLE
fix: kubectl-kcp fail with error message instead of panic if crd defines webhook with service ref

### DIFF
--- a/sdk/apis/apis/v1alpha1/crd_to_apiresourceschema.go
+++ b/sdk/apis/apis/v1alpha1/crd_to_apiresourceschema.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"errors"
 	"fmt"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -67,6 +68,12 @@ func CRDToAPIResourceSchema(crd *apiextensionsv1.CustomResourceDefinition, prefi
 			}
 
 			if crd.Spec.Conversion.Webhook.ClientConfig != nil {
+				if crd.Spec.Conversion.Webhook.ClientConfig.Service != nil {
+					return nil, errors.New("webhooks that refer to services are not supported, please use URL instead")
+				}
+				if crd.Spec.Conversion.Webhook.ClientConfig.URL == nil {
+					return nil, errors.New("webhooks URL must be set")
+				}
 				crConversion.Webhook.ClientConfig = &WebhookClientConfig{
 					URL:      *crd.Spec.Conversion.Webhook.ClientConfig.URL,
 					CABundle: crd.Spec.Conversion.Webhook.ClientConfig.CABundle,


### PR DESCRIPTION
# Summary

## kubectl kcp crd snapshot

In the CRD Webhook can be defined as URL or reference to a service. 
The 2nd variant is not supported. This PR adds error message instead of crash with panic.

### CRD Example:
```yaml
spec:
  conversion:
    strategy: Webhook
    webhook:
      clientConfig:
        caBundle: "..."
        service:
          name: some-service
          namespace: some-namespace
          path: /convert
          port: 443
```
# What Type of PR Is This?
/kind bug

# Related Issue(s)

# Release Notes

```release-note
`kubectl kcp` returns error instead of panic when converting CRD with service webhook reference
```
