### PR TITLE
Fix flaking TestImpersonation

### DIFF
--- a/test/e2e/authorizer/impersonate_test.go
+++ b/test/e2e/authorizer/impersonate_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
@@ -62,13 +63,13 @@ func TestImpersonation(t *testing.T) {
 
 	t.Logf("User-1 should not be able to edit workspace status")
 	var ws *tenancyv1alpha1.Workspace
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		var err error
 		ws, err = user1Client.TenancyV1alpha1().Workspaces().Cluster(org).Get(ctx, wsObj.Name, metav1.GetOptions{})
-		require.NoError(t, err)
+		require.NoError(c, err)
 		ws.Status.Phase = "Scheduling"
 		_, err = user1Client.TenancyV1alpha1().Workspaces().Cluster(org).UpdateStatus(ctx, ws, metav1.UpdateOptions{})
-		return apierrors.IsForbidden(err)
+		require.True(c, apierrors.IsForbidden(err))
 	}, wait.ForeverTestTimeout, time.Millisecond*100, "user-1 should not be able to edit its own workspace status")
 
 	user1Cfg.Impersonate = rest.ImpersonationConfig{
@@ -79,10 +80,10 @@ func TestImpersonation(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("User-1 should NOT be able to edit workspace status with system:masters impersonation")
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		ws.Status.Phase = "Scheduling"
 		_, err = user1Client.TenancyV1alpha1().Workspaces().Cluster(org).UpdateStatus(ctx, ws, metav1.UpdateOptions{})
-		return apierrors.IsForbidden(err)
+		require.True(c, apierrors.IsForbidden(err))
 	}, wait.ForeverTestTimeout, time.Millisecond*100, "user-1 should NOT be able to edit its own workspace status with impersonation")
 }
 


### PR DESCRIPTION

<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

TestImpersonation used require.NoError within require.Eventually, meaning if the user is not immediately able to access the workspace the test fails.


## What Type of PR Is This?

/kind flake

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
