### PR TITLE
make it easier to import the crdpuller from other projects

### DIFF
--- a/cmd/crd-puller/pull-crds.go
+++ b/cmd/crd-puller/pull-crds.go
@@ -31,6 +31,7 @@ import (
 	"github.com/kcp-dev/sdk/cmd/help"
 
 	"github.com/kcp-dev/kcp/pkg/crdpuller"
+	"github.com/kcp-dev/kcp/pkg/crdpuller/scheme"
 )
 
 func main() {
@@ -73,7 +74,7 @@ func main() {
 				return err
 			}
 
-			puller, err := crdpuller.NewSchemaPuller(discoveryClient, crdClient)
+			puller, err := crdpuller.NewSchemaPuller(discoveryClient, crdClient, scheme.DefaultIgnores())
 			if err != nil {
 				return err
 			}

--- a/pkg/crdpuller/discovery.go
+++ b/pkg/crdpuller/discovery.go
@@ -29,10 +29,10 @@ import (
 
 	"k8s.io/apiextensions-apiserver/pkg/apihelpers"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	extensionsapiserver "k8s.io/apiextensions-apiserver/pkg/apiserver"
 	apiextensionsv1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -53,6 +53,7 @@ type schemaPuller struct {
 	resourceFor              func(groupResource schema.GroupResource) (schema.GroupResource, error)
 	getCRD                   func(ctx context.Context, name string) (*apiextensionsv1.CustomResourceDefinition, error)
 	models                   openapi.ModelsByGKV
+	ignoredScheme            *runtime.Scheme
 }
 
 // NewSchemaPuller allows creating a SchemaPuller from the `Config` of
@@ -61,7 +62,12 @@ type schemaPuller struct {
 func NewSchemaPuller(
 	discoveryClient discovery.DiscoveryInterface,
 	crdClient apiextensionsv1client.ApiextensionsV1Interface,
+	ignoredScheme *runtime.Scheme,
 ) (*schemaPuller, error) {
+	if ignoredScheme == nil {
+		ignoredScheme = runtime.NewScheme()
+	}
+
 	openapiSchema, err := discoveryClient.OpenAPISchema()
 	if err != nil {
 		return nil, err
@@ -91,7 +97,8 @@ func NewSchemaPuller(
 		getCRD: func(ctx context.Context, name string) (*apiextensionsv1.CustomResourceDefinition, error) {
 			return crdClient.CustomResourceDefinitions().Get(ctx, name, metav1.GetOptions{})
 		},
-		models: modelsByGKV,
+		models:        modelsByGKV,
+		ignoredScheme: ignoredScheme,
 	}, nil
 }
 
@@ -162,7 +169,8 @@ func (sp *schemaPuller) PullCRDs(ctx context.Context, resourceNames ...string) (
 
 			gvk := gv.WithKind(apiResource.Kind)
 			logger = logger.WithValues("kind", apiResource.Kind)
-			if (kcpscheme.Scheme.Recognizes(gvk) || extensionsapiserver.Scheme.Recognizes(gvk)) && !resourcesToPull.Has(groupResource.String()) {
+			// ignore the resource unles we're asked to explicitly pull it
+			if sp.ignoredScheme.Recognizes(gvk) && !resourcesToPull.Has(groupResource.String()) {
 				logger.Info("ignoring a resource since it is part of the core kcp resources")
 				continue
 			}

--- a/pkg/crdpuller/scheme/doc.go
+++ b/pkg/crdpuller/scheme/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package scheme exists to prevent a dependency on apiextensions-apiserver
+// in the main crdpuller package, which would make it unnecessarily
+// hard to import the crdpuller from other projects.
+package scheme

--- a/pkg/crdpuller/scheme/ignore.go
+++ b/pkg/crdpuller/scheme/ignore.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheme
+
+import (
+	extensionsapiserver "k8s.io/apiextensions-apiserver/pkg/apiserver"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/kcp-dev/kcp/pkg/crdpuller"
+	kcpscheme "github.com/kcp-dev/kcp/pkg/server/scheme"
+)
+
+func DefaultIgnores() *runtime.Scheme {
+	return crdpuller.MergeSchemes(runtime.NewScheme(), kcpscheme.Scheme, extensionsapiserver.Scheme)
+}

--- a/pkg/crdpuller/schemes.go
+++ b/pkg/crdpuller/schemes.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crdpuller
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// MergeSchemes merges multiple source schemes into a target scheme by copying
+// all registered group versions and known types.
+func MergeSchemes(target *runtime.Scheme, sources ...*runtime.Scheme) *runtime.Scheme {
+	for _, source := range sources {
+		for gvk := range source.AllKnownTypes() {
+			if obj, err := source.New(gvk); err == nil {
+				target.AddKnownTypeWithName(gvk, obj)
+			}
+		}
+	}
+
+	return target
+}


### PR DESCRIPTION
## Summary
The api-syncagent imports the crdpuller. Today I tried updating its dependencies to the latest multicluster-runtime, but this would bring the agent to Kubernetes 1.35. This then clashes with the import to kcp when running `go mod tidy`:

```
go: github.com/kcp-dev/api-syncagent/internal/discovery imports
        github.com/kcp-dev/kcp/pkg/crdpuller imports
        k8s.io/apiextensions-apiserver/pkg/apiserver imports
        k8s.io/apiserver/pkg/server imports
        k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle imports
        github.com/kcp-dev/client-go/informers imports
        github.com/kcp-dev/client-go/informers/storagemigration imports
        github.com/kcp-dev/client-go/informers/storagemigration/v1alpha1 imports
        k8s.io/client-go/listers/storagemigration/v1alpha1: module k8s.io/client-go@latest found (v0.35.2), but does not contain package k8s.io/client-go/listers/storagemigration/v1alpha1
```

For testing, I copied the entire crdpuller package into the syncagent and just removed the line about filtering resources part of apiextensions-apiserver. This solved the dependency hell. Therefore I think it's worth it to introduce a small indirection in kcp: instead of hardcoding a specific scheme in the crdpuller to ignore, it can now be configured by the caller, and in a separate package we provide the default scheme to ignore.

I provided a public MergeSchemes func to aid people in constructing their own scheme to ignore.

## What Type of PR Is This?
/kind cleanup

## Release Notes
```release-note
NONE
```
