### PR TITLE
Use non-versioned modules for staging repo dependencies

### DIFF
--- a/docs/generators/cli-doc/go.mod
+++ b/docs/generators/cli-doc/go.mod
@@ -3,15 +3,21 @@ module github.com/kcp-dev/kcp/docs/generators/cli-doc
 go 1.24.0
 
 require (
-	github.com/kcp-dev/kcp v0.0.0-00010101000000-000000000000
-	github.com/kcp-dev/cli v0.0.0-00010101000000-000000000000
+	github.com/kcp-dev/cli v0.0.0
+	github.com/kcp-dev/kcp v0.0.0
 	github.com/spf13/cobra v1.9.1
 )
 
 replace (
 	github.com/charmbracelet/colorprofile => github.com/charmbracelet/colorprofile v0.2.2
 	github.com/charmbracelet/x/ansi => github.com/charmbracelet/x/ansi v0.8.0
+)
+
+replace (
+	github.com/kcp-dev/apimachinery/v2 => ../../../staging/src/github.com/kcp-dev/apimachinery
 	github.com/kcp-dev/cli => ../../../staging/src/github.com/kcp-dev/cli
+	github.com/kcp-dev/client-go => ../../../staging/src/github.com/kcp-dev/client-go
+	github.com/kcp-dev/code-generator/v3 => ../../../staging/src/github.com/kcp-dev/code-generator
 	github.com/kcp-dev/kcp => ../../../
 	github.com/kcp-dev/sdk => ../../../staging/src/github.com/kcp-dev/sdk
 )
@@ -48,8 +54,8 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kcp-dev/apimachinery/v2 v2.0.1-0.20250728122101-adbf20db3e51 // indirect
-	github.com/kcp-dev/sdk v0.0.0-00010101000000-000000000000 // indirect
 	github.com/kcp-dev/logicalcluster/v3 v3.0.5 // indirect
+	github.com/kcp-dev/sdk v0.0.0 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect

--- a/docs/generators/cli-doc/go.sum
+++ b/docs/generators/cli-doc/go.sum
@@ -79,10 +79,6 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
-github.com/kcp-dev/apimachinery/v2 v2.0.1-0.20250728122101-adbf20db3e51 h1:l38RDS+VUMx9etvyaCgJIZa4nM7FaNevNubWN0kDZY4=
-github.com/kcp-dev/apimachinery/v2 v2.0.1-0.20250728122101-adbf20db3e51/go.mod h1:rF1jfvUfPjFXs+HV/LN1BtPzAz1bfjJOwVa+hAVfroQ=
-github.com/kcp-dev/client-go v0.0.0-20250728134101-0355faa9361b h1:2LGrXvY9sc4l5yjKIbMZ86GEou7NyrHhA4qBPaeFfxs=
-github.com/kcp-dev/client-go v0.0.0-20250728134101-0355faa9361b/go.mod h1:QdO8AaGAZPr/rIZ1iVanCM3tUOiiuX897GWv7WTByLE=
 github.com/kcp-dev/logicalcluster/v3 v3.0.5 h1:JbYakokb+5Uinz09oTXomSUJVQsqfxEvU4RyHUYxHOU=
 github.com/kcp-dev/logicalcluster/v3 v3.0.5/go.mod h1:EWBUBxdr49fUB1cLMO4nOdBWmYifLbP1LfoL20KkXYY=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/go.mod
+++ b/go.mod
@@ -20,11 +20,11 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/kcp-dev/apimachinery/v2 v2.0.1-0.20250728122101-adbf20db3e51
-	github.com/kcp-dev/client-go v0.0.0-20250728134101-0355faa9361b
-	github.com/kcp-dev/code-generator/v3 v3.0.0-20250728122101-5b4ff5c24054
+	github.com/kcp-dev/client-go v0.0.0
+	github.com/kcp-dev/code-generator/v3 v3.0.0-00010101000000-000000000000
 	github.com/kcp-dev/embeddedetcd v1.0.3-0.20250805142358-a4839a83564a
 	github.com/kcp-dev/logicalcluster/v3 v3.0.5
-	github.com/kcp-dev/sdk v0.0.0-00010101000000-000000000000
+	github.com/kcp-dev/sdk v0.0.0
 	github.com/martinlindhe/base36 v1.1.1
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 	github.com/prometheus/client_golang v1.22.0

