### PR TITLE
Add --logging-format to cache-server and use ISO8601 timestamps in JSON logs

### DIFF
--- a/cmd/cache-server/main.go
+++ b/cmd/cache-server/main.go
@@ -35,6 +35,7 @@ import (
 	cacheserver "github.com/kcp-dev/kcp/pkg/cache/server"
 	"github.com/kcp-dev/kcp/pkg/cache/server/options"
 	kcpfeatures "github.com/kcp-dev/kcp/pkg/features"
+
 	_ "github.com/kcp-dev/kcp/pkg/logging/json/register"
 )
 

--- a/cmd/cache-server/main.go
+++ b/cmd/cache-server/main.go
@@ -27,12 +27,15 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/component-base/cli"
+	logsapiv1 "k8s.io/component-base/logs/api/v1"
 
 	"github.com/kcp-dev/embeddedetcd"
 	"github.com/kcp-dev/sdk/cmd/help"
 
 	cacheserver "github.com/kcp-dev/kcp/pkg/cache/server"
 	"github.com/kcp-dev/kcp/pkg/cache/server/options"
+	kcpfeatures "github.com/kcp-dev/kcp/pkg/features"
+	_ "github.com/kcp-dev/kcp/pkg/logging/json/register"
 )
 
 func main() {
@@ -72,6 +75,11 @@ func main() {
 		`),
 
 		RunE: func(c *cobra.Command, args []string) error {
+			// run as early as possible to avoid races later when some components (e.g. grpc) start early using klog
+			if err := logsapiv1.ValidateAndApply(serverOptions.Logs, kcpfeatures.DefaultFeatureGate); err != nil {
+				return err
+			}
+
 			completed, err := serverOptions.Complete()
 			if err != nil {
 				return err

--- a/cmd/kcp-front-proxy/main.go
+++ b/cmd/kcp-front-proxy/main.go
@@ -38,8 +38,9 @@ import (
 
 	frontproxyoptions "github.com/kcp-dev/kcp/cmd/kcp-front-proxy/options"
 	kcpfeatures "github.com/kcp-dev/kcp/pkg/features"
-	_ "github.com/kcp-dev/kcp/pkg/logging/json/register"
 	"github.com/kcp-dev/kcp/pkg/proxy"
+
+	_ "github.com/kcp-dev/kcp/pkg/logging/json/register"
 )
 
 func main() {

--- a/cmd/kcp-front-proxy/main.go
+++ b/cmd/kcp-front-proxy/main.go
@@ -38,9 +38,8 @@ import (
 
 	frontproxyoptions "github.com/kcp-dev/kcp/cmd/kcp-front-proxy/options"
 	kcpfeatures "github.com/kcp-dev/kcp/pkg/features"
+	_ "github.com/kcp-dev/kcp/pkg/logging/json/register"
 	"github.com/kcp-dev/kcp/pkg/proxy"
-
-	_ "k8s.io/component-base/logs/json/register"
 )
 
 func main() {

--- a/cmd/kcp/kcp.go
+++ b/cmd/kcp/kcp.go
@@ -41,9 +41,8 @@ import (
 
 	"github.com/kcp-dev/kcp/cmd/kcp/options"
 	kcpfeatures "github.com/kcp-dev/kcp/pkg/features"
+	_ "github.com/kcp-dev/kcp/pkg/logging/json/register"
 	"github.com/kcp-dev/kcp/pkg/server"
-
-	_ "k8s.io/component-base/logs/json/register"
 )
 
 func main() {

--- a/cmd/kcp/kcp.go
+++ b/cmd/kcp/kcp.go
@@ -41,8 +41,9 @@ import (
 
 	"github.com/kcp-dev/kcp/cmd/kcp/options"
 	kcpfeatures "github.com/kcp-dev/kcp/pkg/features"
-	_ "github.com/kcp-dev/kcp/pkg/logging/json/register"
 	"github.com/kcp-dev/kcp/pkg/server"
+
+	_ "github.com/kcp-dev/kcp/pkg/logging/json/register"
 )
 
 func main() {

--- a/cmd/virtual-workspaces/options/options.go
+++ b/cmd/virtual-workspaces/options/options.go
@@ -32,6 +32,8 @@ import (
 
 	cacheoptions "github.com/kcp-dev/kcp/pkg/cache/client/options"
 	corevwoptions "github.com/kcp-dev/kcp/pkg/virtual/options"
+
+	_ "github.com/kcp-dev/kcp/pkg/logging/json/register"
 )
 
 // DefaultRootPathPrefix is basically constant forever, or we risk a breaking change. The

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/xrstf/mockoidc v0.0.0-20250721141841-711cc4e835f6
 	go.uber.org/goleak v1.3.1-0.20251210191316-2b7fd8a0d244
 	go.uber.org/multierr v1.11.0
+	go.uber.org/zap v1.27.0
 	golang.org/x/sys v0.39.0
 	gopkg.in/square/go-jose.v2 v2.6.0
 	k8s.io/api v0.35.1
@@ -180,7 +181,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.36.0 // indirect
 	go.opentelemetry.io/otel/trace v1.36.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.5.0 // indirect
-	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.46.0 // indirect

--- a/pkg/cache/server/options/options.go
+++ b/pkg/cache/server/options/options.go
@@ -23,6 +23,8 @@ import (
 
 	genericoptions "k8s.io/apiserver/pkg/server/options"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
+	"k8s.io/component-base/logs"
+	logsapiv1 "k8s.io/component-base/logs/api/v1"
 	kubeoptions "k8s.io/kubernetes/pkg/kubeapiserver/options"
 
 	etcdoptions "github.com/kcp-dev/embeddedetcd/options"
@@ -36,6 +38,7 @@ type Options struct {
 	Authorization    *genericoptions.DelegatingAuthorizationOptions
 	APIEnablement    *genericoptions.APIEnablementOptions
 	EmbeddedEtcd     etcdoptions.Options
+	Logs             *logs.Options
 	SyntheticDelay   time.Duration
 }
 
@@ -47,6 +50,7 @@ type completedOptions struct {
 	Authorization    *genericoptions.DelegatingAuthorizationOptions
 	APIEnablement    *genericoptions.APIEnablementOptions
 	EmbeddedEtcd     etcdoptions.CompletedOptions
+	Logs             *logs.Options
 	SyntheticDelay   time.Duration
 }
 
@@ -76,6 +80,7 @@ func NewOptions(rootDir string) *Options {
 		Authorization:    genericoptions.NewDelegatingAuthorizationOptions(),
 		APIEnablement:    genericoptions.NewAPIEnablementOptions(),
 		EmbeddedEtcd:     *etcdoptions.NewOptions(rootDir),
+		Logs:             logs.NewOptions(),
 	}
 
 	o.SecureServing.ServerCert.CertDirectory = rootDir
@@ -110,6 +115,7 @@ func (o *Options) Complete() (*CompletedOptions, error) {
 		Authorization:    o.Authorization,
 		APIEnablement:    o.APIEnablement,
 		EmbeddedEtcd:     o.EmbeddedEtcd.Complete(o.Etcd),
+		Logs:             o.Logs,
 	}}, nil
 }
 
@@ -117,5 +123,6 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	o.Etcd.AddFlags(fs)
 	o.EmbeddedEtcd.AddFlags(fs)
 	o.SecureServing.AddFlags(fs)
+	logsapiv1.AddFlags(o.Logs, fs)
 	fs.DurationVar(&o.SyntheticDelay, "synthetic-delay", 0, "The duration of time the cache server will inject a delay for to all inbound requests. Useful for testing.")
 }

--- a/pkg/logging/json/doc.go
+++ b/pkg/logging/json/doc.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package json exists solely to change the date formatting in the JSON log
+// output, which Kubernetes hardcodes to be float-based UNIX timestamps,
+// but which we want as much more useful ISO 8601 date strings. Sadly there
+// is no way to just configure this without replicating the entire JSON logger.
+package json

--- a/pkg/logging/json/json.go
+++ b/pkg/logging/json/json.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package json
+
+import (
+	"github.com/go-logr/logr"
+	"go.uber.org/zap/zapcore"
+
+	"k8s.io/component-base/featuregate"
+	logsapi "k8s.io/component-base/logs/api/v1"
+	upstreamjson "k8s.io/component-base/logs/json"
+)
+
+// Factory produces JSON logger instances with ISO8601 timestamps.
+type Factory struct{}
+
+var _ logsapi.LogFormatFactory = Factory{}
+
+func (f Factory) Feature() featuregate.Feature {
+	return logsapi.LoggingBetaOptions
+}
+
+func (f Factory) Create(c logsapi.LoggingConfiguration, o logsapi.LoggingOptions) (logr.Logger, logsapi.RuntimeControl) {
+	// We intentionally avoid all os.File.Sync calls. Output is unbuffered,
+	// therefore we don't need to flush, and calling the underlying fsync
+	// would just slow down writing.
+	//
+	// The assumption is that logging only needs to ensure that data gets
+	// written to the output stream before the process terminates, but
+	// doesn't need to worry about data not being written because of a
+	// system crash or powerloss.
+	stderr := zapcore.Lock(upstreamjson.AddNopSync(o.ErrorStream))
+
+	// Custom encoder config with ISO8601 timestamps
+	encoderConfig := &zapcore.EncoderConfig{
+		MessageKey: "msg",
+		CallerKey:  "caller",
+		NameKey:    "logger",
+		TimeKey:    "ts",
+		// This right here is the only line we want to change compared to upstream.
+		EncodeTime:     zapcore.ISO8601TimeEncoder,
+		EncodeDuration: zapcore.StringDurationEncoder,
+		EncodeCaller:   zapcore.ShortCallerEncoder,
+	}
+
+	if c.Options.JSON.SplitStream {
+		stdout := zapcore.Lock(upstreamjson.AddNopSync(o.InfoStream))
+		size := c.Options.JSON.InfoBufferSize.Value()
+		if size > 0 {
+			// Prevent integer overflow.
+			if size > 2*1024*1024*1024 {
+				size = 2 * 1024 * 1024 * 1024
+			}
+			stdout = &zapcore.BufferedWriteSyncer{
+				WS:   stdout,
+				Size: int(size),
+			}
+		}
+
+		// stdout for info messages, stderr for errors.
+		return upstreamjson.NewJSONLogger(c.Verbosity, stdout, stderr, encoderConfig)
+	}
+
+	// Write info messages and errors to stderr to prevent mixing with normal program output.
+	return upstreamjson.NewJSONLogger(c.Verbosity, stderr, nil, encoderConfig)
+}

--- a/pkg/logging/json/register/register.go
+++ b/pkg/logging/json/register/register.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package register
+
+import (
+	logsapi "k8s.io/component-base/logs/api/v1"
+
+	"github.com/kcp-dev/kcp/pkg/logging/json"
+)
+
+func init() {
+	// JSON format with ISO8601 timestamps instead of epoch milliseconds
+	if err := logsapi.RegisterLogFormat(logsapi.JSONLogFormat, json.Factory{}, logsapi.LoggingBetaOptions); err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `--logging-format` flag support to cache-server
- Implements custom JSON logger that uses ISO8601 timestamps instead of UNIX timestamps
- Replaces Kubernetes upstream JSON logger imports with kcp-specific implementation across all commands

## Changes
- **cache-server**: Added logging options configuration and early initialization of logging format
- **New package `pkg/logging/json`**: Custom JSON logger factory that wraps upstream implementation but uses ISO8601 time encoding
- **Import updates**: All commands now import `github.com/kcp-dev/kcp/pkg/logging/json/register` instead of `k8s.io/component-base/logs/json/register`

## Test plan
- Build and run cache-server with `--logging-format=json` flag
- Verify JSON log output contains ISO8601 formatted timestamps (e.g., `"ts":"2026-03-13T10:30:45.123Z"`) instead of UNIX timestamps
- Verify all other kcp commands continue to work with the updated imports

```release-note
* Change "ts" in JSON logging format to be ISO 8601 instead of UNIX timestamps.
* Add `--logging-format` flag to the cache-server.
```