### PR TITLE
Wrap WorkspaceType creation in EventuallyWithT

### DIFF
--- a/test/e2e/virtual/terminatingworkspaces/virtualworkspace_test.go
+++ b/test/e2e/virtual/terminatingworkspaces/virtualworkspace_test.go
@@ -150,8 +150,10 @@ func TestTerminatingWorkspacesVirtualWorkspaceAccess(t *testing.T) {
 
 	// create workspacetypes
 	for _, wst := range workspaceTypes {
-		_, err := sourceKcpClusterClient.TenancyV1alpha1().Cluster(wsPath).WorkspaceTypes().Create(ctx, wst, metav1.CreateOptions{})
-		require.NoError(t, err)
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			_, err := sourceKcpClusterClient.TenancyV1alpha1().Cluster(wsPath).WorkspaceTypes().Create(ctx, wst, metav1.CreateOptions{})
+			require.NoError(c, err)
+		}, wait.ForeverTestTimeout, 100*time.Millisecond)
 		source.Artifact(t, func() (runtime.Object, error) {
 			return sourceKcpClusterClient.TenancyV1alpha1().Cluster(wsPath).WorkspaceTypes().Get(ctx, wst.Name, metav1.GetOptions{})
 		})
@@ -545,8 +547,10 @@ func TestTerminatingWorkspacesVirtualWorkspaceWatch(t *testing.T) {
 
 	// create workspacetypes
 	for _, wst := range workspaceTypes {
-		_, err := sourceKcpClusterClient.TenancyV1alpha1().Cluster(wsPath).WorkspaceTypes().Create(ctx, wst, metav1.CreateOptions{})
-		require.NoError(t, err)
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			_, err := sourceKcpClusterClient.TenancyV1alpha1().Cluster(wsPath).WorkspaceTypes().Create(ctx, wst, metav1.CreateOptions{})
+			require.NoError(c, err)
+		}, wait.ForeverTestTimeout, 100*time.Millisecond)
 		source.Artifact(t, func() (runtime.Object, error) {
 			return sourceKcpClusterClient.TenancyV1alpha1().Cluster(wsPath).WorkspaceTypes().Get(ctx, wst.Name, metav1.GetOptions{})
 		})
@@ -714,8 +718,10 @@ func TestTerminatingWorkspacesVirtualWorkspaceWatchBookmark(t *testing.T) {
 	}
 
 	// create workspacetypes
-	_, err = sourceKcpClusterClient.TenancyV1alpha1().Cluster(wsPath).WorkspaceTypes().Create(ctx, wst, metav1.CreateOptions{})
-	require.NoError(t, err)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		_, err = sourceKcpClusterClient.TenancyV1alpha1().Cluster(wsPath).WorkspaceTypes().Create(ctx, wst, metav1.CreateOptions{})
+		require.NoError(c, err)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond)
 	source.Artifact(t, func() (runtime.Object, error) {
 		return sourceKcpClusterClient.TenancyV1alpha1().Cluster(wsPath).WorkspaceTypes().Get(ctx, wst.Name, metav1.GetOptions{})
 	})


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Seen a few failures where WorkspaceType creation failed with:

```text
    virtualworkspace_test.go:154: 
        	Error Trace:	/home/prow/go/src/github.com/kcp-dev/kcp/test/e2e/virtual/terminatingworkspaces/virtualworkspace_test.go:154
        	Error:      	Received unexpected error:
        	            	the server could not find the requested resource (post workspacetypes.tenancy.kcp.io)
        	Test:       	TestTerminatingWorkspacesVirtualWorkspaceAccess
```

That is a bit odd but in CI can see that the APIs being established takes a bit longer than the time the test goes from workspace being created and this call happening.

## What Type of PR Is This?

/kind flake

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
