### PR TITLE
Fix dependencies for the `cli` staging repo

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -37,8 +37,10 @@ rules:
         dependencies:
           - repository: apimachinery
             branch: main
-          - repository: client-go
+          - repository: code-generator
             branch: main
+          - repository: client-go
+            branch: main          
         source:
           branch: main
           dirs:
@@ -49,6 +51,10 @@ rules:
     branches:
       - name: main
         dependencies:
+          - repository: apimachinery
+            branch: main
+          - repository: code-generator
+            branch: main
           - repository: client-go
             branch: main
           - repository: sdk


### PR DESCRIPTION
## Summary

It turns out that you have to specify dependencies of dependencies in the publishing-bot rules otherwise publishing-bot would fail to update direct dependencies. That's because those direct dependencies are already updated to the latest tag, and when some repo tries to pull that updated direct dependency, that fails because dependencies of direct dependency are updated.

Why that happens: it's because publishing-bot does not push to GitHub until the very end of the process. Instead, it creates modules and puts them to the cache (`$GOPATH/pkg/mod/cache/download`) manually, so commands such `go mod download` actually work. But for this, you need to also set `GOPRIVATE` environment variables to a list of repositories that are not yet publicly available. publishing-bot generates the value of `GOPRIVATE` based on specified dependencies, and that's why you have to provide all dependencies and not only direct dependencies.

A good example of that in upstream is `sample-cli-plugin`:
- https://github.com/kubernetes/kubernetes/blob/544dfee60a99eaec9962c3853674dc1e4d7f0c8d/staging/publishing/rules.yaml#L1070-L1085
- https://github.com/kubernetes/kubernetes/blob/544dfee60a99eaec9962c3853674dc1e4d7f0c8d/staging/src/k8s.io/sample-cli-plugin/go.mod#L9-L14

## What Type of PR Is This?

/kind chore

## Release Notes
```release-note
NONE
```

/assign @xrstf @embik 