### PR TITLE
strip debug info in container images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ ARG TARGETARCH
 
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-    make OS=${TARGETOS} ARCH=${TARGETARCH}
+    make OS=${TARGETOS} ARCH=${TARGETARCH} EXTRA_LDFLAGS="-s -w"
 
 # distroless doesn't have coreutils, so we need to create a directory
 # for kcp here and copy it over. Any directory would do.

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ GIT_COMMIT := $(shell git rev-parse --short HEAD || echo 'local')
 GIT_DIRTY := $(shell git diff --quiet && echo 'clean' || echo 'dirty')
 GIT_VERSION := $(shell go mod edit -json | jq '.Require[] | select(.Path == "k8s.io/kubernetes") | .Version' --raw-output)+kcp-$(shell git describe --tags --match='v*' --abbrev=14 "$(GIT_COMMIT)^{commit}" 2>/dev/null || echo v0.0.0-$(GIT_COMMIT))
 BUILD_DATE := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+EXTRA_LDFLAGS ?=
 LDFLAGS := \
 	-X k8s.io/client-go/pkg/version.gitCommit=${GIT_COMMIT} \
 	-X k8s.io/client-go/pkg/version.gitTreeState=${GIT_DIRTY} \
@@ -96,7 +97,8 @@ LDFLAGS := \
 	-X k8s.io/component-base/version.gitMajor=${KUBE_MAJOR_VERSION} \
 	-X k8s.io/component-base/version.gitMinor=${KUBE_MINOR_VERSION} \
 	-X k8s.io/component-base/version.buildDate=${BUILD_DATE} \
-	-extldflags '-static'
+	-extldflags '-static' \
+	${EXTRA_LDFLAGS}
 all: build
 .PHONY: all
 


### PR DESCRIPTION
## Summary
This reduces the total size of the kcp container image from 723 to 529 MB (26% reduction). When running many e2e tests for the kcp-operator, I have since begun to preload kcp into kind so I do not have to re-pull 723MB every time. That gave me the thought of maybe also making the images just smaller if we can.

I don't think we need debugging symbols in our production kcp images. Is there someone out there who regularly uses delve to remotely debug a kcp?

## What Type of PR Is This?
/kind cleanup

## Release Notes
```release-note
All kcp binaries in the container images now have their debugging symbols stripped, saving roughly 25% in total image size.
```
