### PR TITLE
update to Go 1.24.11

### DIFF
--- a/.github/workflows/docs-gen-and-push.yaml
+++ b/.github/workflows/docs-gen-and-push.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # tag=v6.1.0
         with:
-          go-version: v1.24.9
+          go-version: v1.24.11
           cache: true
 
       - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 #tag=v6.1.0

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # tag=v6.1.0
         with:
-          go-version: v1.24.9
+          go-version: v1.24.11
 
       - name: Delete non-semver tags
         run: 'git tag -d $(git tag -l | grep -v "^v")'

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.11-1
           command:
             - make
             - verify-boilerplate
@@ -27,7 +27,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.11-1
           command:
             - make
             - verify-codegen
@@ -44,7 +44,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.11-1
           command:
             - make
             - lint
@@ -83,7 +83,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.11-1
           command:
             - make
             - test
@@ -104,7 +104,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.11-1
           command:
             - ./hack/run-with-prow.sh
             - ./hack/run-with-prometheus.sh
@@ -131,7 +131,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.11-1
           command:
             - ./hack/run-with-prow.sh
             - ./hack/run-with-prometheus.sh
@@ -160,7 +160,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.11-1
           command:
             - ./hack/run-with-prow.sh
             - ./hack/run-with-prometheus.sh
@@ -193,7 +193,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.11-1
           command:
             - ./hack/run-with-prow.sh
             - ./hack/run-with-prometheus.sh
@@ -222,7 +222,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.24.9-1
+        - image: ghcr.io/kcp-dev/infra/build:1.24.11-1
           command:
             - ./hack/run-with-prow.sh
             - ./hack/run-with-prometheus.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Build the binary
-FROM --platform=${BUILDPLATFORM} docker.io/golang:1.24.9 AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/golang:1.24.11 AS builder
 WORKDIR /workspace
 
 # Install dependencies.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ module github.com/kcp-dev/kcp
 // The script hack/verify-go-versions.sh checks that all version
 // references across the codebase are consistent with the versions
 // maintained here.
-// go-build-version 1.24.9
+// go-build-version 1.24.11
 go 1.24.0
 
 require (

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -7,7 +7,7 @@ rules:
       dirs:
       - staging/src/github.com/kcp-dev/apimachinery
   - name: release-0.29
-    go: 1.24.9
+    go: 1.24.11
     source:
       branch: release-0.29
       dirs:
@@ -22,7 +22,7 @@ rules:
       dirs:
       - staging/src/github.com/kcp-dev/code-generator
   - name: release-0.29
-    go: 1.24.9
+    go: 1.24.11
     source:
       branch: release-0.29
       dirs:
@@ -42,7 +42,7 @@ rules:
       dirs:
       - staging/src/github.com/kcp-dev/client-go
   - name: release-0.29
-    go: 1.24.9
+    go: 1.24.11
     dependencies:
     - repository: apimachinery
       branch: release-0.29
@@ -69,7 +69,7 @@ rules:
       dirs:
       - staging/src/github.com/kcp-dev/sdk
   - name: release-0.29
-    go: 1.24.9
+    go: 1.24.11
     dependencies:
     - repository: apimachinery
       branch: release-0.29
@@ -100,7 +100,7 @@ rules:
       dirs:
       - staging/src/github.com/kcp-dev/cli
   - name: release-0.29
-    go: 1.24.9
+    go: 1.24.11
     dependencies:
     - repository: apimachinery
       branch: release-0.29
@@ -118,6 +118,6 @@ rules:
   library: true
 recursive-delete-patterns:
   - '*/.gitattributes'
-default-go-version: 1.24.9
+default-go-version: 1.24.11
 skip-tags: false
 skip-non-semver-tags: true


### PR DESCRIPTION
## Summary
Hot off the presses, Go 1.24.11 fixes some CVE, so let's update.

## What Type of PR Is This?
/kind chore

## Release Notes
```release-note
Update to Go 1.24.11.
```
