### PR TITLE
add path to cachedresource api

### DIFF
--- a/config/crds/cache.kcp.io_cachedresourceendpointslices.yaml
+++ b/config/crds/cache.kcp.io_cachedresourceendpointslices.yaml
@@ -59,6 +59,12 @@ spec:
                     description: name is the name of the CachedResource the reference
                       points to.
                     type: string
+                  path:
+                    description: |-
+                      path is a logical cluster path where the CachedResource is defined. If empty,
+                      the CachedResource is assumed to be co-located with the referencing resource.
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(:[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
                 required:
                 - name
                 type: object

--- a/config/root-phase0/apiexport-cache.kcp.io.yaml
+++ b/config/root-phase0/apiexport-cache.kcp.io.yaml
@@ -7,7 +7,7 @@ spec:
   resources:
   - group: cache.kcp.io
     name: cachedresourceendpointslices
-    schema: v251008-c4825908e.cachedresourceendpointslices.cache.kcp.io
+    schema: v251120-d8e87a979.cachedresourceendpointslices.cache.kcp.io
     storage:
       crd: {}
   - group: cache.kcp.io

--- a/config/root-phase0/apiresourceschema-cachedresourceendpointslices.cache.kcp.io.yaml
+++ b/config/root-phase0/apiresourceschema-cachedresourceendpointslices.cache.kcp.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v251008-c4825908e.cachedresourceendpointslices.cache.kcp.io
+  name: v251120-d8e87a979.cachedresourceendpointslices.cache.kcp.io
 spec:
   group: cache.kcp.io
   names:
@@ -55,6 +55,12 @@ spec:
                 name:
                   description: name is the name of the CachedResource the reference
                     points to.
+                  type: string
+                path:
+                  description: |-
+                    path is a logical cluster path where the CachedResource is defined. If empty,
+                    the CachedResource is assumed to be co-located with the referencing resource.
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(:[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                   type: string
               required:
               - name

--- a/pkg/admission/pathannotation/pathannotation_admission.go
+++ b/pkg/admission/pathannotation/pathannotation_admission.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/kcp-dev/logicalcluster/v3"
 	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
+	cachev1alpha1 "github.com/kcp-dev/sdk/apis/cache/v1alpha1"
 	"github.com/kcp-dev/sdk/apis/core"
 	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
@@ -69,6 +70,7 @@ type pathAnnotationPlugin struct {
 
 var pathAnnotationResources = sets.New[string](
 	apisv1alpha2.Resource("apiexports").String(),
+	cachev1alpha1.Resource("cachedresources").String(),
 	tenancyv1alpha1.Resource("workspacetypes").String(),
 )
 

--- a/pkg/admission/pathannotation/pathannotation_admission_test.go
+++ b/pkg/admission/pathannotation/pathannotation_admission_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/kcp-dev/logicalcluster/v3"
 	apisv1alpha1 "github.com/kcp-dev/sdk/apis/apis/v1alpha1"
 	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
+	cachev1alpha1 "github.com/kcp-dev/sdk/apis/cache/v1alpha1"
 	"github.com/kcp-dev/sdk/apis/core"
 	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
@@ -129,6 +130,15 @@ func TestPathAnnotationAdmit(t *testing.T) {
 			admissionVerb:           admission.Create,
 			admissionResource:       tenancyv1alpha1.SchemeGroupVersion.WithResource("workspacetypes"),
 			admissionObject:         &tenancyv1alpha1.WorkspaceType{},
+			admissionContext:        admissionContextFor("foo"),
+			getLogicalCluster:       getCluster("foo"),
+			validateAdmissionObject: objectHasPathAnnotation("root:foo"),
+		},
+		{
+			name:                    "happy path: a CachedResource is annotated with a path",
+			admissionVerb:           admission.Create,
+			admissionResource:       cachev1alpha1.SchemeGroupVersion.WithResource("cachedresources"),
+			admissionObject:         &cachev1alpha1.CachedResource{},
 			admissionContext:        admissionContextFor("foo"),
 			getLogicalCluster:       getCluster("foo"),
 			validateAdmissionObject: objectHasPathAnnotation("root:foo"),
@@ -238,6 +248,15 @@ func TestPathAnnotationValidate(t *testing.T) {
 			admissionObject:   &apisv1alpha2.APIExport{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{core.LogicalClusterPathAnnotationKey: "root:foo"}}},
 			admissionContext:  admissionContextFor("foo"),
 			getLogicalCluster: getCluster("foo"),
+		},
+		{
+			name:              "a CachedResource with incorrect path annotation is NOT admitted",
+			admissionVerb:     admission.Create,
+			admissionResource: cachev1alpha1.SchemeGroupVersion.WithResource("cachedresources"),
+			admissionObject:   &cachev1alpha1.CachedResource{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{core.LogicalClusterPathAnnotationKey: "root:bar"}}},
+			admissionContext:  admissionContextFor("foo"),
+			getLogicalCluster: getCluster("foo"),
+			expectError:       true,
 		},
 	}
 

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -3395,6 +3395,13 @@ func schema_sdk_apis_cache_v1alpha1_CachedResourceReference(ref common.Reference
 				Description: "CachedResourceReference is a reference to a CachedResource.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"path": {
+						SchemaProps: spec.SchemaProps{
+							Description: "path is a logical cluster path where the CachedResource is defined. If empty, the CachedResource is assumed to be co-located with the referencing resource.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "name is the name of the CachedResource the reference points to.",

--- a/pkg/reconciler/cache/cachedresourceendpointslice/cachedresourceendpointslice_indexers.go
+++ b/pkg/reconciler/cache/cachedresourceendpointslice/cachedresourceendpointslice_indexers.go
@@ -60,6 +60,14 @@ func IndexCachedResourceEndpointSliceByCachedResourceFunc(obj interface{}) ([]st
 	}
 
 	pathLocal := logicalcluster.From(slice).Path()
-	// TODO(gman0): add an optional external path index key once we add "CachedResourceEndpointSlice.spec.cachedResource.path".
-	return []string{pathLocal.Join(slice.Spec.CachedResource.Name).String()}, nil
+	keys := []string{pathLocal.Join(slice.Spec.CachedResource.Name).String()}
+
+	if refPath := logicalcluster.NewPath(slice.Spec.CachedResource.Path); !refPath.Empty() {
+		key := refPath.Join(slice.Spec.CachedResource.Name).String()
+		if key != keys[0] {
+			keys = append(keys, key)
+		}
+	}
+
+	return keys, nil
 }

--- a/pkg/reconciler/cache/cachedresourceendpointsliceurls/cachedresourceendpointsliceurls_controller.go
+++ b/pkg/reconciler/cache/cachedresourceendpointsliceurls/cachedresourceendpointsliceurls_controller.go
@@ -110,8 +110,8 @@ func NewController(
 		getMyShard: func() (*corev1alpha1.Shard, error) {
 			return globalShardClusterInformer.Cluster(core.RootCluster).Lister().Get(shardName)
 		},
-		getCachedResource: func(cluster logicalcluster.Name, name string) (*cachev1alpha1.CachedResource, error) {
-			return indexers.ByPathAndName[*cachev1alpha1.CachedResource](cachev1alpha1.Resource("cachedresources"), globalCachedResourcelusterInformer.Informer().GetIndexer(), cluster.Path(), name)
+		getCachedResource: func(path logicalcluster.Path, name string) (*cachev1alpha1.CachedResource, error) {
+			return indexers.ByPathAndName[*cachev1alpha1.CachedResource](cachev1alpha1.Resource("cachedresources"), globalCachedResourcelusterInformer.Informer().GetIndexer(), path, name)
 		},
 		getCachedResourceEndpointSlice: func(cluster logicalcluster.Name, name string) (*cachev1alpha1.CachedResourceEndpointSlice, error) {
 			obj, err := indexers.ByPathAndNameWithFallback[*cachev1alpha1.CachedResourceEndpointSlice](cachev1alpha1.Resource("cachedresourceendpointslices"), localCachedResourceEndpointSliceClusterInformer.Informer().GetIndexer(), globalCachedResourceEndpointSliceClusterInformer.Informer().GetIndexer(), cluster.Path(), name)
@@ -242,7 +242,7 @@ type controller struct {
 	listAPIExportsByCachedResourceIdentityAndGR func(identityHash string, gr schema.GroupResource) ([]*apisv1alpha2.APIExport, error)
 	listAPIBindingsByAPIExports                 func(exports []*apisv1alpha2.APIExport) ([]*apisv1alpha2.APIBinding, error)
 	getMyShard                                  func() (*corev1alpha1.Shard, error)
-	getCachedResource                           func(cluster logicalcluster.Name, name string) (*cachev1alpha1.CachedResource, error)
+	getCachedResource                           func(path logicalcluster.Path, name string) (*cachev1alpha1.CachedResource, error)
 	getCachedResourceEndpointSlice              func(cluster logicalcluster.Name, name string) (*cachev1alpha1.CachedResourceEndpointSlice, error)
 	patchAPIExportEndpointSlice                 func(ctx context.Context, cluster logicalcluster.Path, patch *cachev1alpha1apply.CachedResourceEndpointSliceApplyConfiguration) error
 	patchCachedResourceEndpointSlice            func(ctx context.Context, cluster logicalcluster.Path, patch *cachev1alpha1apply.CachedResourceEndpointSliceApplyConfiguration) error

--- a/pkg/reconciler/cache/cachedresourceendpointsliceurls/cachedresourceendpointsliceurls_reconciler.go
+++ b/pkg/reconciler/cache/cachedresourceendpointsliceurls/cachedresourceendpointsliceurls_reconciler.go
@@ -56,7 +56,7 @@ type endpointsReconciler struct {
 	listAPIExportsByCachedResourceIdentityAndGR func(identityHash string, gr schema.GroupResource) ([]*apisv1alpha2.APIExport, error)
 	listAPIBindingsByAPIExports                 func(exports []*apisv1alpha2.APIExport) ([]*apisv1alpha2.APIBinding, error)
 	getMyShard                                  func() (*corev1alpha1.Shard, error)
-	getCachedResource                           func(cluster logicalcluster.Name, name string) (*cachev1alpha1.CachedResource, error)
+	getCachedResource                           func(path logicalcluster.Path, name string) (*cachev1alpha1.CachedResource, error)
 	patchAPIExportEndpointSlice                 func(ctx context.Context, cluster logicalcluster.Path, patch *cachev1alpha1apply.CachedResourceEndpointSliceApplyConfiguration) error
 }
 
@@ -105,7 +105,12 @@ func (r *endpointsReconciler) updateEndpoints(ctx context.Context, slice *cachev
 		return nil, nil
 	}
 
-	cr, err := r.getCachedResource(logicalcluster.From(slice), slice.Spec.CachedResource.Name)
+	cachedResourcePath := logicalcluster.NewPath(slice.Spec.CachedResource.Path)
+	if cachedResourcePath.Empty() {
+		cachedResourcePath = logicalcluster.From(slice).Path()
+	}
+
+	cr, err := r.getCachedResource(cachedResourcePath, slice.Spec.CachedResource.Name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/reconciler/cache/cachedresources/cachedresources_reconcile_endpointslice.go
+++ b/pkg/reconciler/cache/cachedresources/cachedresources_reconcile_endpointslice.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/kcp-dev/logicalcluster/v3"
 	cachev1alpha1 "github.com/kcp-dev/sdk/apis/cache/v1alpha1"
+	"github.com/kcp-dev/sdk/apis/core"
 )
 
 // endpointSlice creates CachedResourceEndopointSlice for the published resource.
@@ -43,6 +44,7 @@ func (r *endpointSlice) reconcile(ctx context.Context, cachedResource *cachev1al
 	}
 
 	clusterName := logicalcluster.From(cachedResource)
+	clusterPath := cachedResource.Annotations[core.LogicalClusterPathAnnotationKey]
 
 	_, err := r.getEndpointSlice(ctx, clusterName, cachedResource.Name)
 	if err != nil {
@@ -62,6 +64,7 @@ func (r *endpointSlice) reconcile(ctx context.Context, cachedResource *cachev1al
 				},
 				Spec: cachev1alpha1.CachedResourceEndpointSliceSpec{
 					CachedResource: cachev1alpha1.CachedResourceReference{
+						Path: clusterPath,
 						Name: cachedResource.Name,
 					},
 				},

--- a/staging/src/github.com/kcp-dev/sdk/apis/cache/v1alpha1/types_cachedresource.go
+++ b/staging/src/github.com/kcp-dev/sdk/apis/cache/v1alpha1/types_cachedresource.go
@@ -179,6 +179,13 @@ type ResourceCount struct {
 
 // CachedResourceReference is a reference to a CachedResource.
 type CachedResourceReference struct {
+	// path is a logical cluster path where the CachedResource is defined. If empty,
+	// the CachedResource is assumed to be co-located with the referencing resource.
+	//
+	// +optional
+	// +kubebuilder:validation:Pattern:="^[a-z0-9]([-a-z0-9]*[a-z0-9])?(:[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+	Path string `json:"path,omitempty"`
+
 	// name is the name of the CachedResource the reference points to.
 	//
 	// +required

--- a/staging/src/github.com/kcp-dev/sdk/client/applyconfiguration/cache/v1alpha1/cachedresourcereference.go
+++ b/staging/src/github.com/kcp-dev/sdk/client/applyconfiguration/cache/v1alpha1/cachedresourcereference.go
@@ -21,6 +21,7 @@ package v1alpha1
 // CachedResourceReferenceApplyConfiguration represents a declarative configuration of the CachedResourceReference type for use
 // with apply.
 type CachedResourceReferenceApplyConfiguration struct {
+	Path *string `json:"path,omitempty"`
 	Name *string `json:"name,omitempty"`
 }
 
@@ -28,6 +29,14 @@ type CachedResourceReferenceApplyConfiguration struct {
 // apply.
 func CachedResourceReference() *CachedResourceReferenceApplyConfiguration {
 	return &CachedResourceReferenceApplyConfiguration{}
+}
+
+// WithPath sets the Path field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Path field is set to the value of the last call.
+func (b *CachedResourceReferenceApplyConfiguration) WithPath(value string) *CachedResourceReferenceApplyConfiguration {
+	b.Path = &value
+	return b
 }
 
 // WithName sets the Name field in the declarative configuration to the given value

--- a/test/e2e/reconciler/cachedresourceendpointslice/cachedresourceendpointslice_test.go
+++ b/test/e2e/reconciler/cachedresourceendpointslice/cachedresourceendpointslice_test.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cachedresourceendpointslice
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	kcpapiextensionsclientset "github.com/kcp-dev/client-go/apiextensions/client"
+	cachev1alpha1 "github.com/kcp-dev/sdk/apis/cache/v1alpha1"
+	"github.com/kcp-dev/sdk/apis/core"
+	"github.com/kcp-dev/sdk/apis/third_party/conditions/util/conditions"
+	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
+	kcptesting "github.com/kcp-dev/sdk/testing"
+	kcptestinghelpers "github.com/kcp-dev/sdk/testing/helpers"
+
+	"github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest"
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+)
+
+func TestCachedResourceEndpointSliceWithPath(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "control-plane")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	server := kcptesting.SharedKcpServer(t)
+
+	// Create Organization and Workspaces
+	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
+	providerPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath, kcptesting.WithName("provider"))
+	consumerPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath, kcptesting.WithName("consumer"))
+
+	cfg := server.BaseConfig(t)
+
+	var err error
+	kcpClusterClient, err := kcpclientset.NewForConfig(cfg)
+	require.NoError(t, err, "failed to construct kcp cluster client for server")
+
+	// Create a CRD in the provider workspace using the wildwest fixture
+	t.Logf("Creating wildwest.dev CRD in provider workspace %q", providerPath)
+	kcpApiExtensionClusterClient, err := kcpapiextensionsclientset.NewForConfig(cfg)
+	require.NoError(t, err, "failed to construct kcp apiextensions cluster client")
+	crdClient := kcpApiExtensionClusterClient.ApiextensionsV1().CustomResourceDefinitions()
+	cowboysGR := metav1.GroupResource{Group: "wildwest.dev", Resource: "cowboys"}
+	wildwest.Create(t, providerPath, crdClient, cowboysGR)
+
+	// Create a CachedResource in the provider workspace
+	t.Logf("Creating CachedResource in provider workspace %q", providerPath)
+	cachedResource := &cachev1alpha1.CachedResource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: cowboysGR.String(),
+		},
+		Spec: cachev1alpha1.CachedResourceSpec{
+			GroupVersionResource: cachev1alpha1.GroupVersionResource{
+				Group:    "wildwest.dev",
+				Version:  "v1alpha1",
+				Resource: "cowboys",
+			},
+		},
+	}
+
+	cachedResourceClient := kcpClusterClient.CacheV1alpha1().CachedResources()
+	_, err = cachedResourceClient.Cluster(providerPath).Create(ctx, cachedResource, metav1.CreateOptions{})
+	require.NoError(t, err, "error creating CachedResource")
+
+	// Wait for CachedResource to be ready
+	kcptestinghelpers.EventuallyCondition(t, func() (conditions.Getter, error) {
+		cachedResource, err = cachedResourceClient.Cluster(providerPath).Get(ctx, cachedResource.Name, metav1.GetOptions{})
+		return cachedResource, err
+	}, kcptestinghelpers.Is(cachev1alpha1.ReplicationStarted), fmt.Sprintf("CachedResource %v should become ready", cachedResource.Name))
+
+	// Create a CachedResourceEndpointSlice in the consumer workspace that references
+	// the CachedResource in the provider workspace using the path field
+	t.Logf("Creating CachedResourceEndpointSlice in consumer workspace %q with path reference to provider workspace %q", consumerPath, providerPath)
+	sliceExternalPath := &cachev1alpha1.CachedResourceEndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "cowboys-external-path-slice-",
+		},
+		Spec: cachev1alpha1.CachedResourceEndpointSliceSpec{
+			CachedResource: cachev1alpha1.CachedResourceReference{
+				Path: providerPath.String(),
+				Name: cachedResource.Name,
+			},
+		},
+	}
+
+	sliceClient := kcpClusterClient.CacheV1alpha1().CachedResourceEndpointSlices()
+
+	var sliceExternalPathName string
+	t.Logf("Creating CachedResourceEndpointSlice with external path reference")
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		created, err := sliceClient.Cluster(consumerPath).Create(ctx, sliceExternalPath, metav1.CreateOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+		sliceExternalPathName = created.Name
+		return true, ""
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "expected CachedResourceEndpointSlice creation to succeed")
+
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		sliceExternalPath, err = kcpClusterClient.Cluster(consumerPath).CacheV1alpha1().CachedResourceEndpointSlices().Get(ctx, sliceExternalPathName, metav1.GetOptions{})
+		require.NoError(t, err)
+
+		if conditions.IsTrue(sliceExternalPath, cachev1alpha1.CachedResourceValid) {
+			return true, ""
+		}
+
+		return false, spew.Sdump(sliceExternalPath.Status.Conditions)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "expected valid CachedResource reference")
+
+	t.Logf("Creating CachedResourceEndpointSlice in provider workspace that references the CachedResource in the same workspace")
+	sliceSameWorkspace := &cachev1alpha1.CachedResourceEndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "cowboys-same-workspace-slice-",
+		},
+		Spec: cachev1alpha1.CachedResourceEndpointSliceSpec{
+			CachedResource: cachev1alpha1.CachedResourceReference{
+				Name: cachedResource.Name,
+			},
+		},
+	}
+
+	var sliceSameWorkspaceName string
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		created, err := sliceClient.Cluster(providerPath).Create(ctx, sliceSameWorkspace, metav1.CreateOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+		sliceSameWorkspaceName = created.Name
+		return true, ""
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "expected CachedResourceEndpointSlice creation in same workspace to succeed")
+
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		sliceSameWorkspace, err = kcpClusterClient.Cluster(providerPath).CacheV1alpha1().CachedResourceEndpointSlices().Get(ctx, sliceSameWorkspaceName, metav1.GetOptions{})
+		require.NoError(t, err)
+
+		if conditions.IsTrue(sliceSameWorkspace, cachev1alpha1.CachedResourceValid) {
+			return true, ""
+		}
+
+		return false, spew.Sdump(sliceSameWorkspace.Status.Conditions)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "expected valid CachedResource reference in same workspace")
+
+	t.Logf("CachedResourceEndpointSlice successfully references CachedResource in same workspace")
+
+	sliceInvalidReference := &cachev1alpha1.CachedResourceEndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cowboys-invalid-reference-slice",
+		},
+		Spec: cachev1alpha1.CachedResourceEndpointSliceSpec{
+			CachedResource: cachev1alpha1.CachedResourceReference{
+				Path: providerPath.String(),
+				Name: "nonexistent-cachedresource",
+			},
+		},
+	}
+
+	_, err = sliceClient.Cluster(consumerPath).Create(ctx, sliceInvalidReference, metav1.CreateOptions{})
+	require.NoError(t, err, "CachedResourceEndpointSlice should be created even if CachedResource doesn't exist yet")
+
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		sliceInvalidReference, err = kcpClusterClient.Cluster(consumerPath).CacheV1alpha1().CachedResourceEndpointSlices().Get(ctx, sliceInvalidReference.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+
+		if conditions.IsFalse(sliceInvalidReference, cachev1alpha1.CachedResourceValid) &&
+			conditions.GetReason(sliceInvalidReference, cachev1alpha1.CachedResourceValid) == cachev1alpha1.CachedResourceNotFoundReason {
+			return true, ""
+		}
+		return false, spew.Sdump(sliceInvalidReference.Status.Conditions)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "expected invalid CachedResource reference")
+
+	t.Logf("CachedResourceEndpointSlice correctly reports invalid reference to nonexistent CachedResource")
+}


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary
```
change implements adds path to the cachedresource api so that a CachedResourceEndpointSlice can reference a `CachedResource` located in another workspace.
```
<img width="863" height="873" alt="image" src="https://github.com/user-attachments/assets/e193a93a-eec9-40df-b312-45e193188d2c" />

## What Type of PR Is This?

<!--
/kind feature
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes [3658](https://github.com/kcp-dev/kcp/issues/3658)

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Added to path to cachedresource so that CachedResourceEndpointSlice can reference a CachedResource in another workspace
```
