### PR TITLE
WIP Use t.Context() instead of manual context cancellation in tests

### DIFF
--- a/staging/src/github.com/kcp-dev/sdk/testing/kcp.go
+++ b/staging/src/github.com/kcp-dev/sdk/testing/kcp.go
@@ -17,7 +17,6 @@ limitations under the License.
 package testing
 
 import (
-	"context"
 	"embed"
 	"path/filepath"
 
@@ -86,12 +85,9 @@ func SharedKcpServer(t TestingT) kcptestingserver.RunningServer {
 		s, err := kcptestingserver.NewExternalKCPServer(sharedConfig.Name, externalConfig.kubeconfigPath, externalConfig.shardKubeconfigPaths, filepath.Dir(KubeconfigPath()))
 		require.NoError(t, err, "failed to create persistent server fixture")
 
-		ctx, cancel := context.WithCancel(context.Background())
-		t.Cleanup(cancel)
-
 		rootCfg := s.RootShardSystemMasterBaseConfig(t)
 		t.Logf("Waiting for readiness for server at %s", rootCfg.Host)
-		err = kcptestingserver.WaitForReady(ctx, rootCfg)
+		err = kcptestingserver.WaitForReady(t.Context(), rootCfg)
 		require.NoError(t, err, "external server is not ready")
 
 		kcptestingserver.MonitorEndpoints(t, rootCfg, "/livez", "/readyz")

--- a/staging/src/github.com/kcp-dev/sdk/testing/server/fixture.go
+++ b/staging/src/github.com/kcp-dev/sdk/testing/server/fixture.go
@@ -109,17 +109,12 @@ func NewFixture(t TestingT, cfgs ...Config) Fixture {
 		// Wait for the server to become ready
 		g.Go(func() error {
 			if err := srv.loadCfg(ctx); err != nil {
-				// Cancel the context to kill all goroutines - if any
-				// server failed to setup properly the setup quits
-				// anyhow.
-				cancel()
 				return err
 			}
 
 			rootCfg := srv.RootShardSystemMasterBaseConfig(t)
 			t.Logf("Waiting for readiness for server at %s", rootCfg.Host)
 			if err := WaitForReady(ctx, rootCfg); err != nil {
-				cancel()
 				return err
 			}
 

--- a/staging/src/github.com/kcp-dev/sdk/testing/server/testing.go
+++ b/staging/src/github.com/kcp-dev/sdk/testing/server/testing.go
@@ -16,9 +16,12 @@ limitations under the License.
 
 package server
 
+import "context"
+
 // TestingT is implemented by *testing.T and potentially other test frameworks.
 type TestingT interface {
 	Cleanup(func())
+	Context() context.Context
 	Error(args ...any)
 	Errorf(format string, args ...any)
 	FailNow()

--- a/staging/src/github.com/kcp-dev/sdk/testing/testing.go
+++ b/staging/src/github.com/kcp-dev/sdk/testing/testing.go
@@ -16,9 +16,12 @@ limitations under the License.
 
 package testing
 
+import "context"
+
 // TestingT is implemented by *testing.T and potentially other test frameworks.
 type TestingT interface {
 	Cleanup(func())
+	Context() context.Context
 	Error(args ...any)
 	Errorf(format string, args ...any)
 	FailNow()

--- a/test/e2e/apibinding/apibinding_deletion_test.go
+++ b/test/e2e/apibinding/apibinding_deletion_test.go
@@ -53,8 +53,7 @@ func TestAPIBindingDeletion(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 	providerPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)

--- a/test/e2e/apibinding/apibinding_logicalcluster_test.go
+++ b/test/e2e/apibinding/apibinding_logicalcluster_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package apibinding
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -60,8 +59,7 @@ func TestAPIBindingLogicalCluster(t *testing.T) {
 	t.Logf("providerPath: %v", providerPath)
 	t.Logf("consumerPath: %v", consumerPath)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	cfg := server.BaseConfig(t)
 
@@ -193,8 +191,7 @@ func TestAPIBindingCRDs(t *testing.T) {
 	t.Logf("providerPath: %v", providerPath)
 	t.Logf("consumerPath: %v", consumerPath)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	cfg := server.BaseConfig(t)
 

--- a/test/e2e/apibinding/apibinding_permissionclaims_test.go
+++ b/test/e2e/apibinding/apibinding_permissionclaims_test.go
@@ -55,8 +55,7 @@ func TestAPIBindingPermissionClaimsConditions(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 	providerPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)

--- a/test/e2e/apibinding/apibinding_protected_test.go
+++ b/test/e2e/apibinding/apibinding_protected_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package apibinding
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -47,8 +46,7 @@ func TestProtectedAPI(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 	providerPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)

--- a/test/e2e/apibinding/apibinding_test.go
+++ b/test/e2e/apibinding/apibinding_test.go
@@ -67,8 +67,7 @@ func TestAPIBindingAPIExportReferenceImmutability(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 	providerPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath, kcptesting.WithName("service-provider-1"))
@@ -167,8 +166,7 @@ func TestAPIBinding(t *testing.T) {
 	server := kcptesting.SharedKcpServer(t)
 	cfg := server.BaseConfig(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	t.Logf("Check if we can access shards")
 	var shards *corev1alpha1.ShardList

--- a/test/e2e/apibinding/apibinding_webhook_test.go
+++ b/test/e2e/apibinding/apibinding_webhook_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package apibinding
 
 import (
-	"context"
 	"crypto/tls"
 	"fmt"
 	gohttp "net/http"
@@ -62,8 +61,7 @@ func TestAPIBindingMutatingWebhook(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 	sourcePath, sourceWS := kcptesting.NewWorkspaceFixture(t, server, orgPath)
@@ -247,8 +245,7 @@ func TestAPIBindingValidatingWebhook(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 	sourcePath, sourceWS := kcptesting.NewWorkspaceFixture(t, server, orgPath)

--- a/test/e2e/apibinding/default_apibinding_test.go
+++ b/test/e2e/apibinding/default_apibinding_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package apibinding
 
 import (
-	"context"
 	"fmt"
 	"slices"
 	"strings"
@@ -57,8 +56,7 @@ func TestDefaultAPIBinding(t *testing.T) {
 
 	t.Logf("providerPath: %v", providerPath)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	cfg := server.BaseConfig(t)
 

--- a/test/e2e/apibinding/maximalpermissionpolicy_authorizer_test.go
+++ b/test/e2e/apibinding/maximalpermissionpolicy_authorizer_test.go
@@ -57,8 +57,7 @@ func TestMaximalPermissionPolicyAuthorizerSystemGroupProtection(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	kubeClusterClient, err := kcpkubernetesclientset.NewForConfig(server.BaseConfig(t))
 	require.NoError(t, err, "failed to construct dynamic cluster client for server")
@@ -152,8 +151,7 @@ func TestMaximalPermissionPolicyAuthorizer(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 	rbacServiceProviderPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)

--- a/test/e2e/audit/audit_log_test.go
+++ b/test/e2e/audit/audit_log_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package audit
 
 import (
-	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -59,8 +58,7 @@ func TestAuditLogs(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Listing configmaps")
-	ctx := context.Background()
-	_, err = workspaceKubeClient.Cluster(wsPath).CoreV1().ConfigMaps("default").List(ctx, metav1.ListOptions{})
+	_, err = workspaceKubeClient.Cluster(wsPath).CoreV1().ConfigMaps("default").List(t.Context(), metav1.ListOptions{})
 	require.NoError(t, err, "Error listing configmaps")
 
 	auditLogPath := filepath.Join(artifactDir, "kcp", "main", "kcp.audit")

--- a/test/e2e/authentication/workspace_test.go
+++ b/test/e2e/authentication/workspace_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package authentication
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -45,7 +44,7 @@ import (
 func TestWorkspaceOIDC(t *testing.T) {
 	framework.Suite(t, "control-plane")
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// start kcp and setup clients
 	server := kcptesting.SharedKcpServer(t)
@@ -254,7 +253,7 @@ func TestWorkspaceOIDC(t *testing.T) {
 func TestUserScope(t *testing.T) {
 	framework.Suite(t, "control-plane")
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// start kcp and setup clients
 	server := kcptesting.SharedKcpServer(t)
@@ -343,7 +342,7 @@ func TestUserScope(t *testing.T) {
 func TestForbiddenSystemAccess(t *testing.T) {
 	framework.Suite(t, "control-plane")
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// start kcp and setup clients
 	server := kcptesting.SharedKcpServer(t)
@@ -571,7 +570,7 @@ func TestAcceptableWorkspaceAuthenticationConfigurations(t *testing.T) {
 func TestWorkspaceOIDCTokenReview(t *testing.T) {
 	framework.Suite(t, "control-plane")
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// start kcp and setup clients
 	server := kcptesting.SharedKcpServer(t)

--- a/test/e2e/customresourcedefinition/customresourcedefinition_test.go
+++ b/test/e2e/customresourcedefinition/customresourcedefinition_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package customresourcedefinition
 
 import (
-	"context"
 	"embed"
 	"testing"
 
@@ -44,8 +43,7 @@ func TestCustomResourceCreation(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 	sourcePath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)

--- a/test/e2e/garbagecollector/garbagecollector_test.go
+++ b/test/e2e/garbagecollector/garbagecollector_test.go
@@ -64,8 +64,7 @@ func TestGarbageCollectorBuiltInCoreV1Types(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	cfg := server.BaseConfig(t)
 
@@ -109,8 +108,7 @@ func TestGarbageCollectorTypesFromBinding(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 
@@ -275,8 +273,7 @@ func TestGarbageCollectorNormalCRDs(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	cfg := server.BaseConfig(t)
 
@@ -361,8 +358,7 @@ func TestGarbageCollectorVersionedCRDs(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	cfg := server.BaseConfig(t)
 
@@ -527,8 +523,7 @@ func TestGarbageCollectorClusterScopedCRD(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	cfg := server.BaseConfig(t)
 

--- a/test/e2e/proxy/proxy_test.go
+++ b/test/e2e/proxy/proxy_test.go
@@ -43,7 +43,7 @@ import (
 func TestMappingWithClusterContext(t *testing.T) {
 	framework.Suite(t, "control-plane")
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// start kcp and setup clients;
 	// note that the sharded-test-server will configure a special

--- a/test/e2e/quota/quota_test.go
+++ b/test/e2e/quota/quota_test.go
@@ -60,8 +60,7 @@ func TestKubeQuotaBuiltInCoreV1Types(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	cfg := server.BaseConfig(t)
 
@@ -117,8 +116,7 @@ func TestKubeQuotaCoreV1TypesFromBinding(t *testing.T) {
 
 	source := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	// Test multiple workspaces in parallel
 	for i := range 5 {
@@ -252,8 +250,7 @@ func TestKubeQuotaNormalCRDs(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	cfg := server.BaseConfig(t)
 
@@ -337,8 +334,7 @@ func TestClusterScopedQuota(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	cfg := server.BaseConfig(t)
 

--- a/test/e2e/reconciler/apiexport/apiexport_controller_test.go
+++ b/test/e2e/reconciler/apiexport/apiexport_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package apiexport
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -42,8 +41,7 @@ func TestRequeueWhenIdentitySecretAdded(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 	workspacePath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)

--- a/test/e2e/reconciler/apiexportendpointslice/apiexportendpointslice_test.go
+++ b/test/e2e/reconciler/apiexportendpointslice/apiexportendpointslice_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package apiexportendpointslice
 
 import (
-	"context"
 	"embed"
 	"fmt"
 	"testing"
@@ -54,8 +53,7 @@ var testFiles embed.FS
 
 func TestAPIExportEndpointSliceWithPartition(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	server := kcptesting.SharedKcpServer(t)
 
 	// Create Organization and Workspaces
@@ -181,8 +179,7 @@ func TestAPIBindingEndpointSlicesSharded(t *testing.T) {
 	framework.Suite(t, "control-plane")
 
 	server := kcptesting.SharedKcpServer(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	cfg := server.BaseConfig(t)
 

--- a/test/e2e/reconciler/cache/replication_test.go
+++ b/test/e2e/reconciler/cache/replication_test.go
@@ -436,8 +436,7 @@ func TestReplication(t *testing.T) {
 	framework.Suite(t, "control-plane")
 
 	server := kcptesting.SharedKcpServer(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	kcpRootShardConfig := server.RootShardSystemMasterBaseConfig(t)
 	kcpShardDynamicClient, err := kcpdynamic.NewForConfig(kcpRootShardConfig)
@@ -479,8 +478,7 @@ func TestReplicationDisruptive(t *testing.T) {
 			server := kcptesting.PrivateKcpServer(t,
 				kcptestingserver.WithCustomArguments("--token-auth-file", framework.DefaultTokenAuthFile),
 			)
-			ctx, cancel := context.WithCancel(context.Background())
-			t.Cleanup(cancel)
+			ctx := t.Context()
 
 			kcpRootShardConfig := server.RootShardSystemMasterBaseConfig(t)
 			kcpRootShardDynamicClient, err := kcpdynamic.NewForConfig(kcpRootShardConfig)

--- a/test/e2e/reconciler/workspace/apibinding_initializer_test.go
+++ b/test/e2e/reconciler/workspace/apibinding_initializer_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package workspace
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -43,8 +42,7 @@ func TestWorkspaceTypesAPIBindingInitialization(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 

--- a/test/e2e/server/url_test.go
+++ b/test/e2e/server/url_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package server
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"net/url"
@@ -82,9 +81,7 @@ func TestURLs(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			// TODO(ntnn): Replace with t.Context in go1.24
-			ctx, cancel := context.WithCancel(context.Background())
-			t.Cleanup(cancel)
+			ctx := t.Context()
 
 			u, err := url.Parse(cfg.Host)
 			require.NoError(t, err)
@@ -120,9 +117,7 @@ func TestURLWithClusterKind(t *testing.T) {
 		t.Run(string(scope), func(t *testing.T) {
 			t.Parallel()
 
-			// TODO(ntnn): Replace with t.Context in go1.24
-			ctx, cancel := context.WithCancel(context.Background())
-			t.Cleanup(cancel)
+			ctx := t.Context()
 
 			orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 

--- a/test/e2e/virtual/apiexport/authorizer_test.go
+++ b/test/e2e/virtual/apiexport/authorizer_test.go
@@ -71,8 +71,7 @@ func TestAPIExportAuthorizers(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 
@@ -516,8 +515,7 @@ func TestAPIExportBindingAuthorizer(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 	cfg := server.BaseConfig(t)
@@ -922,8 +920,7 @@ func TestRootAPIExportAuthorizers(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 
@@ -1087,8 +1084,7 @@ func TestRootAPIExportAuthorizers(t *testing.T) {
 func vwURL(t *testing.T, kcpClusterClient kcpclientset.ClusterInterface, path logicalcluster.Path, export string, ws *tenancyv1alpha1.Workspace, wsPath logicalcluster.Path) string {
 	t.Helper()
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	t.Cleanup(cancelFunc)
+	ctx := t.Context()
 
 	var vwURL string
 	kcptestinghelpers.Eventually(t, func() (bool, string) {

--- a/test/e2e/virtual/apiexport/binding_test.go
+++ b/test/e2e/virtual/apiexport/binding_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package apiexport
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -56,8 +55,7 @@ func TestBinding(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	t.Logf("Creating two service workspaces and a consumer workspace")
 	org, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
@@ -257,8 +255,7 @@ func TestAPIBindingPermissionClaimsVerbs(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 	providerPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)
@@ -440,8 +437,7 @@ func TestAPIBindingPermissionClaimsSSA(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 	providerPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)
@@ -595,8 +591,7 @@ func TestAPIBindingPermissionClaimsSelectors(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 	providerPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)
@@ -841,8 +836,7 @@ func TestAPIBindingPermissionClaimsSelectorUpdate(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 	providerPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)

--- a/test/e2e/virtual/apiexport/openapi_test.go
+++ b/test/e2e/virtual/apiexport/openapi_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package apiexport
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -47,8 +46,7 @@ func TestAPIExportOpenAPI(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	cfg := server.BaseConfig(t)
 

--- a/test/e2e/virtual/apiexport/virtualworkspace_test.go
+++ b/test/e2e/virtual/apiexport/virtualworkspace_test.go
@@ -81,8 +81,7 @@ func TestAPIExportVirtualWorkspace(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	cfg := server.BaseConfig(t)
 
@@ -341,8 +340,7 @@ func TestAPIExportAPIBindingsAccess(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 	ws1Path, ws1 := kcptesting.NewWorkspaceFixture(t, server, orgPath, kcptesting.WithName("workspace1"))
@@ -569,8 +567,7 @@ func TestAPIExportPermissionClaims(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	// Need to Create a Producer w/ APIExport
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))

--- a/test/e2e/virtual/replication/virtualworkspace_test.go
+++ b/test/e2e/virtual/replication/virtualworkspace_test.go
@@ -63,8 +63,7 @@ func TestCachedResourceVirtualWorkspace(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	cfg := server.BaseConfig(t)
 

--- a/test/e2e/virtualresources/cachedresources/vr_cachedresources_test.go
+++ b/test/e2e/virtualresources/cachedresources/vr_cachedresources_test.go
@@ -77,8 +77,7 @@ func TestCachedResources(t *testing.T) {
 	t.Logf("consumer1Path: %v", consumer1Path)
 	t.Logf("consumer2Path: %v", consumer2Path)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	cfg := server.BaseConfig(t)
 

--- a/test/e2e/watchcache/watchcache_enabled_test.go
+++ b/test/e2e/watchcache/watchcache_enabled_test.go
@@ -56,8 +56,7 @@ func TestWatchCacheEnabledForCRD(t *testing.T) {
 	framework.Suite(t, "control-plane")
 
 	server := kcptesting.SharedKcpServer(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 	// note that we schedule the workspace on the root shard because
 	// we need a direct and privileged access to it for downloading the metrics
@@ -116,8 +115,7 @@ func TestWatchCacheEnabledForAPIBindings(t *testing.T) {
 	framework.Suite(t, "control-plane")
 
 	server := kcptesting.SharedKcpServer(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 	clusterConfig := server.BaseConfig(t)
 	kcpClusterClient, err := kcpclientset.NewForConfig(clusterConfig)
 	require.NoError(t, err)
@@ -168,8 +166,7 @@ func TestWatchCacheEnabledForBuiltinTypes(t *testing.T) {
 	framework.Suite(t, "control-plane")
 
 	server := kcptesting.SharedKcpServer(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 	clusterConfig := server.BaseConfig(t)
 	kubeClusterClient, err := kcpkubernetesclientset.NewForConfig(clusterConfig)
 	require.NoError(t, err)

--- a/test/e2e/workspace/inactive_test.go
+++ b/test/e2e/workspace/inactive_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package workspace
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -41,9 +40,7 @@ func TestInactiveLogicalCluster(t *testing.T) {
 	t.Parallel()
 	framework.Suite(t, "control-plane")
 
-	// TODO(ntnn): Repalce with t.Context in go1.24
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx := t.Context()
 
 	server := kcptesting.SharedKcpServer(t)
 	cfg := server.BaseConfig(t)

--- a/test/integration/dynamicrestmapper/dynamicrestmapper_test.go
+++ b/test/integration/dynamicrestmapper/dynamicrestmapper_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package dynamicrestmapper
 
 import (
-	"context"
 	"fmt"
 	"math/rand/v2"
 	"strings"
@@ -51,7 +50,7 @@ import (
 
 func TestDynamicRestMapper(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	server, kcpClientSet, _ := framework.StartTestServer(t)
 

--- a/test/integration/framework/server.go
+++ b/test/integration/framework/server.go
@@ -164,11 +164,7 @@ func (s *InProcessServer) Start(ctx context.Context, t kcptestingserver.TestingT
 }
 
 func (s *InProcessServer) Wait(t kcptestingserver.TestingT) {
-	// TODO: replace with t.Context() in go1.24
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-
-	if err := kcptestingserver.WaitForReady(ctx, s.RESTConfig(t, "base")); err != nil {
+	if err := kcptestingserver.WaitForReady(t.Context(), s.RESTConfig(t, "base")); err != nil {
 		t.Fatalf("server did not become ready: %v", err)
 	}
 }
@@ -201,11 +197,7 @@ func (s *InProcessServer) KubeconfigPath() string {
 func (s *InProcessServer) loadCfg(t kcptestingserver.TestingT) {
 	t.Helper()
 	s.loadCfgOnce.Do(func() {
-		// TODO replace with t.Context() in go1.24
-		ctx, cancel := context.WithCancel(context.Background())
-		t.Cleanup(cancel)
-
-		config, err := kcptestingserver.WaitLoadKubeConfig(ctx, s.Config.KubeconfigPath(), "base")
+		config, err := kcptestingserver.WaitLoadKubeConfig(t.Context(), s.Config.KubeconfigPath(), "base")
 		if err != nil {
 			t.Fatalf("failed to load base kubeconfig: %v", err)
 		}

--- a/test/integration/workspace/leak_test.go
+++ b/test/integration/workspace/leak_test.go
@@ -101,8 +101,7 @@ var (
 )
 
 func TestWorkspaceDeletionLeak(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel) // TODO update in go1.24
+	ctx := t.Context()
 
 	_, kcpClient, _ := framework.StartTestServer(t)
 


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary
This change simplifies test context handling by replacing manual context creation and cleanup with `t.Context()`.

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #3535

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
