### PR TITLE
WIP Fix self-subject reviews returning 403 even with the right RBAC permissions

### DIFF
--- a/test/e2e/authorizer/authorizer_test.go
+++ b/test/e2e/authorizer/authorizer_test.go
@@ -279,10 +279,11 @@ func TestAuthorizer(t *testing.T) {
 		{"default SelfSubjectRulesReview for non-admin user should be a fixed list of rules", func(t *testing.T) {
 			ws := org1.Join("workspace2")
 
-			// user shouldn't be able to do a SelfSubjectRulesReview in a workspace they don't have access to.
-			t.Logf("verifying that user-4 cannot create SelfSubjectRulesReview in %s", org1.Join("workspace1"))
+			// self-subject reviews bypass the workspace access gate, so they should succeed
+			// even in workspaces the user doesn't have workspace access to.
+			t.Logf("verifying that user-4 can create SelfSubjectRulesReview in %s (no workspace access)", org1.Join("workspace1"))
 			_, err := user4KubeClusterClient.Cluster(org1.Join("workspace1")).AuthorizationV1().SelfSubjectRulesReviews().Create(ctx, &authorizationv1.SelfSubjectRulesReview{Spec: authorizationv1.SelfSubjectRulesReviewSpec{Namespace: corev1.NamespaceDefault}}, metav1.CreateOptions{})
-			require.Error(t, err)
+			require.NoError(t, err)
 
 			// the user has been admitted to workspace2, they should have the basic set of rules returned on a SelfSubjectRulesReview.
 			t.Logf("creating SelfSubjectRulesReview as user-4 in %s", ws)


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary
- SelfSubjectAccessReviews, SelfSubjectRulesReviews, and SelfSubjectReviews were getting 403 even when users had the right RBAC permissions

## What Type of PR Is This?
/kind bug

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #3809

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
