### PR TITLE
fix initializer update error kind

### DIFF
--- a/pkg/virtual/initializingworkspaces/builder/forwarding.go
+++ b/pkg/virtual/initializingworkspaces/builder/forwarding.go
@@ -210,7 +210,7 @@ func withUpdateValidation(initializer corev1alpha1.LogicalClusterInitializer) re
 					return errors.NewInternalError(fmt.Errorf("error accessing initializers from old object: %w", err))
 				}
 				invalidUpdateErr := errors.NewInvalid(
-					tenancyv1alpha1.Kind("Workspace"),
+					tenancyv1alpha1.Kind("LogicalCluster"),
 					name,
 					field.ErrorList{field.Invalid(
 						field.NewPath("status", "initializers"),


### PR DESCRIPTION
The object which is modified through this virtualworkspace is the LogicalCluster, not the workspace. Therefore the invalidUpdateErr should also be on the LogicalCluster.

<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->
/kind bug

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
