### PR TITLE
Add stopping integration server to cleanup queue

### DIFF
--- a/test/integration/framework/server.go
+++ b/test/integration/framework/server.go
@@ -161,6 +161,7 @@ func (s *InProcessServer) Start(ctx context.Context, t kcptestingserver.TestingT
 			t.Errorf("`kcp` failed: %v", err)
 		}
 	}()
+	t.Cleanup(s.Stop)
 }
 
 func (s *InProcessServer) Wait(t kcptestingserver.TestingT) {


### PR DESCRIPTION


<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

The integration server was stopped by cancelling the context. This works
well but sometimes the test suite was a smidge faster than the server
and tried to delete the test directories kcp and etcd were still using:

    TempDir RemoveAll cleanup: unlinkat .../artifacts/etcd-server/member/wal: directory not empty

To prevent this stopping the server is added to the cleanup queue so the
test teardown only starts deleting the temporary directories after the
server is shutdown properly.

## What Type of PR Is This?

/kind bug
/kind flake

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #3818 

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