--- a/staging/src/github.com/kcp-dev/cli/go.mod
+++ b/staging/src/github.com/kcp-dev/cli/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/google/go-cmp v0.7.0
-	github.com/kcp-dev/client-go v0.0.0-20250728134101-0355faa9361b
+	github.com/kcp-dev/client-go v0.0.0
 	github.com/kcp-dev/logicalcluster/v3 v3.0.5
-	github.com/kcp-dev/sdk v0.0.0-00010101000000-000000000000
+	github.com/kcp-dev/sdk v0.0.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0
@@ -49,7 +49,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/kcp-dev/apimachinery/v2 v2.0.0-20250728122101-adbf20db3e51 // indirect
+	github.com/kcp-dev/apimachinery/v2 v2.0.0-00010101000000-000000000000 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect

--- a/staging/src/github.com/kcp-dev/client-go/go.mod
+++ b/staging/src/github.com/kcp-dev/client-go/go.mod
@@ -4,8 +4,8 @@ go 1.24.0
 
 require (
 	github.com/google/gnostic-models v0.6.9
-	github.com/kcp-dev/apimachinery/v2 v2.0.0-20250717064240-78e565b4a69a
-	github.com/kcp-dev/code-generator/v3 v3.0.0-20250717064843-0c8e5fec4f71
+	github.com/kcp-dev/apimachinery/v2 v2.0.0-00010101000000-000000000000
+	github.com/kcp-dev/code-generator/v3 v3.0.0-00010101000000-000000000000
 	github.com/kcp-dev/logicalcluster/v3 v3.0.5
 	gopkg.in/evanphx/json-patch.v4 v4.12.0
 	k8s.io/api v0.33.3

--- a/staging/src/github.com/kcp-dev/code-generator/examples/go.mod
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/go.mod
@@ -5,8 +5,8 @@ go 1.24.0
 replace acme.corp/pkg => ./pkg
 
 require (
-	github.com/kcp-dev/apimachinery/v2 v2.0.1-0.20250717064240-78e565b4a69a
-	github.com/kcp-dev/client-go v0.0.0-20250721105427-d4a93d7c5fc9
+	github.com/kcp-dev/apimachinery/v2 v2.0.0-00010101000000-000000000000
+	github.com/kcp-dev/client-go v0.0.0
 	github.com/kcp-dev/logicalcluster/v3 v3.0.5
 	k8s.io/apimachinery v0.33.3
 	k8s.io/client-go v0.33.3
@@ -55,4 +55,5 @@ require (
 replace (
 	github.com/kcp-dev/apimachinery/v2 => ../../apimachinery
 	github.com/kcp-dev/client-go => ../../client-go
+	github.com/kcp-dev/code-generator/v3 => ../../code-generator
 )

--- a/staging/src/github.com/kcp-dev/sdk/go.mod
+++ b/staging/src/github.com/kcp-dev/sdk/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/egymgmbh/go-prefix-writer v0.0.0-20180609083313-7326ea162eca
 	github.com/go-logr/logr v1.4.2
 	github.com/google/go-cmp v0.7.0
-	github.com/kcp-dev/apimachinery/v2 v2.0.0-20250728122101-adbf20db3e51
-	github.com/kcp-dev/client-go v0.0.0-20250728134101-0355faa9361b
+	github.com/kcp-dev/apimachinery/v2 v2.0.0-00010101000000-000000000000
+	github.com/kcp-dev/client-go v0.0.0
 	github.com/kcp-dev/logicalcluster/v3 v3.0.5
 	github.com/martinlindhe/base36 v1.1.1
 	github.com/muesli/reflow v0.3.0


### PR DESCRIPTION
## Summary

This is a somewhat simple PR but it's hard to recap its intention in a short title:

- There should be `replace` directives for all dependencies to other staging repositories. For example, if some module depends on `client-go` which depends on `apimachinery` and `code-generator/v3`, there should be `replace` directives for all three modules. It's kind of intuitive, but it's very easy to miss.
- Modules within `kcp-dev/kcp` shall not refer to staging repositories using versions or commit references (pseudo-versions). Instead, `v0.0.0` or `vX.0.0-00010101000000-000000000000` (if `X >= 2`) shall be used. Within `kcp-dev/kcp`, `replace` directives will point to the proper Go module within `staging/src/github.com/kcp-dev`. In published repositories (e.g. `github.com/kcp-dev/apimachinery`), publishing-bot will update all these references upon publishing from staging to published repositories.

## What Type of PR Is This?

/kind cleanup

## Release Notes
```release-note
NONE
```

/assign @xrstf @embik @mjudeikis 