### PR TITLE
Return proper error when resolving identities fails

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -531,14 +531,16 @@ func (s *Server) Run(ctx context.Context) error {
 			logger.Info("bootstrapped root workspace phase 0")
 
 			logger.Info("getting kcp APIExport identities")
+			var identityErr error
 			if err := wait.PollUntilContextCancel(hookCtx, time.Millisecond*500, true, func(ctx context.Context) (bool, error) {
 				if err := s.resolveIdentities(ctx); err != nil {
 					logger.V(3).Info("failed to resolve identities, keeping trying", "err", err)
+					identityErr = err
 					return false, nil
 				}
 				return true, nil
 			}); err != nil {
-				logger.Error(err, "failed to get or create identities")
+				logger.Error(err, "failed to get or create identities: %w", identityErr)
 				return nil // don't klog.Fatal. This only happens when context is cancelled.
 			}
 			logger.Info("finished getting kcp APIExport identities")


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

The error is logged on log level three and when this fails the error is just `context cancelled` without any further info.

This changes it so that if this step fails at least the last error is returned as part of the error.

## What Type of PR Is This?

/kind bug

Imho a bug because just returning context cancellation isn't useful. Could also be cleanup.

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
