### PR TITLE
Deprecate `--shard-external-url` for virtual-workspace

### DIFF
--- a/cmd/sharded-test-server/virtual.go
+++ b/cmd/sharded-test-server/virtual.go
@@ -146,7 +146,6 @@ func newVirtualWorkspace(ctx context.Context, index int, servingCA *crypto.CA, h
 
 	args := []string{
 		fmt.Sprintf("--kubeconfig=%s", kubeconfigPath),
-		fmt.Sprintf("--shard-external-url=https://%s:%d", hostIP, 6443),
 		fmt.Sprintf("--cache-kubeconfig=%s", cacheServerConfigPath),
 		fmt.Sprintf("--authentication-kubeconfig=%s", authenticationKubeconfigPath),
 		fmt.Sprintf("--client-ca-file=%s", clientCAFilePath),

--- a/cmd/virtual-workspaces/command/cmd.go
+++ b/cmd/virtual-workspaces/command/cmd.go
@@ -187,11 +187,7 @@ func Run(ctx context.Context, o *options.Options) error {
 		return err
 	}
 
-	sharedExternalURLGetter := func() string {
-		return o.ShardExternalURL
-	}
-
-	rootAPIServerConfig.Extra.VirtualWorkspaces, err = o.CoreVirtualWorkspaces.NewVirtualWorkspaces(identityConfig, o.RootPathPrefix, sharedExternalURLGetter, wildcardKubeInformers, wildcardKcpInformers, cacheKcpInformers)
+	rootAPIServerConfig.Extra.VirtualWorkspaces, err = o.CoreVirtualWorkspaces.NewVirtualWorkspaces(identityConfig, o.RootPathPrefix, wildcardKubeInformers, wildcardKcpInformers, cacheKcpInformers)
 	if err != nil {
 		return err
 	}

--- a/cmd/virtual-workspaces/options/options.go
+++ b/cmd/virtual-workspaces/options/options.go
@@ -42,10 +42,9 @@ const DefaultRootPathPrefix string = "/services"
 type Options struct {
 	Output io.Writer
 
-	KubeconfigFile   string
-	Context          string
-	RootPathPrefix   string
-	ShardExternalURL string
+	KubeconfigFile string
+	Context        string
+	RootPathPrefix string
 
 	Cache          cacheoptions.Cache
 	SecureServing  genericapiserveroptions.SecureServingOptions
@@ -65,8 +64,7 @@ func NewOptions() *Options {
 	opts := &Options{
 		Output: nil,
 
-		RootPathPrefix:   DefaultRootPathPrefix,
-		ShardExternalURL: "",
+		RootPathPrefix: DefaultRootPathPrefix,
 
 		Cache:          *cacheoptions.NewCache(),
 		SecureServing:  *genericapiserveroptions.NewSecureServingOptions(),
@@ -95,7 +93,8 @@ func (o *Options) AddFlags(flags *pflag.FlagSet) {
 	logsapiv1.AddFlags(o.Logs, flags)
 	o.CoreVirtualWorkspaces.AddFlags(flags)
 
-	flags.StringVar(&o.ShardExternalURL, "shard-external-url", o.ShardExternalURL, "URL used by outside clients to talk to the kcp shard this virtual workspace is related to")
+	flags.String("shard-external-url", "", "DEPRECATED: URL used by outside clients to talk to the kcp shard this virtual workspace is related to")
+	flags.MarkHidden("shard-external-url") //nolint:errcheck
 
 	flags.StringVar(&o.KubeconfigFile, "kubeconfig", o.KubeconfigFile,
 		"The kubeconfig file of the KCP instance that hosts workspaces.")
@@ -111,10 +110,6 @@ func (o *Options) Validate() error {
 	errs = append(errs, o.SecureServing.Validate()...)
 	errs = append(errs, o.Authentication.Validate()...)
 	errs = append(errs, o.CoreVirtualWorkspaces.Validate()...)
-
-	if len(o.ShardExternalURL) == 0 {
-		errs = append(errs, fmt.Errorf(("--shard-external-url is required")))
-	}
 
 	if len(o.KubeconfigFile) == 0 {
 		errs = append(errs, fmt.Errorf("--kubeconfig is required for this command"))

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -745,7 +745,6 @@ func NewConfig(ctx context.Context, opts kcpserveroptions.CompletedOptions) (*Co
 			c.KubeSharedInformerFactory,
 			c.KcpSharedInformerFactory,
 			c.CacheKcpSharedInformerFactory,
-			c.ShardExternalURL,
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/server/virtual.go
+++ b/pkg/server/virtual.go
@@ -57,7 +57,6 @@ func newVirtualConfig(
 	config *rest.Config,
 	kubeSharedInformerFactory kcpkubernetesinformers.SharedInformerFactory,
 	kcpSharedInformerFactory, cacheKcpSharedInformerFactory kcpinformers.SharedInformerFactory,
-	shardExternalURL func() string,
 ) (*VirtualConfig, error) {
 	scheme := runtime.NewScheme()
 	metav1.AddToGroupVersion(scheme, schema.GroupVersion{Group: "", Version: "v1"})
@@ -95,7 +94,6 @@ func newVirtualConfig(
 	c.Extra.VirtualWorkspaces, err = o.Virtual.VirtualWorkspaces.NewVirtualWorkspaces(
 		config,
 		virtualcommandoptions.DefaultRootPathPrefix,
-		shardExternalURL,
 		kubeSharedInformerFactory,
 		kcpSharedInformerFactory,
 		cacheKcpSharedInformerFactory,

--- a/pkg/virtual/options/options.go
+++ b/pkg/virtual/options/options.go
@@ -67,7 +67,6 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 func (o *Options) NewVirtualWorkspaces(
 	config *rest.Config,
 	rootPathPrefix string,
-	shardExternalURL func() string,
 	wildcardKubeInformers kcpkubernetesinformers.SharedInformerFactory,
 	wildcardKcpInformers, cachedKcpInformers kcpinformers.SharedInformerFactory,
 ) ([]rootapiserver.NamedVirtualWorkspace, error) {


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

As noted here the flag is never actually used for virtual-workspace: https://github.com/kcp-dev/kcp-operator/issues/139#issuecomment-3935234308
It doesn't make sense to require a flag that isn't actually being used.

We can also accept but not use that flag and mark it deprecated. Mostly wanna see what breaks when removing it entire.

## What Type of PR Is This?

/kind cleanup

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Deprecated the unused flag `--shard-external-url` for `virtual-workspace` 
```
