### PR TITLE
VR apiserver retrieves endpoint slices by a get call

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -696,6 +696,7 @@ func NewConfig(ctx context.Context, opts kcpserveroptions.CompletedOptions) (*Co
 			&virtualResourcesConfig,
 			vwClientConfig,
 			c.CacheDynamicClient,
+			c.Options.Extra.ShardName,
 			c.ShardVirtualWorkspaceURL,
 			c.ApiExtensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions(),
 			c.KcpSharedInformerFactory.Apis().V1alpha2().APIBindings(),

--- a/pkg/server/virtualresources/config.go
+++ b/pkg/server/virtualresources/config.go
@@ -38,6 +38,7 @@ type ExtraConfig struct {
 	VWClientConfig       *rest.Config
 	DynamicClusterClient kcpdynamic.ClusterInterface
 
+	ShardName                      string
 	ShardVirtualWorkspaceURLGetter func() string
 
 	CRDLister               kcpapiextensionsv1informers.CustomResourceDefinitionClusterInformer
@@ -85,6 +86,7 @@ func NewConfig(
 	cfg *genericapiserver.Config,
 	vwClientConfig *rest.Config,
 	dynamicClusterClient kcpdynamic.ClusterInterface,
+	shardName string,
 	shardVirtualWorkspaceURLGetter func() string,
 	crdLister kcpapiextensionsv1informers.CustomResourceDefinitionClusterInformer,
 	apiBindingInformer apisv1alpha2informers.APIBindingClusterInformer,
@@ -100,6 +102,7 @@ func NewConfig(
 			VWClientConfig:       vwClientConfig,
 			DynamicClusterClient: dynamicClusterClient,
 
+			ShardName:                      shardName,
 			ShardVirtualWorkspaceURLGetter: shardVirtualWorkspaceURLGetter,
 
 			CRDLister:               crdLister,


### PR DESCRIPTION
## Summary

Endpoint slices are now retrieved by GET-ting them from cache. The slice must be co-located with the APIExport that exports the VR, and so the export's shard and cluster name is used.

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind bug

## Related Issue(s)

Fixes #3695 

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
