### PR TITLE
re-enable and fix TestAPIExportAPIBindingsAccess

### DIFF
--- a/test/e2e/virtual/apiexport/apibindings_access_binding1.yaml
+++ b/test/e2e/virtual/apiexport/apibindings_access_binding1.yaml
@@ -1,8 +1,8 @@
-apiVersion: apis.kcp.io/v1alpha1
+apiVersion: apis.kcp.io/v1alpha2
 kind: APIBinding
 metadata:
   name: binding1
 spec:
   reference:
-    workspace:
-      exportName: export1
+    export:
+      name: export1

--- a/test/e2e/virtual/apiexport/apibindings_access_binding2.yaml
+++ b/test/e2e/virtual/apiexport/apibindings_access_binding2.yaml
@@ -1,8 +1,8 @@
-apiVersion: apis.kcp.io/v1alpha1
+apiVersion: apis.kcp.io/v1alpha2
 kind: APIBinding
 metadata:
   name: binding2
 spec:
   reference:
-    workspace:
-      exportName: export2
+    export:
+      name: export2

--- a/test/e2e/virtual/apiexport/apibindings_access_binding3.yaml
+++ b/test/e2e/virtual/apiexport/apibindings_access_binding3.yaml
@@ -1,8 +1,8 @@
-apiVersion: apis.kcp.io/v1alpha1
+apiVersion: apis.kcp.io/v1alpha2
 kind: APIBinding
 metadata:
   name: binding3
 spec:
   reference:
-    workspace:
-      exportName: export3
+    export:
+      name: export3

--- a/test/e2e/virtual/apiexport/apibindings_access_export1.yaml
+++ b/test/e2e/virtual/apiexport/apibindings_access_export1.yaml
@@ -1,7 +1,16 @@
-apiVersion: apis.kcp.io/v1alpha1
+apiVersion: apis.kcp.io/v1alpha2
 kind: APIExport
 metadata:
   name: export1
 spec:
-  latestResourceSchemas:
-  - v1.widgets.example.io
+  resources:
+  - name: widgets
+    group: example.io
+    schema: v1.widgets.example.io
+    storage:
+      crd: {}
+  permissionClaims:
+  - group: apis.kcp.io
+    resource: apibindings
+    verbs:
+    - "*"

--- a/test/e2e/virtual/apiexport/apibindings_access_export2.yaml
+++ b/test/e2e/virtual/apiexport/apibindings_access_export2.yaml
@@ -1,7 +1,16 @@
-apiVersion: apis.kcp.io/v1alpha1
+apiVersion: apis.kcp.io/v1alpha2
 kind: APIExport
 metadata:
   name: export2
 spec:
-  latestResourceSchemas:
-  - v1.widgets.anotherexample.io
+  resources:
+  - name: widgets
+    group: anotherexample.io
+    schema: v1.widgets.anotherexample.io
+    storage:
+      crd: {}
+  permissionClaims:
+  - group: apis.kcp.io
+    resource: apibindings
+    verbs:
+    - "*"

--- a/test/e2e/virtual/apiexport/apibindings_access_export3.yaml
+++ b/test/e2e/virtual/apiexport/apibindings_access_export3.yaml
@@ -1,7 +1,16 @@
-apiVersion: apis.kcp.io/v1alpha1
+apiVersion: apis.kcp.io/v1alpha2
 kind: APIExport
 metadata:
   name: export3
 spec:
-  latestResourceSchemas:
-  - v1.widgets.yetanotherexample.io
+  resources:
+  - name: widgets
+    group: yetanotherexample.io
+    schema: v1.widgets.yetanotherexample.io
+    storage:
+      crd: {}
+  permissionClaims:
+  - group: apis.kcp.io
+    resource: apibindings
+    verbs:
+    - "*"


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

- Updated YAML files from v1alpha1 to v1alpha2 format, including changing spec.reference.workspace.exportName to `spec.reference.export.name` for bindings, and spec.latestResourceSchemas to spec.resources for exports
- Added permissionClaims for apibindings resource to the export YAML files, which is required for the virtual workspace to serve claimed resources
- Fixed bug where the test constructed invalid URLs with duplicate /clusters/* path segments by using the correct client type
- Fixed test flow to accept permission claims before querying the virtual workspace (the virtual workspace only serves claimed resources after at least one binding accepts the claim)
- Added wait for PermissionClaimsApplied condition to avoid race conditions between the test and the controller
- Updated final verification to correctly check that after rejecting claims, only bindings pointing directly to the export remain visible

## What Type of PR Is This?
/kind flake
<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #2263

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
