### PR TITLE
refactor: use testing.T.Context() instead of context.WithCancel

### DIFF
--- a/pkg/authentication/index_test.go
+++ b/pkg/authentication/index_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package authentication
 
 import (
-	"context"
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -41,8 +39,7 @@ func TestCrossShardWorkspaceType(t *testing.T) {
 		teamCluster = "logicalteamcluster"
 	)
 
-	ctx, cancel := context.WithCancelCause(context.Background())
-	defer cancel(errors.New("test has ended"))
+	ctx := t.Context()
 
 	clusterIndex := index.New(nil)
 	authIndex := NewIndex(ctx, nil)

--- a/staging/src/github.com/kcp-dev/code-generator/examples/test/kcp/controller_test.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/test/kcp/controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package kcp
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -36,8 +35,7 @@ import (
 
 // TestFakeClient demonstrates how to use a fake client with SharedInformerFactory in tests.
 func TestFakeClient(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	watcherStarted := make(chan struct{})
 	// Create the fake client.

--- a/staging/src/github.com/kcp-dev/code-generator/examples/test/kcpexisting/controller_test.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/test/kcpexisting/controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package kcpexisting
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -36,8 +35,7 @@ import (
 
 // TestFakeClient demonstrates how to use a fake client with SharedInformerFactory in tests.
 func TestFakeClient(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	watcherStarted := make(chan struct{})
 	// Create the fake client.

--- a/staging/src/github.com/kcp-dev/code-generator/examples/test/singlecluster/controller_test.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/test/singlecluster/controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package singlecluster
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -34,8 +33,7 @@ import (
 
 // TestFakeClient demonstrates how to use a fake client with SharedInformerFactory in tests.
 func TestFakeClient(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	watcherStarted := make(chan struct{})
 	// Create the fake client.

--- a/test/e2e/apibinding/apibinding_deletion_test.go
+++ b/test/e2e/apibinding/apibinding_deletion_test.go
@@ -53,8 +53,7 @@ func TestAPIBindingDeletion(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 	providerPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)

--- a/test/e2e/apibinding/apibinding_logicalcluster_test.go
+++ b/test/e2e/apibinding/apibinding_logicalcluster_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package apibinding
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -60,8 +59,7 @@ func TestAPIBindingLogicalCluster(t *testing.T) {
 	t.Logf("providerPath: %v", providerPath)
 	t.Logf("consumerPath: %v", consumerPath)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	cfg := server.BaseConfig(t)
 
@@ -193,8 +191,7 @@ func TestAPIBindingCRDs(t *testing.T) {
 	t.Logf("providerPath: %v", providerPath)
 	t.Logf("consumerPath: %v", consumerPath)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	cfg := server.BaseConfig(t)
 

--- a/test/e2e/apibinding/apibinding_permissionclaims_test.go
+++ b/test/e2e/apibinding/apibinding_permissionclaims_test.go
@@ -55,8 +55,7 @@ func TestAPIBindingPermissionClaimsConditions(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 	providerPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)

--- a/test/e2e/apibinding/apibinding_protected_test.go
+++ b/test/e2e/apibinding/apibinding_protected_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package apibinding
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -47,8 +46,7 @@ func TestProtectedAPI(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 	providerPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)

--- a/test/e2e/apibinding/apibinding_test.go
+++ b/test/e2e/apibinding/apibinding_test.go
@@ -67,8 +67,7 @@ func TestAPIBindingAPIExportReferenceImmutability(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 	providerPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath, kcptesting.WithName("service-provider-1"))
@@ -167,8 +166,7 @@ func TestAPIBinding(t *testing.T) {
 	server := kcptesting.SharedKcpServer(t)
 	cfg := server.BaseConfig(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	t.Logf("Check if we can access shards")
 	var shards *corev1alpha1.ShardList

--- a/test/e2e/apibinding/apibinding_webhook_test.go
+++ b/test/e2e/apibinding/apibinding_webhook_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package apibinding
 
 import (
-	"context"
 	"crypto/tls"
 	"fmt"
 	gohttp "net/http"
@@ -62,8 +61,7 @@ func TestAPIBindingMutatingWebhook(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 	sourcePath, sourceWS := kcptesting.NewWorkspaceFixture(t, server, orgPath)
@@ -247,8 +245,7 @@ func TestAPIBindingValidatingWebhook(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 	sourcePath, sourceWS := kcptesting.NewWorkspaceFixture(t, server, orgPath)

--- a/test/e2e/apibinding/default_apibinding_test.go
+++ b/test/e2e/apibinding/default_apibinding_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package apibinding
 
 import (
-	"context"
 	"fmt"
 	"slices"
 	"strings"
@@ -57,8 +56,7 @@ func TestDefaultAPIBinding(t *testing.T) {
 
 	t.Logf("providerPath: %v", providerPath)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	cfg := server.BaseConfig(t)
 

--- a/test/e2e/apibinding/maximalpermissionpolicy_authorizer_test.go
+++ b/test/e2e/apibinding/maximalpermissionpolicy_authorizer_test.go
@@ -57,8 +57,7 @@ func TestMaximalPermissionPolicyAuthorizerSystemGroupProtection(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	kubeClusterClient, err := kcpkubernetesclientset.NewForConfig(server.BaseConfig(t))
 	require.NoError(t, err, "failed to construct dynamic cluster client for server")
@@ -152,8 +151,7 @@ func TestMaximalPermissionPolicyAuthorizer(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 	rbacServiceProviderPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)

--- a/test/e2e/authorizer/scopes_test.go
+++ b/test/e2e/authorizer/scopes_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package authorizer
 
 import (
-	"context"
 	"fmt"
 	"sort"
 	"testing"
@@ -149,8 +148,7 @@ func TestSubjectAccessReview(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := t.Context()
 
 			req := &authorizationv1.SubjectAccessReview{
 				Spec: authorizationv1.SubjectAccessReviewSpec{
@@ -179,8 +177,7 @@ func TestSelfSubjectRulesReview(t *testing.T) {
 	t.Parallel()
 	framework.Suite(t, "control-plane")
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	server := kcptesting.SharedKcpServer(t)
 	cfg := server.BaseConfig(t)
@@ -298,8 +295,7 @@ func TestSelfSubjectRulesReview(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := t.Context()
 
 			// impersonate as user, using the cfg as the base.
 			impersonationConfig := rest.CopyConfig(cfg)

--- a/test/e2e/customresourcedefinition/customresourcedefinition_test.go
+++ b/test/e2e/customresourcedefinition/customresourcedefinition_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package customresourcedefinition
 
 import (
-	"context"
 	"embed"
 	"testing"
 
@@ -44,8 +43,7 @@ func TestCustomResourceCreation(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 	sourcePath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)

--- a/test/e2e/garbagecollector/garbagecollector_test.go
+++ b/test/e2e/garbagecollector/garbagecollector_test.go
@@ -64,8 +64,7 @@ func TestGarbageCollectorBuiltInCoreV1Types(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	cfg := server.BaseConfig(t)
 
@@ -109,8 +108,7 @@ func TestGarbageCollectorTypesFromBinding(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 
@@ -275,8 +273,7 @@ func TestGarbageCollectorNormalCRDs(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	cfg := server.BaseConfig(t)
 
@@ -361,8 +358,7 @@ func TestGarbageCollectorVersionedCRDs(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	cfg := server.BaseConfig(t)
 
@@ -527,8 +523,7 @@ func TestGarbageCollectorClusterScopedCRD(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	cfg := server.BaseConfig(t)
 

--- a/test/e2e/quota/quota_test.go
+++ b/test/e2e/quota/quota_test.go
@@ -59,8 +59,7 @@ func TestKubeQuotaBuiltInCoreV1Types(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	cfg := server.BaseConfig(t)
 
@@ -116,8 +115,7 @@ func TestKubeQuotaCoreV1TypesFromBinding(t *testing.T) {
 
 	source := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	// Test multiple workspaces in parallel
 	for i := range 5 {
@@ -251,8 +249,7 @@ func TestKubeQuotaNormalCRDs(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	cfg := server.BaseConfig(t)
 
@@ -336,8 +333,7 @@ func TestClusterScopedQuota(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	cfg := server.BaseConfig(t)
 

--- a/test/e2e/reconciler/apiexport/apiexport_controller_test.go
+++ b/test/e2e/reconciler/apiexport/apiexport_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package apiexport
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -42,8 +41,7 @@ func TestRequeueWhenIdentitySecretAdded(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 	workspacePath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)

--- a/test/e2e/reconciler/apiexportendpointslice/apiexportendpointslice_test.go
+++ b/test/e2e/reconciler/apiexportendpointslice/apiexportendpointslice_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package apiexportendpointslice
 
 import (
-	"context"
 	"embed"
 	"fmt"
 	"testing"
@@ -54,8 +53,7 @@ var testFiles embed.FS
 
 func TestAPIExportEndpointSliceWithPartition(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	server := kcptesting.SharedKcpServer(t)
 
 	// Create Organization and Workspaces
@@ -181,8 +179,7 @@ func TestAPIBindingEndpointSlicesSharded(t *testing.T) {
 	framework.Suite(t, "control-plane")
 
 	server := kcptesting.SharedKcpServer(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	cfg := server.BaseConfig(t)
 

--- a/test/e2e/reconciler/cache/replication_test.go
+++ b/test/e2e/reconciler/cache/replication_test.go
@@ -436,8 +436,7 @@ func TestReplication(t *testing.T) {
 	framework.Suite(t, "control-plane")
 
 	server := kcptesting.SharedKcpServer(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	kcpRootShardConfig := server.RootShardSystemMasterBaseConfig(t)
 	kcpShardDynamicClient, err := kcpdynamic.NewForConfig(kcpRootShardConfig)
@@ -479,8 +478,7 @@ func TestReplicationDisruptive(t *testing.T) {
 			server := kcptesting.PrivateKcpServer(t,
 				kcptestingserver.WithCustomArguments("--token-auth-file", framework.DefaultTokenAuthFile),
 			)
-			ctx, cancel := context.WithCancel(context.Background())
-			t.Cleanup(cancel)
+			ctx := t.Context()
 
 			kcpRootShardConfig := server.RootShardSystemMasterBaseConfig(t)
 			kcpRootShardDynamicClient, err := kcpdynamic.NewForConfig(kcpRootShardConfig)

--- a/test/e2e/reconciler/cachedresourceendpointslice/cachedresourceendpointslice_test.go
+++ b/test/e2e/reconciler/cachedresourceendpointslice/cachedresourceendpointslice_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cachedresourceendpointslice
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -44,8 +43,7 @@ func TestCachedResourceEndpointSliceWithPath(t *testing.T) {
 	t.Parallel()
 	framework.Suite(t, "control-plane")
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	server := kcptesting.SharedKcpServer(t)
 
 	// Create Organization and Workspaces

--- a/test/e2e/reconciler/partitionset/partitionset_test.go
+++ b/test/e2e/reconciler/partitionset/partitionset_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package partitionset
 
 import (
-	"context"
 	"fmt"
 	"reflect"
 	"strings"
@@ -44,8 +43,7 @@ import (
 
 func TestPartitionSet(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	server := kcptesting.SharedKcpServer(t)
 
 	// Create organization and workspace.
@@ -264,8 +262,7 @@ func TestPartitionSet(t *testing.T) {
 
 func TestPartitionSetAdmission(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	server := kcptesting.SharedKcpServer(t)
 
 	// Create organization and workspace.

--- a/test/e2e/reconciler/workspace/apibinding_initializer_test.go
+++ b/test/e2e/reconciler/workspace/apibinding_initializer_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package workspace
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -43,8 +42,7 @@ func TestWorkspaceTypesAPIBindingInitialization(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 

--- a/test/e2e/server/url_test.go
+++ b/test/e2e/server/url_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package server
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"net/url"
@@ -82,9 +81,7 @@ func TestURLs(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			// TODO(ntnn): Replace with t.Context in go1.24
-			ctx, cancel := context.WithCancel(context.Background())
-			t.Cleanup(cancel)
+			ctx := t.Context()
 
 			u, err := url.Parse(cfg.Host)
 			require.NoError(t, err)
@@ -120,9 +117,7 @@ func TestURLWithClusterKind(t *testing.T) {
 		t.Run(string(scope), func(t *testing.T) {
 			t.Parallel()
 
-			// TODO(ntnn): Replace with t.Context in go1.24
-			ctx, cancel := context.WithCancel(context.Background())
-			t.Cleanup(cancel)
+			ctx := t.Context()
 
 			orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 

--- a/test/e2e/virtual/apiexport/authorizer_test.go
+++ b/test/e2e/virtual/apiexport/authorizer_test.go
@@ -71,8 +71,7 @@ func TestAPIExportAuthorizers(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 
@@ -516,8 +515,7 @@ func TestAPIExportBindingAuthorizer(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 	cfg := server.BaseConfig(t)
@@ -922,8 +920,7 @@ func TestRootAPIExportAuthorizers(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 
@@ -1087,8 +1084,7 @@ func TestRootAPIExportAuthorizers(t *testing.T) {
 func vwURL(t *testing.T, kcpClusterClient kcpclientset.ClusterInterface, path logicalcluster.Path, export string, ws *tenancyv1alpha1.Workspace, wsPath logicalcluster.Path) string {
 	t.Helper()
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	t.Cleanup(cancelFunc)
+	ctx := t.Context()
 
 	var vwURL string
 	kcptestinghelpers.Eventually(t, func() (bool, string) {

--- a/test/e2e/virtual/apiexport/binding_test.go
+++ b/test/e2e/virtual/apiexport/binding_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package apiexport
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -56,8 +55,7 @@ func TestBinding(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	t.Logf("Creating two service workspaces and a consumer workspace")
 	org, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
@@ -257,8 +255,7 @@ func TestAPIBindingPermissionClaimsVerbs(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 	providerPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)
@@ -440,8 +437,7 @@ func TestAPIBindingPermissionClaimsSSA(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 	providerPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)
@@ -595,8 +591,7 @@ func TestAPIBindingPermissionClaimsSelectors(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 	providerPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)
@@ -841,8 +836,7 @@ func TestAPIBindingPermissionClaimsSelectorUpdate(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 	providerPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)

--- a/test/e2e/virtual/apiexport/openapi_test.go
+++ b/test/e2e/virtual/apiexport/openapi_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package apiexport
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -47,8 +46,7 @@ func TestAPIExportOpenAPI(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	cfg := server.BaseConfig(t)
 

--- a/test/e2e/virtual/apiexport/virtualworkspace_test.go
+++ b/test/e2e/virtual/apiexport/virtualworkspace_test.go
@@ -80,8 +80,7 @@ func TestAPIExportVirtualWorkspace(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	cfg := server.BaseConfig(t)
 
@@ -340,8 +339,7 @@ func TestAPIExportAPIBindingsAccess(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 	ws1Path, ws1 := kcptesting.NewWorkspaceFixture(t, server, orgPath, kcptesting.WithName("workspace1"))
@@ -568,8 +566,7 @@ func TestAPIExportPermissionClaims(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	// Need to Create a Producer w/ APIExport
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
@@ -1172,8 +1169,7 @@ func createClusterRoleAndBindings(name, subjectName, subjectKind string, verbs [
 }
 
 func admit(t *testing.T, kubeClusterClient kubernetesclientset.Interface, ruleName, subjectName, subjectKind string, verbs []string, resources ...string) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	t.Cleanup(cancelFunc)
+	ctx := t.Context()
 
 	cr, crb := createClusterRoleAndBindings(ruleName, subjectName, subjectKind, verbs, resources...)
 	_, err := kubeClusterClient.RbacV1().ClusterRoles().Create(ctx, cr, metav1.CreateOptions{})

--- a/test/e2e/virtual/replication/virtualworkspace_test.go
+++ b/test/e2e/virtual/replication/virtualworkspace_test.go
@@ -63,8 +63,7 @@ func TestCachedResourceVirtualWorkspace(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	cfg := server.BaseConfig(t)
 
@@ -425,8 +424,7 @@ func createClusterRoleAndBindings(name, subjectName, subjectKind string, verbs [
 }
 
 func admit(t *testing.T, kubeClusterClient kubernetesclientset.Interface, ruleName, subjectName, subjectKind string, verbs []string, resources ...string) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	t.Cleanup(cancelFunc)
+	ctx := t.Context()
 
 	cr, crb := createClusterRoleAndBindings(ruleName, subjectName, subjectKind, verbs, resources...)
 	_, err := kubeClusterClient.RbacV1().ClusterRoles().Create(ctx, cr, metav1.CreateOptions{})

--- a/test/e2e/virtualresources/cachedresources/vr_cachedresources_test.go
+++ b/test/e2e/virtualresources/cachedresources/vr_cachedresources_test.go
@@ -77,8 +77,7 @@ func TestCachedResources(t *testing.T) {
 	t.Logf("consumer1Path: %v", consumer1Path)
 	t.Logf("consumer2Path: %v", consumer2Path)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	cfg := server.BaseConfig(t)
 

--- a/test/e2e/watchcache/watchcache_enabled_test.go
+++ b/test/e2e/watchcache/watchcache_enabled_test.go
@@ -54,8 +54,7 @@ func TestWatchCacheEnabledForCRD(t *testing.T) {
 	framework.Suite(t, "control-plane")
 
 	server := kcptesting.SharedKcpServer(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 	// note that we schedule the workspace on the root shard because
 	// we need a direct and privileged access to it for downloading the metrics
@@ -114,8 +113,7 @@ func TestWatchCacheEnabledForAPIBindings(t *testing.T) {
 	framework.Suite(t, "control-plane")
 
 	server := kcptesting.SharedKcpServer(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 	clusterConfig := server.BaseConfig(t)
 	kcpClusterClient, err := kcpclientset.NewForConfig(clusterConfig)
 	require.NoError(t, err)
@@ -166,8 +164,7 @@ func TestWatchCacheEnabledForBuiltinTypes(t *testing.T) {
 	framework.Suite(t, "control-plane")
 
 	server := kcptesting.SharedKcpServer(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 	clusterConfig := server.BaseConfig(t)
 	kubeClusterClient, err := kcpkubernetesclientset.NewForConfig(clusterConfig)
 	require.NoError(t, err)

--- a/test/e2e/workspace/inactive_test.go
+++ b/test/e2e/workspace/inactive_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package workspace
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -41,9 +40,7 @@ func TestInactiveLogicalCluster(t *testing.T) {
 	t.Parallel()
 	framework.Suite(t, "control-plane")
 
-	// TODO(ntnn): Repalce with t.Context in go1.24
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	server := kcptesting.SharedKcpServer(t)
 	cfg := server.BaseConfig(t)

--- a/test/integration/workspace/leak_test.go
+++ b/test/integration/workspace/leak_test.go
@@ -101,8 +101,7 @@ var (
 )
 
 func TestWorkspaceDeletionLeak(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel) // TODO update in go1.24
+	ctx := t.Context()
 
 	_, kcpClient, _ := framework.StartTestServer(t)
 


### PR DESCRIPTION
Fixes #3535

## Changes
- Replace `ctx, cancel := context.WithCancel(context.Background())` pattern with `t.Context()` in test files
- Remove unused `defer cancel()` / `t.Cleanup(cancel)` calls
- Remove unused context imports where applicable

This is a mechanical refactoring that uses Go 1.21's `testing.T.Context()` method which automatically cancels the context when the test completes.