### PR TITLE
make initializer and terminator workspace URLs distinguishable

### DIFF
--- a/config/crds/tenancy.kcp.io_workspacetypes.yaml
+++ b/config/crds/tenancy.kcp.io_workspacetypes.yaml
@@ -316,6 +316,13 @@ spec:
                   URLs.
                 items:
                   properties:
+                    type:
+                      description: type indicates the type of virtual workspace this
+                        URL represents.
+                      enum:
+                      - initializing
+                      - terminating
+                      type: string
                     url:
                       description: url is a WorkspaceType initialization virtual workspace
                         URL.

--- a/config/root-phase0/apiexport-tenancy.kcp.io.yaml
+++ b/config/root-phase0/apiexport-tenancy.kcp.io.yaml
@@ -18,7 +18,7 @@ spec:
       crd: {}
   - group: tenancy.kcp.io
     name: workspacetypes
-    schema: v251015-1d163d0e5.workspacetypes.tenancy.kcp.io
+    schema: v251204-7c13b4e0a.workspacetypes.tenancy.kcp.io
     storage:
       crd: {}
 status: {}

--- a/config/root-phase0/apiresourceschema-workspacetypes.tenancy.kcp.io.yaml
+++ b/config/root-phase0/apiresourceschema-workspacetypes.tenancy.kcp.io.yaml
@@ -1,7 +1,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v251015-1d163d0e5.workspacetypes.tenancy.kcp.io
+  name: v251204-7c13b4e0a.workspacetypes.tenancy.kcp.io
 spec:
   group: tenancy.kcp.io
   names:
@@ -312,6 +312,13 @@ spec:
                 URLs.
               items:
                 properties:
+                  type:
+                    description: type indicates the type of virtual workspace this
+                      URL represents.
+                    enum:
+                    - initializing
+                    - terminating
+                    type: string
                   url:
                     description: url is a WorkspaceType initialization virtual workspace
                       URL.

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -4499,6 +4499,13 @@ func schema_sdk_apis_tenancy_v1alpha1_VirtualWorkspace(ref common.ReferenceCallb
 							Format:      "",
 						},
 					},
