### PR TITLE
Requeue when Logical Cluster was not found, while shard is alive

### DIFF
--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile.go
@@ -108,6 +108,7 @@ func (c *Controller) reconcile(ctx context.Context, ws *tenancyv1alpha1.Workspac
 			getLogicalCluster: func(ctx context.Context, cluster logicalcluster.Path) (*corev1alpha1.LogicalCluster, error) {
 				return c.kcpExternalClient.Cluster(cluster).CoreV1alpha1().LogicalClusters().Get(ctx, corev1alpha1.LogicalClusterName, metav1.GetOptions{})
 			},
+			getShardByHash: getShardByName,
 			requeueAfter: func(workspace *tenancyv1alpha1.Workspace, after time.Duration) {
 				c.queue.AddAfter(kcpcache.ToClusterAwareKey(logicalcluster.From(workspace).String(), "", workspace.Name), after)
 			},


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Handle transient front-proxy/index lag during workspace initialization
Instead of immediately setting WorkspaceDisappeared, try to check shard liveness when LogicalCluster is NotFound in Initializing.

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->
/kind flake

## Related Issue(s)

Fixes https://github.com/kcp-dev/kcp/issues/3811

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
