### PR TITLE
Order maintainers alphabetically by GitHub handle

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,13 +5,13 @@ The table below lists all current maintainers for the kcp project as defined by 
 | Name                  | GitHub Handle                                    | Domains of reponsibility                                       | Affiliation                 |
 | --------------------- | ------------------------------------------------ | -------------------------------------------------------------- | --------------------------- |
 | Andy Anderson         | [@clubanderson](https://github.com/clubanderson) | Governance                                                     | IBM                         |
+| Marvin Beckers        | [@embik](https://github.com/embik)               | kcp core, kcp-operator, multicluster-provider, infrastructure  | Kubermatic                  |
+| Mangirdas Judeikis    | [@mjudeikis](https://github.com/mjudeikis)       | kcp core                                                       | Upbound                     |
+| Nelo-T. Wallus        | [@ntnn](https://github.com/ntnn)                 | kcp core                                                       | SAP                         |
 | Sebastian Scheele     | [@scheeles](https://github.com/scheeles)         | Governance                                                     | Kubermatic                  |
 | Dr. Stefan Schimanski | [@sttts](https://github.com/sttts)               | Governance, kcp core                                           | NVIDIA                      |
-| Christoph Mewes       | [@xrstf](https://github.com/xrstf)               | kcp core, API Syncagent kcp-operator, infrastructure           | Kubermatic                  |
-| Mangirdas Judeikis    | [@mjudeikis](https://github.com/mjudeikis)       | kcp core                                                       | Upbound                     |
-| Marvin Beckers        | [@embik](https://github.com/embik)               | kcp core, kcp-operator, multicluster-provider, infrastructure  | Kubermatic                  |
-| Nelo-T. Wallus        | [@ntnn](https://github.com/ntnn)                 | kcp core                                                       | SAP                         |
 | Marko Mudrinić        | [@xmudrii](https://github.com/xmudrii)           | kcp core                                                       | Kubermatic                  |
+| Christoph Mewes       | [@xrstf](https://github.com/xrstf)               | kcp core, API Syncagent kcp-operator, infrastructure           | Kubermatic                  |
 
 ## Emeritus Maintainers
 

--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,9 @@
 approvers:
 - clubanderson
+- embik
+- mjudeikis
+- ntnn
 - scheeles
 - sttts
-- xrstf
-- mjudeikis
-- embik
-- ntnn
 - xmudrii
+- xrstf


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Since @xrstf insists, this updates our maintainer list to be alphabetically ordered. Since this *technically* touches a governance document, I will need maintainer quorum on this PR via sufficient `/lgtm` comments.

## What Type of PR Is This?

/kind documentation

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
