### PR TITLE
fix: use v1alpha2 APIBindings informer in DynamicRESTMapper HasSynced check

### DIFF
--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -1712,7 +1712,7 @@ func (s *Server) installDynamicRESTMapper(ctx context.Context) error {
 		Wait: func(ctx context.Context, s *Server) error {
 			return wait.PollUntilContextCancel(ctx, waitPollInterval, true, func(ctx context.Context) (bool, error) {
 				return s.ApiExtensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions().Informer().HasSynced() &&
-					s.KcpSharedInformerFactory.Apis().V1alpha1().APIBindings().Informer().HasSynced() &&
+					s.KcpSharedInformerFactory.Apis().V1alpha2().APIBindings().Informer().HasSynced() &&
 					s.KcpSharedInformerFactory.Apis().V1alpha2().APIExports().Informer().HasSynced() &&
 					s.KcpSharedInformerFactory.Apis().V1alpha1().APIResourceSchemas().Informer().HasSynced() &&
 					s.CacheKcpSharedInformerFactory.Apis().V1alpha2().APIExports().Informer().HasSynced() &&


### PR DESCRIPTION
## Problem

The `DynamicTypesController` is instantiated with a **v1alpha2** `APIBindings` informer:

```go
dynamicTypesController, err := dynamicrestmapper.NewDynamicTypesController(ctx, s.completedConfig.DynamicRESTMapper,
    s.ApiExtensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions(),
    s.KcpSharedInformerFactory.Apis().V1alpha2().APIBindings(),  // ← v1alpha2
    ...
)
```

But the `HasSynced` wait function checks the **v1alpha1** informer:

```go
return s.KcpSharedInformerFactory.Apis().V1alpha1().APIBindings().Informer().HasSynced() && // ← v1alpha1
```

Since the `SharedInformerFactory` creates separate informers per API version (keyed by `reflect.Type`), and `factory.Start()` only starts previously registered informers, the sequence is:

1. Controller registration calls `V1alpha2().APIBindings()` → registers v1alpha2 informer in factory
2. `factory.Start()` starts all registered informers (only v1alpha2)
3. `HasSynced` calls `V1alpha1().APIBindings().Informer()` → lazily creates a **new** v1alpha1 informer, but it is **never started**
4. An unstarted informer has `controller == nil`, so `HasSynced()` returns `false` indefinitely
5. The DynamicRESTMapper controller **never starts** — blocked forever in `PollUntilContextCancel`

## Fix

Change the `HasSynced` check to use `V1alpha2().APIBindings()`, matching the informer version passed to the controller constructor.

## Impact

Without this fix, the DynamicRESTMapper controller never starts, which prevents dynamic API discovery from working correctly for resources introduced via APIBindings.

```release-note
NONE
```