### PR TITLE
use shard external URL for APIExportEndpointSlice.

### DIFF
--- a/pkg/reconciler/apis/apiexportendpointsliceurls/apiexportendpointsliceurls_reconcile.go
+++ b/pkg/reconciler/apis/apiexportendpointsliceurls/apiexportendpointsliceurls_reconcile.go
@@ -150,7 +150,7 @@ func (r *endpointsReconciler) updateEndpoints(ctx context.Context,
 		}
 	}
 
-	u, err := url.Parse(shard.Spec.VirtualWorkspaceURL)
+	u, err := url.Parse(shard.Spec.ExternalURL)
 	if err != nil {
 		// Should never happen
 		logger = logging.WithObject(logger, shard)


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary
/kind bug

Fixes the URL for APIExportEndpointSlice to be the external instead of the internal/base URL. This is required for the api-syncagent to work, otherwise it is crashing because it cannot call the internal URL from an external cluster.

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)


## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
