### PR TITLE
publishing-bot: add dependencies for client-go

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -11,6 +11,11 @@ rules:
   - destination: client-go
     branches:
       - name: main
+        dependencies:
+          - repository: apimachinery
+            branch: main
+          - repository: code-generator
+            branch: main
         source:
           branch: main
           dirs:


### PR DESCRIPTION
## Summary

We didn't add proper dependencies for the client-go staging repo, this should be fixed now.

## What Type of PR Is This?

/kind cleanup

## Related Issue(s)

xref #3640 

## Release Notes

```release-note
NONE
```

/assign @embik @xrstf 