### PR TITLE
Add publishing-bot rules for `release-0.29`

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -1,72 +1,123 @@
 rules:
-  - destination: apimachinery
-    branches:
-      - name: main
-        source:
-          branch: main
-          dirs:
-            - staging/src/github.com/kcp-dev/apimachinery
-    destination-tag-base: v2
-    library: true
-  - destination: code-generator
-    branches:
-      - name: main
-        source:
-          branch: main
-          dirs:
-            - staging/src/github.com/kcp-dev/code-generator
-    destination-tag-base: v3
-    library: true
-  - destination: client-go
-    branches:
-      - name: main
-        dependencies:
-          - repository: apimachinery
-            branch: main
-          - repository: code-generator
-            branch: main
-        source:
-          branch: main
-          dirs:
-            - staging/src/github.com/kcp-dev/client-go
-    destination-tag-base: v0
-    library: true
-  - destination: sdk
-    branches:
-      - name: main
-        dependencies:
-          - repository: apimachinery
-            branch: main
-          - repository: code-generator
-            branch: main
-          - repository: client-go
-            branch: main          
-        source:
-          branch: main
-          dirs:
-            - staging/src/github.com/kcp-dev/sdk
-    destination-tag-base: v0
-    library: true
-  - destination: cli
-    branches:
-      - name: main
-        dependencies:
-          - repository: apimachinery
-            branch: main
-          - repository: code-generator
-            branch: main
-          - repository: client-go
-            branch: main
-          - repository: sdk
-            branch: main
-        source:
-          branch: main
-          dirs:
-            - staging/src/github.com/kcp-dev/cli
-    destination-tag-base: v0
-    library: true
+- destination: apimachinery
+  branches:
+  - name: main
+    source:
+      branch: main
+      dirs:
+      - staging/src/github.com/kcp-dev/apimachinery
+  - name: release-0.29
+    go: 1.24.9
+    source:
+      branch: release-0.29
+      dirs:
+      - staging/src/github.com/kcp-dev/apimachinery
+  destination-tag-base: v2
+  library: true
+- destination: code-generator
+  branches:
+  - name: main
+    source:
+      branch: main
+      dirs:
+      - staging/src/github.com/kcp-dev/code-generator
+  - name: release-0.29
+    go: 1.24.9
+    source:
+      branch: release-0.29
+      dirs:
+      - staging/src/github.com/kcp-dev/code-generator
+  destination-tag-base: v3
+  library: true
+- destination: client-go
+  branches:
+  - name: main
+    dependencies:
+    - repository: apimachinery
+      branch: main
+    - repository: code-generator
+      branch: main
+    source:
+      branch: main
+      dirs:
+      - staging/src/github.com/kcp-dev/client-go
+  - name: release-0.29
+    go: 1.24.9
+    dependencies:
+    - repository: apimachinery
+      branch: release-0.29
+    - repository: code-generator
+      branch: release-0.29
+    source:
+      branch: release-0.29
+      dirs:
+      - staging/src/github.com/kcp-dev/client-go
+  destination-tag-base: v0
+  library: true
+- destination: sdk
+  branches:
+  - name: main
+    dependencies:
+    - repository: apimachinery
+      branch: main
+    - repository: code-generator
+      branch: main
+    - repository: client-go
+      branch: main
+    source:
+      branch: main
+      dirs:
+      - staging/src/github.com/kcp-dev/sdk
+  - name: release-0.29
+    go: 1.24.9
+    dependencies:
+    - repository: apimachinery
+      branch: release-0.29
+    - repository: code-generator
+      branch: release-0.29
+    - repository: client-go
+      branch: release-0.29
+    source:
+      branch: release-0.29
+      dirs:
+      - staging/src/github.com/kcp-dev/sdk
+  destination-tag-base: v0
+  library: true
+- destination: cli
+  branches:
+  - name: main
+    dependencies:
+    - repository: apimachinery
+      branch: main
+    - repository: code-generator
+      branch: main
+    - repository: client-go
+      branch: main
+    - repository: sdk
+      branch: main
+    source:
+      branch: main
+      dirs:
+      - staging/src/github.com/kcp-dev/cli
+  - name: release-0.29
+    go: 1.24.9
+    dependencies:
+    - repository: apimachinery
+      branch: release-0.29
+    - repository: code-generator
+      branch: release-0.29
+    - repository: client-go
+      branch: release-0.29
+    - repository: sdk
+      branch: release-0.29
+    source:
+      branch: release-0.29
+      dirs:
+      - staging/src/github.com/kcp-dev/cli
+  destination-tag-base: v0
+  library: true
 recursive-delete-patterns:
   - '*/.gitattributes'
-default-go-version: 1.24.5
+default-go-version: 1.24.9
 skip-tags: false
 skip-non-semver-tags: true


### PR DESCRIPTION
## Summary

Add publishing-bot rules for the `release-0.29` branch. The diff is larger because this is the first time we use automation for managing this file and it uses a different indentation (we might fix that for the next time in our publishing-bot fork).

Command used (ran in the `publishing-bot` repo):

```bash
_output/update-rules -branch release-0.29 -go 1.24.9 -rules ../kcp/staging/publishing/rules.yaml -o /tmp/rules.yaml
```

## What Type of PR Is This?

/kind cleanup

## Release Notes
```release-note
NONE
```

/assign @xrstf @mjudeikis 