### PR TITLE
sdk: .status.endpoints in endpoint slices should have omitempty tag

### DIFF
--- a/staging/src/github.com/kcp-dev/sdk/apis/apis/v1alpha1/types_apiexportendpointslice.go
+++ b/staging/src/github.com/kcp-dev/sdk/apis/apis/v1alpha1/types_apiexportendpointslice.go
@@ -78,7 +78,7 @@ type APIExportEndpointSliceStatus struct {
 	// +optional
 	// +listType=map
 	// +listMapKey=url
-	APIExportEndpoints []APIExportEndpoint `json:"endpoints"`
+	APIExportEndpoints []APIExportEndpoint `json:"endpoints,omitempty"`
 
 	// +optional
 

--- a/staging/src/github.com/kcp-dev/sdk/apis/cache/v1alpha1/types_cachedresourceendpointslice.go
+++ b/staging/src/github.com/kcp-dev/sdk/apis/cache/v1alpha1/types_cachedresourceendpointslice.go
@@ -73,7 +73,7 @@ type CachedResourceEndpointSliceStatus struct {
 	// +optional
 	// +listType=map
 	// +listMapKey=url
-	CachedResourceEndpoints []CachedResourceEndpoint `json:"endpoints"`
+	CachedResourceEndpoints []CachedResourceEndpoint `json:"endpoints,omitempty"`
 
 	// shardSelector is the selector used to filter the shards. It is used to filter the shards
 	// when determining partition scope when deriving the endpoints. This is set by owning shard,


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

This PR changes endpoint slice definitions (specifically APIExportEndpointSlice and CachedResourceEndpointSlice), and adds `,omitempty` tag to their `.status.endpoints` field.

This really makes difference only in the on-wire format, and JSON unmarshaller handles the missing zero-valued field gracefully in any case.

On the other hand when working with unstructured endpoint slices, not having `omitempty` on the slice occupies a weird tri-state where it can either:

* (a) be present and contain items,
* (b) be present but still be `nil` or empty,
* (c) not be present (theoretical, but still needs to be checked).

See https://github.com/kcp-dev/kcp/pull/3764#discussion_r2624268312 for example.

APIExportEndpointSliceStatus.APIExportEndpoints actually used to have the `omitempty` tag:

https://github.com/kcp-dev/kcp/blob/3299700e246195336e390b1391423dfef41b6f78/sdk/apis/apis/v1alpha1/types_apiexportendpointslice.go#L69-L80

... but lost it in https://github.com/kcp-dev/kcp/pull/3256. I'm not sure if this was by accident, or made intentionally -- in which case we can just leave it as it is.

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind bug
/kind api-change

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
* JSON representation of APIExportEndpointSlice.status.endpoints field is now omitted when empty
* JSON representation of CachedResourceEndpointSlice.status.endpoints field is now omitted when empty
```
