### PR TITLE
fix permission claim label not updated when selector changes

### DIFF
--- a/pkg/reconciler/apis/permissionclaimlabel/permissionclaimlabel_reconcile_test.go
+++ b/pkg/reconciler/apis/permissionclaimlabel/permissionclaimlabel_reconcile_test.go
@@ -22,6 +22,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
+
 	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
 )
 
@@ -69,6 +73,89 @@ func TestClaimSetKeys(t *testing.T) {
 
 			decoded := claimFromSetKey(tc.key)
 			require.Empty(t, cmp.Diff(tc.claim, decoded))
+		})
+	}
+}
+
+func TestSelectorChangeDetection(t *testing.T) {
+	baseClaim := apisv1alpha2.PermissionClaim{
+		GroupResource: apisv1alpha2.GroupResource{
+			Group:    "",
+			Resource: "secrets",
+		},
+		IdentityHash: "test-hash",
+	}
+	key := setKeyForClaim(baseClaim)
+
+	tests := map[string]struct {
+		acceptedSelector apisv1alpha2.PermissionClaimSelector
+		appliedSelector  apisv1alpha2.PermissionClaimSelector
+		shouldDetect     bool
+	}{
+		"matchAll to matchLabels should be detected": {
+			acceptedSelector: apisv1alpha2.PermissionClaimSelector{
+				MatchAll: false,
+				LabelSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"foo": "bar",
+					},
+				},
+			},
+			appliedSelector: apisv1alpha2.PermissionClaimSelector{
+				MatchAll: true,
+			},
+			shouldDetect: true,
+		},
+		"same selector should not be detected": {
+			acceptedSelector: apisv1alpha2.PermissionClaimSelector{
+				MatchAll: false,
+				LabelSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"foo": "bar",
+					},
+				},
+			},
+			appliedSelector: apisv1alpha2.PermissionClaimSelector{
+				MatchAll: false,
+				LabelSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"foo": "bar",
+					},
+				},
+			},
+			shouldDetect: false,
+		},
+	}
+
+	for testName, tc := range tests {
+		t.Run(testName, func(t *testing.T) {
+			expectedClaims := sets.New(key)
+			acceptedClaims := sets.New(key)
+			appliedClaims := sets.New(key)
+			acceptedClaimsMap := map[string]apisv1alpha2.ScopedPermissionClaim{
+				key: {
+					PermissionClaim: baseClaim,
+					Selector:        tc.acceptedSelector,
+				},
+			}
+			appliedClaimsMap := map[string]apisv1alpha2.ScopedPermissionClaim{
+				key: {
+					PermissionClaim: baseClaim,
+					Selector:        tc.appliedSelector,
+				},
+			}
+
+			selectorChanges := detectSelectorChanges(
+				expectedClaims, acceptedClaims, appliedClaims,
+				acceptedClaimsMap, appliedClaimsMap,
+				klog.Background(),
+			)
+
+			if tc.shouldDetect {
+				require.True(t, selectorChanges.Has(key), "Expected selector change to be detected")
+			} else {
+				require.False(t, selectorChanges.Has(key), "Expected no selector change to be detected")
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

```
Fixes permission claim labels not being updated by adding logic to detect selector changes in
APIBinding permission claims.
```
<img width="1642" height="1310" alt="image" src="https://github.com/user-attachments/assets/9b4597e7-2a24-432a-92bf-2339e9c0f0e3" />

<img width="1650" height="1644" alt="image" src="https://github.com/user-attachments/assets/0a3dcb14-03cd-4aa4-9cd6-70568830c544" />

## What Type of PR Is This?
/kind bug
<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes [3681](https://github.com/kcp-dev/kcp/issues/3681)

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Fixed reconciliation logic to detect selector changes in APIBinding permission claims.
```
