### PR TITLE
test/e2e: remove t.Skip() now that #3397 is fixed

### DIFF
--- a/test/e2e/authorizer/serviceaccounts_test.go
+++ b/test/e2e/authorizer/serviceaccounts_test.go
@@ -281,8 +281,6 @@ func TestServiceAccounts(t *testing.T) {
 			})
 
 			t.Run("Access an equally named workspace in another org", func(t *testing.T) {
-				// See https://github.com/kcp-dev/kcp/issues/3397
-				t.Skip()
 				t.Log("Create namespace with the same name")
 				otherOrgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 				otherPath, _ := kcptesting.NewWorkspaceFixture(t, server, otherOrgPath)


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Remove `t.Skip()` from the subtest "Access an equally named workspace in another org" since issue #3397 is now fixed.

## What Type of PR Is This?

/kind cleanup
/kind bug

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #3908  

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
