### PR TITLE
Enable namespace lifecycle plugin  & pre-create kube-system ns

### DIFF
--- a/config/universal/kube-system-namespace.yaml
+++ b/config/universal/kube-system-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kube-system
+  annotations:
+    "bootstrap.kcp.io/create-only": "true"

--- a/pkg/admission/plugins.go
+++ b/pkg/admission/plugins.go
@@ -70,7 +70,8 @@ import (
 )
 
 // AllOrderedPlugins is the list of all the plugins in order.
-var AllOrderedPlugins = beforeWebhooks(kubeapiserveroptions.AllOrderedPlugins,
+var AllOrderedPlugins = beforeWebhooks(
+	kubeapiserveroptions.AllOrderedPlugins,
 	workspacenamespacelifecycle.PluginName,
 	apiresourceschema.PluginName,
 	workspace.PluginName,

--- a/test/e2e/quota/quota_test.go
+++ b/test/e2e/quota/quota_test.go
@@ -402,9 +402,9 @@ func TestClusterScopedQuota(t *testing.T) {
 			if !ok {
 				return false, fmt.Sprintf("waiting for %q count/configmaps to show up in used", wsPath)
 			}
-			// 1 for each kube-root-ca.crt x 2 namespaces = 2
-			if !used.Equal(resource.MustParse("2")) {
-				return false, fmt.Sprintf("waiting for %q count/configmaps %s to be 2", wsPath, used.String())
+			// 1 for each kube-root-ca.crt x 3 namespaces = 3
+			if !used.Equal(resource.MustParse("3")) {
+				return false, fmt.Sprintf("waiting for %q count/configmaps %s to be 3", wsPath, used.String())
 			}
 
 			used, ok = quota.Status.Used["count/workspaces.tenancy.kcp.io"]
@@ -416,7 +416,7 @@ func TestClusterScopedQuota(t *testing.T) {
 			}
 
 			return true, ""
-		}, wait.ForeverTestTimeout, 100*time.Millisecond, "error waiting for 2 used configmaps and 1 used workspace")
+		}, wait.ForeverTestTimeout, 100*time.Millisecond, "error waiting for 3 used configmaps and 1 used workspace")
 
 		t.Logf("Make sure quota is enforcing configmap limits for %q", wsPath)
 		kcptestinghelpers.Eventually(t, func() (bool, string) {


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

## What Type of PR Is This?

/kind feature

Enable namepspace lifecycle plugin and add `kube-system` namespace
```
~/go/src/github.com/kcp-dev/kcp kube.system.ns* ❯ k create ns bob                                                             15:56:46
Error from server (AlreadyExists): namespaces "bob" already exists
~/go/src/github.com/kcp-dev/kcp kube.system.ns* ❯ k delete ns bob                                                             15:56:50
namespace "bob" deleted

~/go/src/github.com/kcp-dev/kcp kube.system.ns* 5s ❯                                                                          15:56:59
~/go/src/github.com/kcp-dev/kcp kube.system.ns* ❯ k get ns                                                                    15:56:59
NAME          STATUS   AGE
default       Active   9m15s
kube-system   Active   9m15s
~/go/src/github.com/kcp-dev/kcp kube.system.ns* ❯ k delete ns --all                                                           15:57:01
Error from server (Forbidden): namespaces "default" is forbidden: this namespace may not be deleted
Error from server (Forbidden): namespaces "kube-system" is forbidden: this namespace may not be deleted
```

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Add kubernetes lifecycle plugin & add kube-system namespace
```
