### PR TITLE
Do not call require.X in kcptestinghelpers

### DIFF
--- a/staging/src/github.com/kcp-dev/sdk/testing/helpers/eventually.go
+++ b/staging/src/github.com/kcp-dev/sdk/testing/helpers/eventually.go
@@ -120,7 +120,9 @@ func EventuallyCondition(t TestingT, getter func() (conditions.Getter, error), e
 	t.Helper()
 	Eventually(t, func() (bool, string) {
 		obj, err := getter()
-		require.NoError(t, err, "Error fetching object")
+		if err != nil {
+			return false, fmt.Sprintf("Error in condition getter: %v", err)
+		}
 		condition, descriptor, done := evaluator.matches(obj)
 		var reason string
 		if !done {


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Fix for flake: TestWorkspaceController/add_a_shard_after_a_workspace_is_unschedulable,_expect_it_to_be_scheduled #3522 

We had a similar discovery by @SimonTheLeg previously

## What Type of PR Is This?

/kind bug

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes NONE

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
