### PR TITLE
attempt to fix flake in TestCachedResources

### DIFF
--- a/test/e2e/virtualresources/cachedresources/vr_cachedresources_test.go
+++ b/test/e2e/virtualresources/cachedresources/vr_cachedresources_test.go
@@ -364,7 +364,7 @@ func TestCachedResources(t *testing.T) {
 			}
 		}
 		return true, ""
-	}, wait.ForeverTestTimeout, time.Second*1, "waiting for two sheriffs")
+	}, wait.ForeverTestTimeout*2, time.Millisecond*500, "waiting for two sheriffs")
 
 	t.Log("Stopping watches")
 	for _, stop := range watchStopFuncs {


### PR DESCRIPTION


<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

A flake can happen when waiting for the 2 sherriffs. One way to attempt to deflake this is to increase the timeout and reduce the retry interval.

additional debugging and context here:
https://github.com/kcp-dev/kcp/issues/3812#issuecomment-3848142190

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind flake

## Related Issue(s)

Fixes https://github.com/kcp-dev/kcp/issues/3812

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
