### PR TITLE
Fix TestInactiveLogicalCluster flake

### DIFF
--- a/test/e2e/workspace/inactive_test.go
+++ b/test/e2e/workspace/inactive_test.go
@@ -48,14 +48,18 @@ func TestInactiveLogicalCluster(t *testing.T) {
 	kubeClient, err := kcpkubernetesclientset.NewForConfig(cfg)
 	require.NoError(t, err)
 
-	t.Log("Get the logicalcluster")
-	lc, err := kcpClient.Cluster(orgPath).CoreV1alpha1().LogicalClusters().Get(t.Context(), "cluster", v1.GetOptions{})
-	require.NoError(t, err)
-
-	t.Log("Mark the logicalcluster as inactive")
-	lc.Annotations[filters.InactiveAnnotation] = "true"
-	lc, err = kcpClient.Cluster(orgPath).CoreV1alpha1().LogicalClusters().Update(t.Context(), lc, v1.UpdateOptions{})
-	require.NoError(t, err)
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		lc, err := kcpClient.Cluster(orgPath).CoreV1alpha1().LogicalClusters().Get(t.Context(), "cluster", v1.GetOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+		lc.Annotations[filters.InactiveAnnotation] = "true"
+		_, err = kcpClient.Cluster(orgPath).CoreV1alpha1().LogicalClusters().Update(t.Context(), lc, v1.UpdateOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+		return true, ""
+	}, wait.ForeverTestTimeout, time.Millisecond*100)
 
 	t.Log("Verify that normal requests fail")
 	kcptestinghelpers.Eventually(t, func() (bool, string) {
@@ -67,9 +71,18 @@ func TestInactiveLogicalCluster(t *testing.T) {
 	}, wait.ForeverTestTimeout, time.Millisecond*100)
 
 	t.Log("Remove inactive annotation again")
-	delete(lc.Annotations, filters.InactiveAnnotation)
-	_, err = kcpClient.Cluster(orgPath).CoreV1alpha1().LogicalClusters().Update(t.Context(), lc, v1.UpdateOptions{})
-	require.NoError(t, err)
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		lc, err := kcpClient.Cluster(orgPath).CoreV1alpha1().LogicalClusters().Get(t.Context(), "cluster", v1.GetOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+		delete(lc.Annotations, filters.InactiveAnnotation)
+		_, err = kcpClient.Cluster(orgPath).CoreV1alpha1().LogicalClusters().Update(t.Context(), lc, v1.UpdateOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+		return true, ""
+	}, wait.ForeverTestTimeout, time.Millisecond*100)
 
 	t.Log("Verify that normal requests succeed again")
 	kcptestinghelpers.Eventually(t, func() (bool, string) {


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

The update removing the inactive annotation is never retried. That isn't
a problem as long as there isn't anything else modifying the lc before
the test moves to the logical cluster annotation.

If however another reconciler modifies the object before that happens
the test fails because of the RV mismatch, and since it doesn't retry
the entire test fails.

Hence it flakes in CI.

## What Type of PR Is This?

/kind flake

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
