### PR TITLE
Move client-go copyright header to be date'less

### DIFF
--- a/pkg/reconciler/dynamicrestmapper/defaultrestmapper_kcp.go
+++ b/pkg/reconciler/dynamicrestmapper/defaultrestmapper_kcp.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright 2026 The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/client/clientset.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/client/clientset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/client/fake/clientset.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/client/fake/clientset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/client/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/client/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/client/fake/register.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/client/fake/register.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/client/scheme/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/client/scheme/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/client/scheme/register.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/client/scheme/register.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1/apiextensions_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1/apiextensions_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1/customresourcedefinition.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1/customresourcedefinition.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1/fake/apiextensions_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1/fake/apiextensions_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1/fake/customresourcedefinition.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1/fake/customresourcedefinition.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1beta1/apiextensions_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1beta1/apiextensions_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1beta1/customresourcedefinition.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1beta1/customresourcedefinition.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1beta1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1beta1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1beta1/fake/apiextensions_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1beta1/fake/apiextensions_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1beta1/fake/customresourcedefinition.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1beta1/fake/customresourcedefinition.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1beta1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1beta1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1beta1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1beta1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/informers/apiextensions/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/informers/apiextensions/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/informers/apiextensions/v1/customresourcedefinition.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/informers/apiextensions/v1/customresourcedefinition.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/informers/apiextensions/v1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/informers/apiextensions/v1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/informers/apiextensions/v1beta1/customresourcedefinition.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/informers/apiextensions/v1beta1/customresourcedefinition.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/informers/apiextensions/v1beta1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/informers/apiextensions/v1beta1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/informers/factory.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/informers/factory.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/informers/generic.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/informers/generic.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/informers/internalinterfaces/factory_interfaces.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/informers/internalinterfaces/factory_interfaces.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/listers/apiextensions/v1/customresourcedefinition.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/listers/apiextensions/v1/customresourcedefinition.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/listers/apiextensions/v1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/listers/apiextensions/v1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/listers/apiextensions/v1beta1/customresourcedefinition.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/listers/apiextensions/v1beta1/customresourcedefinition.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/listers/apiextensions/v1beta1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/listers/apiextensions/v1beta1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/hack/boilerplate/boilerplate.go.txt
+++ b/staging/src/github.com/kcp-dev/client-go/hack/boilerplate/boilerplate.go.txt
@@ -1,5 +1,5 @@
 /*
-Copyright YEAR The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/v1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/v1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/v1/mutatingwebhookconfiguration.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/v1/mutatingwebhookconfiguration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/v1/validatingadmissionpolicy.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/v1/validatingadmissionpolicy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/v1/validatingadmissionpolicybinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/v1/validatingadmissionpolicybinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/v1/validatingwebhookconfiguration.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/v1/validatingwebhookconfiguration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/v1alpha1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/v1alpha1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/v1alpha1/mutatingadmissionpolicy.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/v1alpha1/mutatingadmissionpolicy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/v1alpha1/mutatingadmissionpolicybinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/v1alpha1/mutatingadmissionpolicybinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/v1alpha1/validatingadmissionpolicy.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/v1alpha1/validatingadmissionpolicy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/v1alpha1/validatingadmissionpolicybinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/v1alpha1/validatingadmissionpolicybinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/v1beta1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/v1beta1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/v1beta1/mutatingadmissionpolicy.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/v1beta1/mutatingadmissionpolicy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/v1beta1/mutatingadmissionpolicybinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/v1beta1/mutatingadmissionpolicybinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/v1beta1/validatingadmissionpolicy.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/v1beta1/validatingadmissionpolicy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/v1beta1/validatingadmissionpolicybinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/v1beta1/validatingadmissionpolicybinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/v1beta1/validatingwebhookconfiguration.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/admissionregistration/v1beta1/validatingwebhookconfiguration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/apiserverinternal/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/apiserverinternal/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/apiserverinternal/v1alpha1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/apiserverinternal/v1alpha1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/apiserverinternal/v1alpha1/storageversion.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/apiserverinternal/v1alpha1/storageversion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/apps/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/apps/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/apps/v1/controllerrevision.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/apps/v1/controllerrevision.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/apps/v1/daemonset.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/apps/v1/daemonset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/apps/v1/deployment.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/apps/v1/deployment.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/apps/v1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/apps/v1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/apps/v1/replicaset.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/apps/v1/replicaset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/apps/v1/statefulset.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/apps/v1/statefulset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/apps/v1beta1/controllerrevision.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/apps/v1beta1/controllerrevision.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/apps/v1beta1/deployment.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/apps/v1beta1/deployment.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/apps/v1beta1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/apps/v1beta1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/apps/v1beta1/statefulset.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/apps/v1beta1/statefulset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/apps/v1beta2/controllerrevision.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/apps/v1beta2/controllerrevision.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/apps/v1beta2/daemonset.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/apps/v1beta2/daemonset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/apps/v1beta2/deployment.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/apps/v1beta2/deployment.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/apps/v1beta2/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/apps/v1beta2/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/apps/v1beta2/replicaset.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/apps/v1beta2/replicaset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/apps/v1beta2/statefulset.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/apps/v1beta2/statefulset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/autoscaling/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/autoscaling/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/autoscaling/v1/horizontalpodautoscaler.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/autoscaling/v1/horizontalpodautoscaler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/autoscaling/v1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/autoscaling/v1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/autoscaling/v2/horizontalpodautoscaler.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/autoscaling/v2/horizontalpodautoscaler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/autoscaling/v2/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/autoscaling/v2/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/autoscaling/v2beta1/horizontalpodautoscaler.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/autoscaling/v2beta1/horizontalpodautoscaler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/autoscaling/v2beta1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/autoscaling/v2beta1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/autoscaling/v2beta2/horizontalpodautoscaler.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/autoscaling/v2beta2/horizontalpodautoscaler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/autoscaling/v2beta2/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/autoscaling/v2beta2/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/batch/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/batch/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/batch/v1/cronjob.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/batch/v1/cronjob.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/batch/v1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/batch/v1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/batch/v1/job.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/batch/v1/job.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/batch/v1beta1/cronjob.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/batch/v1beta1/cronjob.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/batch/v1beta1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/batch/v1beta1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/certificates/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/certificates/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/certificates/v1/certificatesigningrequest.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/certificates/v1/certificatesigningrequest.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/certificates/v1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/certificates/v1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/certificates/v1alpha1/clustertrustbundle.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/certificates/v1alpha1/clustertrustbundle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/certificates/v1alpha1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/certificates/v1alpha1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/certificates/v1alpha1/podcertificaterequest.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/certificates/v1alpha1/podcertificaterequest.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/certificates/v1beta1/certificatesigningrequest.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/certificates/v1beta1/certificatesigningrequest.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/certificates/v1beta1/clustertrustbundle.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/certificates/v1beta1/clustertrustbundle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/certificates/v1beta1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/certificates/v1beta1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/coordination/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/coordination/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/coordination/v1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/coordination/v1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/coordination/v1/lease.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/coordination/v1/lease.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/coordination/v1alpha2/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/coordination/v1alpha2/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/coordination/v1alpha2/leasecandidate.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/coordination/v1alpha2/leasecandidate.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/coordination/v1beta1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/coordination/v1beta1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/coordination/v1beta1/lease.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/coordination/v1beta1/lease.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/coordination/v1beta1/leasecandidate.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/coordination/v1beta1/leasecandidate.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/core/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/core/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/core/v1/componentstatus.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/core/v1/componentstatus.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/core/v1/configmap.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/core/v1/configmap.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/core/v1/endpoints.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/core/v1/endpoints.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/core/v1/event.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/core/v1/event.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/core/v1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/core/v1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/core/v1/limitrange.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/core/v1/limitrange.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/core/v1/namespace.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/core/v1/namespace.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/core/v1/node.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/core/v1/node.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/core/v1/persistentvolume.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/core/v1/persistentvolume.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/core/v1/persistentvolumeclaim.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/core/v1/persistentvolumeclaim.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/core/v1/pod.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/core/v1/pod.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/core/v1/podtemplate.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/core/v1/podtemplate.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/core/v1/replicationcontroller.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/core/v1/replicationcontroller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/core/v1/resourcequota.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/core/v1/resourcequota.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/core/v1/secret.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/core/v1/secret.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/core/v1/service.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/core/v1/service.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/core/v1/serviceaccount.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/core/v1/serviceaccount.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/discovery/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/discovery/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/discovery/v1/endpointslice.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/discovery/v1/endpointslice.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/discovery/v1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/discovery/v1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/discovery/v1beta1/endpointslice.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/discovery/v1beta1/endpointslice.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/discovery/v1beta1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/discovery/v1beta1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/events/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/events/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/events/v1/event.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/events/v1/event.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/events/v1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/events/v1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/events/v1beta1/event.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/events/v1beta1/event.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/events/v1beta1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/events/v1beta1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/extensions/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/extensions/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/extensions/v1beta1/daemonset.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/extensions/v1beta1/daemonset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/extensions/v1beta1/deployment.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/extensions/v1beta1/deployment.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/extensions/v1beta1/ingress.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/extensions/v1beta1/ingress.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/extensions/v1beta1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/extensions/v1beta1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/extensions/v1beta1/networkpolicy.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/extensions/v1beta1/networkpolicy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/extensions/v1beta1/replicaset.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/extensions/v1beta1/replicaset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/factory.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/factory.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/flowcontrol/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/flowcontrol/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/flowcontrol/v1/flowschema.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/flowcontrol/v1/flowschema.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/flowcontrol/v1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/flowcontrol/v1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/flowcontrol/v1/prioritylevelconfiguration.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/flowcontrol/v1/prioritylevelconfiguration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/flowcontrol/v1beta1/flowschema.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/flowcontrol/v1beta1/flowschema.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/flowcontrol/v1beta1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/flowcontrol/v1beta1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/flowcontrol/v1beta1/prioritylevelconfiguration.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/flowcontrol/v1beta1/prioritylevelconfiguration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/flowcontrol/v1beta2/flowschema.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/flowcontrol/v1beta2/flowschema.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/flowcontrol/v1beta2/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/flowcontrol/v1beta2/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/flowcontrol/v1beta2/prioritylevelconfiguration.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/flowcontrol/v1beta2/prioritylevelconfiguration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/flowcontrol/v1beta3/flowschema.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/flowcontrol/v1beta3/flowschema.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/flowcontrol/v1beta3/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/flowcontrol/v1beta3/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/flowcontrol/v1beta3/prioritylevelconfiguration.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/flowcontrol/v1beta3/prioritylevelconfiguration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/generic.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/generic.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/internalinterfaces/factory_interfaces.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/internalinterfaces/factory_interfaces.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/networking/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/networking/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/networking/v1/ingress.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/networking/v1/ingress.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/networking/v1/ingressclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/networking/v1/ingressclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/networking/v1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/networking/v1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/networking/v1/ipaddress.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/networking/v1/ipaddress.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/networking/v1/networkpolicy.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/networking/v1/networkpolicy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/networking/v1/servicecidr.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/networking/v1/servicecidr.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/networking/v1beta1/ingress.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/networking/v1beta1/ingress.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/networking/v1beta1/ingressclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/networking/v1beta1/ingressclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/networking/v1beta1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/networking/v1beta1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/networking/v1beta1/ipaddress.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/networking/v1beta1/ipaddress.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/networking/v1beta1/servicecidr.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/networking/v1beta1/servicecidr.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/node/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/node/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/node/v1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/node/v1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/node/v1/runtimeclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/node/v1/runtimeclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/node/v1alpha1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/node/v1alpha1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/node/v1alpha1/runtimeclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/node/v1alpha1/runtimeclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/node/v1beta1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/node/v1beta1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/node/v1beta1/runtimeclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/node/v1beta1/runtimeclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/policy/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/policy/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/policy/v1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/policy/v1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/policy/v1/poddisruptionbudget.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/policy/v1/poddisruptionbudget.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/policy/v1beta1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/policy/v1beta1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/policy/v1beta1/poddisruptionbudget.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/policy/v1beta1/poddisruptionbudget.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/rbac/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/rbac/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/rbac/v1/clusterrole.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/rbac/v1/clusterrole.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/rbac/v1/clusterrolebinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/rbac/v1/clusterrolebinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/rbac/v1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/rbac/v1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/rbac/v1/role.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/rbac/v1/role.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/rbac/v1/rolebinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/rbac/v1/rolebinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/rbac/v1alpha1/clusterrole.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/rbac/v1alpha1/clusterrole.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/rbac/v1alpha1/clusterrolebinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/rbac/v1alpha1/clusterrolebinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/rbac/v1alpha1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/rbac/v1alpha1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/rbac/v1alpha1/role.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/rbac/v1alpha1/role.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/rbac/v1alpha1/rolebinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/rbac/v1alpha1/rolebinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/rbac/v1beta1/clusterrole.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/rbac/v1beta1/clusterrole.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/rbac/v1beta1/clusterrolebinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/rbac/v1beta1/clusterrolebinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/rbac/v1beta1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/rbac/v1beta1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/rbac/v1beta1/role.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/rbac/v1beta1/role.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/rbac/v1beta1/rolebinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/rbac/v1beta1/rolebinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/resource/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/resource/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/resource/v1/deviceclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/resource/v1/deviceclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/resource/v1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/resource/v1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/resource/v1/resourceclaim.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/resource/v1/resourceclaim.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/resource/v1/resourceclaimtemplate.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/resource/v1/resourceclaimtemplate.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/resource/v1/resourceslice.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/resource/v1/resourceslice.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/resource/v1alpha3/devicetaintrule.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/resource/v1alpha3/devicetaintrule.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/resource/v1alpha3/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/resource/v1alpha3/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/resource/v1beta1/deviceclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/resource/v1beta1/deviceclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/resource/v1beta1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/resource/v1beta1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/resource/v1beta1/resourceclaim.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/resource/v1beta1/resourceclaim.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/resource/v1beta1/resourceclaimtemplate.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/resource/v1beta1/resourceclaimtemplate.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/resource/v1beta1/resourceslice.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/resource/v1beta1/resourceslice.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/resource/v1beta2/deviceclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/resource/v1beta2/deviceclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/resource/v1beta2/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/resource/v1beta2/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/resource/v1beta2/resourceclaim.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/resource/v1beta2/resourceclaim.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/resource/v1beta2/resourceclaimtemplate.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/resource/v1beta2/resourceclaimtemplate.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/resource/v1beta2/resourceslice.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/resource/v1beta2/resourceslice.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/scheduling/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/scheduling/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/scheduling/v1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/scheduling/v1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/scheduling/v1/priorityclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/scheduling/v1/priorityclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/scheduling/v1alpha1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/scheduling/v1alpha1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/scheduling/v1alpha1/priorityclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/scheduling/v1alpha1/priorityclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/scheduling/v1beta1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/scheduling/v1beta1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/scheduling/v1beta1/priorityclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/scheduling/v1beta1/priorityclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/storage/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/storage/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/storage/v1/csidriver.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/storage/v1/csidriver.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/storage/v1/csinode.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/storage/v1/csinode.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/storage/v1/csistoragecapacity.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/storage/v1/csistoragecapacity.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/storage/v1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/storage/v1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/storage/v1/storageclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/storage/v1/storageclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/storage/v1/volumeattachment.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/storage/v1/volumeattachment.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/storage/v1/volumeattributesclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/storage/v1/volumeattributesclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/storage/v1alpha1/csistoragecapacity.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/storage/v1alpha1/csistoragecapacity.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/storage/v1alpha1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/storage/v1alpha1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/storage/v1alpha1/volumeattachment.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/storage/v1alpha1/volumeattachment.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/storage/v1alpha1/volumeattributesclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/storage/v1alpha1/volumeattributesclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/storage/v1beta1/csidriver.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/storage/v1beta1/csidriver.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/storage/v1beta1/csinode.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/storage/v1beta1/csinode.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/storage/v1beta1/csistoragecapacity.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/storage/v1beta1/csistoragecapacity.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/storage/v1beta1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/storage/v1beta1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/storage/v1beta1/storageclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/storage/v1beta1/storageclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/storage/v1beta1/volumeattachment.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/storage/v1beta1/volumeattachment.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/storage/v1beta1/volumeattributesclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/storage/v1beta1/volumeattributesclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/storagemigration/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/storagemigration/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/storagemigration/v1alpha1/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/storagemigration/v1alpha1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/informers/storagemigration/v1alpha1/storageversionmigration.go
+++ b/staging/src/github.com/kcp-dev/client-go/informers/storagemigration/v1alpha1/storageversionmigration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/clientset.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/clientset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/fake/clientset.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/fake/clientset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/fake/register.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/fake/register.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/scheme/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/scheme/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/scheme/register.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/scheme/register.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1/admissionregistration_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1/admissionregistration_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1/fake/admissionregistration_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1/fake/admissionregistration_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1/fake/mutatingwebhookconfiguration.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1/fake/mutatingwebhookconfiguration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1/fake/validatingadmissionpolicy.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1/fake/validatingadmissionpolicy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1/fake/validatingadmissionpolicybinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1/fake/validatingadmissionpolicybinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1/fake/validatingwebhookconfiguration.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1/fake/validatingwebhookconfiguration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1/mutatingwebhookconfiguration.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1/mutatingwebhookconfiguration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1/validatingadmissionpolicy.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1/validatingadmissionpolicy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1/validatingadmissionpolicybinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1/validatingadmissionpolicybinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1/validatingwebhookconfiguration.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1/validatingwebhookconfiguration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1alpha1/admissionregistration_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1alpha1/admissionregistration_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1alpha1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1alpha1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1alpha1/fake/admissionregistration_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1alpha1/fake/admissionregistration_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1alpha1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1alpha1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1alpha1/fake/mutatingadmissionpolicy.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1alpha1/fake/mutatingadmissionpolicy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1alpha1/fake/mutatingadmissionpolicybinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1alpha1/fake/mutatingadmissionpolicybinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1alpha1/fake/validatingadmissionpolicy.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1alpha1/fake/validatingadmissionpolicy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1alpha1/fake/validatingadmissionpolicybinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1alpha1/fake/validatingadmissionpolicybinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1alpha1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1alpha1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1alpha1/mutatingadmissionpolicy.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1alpha1/mutatingadmissionpolicy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1alpha1/mutatingadmissionpolicybinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1alpha1/mutatingadmissionpolicybinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1alpha1/validatingadmissionpolicy.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1alpha1/validatingadmissionpolicy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1alpha1/validatingadmissionpolicybinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1alpha1/validatingadmissionpolicybinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/admissionregistration_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/admissionregistration_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/fake/admissionregistration_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/fake/admissionregistration_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/fake/mutatingadmissionpolicy.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/fake/mutatingadmissionpolicy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/fake/mutatingadmissionpolicybinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/fake/mutatingadmissionpolicybinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/fake/mutatingwebhookconfiguration.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/fake/mutatingwebhookconfiguration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/fake/validatingadmissionpolicy.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/fake/validatingadmissionpolicy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/fake/validatingadmissionpolicybinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/fake/validatingadmissionpolicybinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/fake/validatingwebhookconfiguration.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/fake/validatingwebhookconfiguration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/mutatingadmissionpolicy.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/mutatingadmissionpolicy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/mutatingadmissionpolicybinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/mutatingadmissionpolicybinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingadmissionpolicy.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingadmissionpolicy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingadmissionpolicybinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingadmissionpolicybinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingwebhookconfiguration.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingwebhookconfiguration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apiserverinternal/v1alpha1/apiserverinternal_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apiserverinternal/v1alpha1/apiserverinternal_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apiserverinternal/v1alpha1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apiserverinternal/v1alpha1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apiserverinternal/v1alpha1/fake/apiserverinternal_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apiserverinternal/v1alpha1/fake/apiserverinternal_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apiserverinternal/v1alpha1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apiserverinternal/v1alpha1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apiserverinternal/v1alpha1/fake/storageversion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apiserverinternal/v1alpha1/fake/storageversion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apiserverinternal/v1alpha1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apiserverinternal/v1alpha1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apiserverinternal/v1alpha1/storageversion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apiserverinternal/v1alpha1/storageversion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1/apps_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1/apps_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1/controllerrevision.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1/controllerrevision.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1/daemonset.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1/daemonset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1/deployment.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1/deployment.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1/fake/apps_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1/fake/apps_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1/fake/controllerrevision.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1/fake/controllerrevision.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1/fake/daemonset.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1/fake/daemonset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1/fake/deployment.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1/fake/deployment.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1/fake/replicaset.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1/fake/replicaset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1/fake/statefulset.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1/fake/statefulset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1/replicaset.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1/replicaset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1/statefulset.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1/statefulset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta1/apps_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta1/apps_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta1/controllerrevision.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta1/controllerrevision.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta1/deployment.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta1/deployment.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta1/fake/apps_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta1/fake/apps_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta1/fake/controllerrevision.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta1/fake/controllerrevision.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta1/fake/deployment.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta1/fake/deployment.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta1/fake/statefulset.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta1/fake/statefulset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta1/statefulset.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta1/statefulset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta2/apps_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta2/apps_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta2/controllerrevision.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta2/controllerrevision.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta2/daemonset.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta2/daemonset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta2/deployment.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta2/deployment.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta2/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta2/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta2/fake/apps_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta2/fake/apps_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta2/fake/controllerrevision.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta2/fake/controllerrevision.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta2/fake/daemonset.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta2/fake/daemonset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta2/fake/deployment.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta2/fake/deployment.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta2/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta2/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta2/fake/replicaset.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta2/fake/replicaset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta2/fake/statefulset.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta2/fake/statefulset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta2/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta2/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta2/replicaset.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta2/replicaset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta2/statefulset.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta2/statefulset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1/authentication_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1/authentication_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1/fake/authentication_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1/fake/authentication_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1/fake/selfsubjectreview.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1/fake/selfsubjectreview.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1/fake/tokenreview.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1/fake/tokenreview.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1/selfsubjectreview.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1/selfsubjectreview.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1/tokenreview.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1/tokenreview.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1alpha1/authentication_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1alpha1/authentication_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1alpha1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1alpha1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1alpha1/fake/authentication_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1alpha1/fake/authentication_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1alpha1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1alpha1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1alpha1/fake/selfsubjectreview.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1alpha1/fake/selfsubjectreview.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1alpha1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1alpha1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1alpha1/selfsubjectreview.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1alpha1/selfsubjectreview.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1beta1/authentication_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1beta1/authentication_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1beta1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1beta1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1beta1/fake/authentication_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1beta1/fake/authentication_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1beta1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1beta1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1beta1/fake/selfsubjectreview.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1beta1/fake/selfsubjectreview.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1beta1/fake/tokenreview.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1beta1/fake/tokenreview.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1beta1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1beta1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1beta1/selfsubjectreview.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1beta1/selfsubjectreview.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1beta1/tokenreview.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1beta1/tokenreview.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1/authorization_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1/authorization_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1/fake/authorization_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1/fake/authorization_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1/fake/localsubjectaccessreview.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1/fake/localsubjectaccessreview.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1/fake/selfsubjectaccessreview.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1/fake/selfsubjectaccessreview.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1/fake/selfsubjectrulesreview.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1/fake/selfsubjectrulesreview.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1/fake/subjectaccessreview.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1/fake/subjectaccessreview.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1/localsubjectaccessreview.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1/localsubjectaccessreview.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1/selfsubjectaccessreview.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1/selfsubjectaccessreview.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1/selfsubjectrulesreview.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1/selfsubjectrulesreview.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1/subjectaccessreview.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1/subjectaccessreview.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1beta1/authorization_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1beta1/authorization_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1beta1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1beta1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1beta1/fake/authorization_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1beta1/fake/authorization_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1beta1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1beta1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1beta1/fake/localsubjectaccessreview.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1beta1/fake/localsubjectaccessreview.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1beta1/fake/selfsubjectaccessreview.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1beta1/fake/selfsubjectaccessreview.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1beta1/fake/selfsubjectrulesreview.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1beta1/fake/selfsubjectrulesreview.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1beta1/fake/subjectaccessreview.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1beta1/fake/subjectaccessreview.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1beta1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1beta1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1beta1/localsubjectaccessreview.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1beta1/localsubjectaccessreview.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1beta1/selfsubjectaccessreview.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1beta1/selfsubjectaccessreview.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1beta1/selfsubjectrulesreview.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1beta1/selfsubjectrulesreview.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1beta1/subjectaccessreview.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1beta1/subjectaccessreview.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v1/autoscaling_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v1/autoscaling_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v1/fake/autoscaling_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v1/fake/autoscaling_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v1/fake/horizontalpodautoscaler.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v1/fake/horizontalpodautoscaler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v1/horizontalpodautoscaler.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v1/horizontalpodautoscaler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2/autoscaling_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2/autoscaling_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2/fake/autoscaling_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2/fake/autoscaling_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2/fake/horizontalpodautoscaler.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2/fake/horizontalpodautoscaler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2/horizontalpodautoscaler.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2/horizontalpodautoscaler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2beta1/autoscaling_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2beta1/autoscaling_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2beta1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2beta1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2beta1/fake/autoscaling_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2beta1/fake/autoscaling_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2beta1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2beta1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2beta1/fake/horizontalpodautoscaler.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2beta1/fake/horizontalpodautoscaler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2beta1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2beta1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2beta1/horizontalpodautoscaler.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2beta1/horizontalpodautoscaler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2beta2/autoscaling_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2beta2/autoscaling_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2beta2/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2beta2/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2beta2/fake/autoscaling_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2beta2/fake/autoscaling_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2beta2/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2beta2/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2beta2/fake/horizontalpodautoscaler.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2beta2/fake/horizontalpodautoscaler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2beta2/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2beta2/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2beta2/horizontalpodautoscaler.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2beta2/horizontalpodautoscaler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1/batch_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1/batch_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1/cronjob.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1/cronjob.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1/fake/batch_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1/fake/batch_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1/fake/cronjob.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1/fake/cronjob.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1/fake/job.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1/fake/job.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1/job.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1/job.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1beta1/batch_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1beta1/batch_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1beta1/cronjob.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1beta1/cronjob.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1beta1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1beta1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1beta1/fake/batch_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1beta1/fake/batch_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1beta1/fake/cronjob.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1beta1/fake/cronjob.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1beta1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1beta1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1beta1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1beta1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1/certificates_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1/certificates_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1/certificatesigningrequest.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1/certificatesigningrequest.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1/fake/certificates_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1/fake/certificates_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1/fake/certificatesigningrequest.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1/fake/certificatesigningrequest.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1alpha1/certificates_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1alpha1/certificates_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1alpha1/clustertrustbundle.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1alpha1/clustertrustbundle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1alpha1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1alpha1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1alpha1/fake/certificates_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1alpha1/fake/certificates_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1alpha1/fake/clustertrustbundle.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1alpha1/fake/clustertrustbundle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1alpha1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1alpha1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1alpha1/fake/podcertificaterequest.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1alpha1/fake/podcertificaterequest.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1alpha1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1alpha1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1alpha1/podcertificaterequest.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1alpha1/podcertificaterequest.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1beta1/certificates_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1beta1/certificates_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1beta1/certificatesigningrequest.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1beta1/certificatesigningrequest.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1beta1/clustertrustbundle.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1beta1/clustertrustbundle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1beta1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1beta1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1beta1/fake/certificates_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1beta1/fake/certificates_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1beta1/fake/certificatesigningrequest.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1beta1/fake/certificatesigningrequest.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1beta1/fake/clustertrustbundle.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1beta1/fake/clustertrustbundle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1beta1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1beta1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1beta1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1beta1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1/coordination_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1/coordination_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1/fake/coordination_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1/fake/coordination_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1/fake/lease.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1/fake/lease.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1/lease.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1/lease.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1alpha2/coordination_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1alpha2/coordination_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1alpha2/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1alpha2/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1alpha2/fake/coordination_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1alpha2/fake/coordination_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1alpha2/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1alpha2/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1alpha2/fake/leasecandidate.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1alpha2/fake/leasecandidate.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1alpha2/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1alpha2/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1alpha2/leasecandidate.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1alpha2/leasecandidate.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1beta1/coordination_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1beta1/coordination_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1beta1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1beta1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1beta1/fake/coordination_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1beta1/fake/coordination_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1beta1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1beta1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1beta1/fake/lease.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1beta1/fake/lease.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1beta1/fake/leasecandidate.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1beta1/fake/leasecandidate.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1beta1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1beta1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1beta1/lease.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1beta1/lease.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1beta1/leasecandidate.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1beta1/leasecandidate.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/componentstatus.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/componentstatus.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/configmap.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/configmap.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/core_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/core_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/endpoints.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/endpoints.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/event.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/event.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/componentstatus.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/componentstatus.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/configmap.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/configmap.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/core_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/core_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/endpoints.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/endpoints.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/event.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/event.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/limitrange.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/limitrange.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/namespace.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/namespace.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/node.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/node.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/persistentvolume.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/persistentvolume.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/persistentvolumeclaim.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/persistentvolumeclaim.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/pod.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/pod.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/podtemplate.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/podtemplate.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/replicationcontroller.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/replicationcontroller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/resourcequota.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/resourcequota.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/secret.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/secret.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/service.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/service.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/serviceaccount.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/serviceaccount.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/limitrange.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/limitrange.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/namespace.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/namespace.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/node.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/node.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/persistentvolume.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/persistentvolume.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/persistentvolumeclaim.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/persistentvolumeclaim.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/pod.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/pod.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/podtemplate.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/podtemplate.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/replicationcontroller.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/replicationcontroller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/resourcequota.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/resourcequota.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/secret.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/secret.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/service.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/service.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/serviceaccount.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/serviceaccount.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1/discovery_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1/discovery_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1/endpointslice.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1/endpointslice.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1/fake/discovery_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1/fake/discovery_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1/fake/endpointslice.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1/fake/endpointslice.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1beta1/discovery_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1beta1/discovery_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1beta1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1beta1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1beta1/endpointslice.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1beta1/endpointslice.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1beta1/fake/discovery_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1beta1/fake/discovery_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1beta1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1beta1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1beta1/fake/endpointslice.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1beta1/fake/endpointslice.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1beta1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1beta1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1/event.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1/event.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1/events_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1/events_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1/fake/event.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1/fake/event.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1/fake/events_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1/fake/events_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1beta1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1beta1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1beta1/event.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1beta1/event.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1beta1/events_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1beta1/events_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1beta1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1beta1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1beta1/fake/event.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1beta1/fake/event.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1beta1/fake/events_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1beta1/fake/events_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1beta1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1beta1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/extensions/v1beta1/daemonset.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/extensions/v1beta1/daemonset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/extensions/v1beta1/deployment.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/extensions/v1beta1/deployment.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/extensions/v1beta1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/extensions/v1beta1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/extensions/v1beta1/extensions_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/extensions/v1beta1/extensions_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/extensions/v1beta1/fake/daemonset.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/extensions/v1beta1/fake/daemonset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/extensions/v1beta1/fake/deployment.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/extensions/v1beta1/fake/deployment.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/extensions/v1beta1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/extensions/v1beta1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/extensions/v1beta1/fake/extensions_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/extensions/v1beta1/fake/extensions_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/extensions/v1beta1/fake/ingress.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/extensions/v1beta1/fake/ingress.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/extensions/v1beta1/fake/networkpolicy.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/extensions/v1beta1/fake/networkpolicy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/extensions/v1beta1/fake/replicaset.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/extensions/v1beta1/fake/replicaset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/extensions/v1beta1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/extensions/v1beta1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/extensions/v1beta1/ingress.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/extensions/v1beta1/ingress.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/extensions/v1beta1/networkpolicy.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/extensions/v1beta1/networkpolicy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/extensions/v1beta1/replicaset.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/extensions/v1beta1/replicaset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1/fake/flowcontrol_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1/fake/flowcontrol_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1/fake/flowschema.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1/fake/flowschema.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1/fake/prioritylevelconfiguration.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1/fake/prioritylevelconfiguration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1/flowcontrol_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1/flowcontrol_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1/flowschema.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1/flowschema.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1/prioritylevelconfiguration.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1/prioritylevelconfiguration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta1/fake/flowcontrol_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta1/fake/flowcontrol_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta1/fake/flowschema.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta1/fake/flowschema.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta1/fake/prioritylevelconfiguration.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta1/fake/prioritylevelconfiguration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta1/flowcontrol_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta1/flowcontrol_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta1/flowschema.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta1/flowschema.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta1/prioritylevelconfiguration.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta1/prioritylevelconfiguration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta2/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta2/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta2/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta2/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta2/fake/flowcontrol_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta2/fake/flowcontrol_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta2/fake/flowschema.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta2/fake/flowschema.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta2/fake/prioritylevelconfiguration.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta2/fake/prioritylevelconfiguration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta2/flowcontrol_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta2/flowcontrol_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta2/flowschema.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta2/flowschema.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta2/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta2/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta2/prioritylevelconfiguration.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta2/prioritylevelconfiguration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta3/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta3/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta3/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta3/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta3/fake/flowcontrol_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta3/fake/flowcontrol_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta3/fake/flowschema.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta3/fake/flowschema.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta3/fake/prioritylevelconfiguration.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta3/fake/prioritylevelconfiguration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta3/flowcontrol_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta3/flowcontrol_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta3/flowschema.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta3/flowschema.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta3/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta3/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta3/prioritylevelconfiguration.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta3/prioritylevelconfiguration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1/fake/ingress.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1/fake/ingress.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1/fake/ingressclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1/fake/ingressclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1/fake/ipaddress.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1/fake/ipaddress.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1/fake/networking_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1/fake/networking_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1/fake/networkpolicy.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1/fake/networkpolicy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1/fake/servicecidr.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1/fake/servicecidr.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1/ingress.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1/ingress.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1/ingressclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1/ingressclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1/ipaddress.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1/ipaddress.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1/networking_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1/networking_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1/networkpolicy.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1/networkpolicy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1/servicecidr.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1/servicecidr.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1beta1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1beta1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1beta1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1beta1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1beta1/fake/ingress.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1beta1/fake/ingress.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1beta1/fake/ingressclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1beta1/fake/ingressclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1beta1/fake/ipaddress.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1beta1/fake/ipaddress.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1beta1/fake/networking_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1beta1/fake/networking_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1beta1/fake/servicecidr.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1beta1/fake/servicecidr.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1beta1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1beta1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1beta1/ingress.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1beta1/ingress.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1beta1/ingressclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1beta1/ingressclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1beta1/ipaddress.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1beta1/ipaddress.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1beta1/networking_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1beta1/networking_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1beta1/servicecidr.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1beta1/servicecidr.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1/fake/node_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1/fake/node_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1/fake/runtimeclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1/fake/runtimeclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1/node_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1/node_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1/runtimeclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1/runtimeclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1alpha1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1alpha1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1alpha1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1alpha1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1alpha1/fake/node_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1alpha1/fake/node_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1alpha1/fake/runtimeclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1alpha1/fake/runtimeclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1alpha1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1alpha1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1alpha1/node_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1alpha1/node_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1alpha1/runtimeclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1alpha1/runtimeclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1beta1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1beta1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1beta1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1beta1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1beta1/fake/node_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1beta1/fake/node_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1beta1/fake/runtimeclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1beta1/fake/runtimeclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1beta1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1beta1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1beta1/node_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1beta1/node_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1beta1/runtimeclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1beta1/runtimeclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1/eviction.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1/eviction.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1/fake/eviction.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1/fake/eviction.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1/fake/poddisruptionbudget.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1/fake/poddisruptionbudget.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1/fake/policy_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1/fake/policy_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1/poddisruptionbudget.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1/poddisruptionbudget.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1/policy_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1/policy_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1beta1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1beta1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1beta1/eviction.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1beta1/eviction.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1beta1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1beta1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1beta1/fake/eviction.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1beta1/fake/eviction.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1beta1/fake/poddisruptionbudget.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1beta1/fake/poddisruptionbudget.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1beta1/fake/policy_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1beta1/fake/policy_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1beta1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1beta1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1beta1/poddisruptionbudget.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1beta1/poddisruptionbudget.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1beta1/policy_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1beta1/policy_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1/clusterrole.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1/clusterrole.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1/clusterrolebinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1/clusterrolebinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1/fake/clusterrole.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1/fake/clusterrole.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1/fake/clusterrolebinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1/fake/clusterrolebinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1/fake/rbac_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1/fake/rbac_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1/fake/role.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1/fake/role.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1/fake/rolebinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1/fake/rolebinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1/rbac_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1/rbac_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1/role.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1/role.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1/rolebinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1/rolebinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1alpha1/clusterrole.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1alpha1/clusterrole.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1alpha1/clusterrolebinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1alpha1/clusterrolebinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1alpha1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1alpha1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1alpha1/fake/clusterrole.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1alpha1/fake/clusterrole.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1alpha1/fake/clusterrolebinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1alpha1/fake/clusterrolebinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1alpha1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1alpha1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1alpha1/fake/rbac_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1alpha1/fake/rbac_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1alpha1/fake/role.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1alpha1/fake/role.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1alpha1/fake/rolebinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1alpha1/fake/rolebinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1alpha1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1alpha1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1alpha1/rbac_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1alpha1/rbac_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1alpha1/role.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1alpha1/role.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1alpha1/rolebinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1alpha1/rolebinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1beta1/clusterrole.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1beta1/clusterrole.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1beta1/clusterrolebinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1beta1/clusterrolebinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1beta1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1beta1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1beta1/fake/clusterrole.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1beta1/fake/clusterrole.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1beta1/fake/clusterrolebinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1beta1/fake/clusterrolebinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1beta1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1beta1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1beta1/fake/rbac_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1beta1/fake/rbac_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1beta1/fake/role.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1beta1/fake/role.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1beta1/fake/rolebinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1beta1/fake/rolebinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1beta1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1beta1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1beta1/rbac_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1beta1/rbac_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1beta1/role.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1beta1/role.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1beta1/rolebinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1beta1/rolebinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1/deviceclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1/deviceclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1/fake/deviceclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1/fake/deviceclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1/fake/resource_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1/fake/resource_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1/fake/resourceclaim.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1/fake/resourceclaim.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1/fake/resourceclaimtemplate.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1/fake/resourceclaimtemplate.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1/fake/resourceslice.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1/fake/resourceslice.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1/resource_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1/resource_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1/resourceclaim.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1/resourceclaim.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1/resourceclaimtemplate.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1/resourceclaimtemplate.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1/resourceslice.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1/resourceslice.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1alpha3/devicetaintrule.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1alpha3/devicetaintrule.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1alpha3/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1alpha3/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1alpha3/fake/devicetaintrule.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1alpha3/fake/devicetaintrule.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1alpha3/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1alpha3/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1alpha3/fake/resource_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1alpha3/fake/resource_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1alpha3/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1alpha3/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1alpha3/resource_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1alpha3/resource_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta1/deviceclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta1/deviceclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta1/fake/deviceclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta1/fake/deviceclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta1/fake/resource_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta1/fake/resource_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta1/fake/resourceclaim.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta1/fake/resourceclaim.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta1/fake/resourceclaimtemplate.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta1/fake/resourceclaimtemplate.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta1/fake/resourceslice.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta1/fake/resourceslice.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta1/resource_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta1/resource_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta1/resourceclaim.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta1/resourceclaim.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta1/resourceclaimtemplate.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta1/resourceclaimtemplate.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta1/resourceslice.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta1/resourceslice.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta2/deviceclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta2/deviceclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta2/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta2/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta2/fake/deviceclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta2/fake/deviceclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta2/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta2/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta2/fake/resource_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta2/fake/resource_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta2/fake/resourceclaim.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta2/fake/resourceclaim.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta2/fake/resourceclaimtemplate.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta2/fake/resourceclaimtemplate.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta2/fake/resourceslice.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta2/fake/resourceslice.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta2/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta2/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta2/resource_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta2/resource_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta2/resourceclaim.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta2/resourceclaim.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta2/resourceclaimtemplate.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta2/resourceclaimtemplate.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta2/resourceslice.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta2/resourceslice.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1/fake/priorityclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1/fake/priorityclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1/fake/scheduling_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1/fake/scheduling_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1/priorityclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1/priorityclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1/scheduling_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1/scheduling_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1alpha1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1alpha1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1alpha1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1alpha1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1alpha1/fake/priorityclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1alpha1/fake/priorityclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1alpha1/fake/scheduling_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1alpha1/fake/scheduling_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1alpha1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1alpha1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1alpha1/priorityclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1alpha1/priorityclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1alpha1/scheduling_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1alpha1/scheduling_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1beta1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1beta1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1beta1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1beta1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1beta1/fake/priorityclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1beta1/fake/priorityclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1beta1/fake/scheduling_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1beta1/fake/scheduling_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1beta1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1beta1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1beta1/priorityclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1beta1/priorityclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1beta1/scheduling_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1beta1/scheduling_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/csidriver.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/csidriver.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/csinode.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/csinode.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/csistoragecapacity.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/csistoragecapacity.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/fake/csidriver.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/fake/csidriver.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/fake/csinode.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/fake/csinode.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/fake/csistoragecapacity.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/fake/csistoragecapacity.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/fake/storage_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/fake/storage_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/fake/storageclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/fake/storageclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/fake/volumeattachment.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/fake/volumeattachment.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/fake/volumeattributesclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/fake/volumeattributesclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/storage_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/storage_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/storageclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/storageclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/volumeattachment.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/volumeattachment.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/volumeattributesclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/volumeattributesclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1alpha1/csistoragecapacity.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1alpha1/csistoragecapacity.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1alpha1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1alpha1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1alpha1/fake/csistoragecapacity.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1alpha1/fake/csistoragecapacity.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1alpha1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1alpha1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1alpha1/fake/storage_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1alpha1/fake/storage_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1alpha1/fake/volumeattachment.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1alpha1/fake/volumeattachment.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1alpha1/fake/volumeattributesclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1alpha1/fake/volumeattributesclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1alpha1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1alpha1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1alpha1/storage_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1alpha1/storage_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1alpha1/volumeattachment.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1alpha1/volumeattachment.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1alpha1/volumeattributesclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1alpha1/volumeattributesclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/csidriver.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/csidriver.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/csinode.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/csinode.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/csistoragecapacity.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/csistoragecapacity.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/fake/csidriver.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/fake/csidriver.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/fake/csinode.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/fake/csinode.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/fake/csistoragecapacity.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/fake/csistoragecapacity.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/fake/storage_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/fake/storage_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/fake/storageclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/fake/storageclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/fake/volumeattachment.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/fake/volumeattachment.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/fake/volumeattributesclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/fake/volumeattributesclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/storage_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/storage_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/storageclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/storageclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/volumeattachment.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/volumeattachment.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/volumeattributesclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/volumeattributesclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storagemigration/v1alpha1/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storagemigration/v1alpha1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storagemigration/v1alpha1/fake/doc.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storagemigration/v1alpha1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storagemigration/v1alpha1/fake/storagemigration_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storagemigration/v1alpha1/fake/storagemigration_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storagemigration/v1alpha1/fake/storageversionmigration.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storagemigration/v1alpha1/fake/storageversionmigration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storagemigration/v1alpha1/generated_expansion.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storagemigration/v1alpha1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storagemigration/v1alpha1/storagemigration_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storagemigration/v1alpha1/storagemigration_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storagemigration/v1alpha1/storageversionmigration.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storagemigration/v1alpha1/storageversionmigration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/admissionregistration/v1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/admissionregistration/v1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/admissionregistration/v1/mutatingwebhookconfiguration.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/admissionregistration/v1/mutatingwebhookconfiguration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/admissionregistration/v1/validatingadmissionpolicy.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/admissionregistration/v1/validatingadmissionpolicy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/admissionregistration/v1/validatingadmissionpolicybinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/admissionregistration/v1/validatingadmissionpolicybinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/admissionregistration/v1/validatingwebhookconfiguration.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/admissionregistration/v1/validatingwebhookconfiguration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/admissionregistration/v1alpha1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/admissionregistration/v1alpha1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/admissionregistration/v1alpha1/mutatingadmissionpolicy.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/admissionregistration/v1alpha1/mutatingadmissionpolicy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/admissionregistration/v1alpha1/mutatingadmissionpolicybinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/admissionregistration/v1alpha1/mutatingadmissionpolicybinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/admissionregistration/v1alpha1/validatingadmissionpolicy.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/admissionregistration/v1alpha1/validatingadmissionpolicy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/admissionregistration/v1alpha1/validatingadmissionpolicybinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/admissionregistration/v1alpha1/validatingadmissionpolicybinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/admissionregistration/v1beta1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/admissionregistration/v1beta1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/admissionregistration/v1beta1/mutatingadmissionpolicy.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/admissionregistration/v1beta1/mutatingadmissionpolicy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/admissionregistration/v1beta1/mutatingadmissionpolicybinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/admissionregistration/v1beta1/mutatingadmissionpolicybinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/admissionregistration/v1beta1/validatingadmissionpolicy.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/admissionregistration/v1beta1/validatingadmissionpolicy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/admissionregistration/v1beta1/validatingadmissionpolicybinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/admissionregistration/v1beta1/validatingadmissionpolicybinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/admissionregistration/v1beta1/validatingwebhookconfiguration.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/admissionregistration/v1beta1/validatingwebhookconfiguration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/apiserverinternal/v1alpha1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/apiserverinternal/v1alpha1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/apiserverinternal/v1alpha1/storageversion.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/apiserverinternal/v1alpha1/storageversion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/apps/v1/controllerrevision.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/apps/v1/controllerrevision.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/apps/v1/daemonset.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/apps/v1/daemonset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/apps/v1/deployment.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/apps/v1/deployment.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/apps/v1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/apps/v1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/apps/v1/replicaset.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/apps/v1/replicaset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/apps/v1/statefulset.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/apps/v1/statefulset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/apps/v1beta1/controllerrevision.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/apps/v1beta1/controllerrevision.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/apps/v1beta1/deployment.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/apps/v1beta1/deployment.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/apps/v1beta1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/apps/v1beta1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/apps/v1beta1/statefulset.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/apps/v1beta1/statefulset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/apps/v1beta2/controllerrevision.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/apps/v1beta2/controllerrevision.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/apps/v1beta2/daemonset.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/apps/v1beta2/daemonset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/apps/v1beta2/deployment.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/apps/v1beta2/deployment.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/apps/v1beta2/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/apps/v1beta2/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/apps/v1beta2/replicaset.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/apps/v1beta2/replicaset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/apps/v1beta2/statefulset.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/apps/v1beta2/statefulset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/autoscaling/v1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/autoscaling/v1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/autoscaling/v1/horizontalpodautoscaler.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/autoscaling/v1/horizontalpodautoscaler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/autoscaling/v2/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/autoscaling/v2/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/autoscaling/v2/horizontalpodautoscaler.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/autoscaling/v2/horizontalpodautoscaler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/autoscaling/v2beta1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/autoscaling/v2beta1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/autoscaling/v2beta1/horizontalpodautoscaler.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/autoscaling/v2beta1/horizontalpodautoscaler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/autoscaling/v2beta2/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/autoscaling/v2beta2/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/autoscaling/v2beta2/horizontalpodautoscaler.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/autoscaling/v2beta2/horizontalpodautoscaler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/batch/v1/cronjob.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/batch/v1/cronjob.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/batch/v1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/batch/v1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/batch/v1/job.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/batch/v1/job.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/batch/v1beta1/cronjob.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/batch/v1beta1/cronjob.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/batch/v1beta1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/batch/v1beta1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/certificates/v1/certificatesigningrequest.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/certificates/v1/certificatesigningrequest.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/certificates/v1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/certificates/v1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/certificates/v1alpha1/clustertrustbundle.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/certificates/v1alpha1/clustertrustbundle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/certificates/v1alpha1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/certificates/v1alpha1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/certificates/v1alpha1/podcertificaterequest.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/certificates/v1alpha1/podcertificaterequest.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/certificates/v1beta1/certificatesigningrequest.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/certificates/v1beta1/certificatesigningrequest.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/certificates/v1beta1/clustertrustbundle.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/certificates/v1beta1/clustertrustbundle.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/certificates/v1beta1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/certificates/v1beta1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/coordination/v1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/coordination/v1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/coordination/v1/lease.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/coordination/v1/lease.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/coordination/v1alpha2/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/coordination/v1alpha2/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/coordination/v1alpha2/leasecandidate.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/coordination/v1alpha2/leasecandidate.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/coordination/v1beta1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/coordination/v1beta1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/coordination/v1beta1/lease.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/coordination/v1beta1/lease.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/coordination/v1beta1/leasecandidate.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/coordination/v1beta1/leasecandidate.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/core/v1/componentstatus.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/core/v1/componentstatus.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/core/v1/configmap.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/core/v1/configmap.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/core/v1/endpoints.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/core/v1/endpoints.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/core/v1/event.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/core/v1/event.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/core/v1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/core/v1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/core/v1/limitrange.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/core/v1/limitrange.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/core/v1/namespace.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/core/v1/namespace.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/core/v1/node.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/core/v1/node.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/core/v1/persistentvolume.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/core/v1/persistentvolume.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/core/v1/persistentvolumeclaim.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/core/v1/persistentvolumeclaim.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/core/v1/pod.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/core/v1/pod.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/core/v1/podtemplate.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/core/v1/podtemplate.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/core/v1/replicationcontroller.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/core/v1/replicationcontroller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/core/v1/resourcequota.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/core/v1/resourcequota.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/core/v1/secret.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/core/v1/secret.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/core/v1/service.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/core/v1/service.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/core/v1/serviceaccount.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/core/v1/serviceaccount.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/discovery/v1/endpointslice.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/discovery/v1/endpointslice.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/discovery/v1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/discovery/v1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/discovery/v1beta1/endpointslice.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/discovery/v1beta1/endpointslice.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/discovery/v1beta1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/discovery/v1beta1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/events/v1/event.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/events/v1/event.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/events/v1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/events/v1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/events/v1beta1/event.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/events/v1beta1/event.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/events/v1beta1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/events/v1beta1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/extensions/v1beta1/daemonset.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/extensions/v1beta1/daemonset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/extensions/v1beta1/deployment.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/extensions/v1beta1/deployment.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/extensions/v1beta1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/extensions/v1beta1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/extensions/v1beta1/ingress.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/extensions/v1beta1/ingress.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/extensions/v1beta1/networkpolicy.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/extensions/v1beta1/networkpolicy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/extensions/v1beta1/replicaset.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/extensions/v1beta1/replicaset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/flowcontrol/v1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/flowcontrol/v1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/flowcontrol/v1/flowschema.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/flowcontrol/v1/flowschema.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/flowcontrol/v1/prioritylevelconfiguration.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/flowcontrol/v1/prioritylevelconfiguration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/flowcontrol/v1beta1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/flowcontrol/v1beta1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/flowcontrol/v1beta1/flowschema.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/flowcontrol/v1beta1/flowschema.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/flowcontrol/v1beta1/prioritylevelconfiguration.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/flowcontrol/v1beta1/prioritylevelconfiguration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/flowcontrol/v1beta2/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/flowcontrol/v1beta2/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/flowcontrol/v1beta2/flowschema.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/flowcontrol/v1beta2/flowschema.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/flowcontrol/v1beta2/prioritylevelconfiguration.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/flowcontrol/v1beta2/prioritylevelconfiguration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/flowcontrol/v1beta3/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/flowcontrol/v1beta3/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/flowcontrol/v1beta3/flowschema.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/flowcontrol/v1beta3/flowschema.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/flowcontrol/v1beta3/prioritylevelconfiguration.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/flowcontrol/v1beta3/prioritylevelconfiguration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/imagepolicy/v1alpha1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/imagepolicy/v1alpha1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/imagepolicy/v1alpha1/imagereview.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/imagepolicy/v1alpha1/imagereview.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/networking/v1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/networking/v1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/networking/v1/ingress.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/networking/v1/ingress.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/networking/v1/ingressclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/networking/v1/ingressclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/networking/v1/ipaddress.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/networking/v1/ipaddress.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/networking/v1/networkpolicy.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/networking/v1/networkpolicy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/networking/v1/servicecidr.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/networking/v1/servicecidr.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/networking/v1beta1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/networking/v1beta1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/networking/v1beta1/ingress.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/networking/v1beta1/ingress.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/networking/v1beta1/ingressclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/networking/v1beta1/ingressclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/networking/v1beta1/ipaddress.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/networking/v1beta1/ipaddress.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/networking/v1beta1/servicecidr.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/networking/v1beta1/servicecidr.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/node/v1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/node/v1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/node/v1/runtimeclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/node/v1/runtimeclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/node/v1alpha1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/node/v1alpha1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/node/v1alpha1/runtimeclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/node/v1alpha1/runtimeclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/node/v1beta1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/node/v1beta1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/node/v1beta1/runtimeclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/node/v1beta1/runtimeclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/policy/v1/eviction.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/policy/v1/eviction.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/policy/v1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/policy/v1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/policy/v1/poddisruptionbudget.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/policy/v1/poddisruptionbudget.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/policy/v1beta1/eviction.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/policy/v1beta1/eviction.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/policy/v1beta1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/policy/v1beta1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/policy/v1beta1/poddisruptionbudget.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/policy/v1beta1/poddisruptionbudget.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/rbac/v1/clusterrole.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/rbac/v1/clusterrole.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/rbac/v1/clusterrolebinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/rbac/v1/clusterrolebinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/rbac/v1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/rbac/v1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/rbac/v1/role.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/rbac/v1/role.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/rbac/v1/rolebinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/rbac/v1/rolebinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/rbac/v1alpha1/clusterrole.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/rbac/v1alpha1/clusterrole.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/rbac/v1alpha1/clusterrolebinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/rbac/v1alpha1/clusterrolebinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/rbac/v1alpha1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/rbac/v1alpha1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/rbac/v1alpha1/role.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/rbac/v1alpha1/role.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/rbac/v1alpha1/rolebinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/rbac/v1alpha1/rolebinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/rbac/v1beta1/clusterrole.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/rbac/v1beta1/clusterrole.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/rbac/v1beta1/clusterrolebinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/rbac/v1beta1/clusterrolebinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/rbac/v1beta1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/rbac/v1beta1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/rbac/v1beta1/role.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/rbac/v1beta1/role.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/rbac/v1beta1/rolebinding.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/rbac/v1beta1/rolebinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/resource/v1/deviceclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/resource/v1/deviceclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/resource/v1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/resource/v1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/resource/v1/resourceclaim.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/resource/v1/resourceclaim.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/resource/v1/resourceclaimtemplate.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/resource/v1/resourceclaimtemplate.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/resource/v1/resourceslice.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/resource/v1/resourceslice.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/resource/v1alpha3/devicetaintrule.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/resource/v1alpha3/devicetaintrule.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/resource/v1alpha3/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/resource/v1alpha3/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/resource/v1beta1/deviceclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/resource/v1beta1/deviceclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/resource/v1beta1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/resource/v1beta1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/resource/v1beta1/resourceclaim.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/resource/v1beta1/resourceclaim.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/resource/v1beta1/resourceclaimtemplate.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/resource/v1beta1/resourceclaimtemplate.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/resource/v1beta1/resourceslice.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/resource/v1beta1/resourceslice.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/resource/v1beta2/deviceclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/resource/v1beta2/deviceclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/resource/v1beta2/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/resource/v1beta2/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/resource/v1beta2/resourceclaim.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/resource/v1beta2/resourceclaim.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/resource/v1beta2/resourceclaimtemplate.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/resource/v1beta2/resourceclaimtemplate.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/resource/v1beta2/resourceslice.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/resource/v1beta2/resourceslice.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/scheduling/v1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/scheduling/v1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/scheduling/v1/priorityclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/scheduling/v1/priorityclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/scheduling/v1alpha1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/scheduling/v1alpha1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/scheduling/v1alpha1/priorityclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/scheduling/v1alpha1/priorityclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/scheduling/v1beta1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/scheduling/v1beta1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/scheduling/v1beta1/priorityclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/scheduling/v1beta1/priorityclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/storage/v1/csidriver.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/storage/v1/csidriver.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/storage/v1/csinode.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/storage/v1/csinode.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/storage/v1/csistoragecapacity.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/storage/v1/csistoragecapacity.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/storage/v1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/storage/v1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/storage/v1/storageclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/storage/v1/storageclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/storage/v1/volumeattachment.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/storage/v1/volumeattachment.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/storage/v1/volumeattributesclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/storage/v1/volumeattributesclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/storage/v1alpha1/csistoragecapacity.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/storage/v1alpha1/csistoragecapacity.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/storage/v1alpha1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/storage/v1alpha1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/storage/v1alpha1/volumeattachment.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/storage/v1alpha1/volumeattachment.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/storage/v1alpha1/volumeattributesclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/storage/v1alpha1/volumeattributesclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/storage/v1beta1/csidriver.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/storage/v1beta1/csidriver.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/storage/v1beta1/csinode.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/storage/v1beta1/csinode.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/storage/v1beta1/csistoragecapacity.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/storage/v1beta1/csistoragecapacity.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/storage/v1beta1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/storage/v1beta1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/storage/v1beta1/storageclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/storage/v1beta1/storageclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/storage/v1beta1/volumeattachment.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/storage/v1beta1/volumeattachment.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/storage/v1beta1/volumeattributesclass.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/storage/v1beta1/volumeattributesclass.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/storagemigration/v1alpha1/expansion_generated.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/storagemigration/v1alpha1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/github.com/kcp-dev/client-go/listers/storagemigration/v1alpha1/storageversionmigration.go
+++ b/staging/src/github.com/kcp-dev/client-go/listers/storagemigration/v1alpha1/storageversionmigration.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

## What Type of PR Is This?

Move client-go copyright header to be dateless as it will be regenerated with a new date each year. And this will generate an obfuscated git history of what actually changed. 

/kind bug 
<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
make client-go copyright header dateless
```
