### PR TITLE
add workspace clusterID when in interactive mode

### DIFF
--- a/staging/src/github.com/kcp-dev/cli/pkg/workspace/plugin/interactive.go
+++ b/staging/src/github.com/kcp-dev/cli/pkg/workspace/plugin/interactive.go
@@ -17,6 +17,7 @@ limitations under the License.
 package plugin
 
 import (
+	"fmt"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -125,6 +126,9 @@ func (m model) View() string {
 				typeRef = m.currentNode.info.Type.Path + ":" + typeRef
 			}
 			detailParts = append(detailParts, typeRef)
+		}
+		if m.currentNode.info.Cluster != "" {
+			detailParts = append(detailParts, fmt.Sprintf("cluster:%s", m.currentNode.info.Cluster))
 		}
 		details = detailStyle.Render(strings.Join(detailParts, " | "))
 	}


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary
```
change adds workspace cluster ID as part of the workspace
details when in interactive mode.
```
<img width="1259" height="232" alt="image" src="https://github.com/user-attachments/assets/d1635ea5-a3ef-4a09-8397-b3bfd2ae3191" />


## What Type of PR Is This?

<!--
/kind feature
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes [3727](https://github.com/kcp-dev/kcp/issues/3727)

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Added workspace cluster id as part of information displayed when in interactive mode.
```
