### PR TITLE
fix: set the interim workspace phase as Scheduling

### DIFF
--- a/pkg/admission/workspace/admission.go
+++ b/pkg/admission/workspace/admission.go
@@ -95,10 +95,6 @@ func (o *workspace) Admit(ctx context.Context, a admission.Attributes, _ admissi
 	if a.GetOperation() == admission.Create {
 		isSystemPrivileged := sets.New[string](a.GetUserInfo().GetGroups()...).Has(kuser.SystemPrivilegedGroup)
 
-		if ws.Status.Phase == "" {
-			ws.Status.Phase = corev1alpha1.LogicalClusterPhaseScheduling
-		}
-
 		// create owner anntoation
 		if !isSystemPrivileged {
 			userInfo, err := WorkspaceOwnerAnnotationValue(a.GetUserInfo())

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_metadata.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_metadata.go
@@ -37,6 +37,12 @@ func (r *metaDataReconciler) reconcile(ctx context.Context, workspace *tenancyv1
 	}
 
 	changed := false
+
+	if workspace.Status.Phase == "" {
+		workspace.Status.Phase = corev1alpha1.LogicalClusterPhaseScheduling
+		changed = true
+	}
+
 	expected := string(workspace.Status.Phase)
 	if !workspace.DeletionTimestamp.IsZero() {
 		expected = "Deleting"


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

This aims to fix the flake in the workspace not being ready in the initial phase in the e2e test.
Sets the initial phase in the workspace metadata reconciler during workspace creation to "Scheduling", suspecting the clue was the race conditions between different reconcilers, then it should transition to "Initializing" and "Ready" properly.
## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->
/kind flake

## Related Issue(s)

Fixes https://github.com/kcp-dev/kcp/issues/3811

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
