### PR TITLE
ensure current workspace is highlighted when in interactive mode

### DIFF
--- a/staging/src/github.com/kcp-dev/cli/pkg/workspace/plugin/tree.go
+++ b/staging/src/github.com/kcp-dev/cli/pkg/workspace/plugin/tree.go
@@ -273,7 +273,7 @@ func (o *TreeOptions) populateInteractiveNodeBubble(ctx context.Context, node *t
 
 			node.children = append(node.children, childNode)
 
-			if !loadAllChildren {
+			if !loadAllChildren || currentWorkspace.HasPrefix(childPath) || childPath == currentWorkspace {
 				if err := o.populateInteractiveNodeBubble(ctx, childNode, childPath, childName, currentWorkspace, currentNode); err != nil {
 					return err
 				}


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary
```
change ensures that the current active workspace is highlighted,
when in interactive mode
```
<img width="941" height="637" alt="image" src="https://github.com/user-attachments/assets/ce6aff9b-31a9-4a7a-a207-7e4aff8000ee" />


## What Type of PR Is This?
/kind bug
<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes [3850](https://github.com/kcp-dev/kcp/issues/3850)

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
