### PR TITLE
proxy:implement readyz and livez handlers

### DIFF
--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	genericapifilters "k8s.io/apiserver/pkg/endpoints/filters"
 	genericfilters "k8s.io/apiserver/pkg/server/filters"
+	"k8s.io/apiserver/pkg/server/healthz"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 
@@ -144,15 +145,8 @@ func NewServer(ctx context.Context, c CompletedConfig) (*Server, error) {
 	handler = genericfilters.WithCORS(handler, c.Options.CorsAllowedOriginList, nil, nil, nil, "true")
 
 	mux := http.NewServeMux()
-	// TODO: implement proper readyz handler
-	mux.Handle("/readyz", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("OK")) //nolint:errcheck
-	}))
-
-	// TODO: implement proper livez handler
-	mux.Handle("/livez", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("OK")) //nolint:errcheck
-	}))
+	healthz.InstallReadyzHandler(mux, healthz.NewInformerSyncHealthz(s.KcpSharedInformerFactory))
+	healthz.InstallLivezHandler(mux, healthz.PingHealthz)
 
 	mux.Handle("/", handler)
 	s.Handler = mux


### PR DESCRIPTION
## Summary

Replace the stub `OK` responses on `/readyz` and `/livez` with health checks using the recommended `k8s.io/apiserver/pkg/server/healthz` package from issue description.

In short,
- `/readyz` uses `NewInformerSyncHealthz` and reports ready only once the shared informer factory caches have [synced](https://github.com/kcp-dev/kcp/blob/main/pkg/proxy/server.go#L199)
-  for liveness ping (didn't find any meaningful broken-but-alive state, I assume that simple ping-pong would be fine)

## What Type of PR Is This?

/kind feature

## Related Issue(s)

Fixes #3916

## Release Notes

```release-note
Add  `/readyz` now uses `NewInformerSyncHealthz` 
Add `/livez` now uses `PingHealthz`
```
