### PR TITLE
ws command: skip tree on workspaces that are being deleted

### DIFF
--- a/staging/src/github.com/kcp-dev/cli/pkg/workspace/plugin/tree.go
+++ b/staging/src/github.com/kcp-dev/cli/pkg/workspace/plugin/tree.go
@@ -235,6 +235,11 @@ func (o *TreeOptions) populateInteractiveNodeBubble(ctx context.Context, node *t
 		loadAllChildren := node.expanded
 
 		for _, ws := range results.Items {
+			// Skip workspaces that are being deleted, as they may no longer be
+			// accessible and listing their children could result in a 403.
+			if ws.DeletionTimestamp != nil {
+				continue
+			}
 			_, childPath, err := pluginhelpers.ParseClusterURL(ws.Spec.URL)
 			if err != nil {
 				return fmt.Errorf("workspace URL %q does not point to valid workspace", ws.Spec.URL)
@@ -317,6 +322,9 @@ func (o *TreeOptions) populateBranch(ctx context.Context, tree treeprint.Tree, p
 	}
 
 	for _, workspace := range results.Items {
+		if workspace.DeletionTimestamp != nil {
+			continue
+		}
 		_, current, err := pluginhelpers.ParseClusterURL(workspace.Spec.URL)
 		if err != nil {
 			return fmt.Errorf("current config context URL %q does not point to workspace", workspace.Spec.URL)


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

    ws plugin: skip tree on workspaces that are being deleted

    This avoids a 403 when a workspace is being deleted.
    There is a window of time when the kcp user loses
    permissiosn for listing children of the workspace
    which is being deleted.

tested this fix with:
```
make build
cp ./bin/kubectl-ws /home/lubo/.krew/store/ws/v0.30.0/bin/kubectl-ws
...
seq 60 | xargs -n1 -I{} sh -c 'kubectl ws tree --v=10; sleep 1'
```
multiple times and there are no more 403 errors.

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes https://github.com/kcp-dev/kcp/issues/3834

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
workspace plugin: fix a bug where calling the 'tree' command on a parent workspace that has deleting children can result in a 403 error.
```
