### PR TITLE
cache: set log levels for embeddedetcd to "error"

### DIFF
--- a/pkg/cache/server/config.go
+++ b/pkg/cache/server/config.go
@@ -95,6 +95,7 @@ func NewConfig(opts *cacheserveroptions.CompletedOptions, optionalLocalShardRest
 		if err != nil {
 			return nil, err
 		}
+		c.EmbeddedEtcd.LogLevel = "error"
 	}
 	// change the storage prefix under which all resources are kept
 	// this allows us to store the same GR under a different


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

This PR sets log levels for embeddedetcd in the cache server to `error`. This is similar to what we set in kcp's apiserver, otherwise the logs are flooded with embeddedetcd's info logs.

https://github.com/kcp-dev/kcp/blob/8d6365a7a901a1c7790d06b82d18794f8f8c21a8/pkg/server/config.go#L203-L210

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind cleanup

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
