### PR TITLE
Use GitHub markdown for warnings in staging READMEs

### DIFF
--- a/staging/src/github.com/kcp-dev/apimachinery/README.md
+++ b/staging/src/github.com/kcp-dev/apimachinery/README.md
@@ -1,5 +1,9 @@
-> ⚠️ **This is an automatically published staged repository for kcp**.   
-> Contributions, including issues and pull requests, should be made to the main kcp repository: [https://github.com/kcp-dev/kcp](https://github.com/kcp-dev/kcp).  
+> [!WARNING]
+> **This is an automatically published staged repository for kcp**.   
+> 
+> Contributions, including issues and pull requests, should be made to the main kcp repository:
+> [https://github.com/kcp-dev/kcp](https://github.com/kcp-dev/kcp).  
+> 
 > This repository is read-only for importing, and not used for direct contributions.  
 > See the [monorepo structure document](https://docs.kcp.io/kcp/main/contributing/monorepo/) for more details.
 

--- a/staging/src/github.com/kcp-dev/cli/README.md
+++ b/staging/src/github.com/kcp-dev/cli/README.md
@@ -1,5 +1,9 @@
-> ⚠️ **This is an automatically published staged repository for kcp**.   
-> Contributions, including issues and pull requests, should be made to the main kcp repository: [https://github.com/kcp-dev/kcp](https://github.com/kcp-dev/kcp).  
+> [!WARNING]
+> **This is an automatically published staged repository for kcp**.   
+> 
+> Contributions, including issues and pull requests, should be made to the main kcp repository:
+> [https://github.com/kcp-dev/kcp](https://github.com/kcp-dev/kcp).  
+> 
 > This repository is read-only for importing, and not used for direct contributions.  
 > See the [monorepo structure document](https://docs.kcp.io/kcp/main/contributing/monorepo/) for more details.
 

--- a/staging/src/github.com/kcp-dev/client-go/README.md
+++ b/staging/src/github.com/kcp-dev/client-go/README.md
@@ -1,5 +1,9 @@
-> ⚠️ **This is an automatically published staged repository for kcp**.   
-> Contributions, including issues and pull requests, should be made to the main kcp repository: [https://github.com/kcp-dev/kcp](https://github.com/kcp-dev/kcp).  
+> [!WARNING]
+> **This is an automatically published staged repository for kcp**.   
+> 
+> Contributions, including issues and pull requests, should be made to the main kcp repository:
+> [https://github.com/kcp-dev/kcp](https://github.com/kcp-dev/kcp).  
+> 
 > This repository is read-only for importing, and not used for direct contributions.  
 > See the [monorepo structure document](https://docs.kcp.io/kcp/main/contributing/monorepo/) for more details.
 

--- a/staging/src/github.com/kcp-dev/code-generator/README.md
+++ b/staging/src/github.com/kcp-dev/code-generator/README.md
@@ -1,5 +1,9 @@
-> ⚠️ **This is an automatically published staged repository for kcp**.   
-> Contributions, including issues and pull requests, should be made to the main kcp repository: [https://github.com/kcp-dev/kcp](https://github.com/kcp-dev/kcp).  
+> [!WARNING]
+> **This is an automatically published staged repository for kcp**.   
+> 
+> Contributions, including issues and pull requests, should be made to the main kcp repository:
+> [https://github.com/kcp-dev/kcp](https://github.com/kcp-dev/kcp).  
+> 
 > This repository is read-only for importing, and not used for direct contributions.  
 > See the [monorepo structure document](https://docs.kcp.io/kcp/main/contributing/monorepo/) for more details.
 

--- a/staging/src/github.com/kcp-dev/sdk/README.md
+++ b/staging/src/github.com/kcp-dev/sdk/README.md
@@ -1,5 +1,9 @@
-> ⚠️ **This is an automatically published staged repository for kcp**.   
-> Contributions, including issues and pull requests, should be made to the main kcp repository: [https://github.com/kcp-dev/kcp](https://github.com/kcp-dev/kcp).  
+> [!WARNING]
+> **This is an automatically published staged repository for kcp**.   
+> 
+> Contributions, including issues and pull requests, should be made to the main kcp repository:
+> [https://github.com/kcp-dev/kcp](https://github.com/kcp-dev/kcp).  
+> 
 > This repository is read-only for importing, and not used for direct contributions.  
 > See the [monorepo structure document](https://docs.kcp.io/kcp/main/contributing/monorepo/) for more details.
 


### PR DESCRIPTION
## Summary

As the title says, this is a simple update to use GitHub markdown for warnings in staging READMEs.

## What Type of PR Is This?

/kind cleanup

## Release Notes
```release-note
NONE
```

/assign @xrstf @embik 