### PR TITLE
Disable WatchList feature gate

### DIFF
--- a/pkg/features/kcp_features.go
+++ b/pkg/features/kcp_features.go
@@ -18,6 +18,7 @@ package features
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
@@ -168,6 +169,14 @@ func disableFeatures() error {
 		// We disable SizeBasedListCostEstimate by default in kcp as stats collector does not have cluster awarness yet.
 		// We add this here to track changes in future k8s releases.
 		genericfeatures.SizeBasedListCostEstimate: false,
+
+		// At the moment WatchList breaks kcp when restarting an instance.
+		// The precise problem is that the already bootstrapped
+		// resources (e.g. the bound tenancy API) are not being seen by
+		// the informers when starting with an initialized etcd, which
+		// in turn leads to the APIs missing and the bootstrap never
+		// completing.
+		genericfeatures.WatchList: false,
 	}
 	for f, v := range toDisable {
 		err := utilfeature.DefaultMutableFeatureGate.Set(fmt.Sprintf("%s=%v", f, v))
@@ -175,5 +184,12 @@ func disableFeatures() error {
 			return err
 		}
 	}
+
+	// Additionaly disable WatchList in clients, otherwise things like
+	// bookmarks break.
+	if err := os.Setenv("KUBE_FEATURE_WatchListClient", "false"); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/test/e2e/virtual/terminatingworkspaces/virtualworkspace_test.go
+++ b/test/e2e/virtual/terminatingworkspaces/virtualworkspace_test.go
@@ -40,6 +40,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/endpoints/discovery"
+	genericfeatures "k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/rest"
 
 	kcpdiscovery "github.com/kcp-dev/client-go/discovery"
@@ -55,6 +57,7 @@ import (
 	kcptesting "github.com/kcp-dev/sdk/testing"
 
 	"github.com/kcp-dev/kcp/cmd/virtual-workspaces/options"
+	_ "github.com/kcp-dev/kcp/pkg/features"
 	"github.com/kcp-dev/kcp/pkg/virtual/terminatingworkspaces"
 	"github.com/kcp-dev/kcp/test/e2e/framework"
 )
@@ -692,6 +695,10 @@ func TestTerminatingWorkspacesVirtualWorkspaceWatch(t *testing.T) {
 func TestTerminatingWorkspacesVirtualWorkspaceWatchBookmark(t *testing.T) {
 	t.Parallel()
 	framework.Suite(t, "control-plane")
+
+	if !utilfeature.DefaultFeatureGate.Enabled(genericfeatures.WatchList) {
+		t.Skip("Skipping because the WatchList feature gate is disabled")
+	}
 
 	source := kcptesting.SharedKcpServer(t)
 	wsPath, _ := kcptesting.NewWorkspaceFixture(t, source, core.RootCluster.Path())


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

WatchList breaks restarting a kcp instance.
We're disabling it so main works again until we have a proper fix.

## What Type of PR Is This?

/kind bug

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
