### PR TITLE
fix flake in TestTerminatingWorkspacesVirtualWorkspaceWatch

### DIFF
--- a/test/e2e/virtual/terminatingworkspaces/virtualworkspace_test.go
+++ b/test/e2e/virtual/terminatingworkspaces/virtualworkspace_test.go
@@ -620,7 +620,7 @@ func TestTerminatingWorkspacesVirtualWorkspaceWatch(t *testing.T) {
 				watcher, err = clientset.CoreV1alpha1().LogicalClusters().Watch(ctx, metav1.ListOptions{})
 				require.NoError(c, err)
 				require.NotNil(c, watcher) // if we are too fast, it is possible for .Watch to return no error but a nil watcher
-			}, wait.ForeverTestTimeout, 100*time.Millisecond)
+			}, wait.ForeverTestTimeout*2, 100*time.Millisecond)
 			con.watcher = watcher
 		}
 	}


### PR DESCRIPTION
The issue seems to be delayed RBAC propagation.
Naively attempt to increase the timeout.

<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes https://github.com/kcp-dev/kcp/issues/3770

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
