### PR TITLE
3915 add pkg identity

### DIFF
--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The kcp Authors.
+Copyright 2026 The kcp Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package apiexport
+package identity
 
 import (
 	"context"
@@ -31,28 +31,38 @@ import (
 	"github.com/kcp-dev/kcp/pkg/crypto"
 )
 
-func GenerateIdentitySecret(ctx context.Context, ns string, apiExportName string) (*corev1.Secret, error) {
+// GenerateIdentitySecret creates a Kubernetes Secret containing a randomly generated
+// identity key used for APIExport identity.
+//
+// The secret will be created in the given namespace with the provided name.
+// The identity key is stored in StringData under apisv1alpha1.SecretKeyAPIExportIdentity.
+//
+// A warning is logged if key generation takes longer than 100ms.
+func GenerateIdentitySecret(ctx context.Context, namespace, name string) (*corev1.Secret, error) {
 	logger := klog.FromContext(ctx)
+
 	start := time.Now()
 	key := crypto.Random256BitsString()
 	if dur := time.Since(start); dur > time.Millisecond*100 {
 		logger.Info("identity key generation took a long time", "duration", dur)
 	}
 
-	secret := &corev1.Secret{
+	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:   ns,
-			Name:        apiExportName,
+			Namespace:   namespace,
+			Name:        name,
 			Annotations: map[string]string{},
 		},
 		StringData: map[string]string{
 			apisv1alpha1.SecretKeyAPIExportIdentity: key,
 		},
-	}
-
-	return secret, nil
+	}, nil
 }
 
+// IdentityHash computes a SHA-256 hash of the identity key stored in the given Secret.
+//
+// The identity key is expected to be present in secret.Data under
+// apisv1alpha1.SecretKeyAPIExportIdentity.
 func IdentityHash(secret *corev1.Secret) (string, error) {
 	key := secret.Data[apisv1alpha1.SecretKeyAPIExportIdentity]
 	if len(key) == 0 {

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package identity
+
+// Tests included:
+// 1. TestGenerateIdentitySecret	- verifies that GenerateIdentitySecret creates a Secret
+// with the expected metadata and a non-empty identity key.
+// 2. TestIdentityHash 						- verifies that IdentityHash correctly computes the SHA-256
+// hash of the identity key stored in a Secret, and returns an error when the key is missing.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+
+	apisv1alpha1 "github.com/kcp-dev/sdk/apis/apis/v1alpha1"
+)
+
+// TestGenerateIdentitySecret verifies that GenerateIdentitySecret creates a Secret
+// with the expected metadata and a non-empty identity key.
+func TestGenerateIdentitySecret(t *testing.T) {
+	namespace := "test-namespace"
+	name := "test-name"
+
+	secret, err := GenerateIdentitySecret(context.Background(), namespace, name)
+
+	require.NoError(t, err)
+
+	// Verify metadata
+	require.Equal(t, namespace, secret.Namespace)
+	require.Equal(t, name, secret.Name)
+
+	// Verify identity key is present and non-empty
+	key, exists := secret.StringData[apisv1alpha1.SecretKeyAPIExportIdentity]
+	require.True(t, exists, "identity key should exist in StringData")
+	require.NotEmpty(t, key, "identity key should not be empty")
+}
+
+// TestIdentityHash verifies that IdentityHash correctly computes the SHA-256
+// hash of the identity key stored in a Secret, and returns an error when the key is missing.
+func TestIdentityHash(t *testing.T) {
+	tests := map[string]struct {
+		secret        *corev1.Secret
+		expectedHash  string
+		expectError   bool
+		errorContains string
+	}{
+		"valid secret returns correct hash": {
+			secret: &corev1.Secret{
+				Data: map[string][]byte{
+					apisv1alpha1.SecretKeyAPIExportIdentity: []byte("xxx"),
+				},
+			},
+			expectedHash: "cd2eb0837c9b4c962c22d2ff8b5441b7b45805887f051d39bf133b583baf6860",
+			expectError:  false,
+		},
+		"missing key returns error": {
+			secret: &corev1.Secret{
+				Data: map[string][]byte{},
+			},
+			expectError:   true,
+			errorContains: "missing",
+		},
+		"nil data returns error": {
+			secret:        &corev1.Secret{},
+			expectError:   true,
+			errorContains: "missing",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			hash, err := IdentityHash(tt.secret)
+
+			if tt.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errorContains)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedHash, hash)
+		})
+	}
+}

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -16,12 +16,6 @@ limitations under the License.
 
 package identity
 
