### PR TITLE
add workspace path to audit event logs

### DIFF
--- a/pkg/cache/server/config.go
+++ b/pkg/cache/server/config.go
@@ -141,7 +141,7 @@ func NewConfig(opts *cacheserveroptions.CompletedOptions, optionalLocalShardRest
 		apiHandler = genericapiserver.DefaultBuildHandlerChainFromImpersonationToAuthz(apiHandler, genericConfig)
 		apiHandler = genericapiserver.DefaultBuildHandlerChainFromStartToBeforeImpersonation(apiHandler, genericConfig)
 
-		apiHandler = filters.WithAuditEventClusterAnnotation(apiHandler)
+		apiHandler = filters.WithAuditEventClusterAnnotation(apiHandler, nil)
 		apiHandler = filters.WithClusterScope(apiHandler)
 		apiHandler = WithShardScope(apiHandler)
 		apiHandler = WithServiceScope(apiHandler)

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -526,7 +526,7 @@ func NewConfig(ctx context.Context, opts kcpserveroptions.CompletedOptions) (*Co
 		// But this is not harmful as the kcp warnings are not many.
 		apiHandler = filters.WithWarningRecorder(apiHandler)
 
-		apiHandler = kcpfilters.WithAuditEventClusterAnnotation(apiHandler)
+		apiHandler = kcpfilters.WithAuditEventClusterAnnotation(apiHandler, c.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters())
 		apiHandler = kcpfilters.WithBlockInactiveLogicalClusters(apiHandler, c.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters())
 
 		// Add a mux before the chain, for other handlers with their own handler chain to hook in. For example, when

--- a/test/e2e/audit/policy.yaml
+++ b/test/e2e/audit/policy.yaml
@@ -4,6 +4,6 @@ rules:
   - level: Request
     verbs: ["list"]
     resources:
-    - group: "" 
-      resources: ["configmaps"]
+      - group: ""
+        resources: ["configmaps"]
     namespaces: ["default"]


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary
```
change adds workspace path to the audit event logs
```
```json 
{
  "kind": "Event",
  "apiVersion": "audit.k8s.io/v1",
  "level": "Request",
  "auditID": "5684337a-48d6-4491-aed2-a0bca6fcda2b",
  "stage": "RequestReceived",
  "requestURI": "/api/v1/namespaces/default/configmaps?limit=500",
  "verb": "list",
  "user": {
    "username": "kcp-admin",
    "uid": "e6741a4d-fc7c-44c5-b5ec-9357b44b7e0b",
    "groups": [
      "system:kcp:admin",
      "system:authenticated"
    ]
  },
  "sourceIPs": [
    "127.0.0.1"
  ],
  "userAgent": "kubectl/v1.30.1 (darwin/arm64) kubernetes/6911225",
  "objectRef": {
    "resource": "configmaps",
    "namespace": "default",
    "apiVersion": "v1"
  },
  "requestReceivedTimestamp": "2025-12-09T16:03:44.214758Z",
  "stageTimestamp": "2025-12-09T16:03:44.214758Z",
**  "annotations": {
    "kcp.io/cluster": "16iai06e7ob717ht",
    "kcp.io/path": "root:consumer:meme",
    "tenancy.kcp.io/workspace": "16iai06e7ob717ht"
  }**
}
```

## What Type of PR Is This?
/kind feature
<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes [3734](https://github.com/kcp-dev/kcp/issues/3734)

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Added workspace path to the event logs annotation.
```
