### PR TITLE
fix(apiexport): deep copy user Extra map to prevent concurrent map writes

### DIFF
--- a/pkg/virtual/apiexport/builder/build_test.go
+++ b/pkg/virtual/apiexport/builder/build_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2025 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builder
+
+import (
+	"sync"
+	"testing"
+
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+// TestNewImpersonationConfigConcurrency verifies that newImpersonationConfig
+// can be called concurrently with a shared user.Info without causing a race
+// on the Extra map. This is a regression test for
+// https://github.com/kcp-dev/kcp/issues/3855.
+func TestNewImpersonationConfigConcurrency(t *testing.T) {
+	sharedUser := &user.DefaultInfo{
+		Name:   "testuser",
+		Groups: []string{"group1", "group2"},
+		Extra: map[string][]string{
+			"existing-key": {"val1", "val2"},
+		},
+	}
+
+	const goroutines = 100
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			// Call the production helper that deep-copies Extra and appends warrants.
+			cfg := newImpersonationConfig(sharedUser, `{"user":"system:serviceaccount:default:rest"}`)
+
+			// Verify the returned config has the warrant.
+			if len(cfg.Extra["authorization.kcp.io/warrant"]) != 1 {
+				t.Errorf("expected 1 warrant, got %d", len(cfg.Extra["authorization.kcp.io/warrant"]))
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Verify the original user's Extra map was not mutated.
+	if _, found := sharedUser.Extra["authorization.kcp.io/warrant"]; found {
+		t.Fatal("original user Extra map was mutated: warrant key should not exist")
+	}
+	if got := sharedUser.Extra["existing-key"]; len(got) != 2 || got[0] != "val1" || got[1] != "val2" {
+		t.Fatalf("original user Extra values were mutated: got %v", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Extract `newImpersonationConfig` helper that deep copies `user.GetExtra()` map before mutating it, preventing `fatal error: concurrent map writes`
- Add regression test that calls `newImpersonationConfig` concurrently from 100 goroutines with a shared `user.Info` and verifies no race

## Problem

`BuildVirtualWorkspace` in `pkg/virtual/apiexport/builder/build.go` assigned `user.GetExtra()` (a shared map reference) directly to `impersonationConfig.Impersonate.Extra`, then mutated it by appending a warrant key at line 152. When multiple concurrent requests share the same `user.Info`, this causes a concurrent map write panic that crashes the KCP server into CrashLoopBackOff.

## Fix

Extract a `newImpersonationConfig` helper that deep copies the Extra map (both keys and value slices via `slices.Clone`) before assigning it to the impersonation config and appending warrant data. This follows the same defensive copy pattern already used in:
- `pkg/authentication/extra.go:49-58`
- `pkg/admission/workspace/admission.go:313-317`

Fixes https://github.com/kcp-dev/kcp/issues/3855

```release-note
Fix concurrent map writes panic in apiexport virtual workspace when
multiple requests share the same user.Info reference.
```

## Test plan

- [x] `go test -race ./pkg/virtual/apiexport/builder/...` passes
- [x] `go build ./pkg/virtual/apiexport/builder/...` compiles cleanly
- [x] CI passes