### PR TITLE
publishing-bot: fix rules order

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -8,6 +8,15 @@ rules:
             - staging/src/github.com/kcp-dev/apimachinery
     destination-tag-base: v2
     library: true
+  - destination: code-generator
+    branches:
+      - name: main
+        source:
+          branch: main
+          dirs:
+            - staging/src/github.com/kcp-dev/code-generator
+    destination-tag-base: v3
+    library: true
   - destination: client-go
     branches:
       - name: main
@@ -21,15 +30,6 @@ rules:
           dirs:
             - staging/src/github.com/kcp-dev/client-go
     destination-tag-base: v0
-    library: true
-  - destination: code-generator
-    branches:
-      - name: main
-        source:
-          branch: main
-          dirs:
-            - staging/src/github.com/kcp-dev/code-generator
-    destination-tag-base: v3
     library: true
 recursive-delete-patterns:
   - '*/.gitattributes'


### PR DESCRIPTION
## Summary

Ooops:

```
E1028 16:20:05.066275       1 publisher.go:454] validation errors:
    - repository "client-go" cannot depend on "code-generator" later in the rules file. Please define rules for "code-generator" above the rules for "client-go"
I1028 16:20:05.077250       1 main.go:185] Failed to run publisher: validation errors:
- repository "client-go" cannot depend on "code-generator" later in the rules file. Please define rules for "code-generator" above the rules for "client-go"
```

## What Type of PR Is This?

/kind cleanup

## Related Issue(s)

xref #3686 #3640

## Release Notes

```release-note
NONE
```

/assign @xrstf @mjudeikis 