### PR TITLE
fix:  for specific apibinding

### DIFF
--- a/staging/src/github.com/kcp-dev/cli/pkg/helpers/apis/apis/apibinding.go
+++ b/staging/src/github.com/kcp-dev/cli/pkg/helpers/apis/apis/apibinding.go
@@ -77,11 +77,10 @@ func NewAPIBinding(nativeBinding any) APIBinding {
 
 func NewAPIBindingList(nativeBinding any) APIBindingList {
 	switch asserted := nativeBinding.(type) {
-	case *apisv1alpha1.APIBinding:
-		return &apiBindingListV1alpha1{bindings: []*apisv1alpha1.APIBinding{asserted}}
-	case *apisv1alpha2.APIBinding:
-		return &apiBindingListV1alpha2{bindings: []*apisv1alpha2.APIBinding{asserted}}
+	case *apiBindingV1alpha2:
+		return &apiBindingListV1alpha2{bindings: []*apisv1alpha2.APIBinding{asserted.binding}}
+	case *apiBindingV1alpha1:
+		return &apiBindingListV1alpha1{bindings: []*apisv1alpha1.APIBinding{asserted.binding}}
 	}
-
 	panic("Unsupported APIBinding version provided.")
 }


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Correct the type assertion to make `kcp claims get apibinding APIBINDING_NAME` working.

The logic [here](https://github.com/kcp-dev/kcp/blob/main/staging/src/github.com/kcp-dev/cli/pkg/claims/plugin/claims.go#L117-L121) implies that `binding` object is a type of `apiBindingV1Alpha1` or `apiBindingV1Alpha2`.

**NOTE**: the current logic of the plugin (printing a table) has not been touched in this PR as it solely focuses on fixing the panic `panic: Unsupported APIBinding version provided.`

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind bug

## Related Issue(s)

Fixes #3948 

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
