### PR TITLE
re-generate phase0 manifests

### DIFF
--- a/config/root-phase0/apiexport-shards.core.kcp.io.yaml
+++ b/config/root-phase0/apiexport-shards.core.kcp.io.yaml
@@ -6,7 +6,7 @@ spec:
   resources:
   - group: core.kcp.io
     name: shards
-    schema: v240903-d6797056a.shards.core.kcp.io
+    schema: v260302-ae9fdd9c1.shards.core.kcp.io
     storage:
       crd: {}
 status: {}

--- a/config/root-phase0/apiresourceschema-shards.core.kcp.io.yaml
+++ b/config/root-phase0/apiresourceschema-shards.core.kcp.io.yaml
@@ -1,7 +1,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v240903-d6797056a.shards.core.kcp.io
+  name: v260302-ae9fdd9c1.shards.core.kcp.io
 spec:
   group: core.kcp.io
   names:


### PR DESCRIPTION
## Summary
When doing the `kcp` renaming mega PR, I first changed all the code and then must have manually updated some generated files. This lead to the outcome that the root-phase0 APIResourceSchemas were updated, but their name was never re-calculated and so I accidentally made a PR that tried to upgrade an APIResourceSchema in-place.

I do not really understand what happened. But when you go back to ae9fdd9c1 and then do a `make codegen`, you will see the correct new names being generated. Why the `make codegen` commit right after that (181f6f1a0) did not rename the ARS, I have no idea.

So I went to ae9fdd9c1, did a `make codegen`, stash the changes and then unstashed them on main, leading to this PR here.

## What Type of PR Is This?
/kind regression

## Related Issue(s)
Fixes #3873

## Release Notes
```release-note
NONE
```
