### PR TITLE
Deprecate --external-hostname and set based on --shard-base-url or --bind-address

### DIFF
--- a/pkg/server/options/flags.go
+++ b/pkg/server/options/flags.go
@@ -122,7 +122,6 @@ var (
 		"shutdown-delay-duration",                 // Time to delay the termination. During that time the server keeps serving requests normally. The endpoints /healthz and /livez will return success, but /readyz immediately returns failure. Graceful termination starts after this delay has elapsed. This can be used to allow load balancer to stop sending traffic to this server.
 		"shutdown-send-retry-after",               // If true the HTTP Server will continue listening until all non long running request(s) in flight have been drained, during this window all incoming requests will be rejected with a status code 429 and a 'Retry-After' response header, in addition 'Connection: close' response header is set in order to tear down the TCP connection when idle.
 		"strict-transport-security-directives",    // List of directives for HSTS, comma separated. If this list is empty, then HSTS directives will not be added. Example: 'max-age=31536000,includeSubDomains,preload'
-		"external-hostname",                       // The hostname to use when generating externalized URLs for this master (e.g. Swagger API Docs or OpenID Discovery).
 		"shutdown-watch-termination-grace-period", // his option, if set, represents the maximum amount of grace period the apiserver will wait for active watch request(s) to drain during the graceful server shutdown window.
 		"emulated-version",                        // The versions different components emulate their capabilities (APIs, features, ...) of.
 		"storage-initialization-timeout",          // Maximum amount of time to wait for storage initialization before declaring apiserver ready. Defaults to 1m.
@@ -178,6 +177,7 @@ var (
 		"max-requests-inflight",          // This and --max-mutating-requests-inflight are summed to determine the server's total concurrency limit (which must be positive) if --enable-priority-and-fairness is true. Otherwise, this flag limits the maximum number of non-mutating requests in flight, or a zero value disables the limit completely.
 		"min-request-timeout",            // An optional field indicating the minimum number of seconds a handler must keep a request open before timing it out. Currently only honored by the watch request handler, which picks a randomized value above this number as the connection timeout, to spread out load.
 		"request-timeout",                // An optional field indicating the duration a handler must keep a request open before timing it out. This is the default request timeout for requests but may be overridden by flags such as --min-request-timeout for specific types of requests.
+		"external-hostname",              // The hostname to use when generating externalized URLs for this master (e.g. Swagger API Docs or OpenID Discovery).
 
 		// etcd flags
 		"default-watch-cache-size",  // Default watch cache size. If zero, watch cache will be disabled for resources that do not have a default watch size set.


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Disallow setting `--external-hostname` and set based on `--shard-base-url` or `--bind-address` instead.

In kcp-operator we are already forcing `--external-hostname` to `--shard-base-url`: https://github.com/kcp-dev/kcp-operator/blob/850a5f963929303bc1b3c311aa7a23360ab7b871/internal/resources/shard/deployment.go#L203-L204

## What Type of PR Is This?

/kind cleanup

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Somewhat related to #3830, but not directly.

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Deprecate `--external-hostname`, determined based on `--shard-base-url` or `--bind-address` instead
```
