### PR TITLE
Try prevent flaking by placing org and ws on same shard

### DIFF
--- a/test/e2e/reconciler/workspacedeletion/controller_test.go
+++ b/test/e2e/reconciler/workspacedeletion/controller_test.go
@@ -62,7 +62,12 @@ func TestWorkspaceDeletion(t *testing.T) {
 		{
 			name: "create and clean workspace",
 			work: func(ctx context.Context, t *testing.T, server runningServer) {
-				orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
+				// The kcptesting.WithRootShard was added due to the
+				// test flaking in CI, it is not actually required for
+				// the test execution. However we observed that this
+				// subtest was flaking while the next subtest - which is
+				// pinning the workspaces to the root shard - was not.
+				orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithRootShard(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 
 				t.Logf("Create a workspace with a shard")
 				workspace, err := server.kcpClusterClient.Cluster(orgPath).TenancyV1alpha1().Workspaces().Create(ctx, &tenancyv1alpha1.Workspace{
@@ -194,6 +199,12 @@ func TestWorkspaceDeletion(t *testing.T) {
 		{
 			name: "nested workspace cleanup when an org workspace is deleted",
 			work: func(ctx context.Context, t *testing.T, server runningServer) {
+				// On the - kcptesting.WithRootShard the test doesn't
+				// need the root shard explicitly, it just needs to know
+				// the shard to get the client for the shard.
+				// In a future refactor the placement on the root shard
+				// could be removed and the client for the correct
+				// shards be build dynamically.
 				orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithRootShard(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 
 				t.Logf("Should have finalizer in org workspace")


### PR DESCRIPTION

<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

`create and clean workspace` has been flaking due to eventually timeouts, while the other subtest hasn't flaked. The other subtest places the org and workspace on the root shard explicitly, this test didn't.

My guess is that the cross-shard operation (plus all the other tests) is just enough delay for the test to fail every now and then. It's worth a try - at worst the two tests will have a similar setup.


## What Type of PR Is This?

/kind flake


<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
