### PR TITLE
fix endless retry loop during external cache bootstrap by more than one kcp server replica

### DIFF
--- a/config/helpers/bootstrap.go
+++ b/config/helpers/bootstrap.go
@@ -165,6 +165,10 @@ func createResource(ctx context.Context, client dynamic.Interface, mapper meta.R
 		return fmt.Errorf("could not get REST mapping for %s: %w", gvk, err)
 	}
 
+	// Clear resourceVersion before CREATE - it may have been set by a previous
+	// failed attempt that got AlreadyExists and then retried.
+	u.SetResourceVersion("")
+
 	upserted, err := client.Resource(m.Resource).Namespace(u.GetNamespace()).Create(ctx, u, metav1.CreateOptions{})
 	if err != nil {
 		if apierrors.IsAlreadyExists(err) {


### PR DESCRIPTION
When running multiple kcp replicas that bootstrap against an external cache server, the bootstrap process can get stuck in an infinite retry loop.

The bootstrap flow processes resources concurrently and retries on transient failures. When two replicas try to create the same resource (e.g. an APIExport) simultaneously, one will succeed and the other receives an AlreadyExists error. The error handler then fetches the existing resource and sets its resourceVersion on the shared unstructured object to prepare for an update.

However, the bootstrap retry loop reuses the same slice of unstructured objects across attempts. If the retry happens (due to another concurrent failure in the same batch), the next CREATE request for that object will include the stale resourceVersion from the previous attempt. The apiserver rejects this with "resourceVersion should not be set on objects to be created", and since this is not a retryable error category, it causes the bootstrap to fail.

This race condition is timing-dependent and only manifests when multiple replicas start concurrently against a shared cache server, making it appear as a flaky test failure.

## Release Note
```release-note
Fix external cache bootstrapping issues that sometimes prevented shards from bootstrapping successfully.
```