### PR TITLE
Move to 127.0.0.1 for kcp start

### DIFF
--- a/pkg/server/options/options.go
+++ b/pkg/server/options/options.go
@@ -332,6 +332,16 @@ func (o *Options) Complete(ctx context.Context, rootDir string) (*CompletedOptio
 	// o.GenericControlPlane.Complete creates self-signed certificates
 	// with the advertise address by default. This can cause spurious
 	// errors if the server binds on multiple interfaces.
+	//
+	// Set AdvertiseAddress to 127.0.0.1 by default. This ensures that
+	// self-signed certificates are generated with 127.0.0.1 as the CN,
+	// which is stable across network changes (unlike NIC IPs that can change).
+	// The --advertise-address flag is intentionally not exposed to users,
+	// so we set a sensible default here.
+	if o.GenericControlPlane.GenericServerRunOptions.AdvertiseAddress == nil || o.GenericControlPlane.GenericServerRunOptions.AdvertiseAddress.IsUnspecified() {
+		o.GenericControlPlane.GenericServerRunOptions.AdvertiseAddress = net.ParseIP("127.0.0.1")
+	}
+
 	possibleIPs := []net.IP{
 		o.GenericControlPlane.GenericServerRunOptions.AdvertiseAddress,
 		o.GenericControlPlane.SecureServing.BindAddress,


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

When running `kcp start`, it takes the IP of the primary NIC. So when moving between networks or VPNs, this changes, so it invalidates the certificate. 

## What Type of PR Is This?
/kind cleanup
<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
