### PR TITLE
update-codegen-clients.sh: remove TODO about generate-groups.sh

### DIFF
--- a/hack/update-codegen-clients.sh
+++ b/hack/update-codegen-clients.sh
@@ -30,7 +30,6 @@ CODEGEN_PKG=${CODEGEN_PKG:-$(cd "${SCRIPT_ROOT}"; go list -f '{{.Dir}}' -m k8s.i
 CLUSTER_CODEGEN_PKG=${CLUSTER_CODEGEN_PKG:-$(cd "${SCRIPT_ROOT}"; go list -f '{{.Dir}}' -m github.com/kcp-dev/code-generator/v3)}
 OPENAPI_PKG=${OPENAPI_PKG:-$(cd "${SCRIPT_ROOT}"; go list -f '{{.Dir}}' -m k8s.io/kube-openapi)}
 
-# TODO: use generate-groups.sh directly instead once https://github.com/kubernetes/kubernetes/pull/114987 is available
 go install "${CODEGEN_PKG}"/cmd/applyconfiguration-gen
 go install "${CODEGEN_PKG}"/cmd/client-gen
 


### PR DESCRIPTION

<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Calling generate-groups.sh (kube_codegen.sh) is less flexible than calling the generators directly. One main point is that the generators accept multiple inputs at the same time, while the gen_client function accept a single input dir:

   USAGE: kube::codegen::gen_client [FLAGS] <input-dir>

This doesn't work well with the additional inputs that are currently passed from different root packages.

Remove the TODO to use gnerate-groups.sh and keep calling the generators directly.

Additionally, the openapi gen is also currently called directly and not switching it to the respective function would be inconsistent. Switching it to the function is a breaking change as the API currently has violations and the function performs validation.

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind cleanup

## Related Issue(s)

Fixes https://github.com/kcp-dev/kcp/issues/3563

additional context
https://github.com/kcp-dev/kcp/issues/3563#issuecomment-3790586486

> If the lines are still needed and the best solution update the comment to reflect that.

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