-// Tests included:
-// 1. TestGenerateIdentitySecret	- verifies that GenerateIdentitySecret creates a Secret
-// with the expected metadata and a non-empty identity key.
-// 2. TestIdentityHash 						- verifies that IdentityHash correctly computes the SHA-256
-// hash of the identity key stored in a Secret, and returns an error when the key is missing.
-
 import (
 	"context"
 	"testing"

--- a/pkg/reconciler/apis/apiexport/apiexport_reconcile.go
+++ b/pkg/reconciler/apis/apiexport/apiexport_reconcile.go
@@ -37,6 +37,7 @@ import (
 
 	virtualworkspacesoptions "github.com/kcp-dev/kcp/cmd/virtual-workspaces/options"
 	kcpfeatures "github.com/kcp-dev/kcp/pkg/features"
+	"github.com/kcp-dev/kcp/pkg/identity"
 	"github.com/kcp-dev/kcp/pkg/logging"
 	apiexportbuilder "github.com/kcp-dev/kcp/pkg/virtual/apiexport/builder"
 )
@@ -176,7 +177,7 @@ func (c *controller) ensureSecretNamespaceExists(ctx context.Context, clusterNam
 }
 
 func (c *controller) createIdentitySecret(ctx context.Context, clusterName logicalcluster.Path, apiExportName string) error {
-	secret, err := GenerateIdentitySecret(ctx, c.secretNamespace, apiExportName)
+	secret, err := identity.GenerateIdentitySecret(ctx, c.secretNamespace, apiExportName)
 	if err != nil {
 		return err
 	}
@@ -194,7 +195,7 @@ func (c *controller) updateOrVerifyIdentitySecretHash(ctx context.Context, clust
 		return err
 	}
 
-	hash, err := IdentityHash(secret)
+	hash, err := identity.IdentityHash(secret)
 	if err != nil {
 		return err
 	}

--- a/pkg/reconciler/cache/cachedresources/cachedresources_reconcile.go
+++ b/pkg/reconciler/cache/cachedresources/cachedresources_reconcile.go
@@ -18,7 +18,6 @@ package cachedresources
 
 import (
 	"context"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -31,12 +30,11 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/kcp-dev/logicalcluster/v3"
-	apisv1alpha1 "github.com/kcp-dev/sdk/apis/apis/v1alpha1"
 	cachev1alpha1 "github.com/kcp-dev/sdk/apis/cache/v1alpha1"
 
 	cacheclient "github.com/kcp-dev/kcp/pkg/cache/client"
 	"github.com/kcp-dev/kcp/pkg/cache/client/shard"
-	"github.com/kcp-dev/kcp/pkg/crypto"
+	"github.com/kcp-dev/kcp/pkg/identity"
 	"github.com/kcp-dev/kcp/pkg/logging"
 	replicationcontroller "github.com/kcp-dev/kcp/pkg/reconciler/cache/cachedresources/replication"
 )
@@ -73,7 +71,7 @@ func (c *Controller) reconcile(ctx context.Context, cluster logicalcluster.Name,
 				return mapping.Scope, nil
 			},
 		},
-		&identity{
+		&identityReconciler{
 			ensureSecretNamespaceExists: c.ensureSecretNamespaceExists,
 			getSecret:                   c.getSecret,
 			createIdentitySecret:        c.createIdentitySecret,
@@ -223,7 +221,7 @@ func (c *Controller) ensureSecretNamespaceExists(ctx context.Context, clusterNam
 }
 
 func (c *Controller) createIdentitySecret(ctx context.Context, clusterName logicalcluster.Path, defaultSecretNamespace, cachedResourceName string) error {
-	secret, err := GenerateIdentitySecret(ctx, defaultSecretNamespace, cachedResourceName)
+	secret, err := identity.GenerateIdentitySecret(ctx, defaultSecretNamespace, cachedResourceName)
 	if err != nil {
 		return err
 	}
@@ -233,27 +231,4 @@ func (c *Controller) createIdentitySecret(ctx context.Context, clusterName logic
 	ctx = klog.NewContext(ctx, logger)
 	logger.V(2).Info("creating identity secret")
 	return c.createSecret(ctx, clusterName, secret)
-}
-
-// TODO: This is copy from apiexport controller. We should move it to a shared location.
-func GenerateIdentitySecret(ctx context.Context, ns string, name string) (*corev1.Secret, error) {
-	logger := klog.FromContext(ctx)
-	start := time.Now()
-	key := crypto.Random256BitsString()
-	if dur := time.Since(start); dur > time.Millisecond*100 {
-		logger.Info("identity key generation took a long time", "duration", dur)
-	}
-
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace:   ns,
-			Name:        name,
-			Annotations: map[string]string{},
-		},
-		StringData: map[string]string{
-			apisv1alpha1.SecretKeyAPIExportIdentity: key,
-		},
-	}
-
-	return secret, nil
 }

--- a/pkg/reconciler/cache/cachedresources/cachedresources_reconcile_identity.go
+++ b/pkg/reconciler/cache/cachedresources/cachedresources_reconcile_identity.go
@@ -18,21 +18,21 @@ package cachedresources
 
 import (
 	"context"
-	"crypto/sha256"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/kcp-dev/logicalcluster/v3"
-	apisv1alpha1 "github.com/kcp-dev/sdk/apis/apis/v1alpha1"
 	cachev1alpha1 "github.com/kcp-dev/sdk/apis/cache/v1alpha1"
 	conditionsv1alpha1 "github.com/kcp-dev/sdk/apis/third_party/conditions/apis/conditions/v1alpha1"
 	"github.com/kcp-dev/sdk/apis/third_party/conditions/util/conditions"
+
+	"github.com/kcp-dev/kcp/pkg/identity"
 )
 
-// identity creates identity secret for the published resource and computes hash of the secret.
-type identity struct {
+// identityReconciler creates identity secret for the published resource and computes hash of the secret.
+type identityReconciler struct {
 	ensureSecretNamespaceExists func(ctx context.Context, clusterName logicalcluster.Name, defaultSecretNamespace string)
 	getSecret                   func(ctx context.Context, clusterName logicalcluster.Name, namespace, name string) (*corev1.Secret, error)
 	createIdentitySecret        func(ctx context.Context, clusterName logicalcluster.Path, defaultSecretNamespace, name string) error
@@ -40,7 +40,7 @@ type identity struct {
 	secretNamespace string
 }
 
-func (r *identity) reconcile(ctx context.Context, cachedResource *cachev1alpha1.CachedResource) (reconcileStatus, error) {
+func (r *identityReconciler) reconcile(ctx context.Context, cachedResource *cachev1alpha1.CachedResource) (reconcileStatus, error) {
 	if !cachedResource.DeletionTimestamp.IsZero() {
 		return reconcileStatusContinue, nil
 	}
@@ -108,13 +108,13 @@ func (r *identity) reconcile(ctx context.Context, cachedResource *cachev1alpha1.
 	return reconcileStatusContinue, nil
 }
 
-func (r *identity) updateOrVerifyIdentitySecretHash(ctx context.Context, clusterName logicalcluster.Name, cachedResource *cachev1alpha1.CachedResource, defaultSecretNamespace string) error {
+func (r *identityReconciler) updateOrVerifyIdentitySecretHash(ctx context.Context, clusterName logicalcluster.Name, cachedResource *cachev1alpha1.CachedResource, defaultSecretNamespace string) error {
 	secret, err := r.getSecret(ctx, clusterName, cachedResource.Spec.Identity.SecretRef.Namespace, cachedResource.Spec.Identity.SecretRef.Name)
 	if err != nil {
 		return err
 	}
 
-	hash, err := IdentityHash(secret)
+	hash, err := identity.IdentityHash(secret)
 	if err != nil {
 		return err
 	}
@@ -128,16 +128,4 @@ func (r *identity) updateOrVerifyIdentitySecretHash(ctx context.Context, cluster
 	}
 
 	return nil
-}
-
-// TODO: This is copy from apiexport controller. We should move it to a shared location.
-func IdentityHash(secret *corev1.Secret) (string, error) {
-	key := secret.Data[apisv1alpha1.SecretKeyAPIExportIdentity]
-	if len(key) == 0 {
-		return "", fmt.Errorf("secret is missing data.%s", apisv1alpha1.SecretKeyAPIExportIdentity)
-	}
-
-	hashBytes := sha256.Sum256(key)
-	hash := fmt.Sprintf("%x", hashBytes)
-	return hash, nil
 }

--- a/pkg/reconciler/cache/cachedresources/cachedresources_reconcile_identity_test.go
+++ b/pkg/reconciler/cache/cachedresources/cachedresources_reconcile_identity_test.go
@@ -36,7 +36,7 @@ import (
 func TestReconcileIdentity(t *testing.T) {
 	tests := map[string]struct {
 		CachedResource            *cachev1alpha1.CachedResource
-		reconciler                *identity
+		reconciler                *identityReconciler
 		expectedErr               error
 		expectedStatus            reconcileStatus
 		expectedConditions        conditionsv1alpha1.Conditions
@@ -51,7 +51,7 @@ func TestReconcileIdentity(t *testing.T) {
 					},
 				},
 			},
-			reconciler: &identity{
+			reconciler: &identityReconciler{
 				ensureSecretNamespaceExists: func(ctx context.Context, clusterName logicalcluster.Name, defaultSecretNamespace string) {},
 				getSecret: func(ctx context.Context, clusterName logicalcluster.Name, namespace, name string) (*corev1.Secret, error) {
 					return nil, apierrors.NewNotFound(corev1.Resource("resources"), name)
@@ -81,7 +81,7 @@ func TestReconcileIdentity(t *testing.T) {
 					Name: "cr-name",
 				},
 			},
-			reconciler: &identity{
+			reconciler: &identityReconciler{
 				ensureSecretNamespaceExists: func(ctx context.Context, clusterName logicalcluster.Name, defaultSecretNamespace string) {},
 				getSecret: func(ctx context.Context, clusterName logicalcluster.Name, namespace, name string) (*corev1.Secret, error) {
 					return nil, apierrors.NewNotFound(corev1.Resource("resources"), name)
@@ -118,7 +118,7 @@ func TestReconcileIdentity(t *testing.T) {
 					},
 				},
 			},
-			reconciler: &identity{
+			reconciler: &identityReconciler{
 				getSecret: func(ctx context.Context, clusterName logicalcluster.Name, namespace, name string) (*corev1.Secret, error) {
 					return &corev1.Secret{}, nil
 				},
@@ -160,7 +160,7 @@ func TestReconcileIdentity(t *testing.T) {
 					IdentityHash: "some-sha256-digest-for-xxx",
 				},
 			},
-			reconciler: &identity{
+			reconciler: &identityReconciler{
 				getSecret: func(ctx context.Context, clusterName logicalcluster.Name, namespace, name string) (*corev1.Secret, error) {
 					return &corev1.Secret{
 						Data: map[string][]byte{
@@ -204,7 +204,7 @@ func TestReconcileIdentity(t *testing.T) {
 					},
 				},
 			},
-			reconciler: &identity{
+			reconciler: &identityReconciler{
 				getSecret: func(ctx context.Context, clusterName logicalcluster.Name, namespace, name string) (*corev1.Secret, error) {
 					return &corev1.Secret{
 						Data: map[string][]byte{
@@ -246,7 +246,7 @@ func TestReconcileIdentity(t *testing.T) {
 					IdentityHash: "cd2eb0837c9b4c962c22d2ff8b5441b7b45805887f051d39bf133b583baf6860",
 				},
 			},
-			reconciler: &identity{
+			reconciler: &identityReconciler{
 				getSecret: func(ctx context.Context, clusterName logicalcluster.Name, namespace, name string) (*corev1.Secret, error) {
 					return &corev1.Secret{
 						Data: map[string][]byte{


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

This PR centralizes identity-related logic by introducing a new `pkg/identity` package.

It moves duplicated implementations of `GenerateIdentitySecret()` and `IdentityHash()` into a shared location.

All existing functions calls are updated to use the new package, and unit tests are added.

## What Type of PR Is This?

<!--

Add one of the following kinds:

-->

/kind cleanup

## Related Issue(s)

Fixes #3915 

## Release Notes

<!--

Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.

-->

```release-note
Internal: consolidate identity secret generation and hashing logic into pkg/identity
```
