### PR TITLE
Split BindRootAPIs and use errgroup.Group

### DIFF
--- a/config/helpers/bootstrap.go
+++ b/config/helpers/bootstrap.go
@@ -48,6 +48,7 @@ import (
 	tenancyhelper "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1/helper"
 	kcpclient "github.com/kcp-dev/sdk/client/clientset/versioned"
 
+	"github.com/kcp-dev/kcp/pkg/errgroup"
 	"github.com/kcp-dev/kcp/pkg/logging"
 )
 
@@ -240,62 +241,69 @@ func createResourceFromFS(ctx context.Context, client dynamic.Interface, mapper 
 }
 
 func BindRootAPIs(ctx context.Context, kcpClient kcpclient.Interface, exportNames ...string) error {
+	g := errgroup.WithContext(ctx)
+	for _, exportName := range exportNames {
+		g.Go(func(ctx context.Context) error {
+			if err := BindRootAPI(ctx, kcpClient, exportName); err != nil {
+				return fmt.Errorf("failed to bind root API %s: %w", exportName, err)
+			}
+			return nil
+		})
+	}
+	return g.Wait()
+}
+
+func BindRootAPI(ctx context.Context, kcpClient kcpclient.Interface, exportName string) error {
 	logger := klog.FromContext(ctx)
 
-	for _, exportName := range exportNames {
-		binding := &apisv1alpha2.APIBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: exportName,
-			},
-			Spec: apisv1alpha2.APIBindingSpec{
-				Reference: apisv1alpha2.BindingReference{
-					Export: &apisv1alpha2.ExportBindingReference{
-						Path: core.RootCluster.Path().String(),
-						Name: exportName,
-					},
+	binding := &apisv1alpha2.APIBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: exportName,
+		},
+		Spec: apisv1alpha2.APIBindingSpec{
+			Reference: apisv1alpha2.BindingReference{
+				Export: &apisv1alpha2.ExportBindingReference{
+					Path: core.RootCluster.Path().String(),
+					Name: exportName,
 				},
 			},
-		}
-
-		created, err := kcpClient.ApisV1alpha2().APIBindings().Create(ctx, binding, metav1.CreateOptions{})
-		if err == nil {
-			logger := logging.WithObject(logger, created)
-			logger.V(2).Info("Created API binding")
-			continue
-		}
-		if !apierrors.IsAlreadyExists(err) {
-			return err
-		}
-
-		if err := wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (bool, error) {
-			existing, err := kcpClient.ApisV1alpha2().APIBindings().Get(ctx, exportName, metav1.GetOptions{})
-			if err != nil {
-				logger.Error(err, "error getting APIBinding", "name", exportName)
-				// Always keep trying. Don't ever return an error out of this function.
-				return false, nil
-			}
-
-			logger := logging.WithObject(logger, existing)
-			logger.V(2).Info("Updating API binding")
-
-			existing.Spec = binding.Spec
-
-			_, err = kcpClient.ApisV1alpha2().APIBindings().Update(ctx, existing, metav1.UpdateOptions{})
-			if err == nil {
-				return true, nil
-			}
-			if apierrors.IsConflict(err) {
-				logger.V(2).Info("API binding update conflict, retrying")
-				return false, nil
-			}
-
-			logger.Error(err, "error updating APIBinding")
-			// Always keep trying. Don't ever return an error out of this function.
-			return false, nil
-		}); err != nil {
-			return err
-		}
+		},
 	}
 
-	return nil
+	created, err := kcpClient.ApisV1alpha2().APIBindings().Create(ctx, binding, metav1.CreateOptions{})
+	if err == nil {
+		logger := logging.WithObject(logger, created)
+		logger.V(2).Info("Created API binding")
+		return nil
+	}
+	if !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+
+	return wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (bool, error) {
+		existing, err := kcpClient.ApisV1alpha2().APIBindings().Get(ctx, exportName, metav1.GetOptions{})
+		if err != nil {
+			logger.Error(err, "error getting APIBinding", "name", exportName)
+			// Always keep trying. Don't ever return an error out of this function.
+			return false, nil
+		}
+
+		logger := logging.WithObject(logger, existing)
+		logger.V(2).Info("Updating API binding")
+
+		existing.Spec = binding.Spec
+
+		_, err = kcpClient.ApisV1alpha2().APIBindings().Update(ctx, existing, metav1.UpdateOptions{})
+		if err == nil {
+			return true, nil
+		}
+		if apierrors.IsConflict(err) {
+			logger.V(2).Info("API binding update conflict, retrying")
+			return false, nil
+		}
+
+		logger.Error(err, "error updating APIBinding")
+		// Always keep trying. Don't ever return an error out of this function.
+		return false, nil
+	})
 }


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Split from https://github.com/kcp-dev/kcp/pull/3847 because something is going wrong and I want to reduce the scope of that PR.

## What Type of PR Is This?

/kind cleanup

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