+					"type": {
+						SchemaProps: spec.SchemaProps{
+							Description: "type indicates the type of virtual workspace this URL represents.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"url"},
 			},

--- a/pkg/reconciler/tenancy/workspacetype/workspacetype_controller_reconcile_test.go
+++ b/pkg/reconciler/tenancy/workspacetype/workspacetype_controller_reconcile_test.go
@@ -137,12 +137,30 @@ func TestReconcile(t *testing.T) {
 				},
 				Status: tenancyv1alpha1.WorkspaceTypeStatus{
 					VirtualWorkspaces: []tenancyv1alpha1.VirtualWorkspace{
-						{URL: "https://item.com/services/initializingworkspaces/root:org:team:ws:sometype"},
-						{URL: "https://item.com/services/terminatingworkspaces/root:org:team:ws:sometype"},
-						{URL: "https://something.com/services/initializingworkspaces/root:org:team:ws:sometype"},
-						{URL: "https://something.com/services/terminatingworkspaces/root:org:team:ws:sometype"},
-						{URL: "https://whatever.com/services/initializingworkspaces/root:org:team:ws:sometype"},
-						{URL: "https://whatever.com/services/terminatingworkspaces/root:org:team:ws:sometype"},
+						{
+							URL:  "https://item.com/services/initializingworkspaces/root:org:team:ws:sometype",
+							Type: tenancyv1alpha1.VirtualWorkspaceTypeInitializing,
+						},
+						{
+							URL:  "https://item.com/services/terminatingworkspaces/root:org:team:ws:sometype",
+							Type: tenancyv1alpha1.VirtualWorkspaceTypeTerminating,
+						},
+						{
+							URL:  "https://something.com/services/initializingworkspaces/root:org:team:ws:sometype",
+							Type: tenancyv1alpha1.VirtualWorkspaceTypeInitializing,
+						},
+						{
+							URL:  "https://something.com/services/terminatingworkspaces/root:org:team:ws:sometype",
+							Type: tenancyv1alpha1.VirtualWorkspaceTypeTerminating,
+						},
+						{
+							URL:  "https://whatever.com/services/initializingworkspaces/root:org:team:ws:sometype",
+							Type: tenancyv1alpha1.VirtualWorkspaceTypeInitializing,
+						},
+						{
+							URL:  "https://whatever.com/services/terminatingworkspaces/root:org:team:ws:sometype",
+							Type: tenancyv1alpha1.VirtualWorkspaceTypeTerminating,
+						},
 					},
 					Conditions: conditionsv1alpha1.Conditions{
 						{
@@ -173,7 +191,10 @@ func TestReconcile(t *testing.T) {
 				},
 				Status: tenancyv1alpha1.WorkspaceTypeStatus{
 					VirtualWorkspaces: []tenancyv1alpha1.VirtualWorkspace{
-						{URL: "https://item.com/services/initializingworkspaces/root:org:team:ws:sometype"},
+						{
+							URL:  "https://item.com/services/initializingworkspaces/root:org:team:ws:sometype",
+							Type: tenancyv1alpha1.VirtualWorkspaceTypeInitializing,
+						},
 					},
 					Conditions: conditionsv1alpha1.Conditions{
 						{
@@ -196,12 +217,30 @@ func TestReconcile(t *testing.T) {
 				},
 				Status: tenancyv1alpha1.WorkspaceTypeStatus{
 					VirtualWorkspaces: []tenancyv1alpha1.VirtualWorkspace{
-						{URL: "https://item.com/services/initializingworkspaces/root:org:team:ws:sometype"},
-						{URL: "https://item.com/services/terminatingworkspaces/root:org:team:ws:sometype"},
-						{URL: "https://something.com/services/initializingworkspaces/root:org:team:ws:sometype"},
-						{URL: "https://something.com/services/terminatingworkspaces/root:org:team:ws:sometype"},
-						{URL: "https://whatever.com/services/initializingworkspaces/root:org:team:ws:sometype"},
-						{URL: "https://whatever.com/services/terminatingworkspaces/root:org:team:ws:sometype"},
+						{
+							URL:  "https://item.com/services/initializingworkspaces/root:org:team:ws:sometype",
+							Type: tenancyv1alpha1.VirtualWorkspaceTypeInitializing,
+						},
+						{
+							URL:  "https://item.com/services/terminatingworkspaces/root:org:team:ws:sometype",
+							Type: tenancyv1alpha1.VirtualWorkspaceTypeTerminating,
+						},
+						{
+							URL:  "https://something.com/services/initializingworkspaces/root:org:team:ws:sometype",
+							Type: tenancyv1alpha1.VirtualWorkspaceTypeInitializing,
+						},
+						{
+							URL:  "https://something.com/services/terminatingworkspaces/root:org:team:ws:sometype",
+							Type: tenancyv1alpha1.VirtualWorkspaceTypeTerminating,
+						},
+						{
+							URL:  "https://whatever.com/services/initializingworkspaces/root:org:team:ws:sometype",
+							Type: tenancyv1alpha1.VirtualWorkspaceTypeInitializing,
+						},
+						{
+							URL:  "https://whatever.com/services/terminatingworkspaces/root:org:team:ws:sometype",
+							Type: tenancyv1alpha1.VirtualWorkspaceTypeTerminating,
+						},
 					},
 					Conditions: conditionsv1alpha1.Conditions{
 						{
@@ -237,7 +276,17 @@ func TestReconcile(t *testing.T) {
 			}
 			c.reconcile(context.TODO(), testCase.wt)
 			c.reconcile(context.TODO(), testCase.wt) // relationships require resolved extensions
-			if diff := cmp.Diff(testCase.wt, testCase.expected, cmpopts.IgnoreTypes(metav1.Time{})); diff != "" {
+			if diff := cmp.Diff(
+				testCase.wt,
+				testCase.expected,
+				cmpopts.IgnoreTypes(metav1.Time{}),
+				cmpopts.SortSlices(func(a, b tenancyv1alpha1.VirtualWorkspace) bool {
+					if a.URL != b.URL { // SortSlices makes the comparison order-agnostic
+						return a.URL < b.URL
+					}
+					return a.Type < b.Type
+				}),
+			); diff != "" {
 				t.Errorf("incorrect WorkspaceType after reconciliation: %v", diff)
 			}
 		})

--- a/staging/src/github.com/kcp-dev/sdk/apis/tenancy/v1alpha1/types_workspacetype.go
+++ b/staging/src/github.com/kcp-dev/sdk/apis/tenancy/v1alpha1/types_workspacetype.go
@@ -244,7 +244,23 @@ type VirtualWorkspace struct {
 	// +kubebuilder:format:URL
 	// +required
 	URL string `json:"url"`
+
+	// type indicates the type of virtual workspace this URL represents.
+	//
+	// +optional
+	// +kubebuilder:validation:Enum=initializing;terminating
+	Type VirtualWorkspaceType `json:"type,omitempty"`
 }
+
+// VirtualWorkspaceType indicates the type of virtual workspace.
+type VirtualWorkspaceType string
+
+const (
+	// VirtualWorkspaceTypeInitializing indicates this is an initializing workspace URL.
+	VirtualWorkspaceTypeInitializing VirtualWorkspaceType = "initializing"
+	// VirtualWorkspaceTypeTerminating indicates this is a terminating workspace URL.
+	VirtualWorkspaceTypeTerminating VirtualWorkspaceType = "terminating"
+)
 
 func (in *WorkspaceType) GetConditions() conditionsv1alpha1.Conditions {
 	return in.Status.Conditions

--- a/staging/src/github.com/kcp-dev/sdk/client/applyconfiguration/tenancy/v1alpha1/virtualworkspace.go
+++ b/staging/src/github.com/kcp-dev/sdk/client/applyconfiguration/tenancy/v1alpha1/virtualworkspace.go
@@ -18,10 +18,15 @@ limitations under the License.
 
 package v1alpha1
 
+import (
+	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
+)
+
 // VirtualWorkspaceApplyConfiguration represents a declarative configuration of the VirtualWorkspace type for use
 // with apply.
 type VirtualWorkspaceApplyConfiguration struct {
-	URL *string `json:"url,omitempty"`
+	URL  *string                               `json:"url,omitempty"`
+	Type *tenancyv1alpha1.VirtualWorkspaceType `json:"type,omitempty"`
 }
 
 // VirtualWorkspaceApplyConfiguration constructs a declarative configuration of the VirtualWorkspace type for use with
@@ -35,5 +40,13 @@ func VirtualWorkspace() *VirtualWorkspaceApplyConfiguration {
 // If called multiple times, the URL field is set to the value of the last call.
 func (b *VirtualWorkspaceApplyConfiguration) WithURL(value string) *VirtualWorkspaceApplyConfiguration {
 	b.URL = &value
+	return b
+}
+
+// WithType sets the Type field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Type field is set to the value of the last call.
+func (b *VirtualWorkspaceApplyConfiguration) WithType(value tenancyv1alpha1.VirtualWorkspaceType) *VirtualWorkspaceApplyConfiguration {
+	b.Type = &value
 	return b
 }


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary
```
change adds a type field to the VirtualWorkspace api schema to make the initializer and terminator workspace URLs distinguishable.
```
<img width="846" height="408" alt="Screenshot 2025-11-08 at 02 01 25" src="https://github.com/user-attachments/assets/396cdec3-b1a3-4376-b891-8acc15a7ecd2" />


## What Type of PR Is This?
/kind feature
<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes [3699](https://github.com/kcp-dev/kcp/issues/3699)

## Release Notes


<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Adds a `type` field to the VirtualWorkspace API schema to distinguish between initializing and terminating workspace URLs.
```
