### PR TITLE
[release-0.28] fix endless retry loop during external cache bootstrap by more than one kcp server replica

### DIFF
--- a/config/helpers/bootstrap.go
+++ b/config/helpers/bootstrap.go
@@ -207,6 +207,10 @@ func createResourceFromFS(ctx context.Context, client dynamic.Interface, mapper 
 		return fmt.Errorf("could not get REST mapping for %s: %w", gvk, err)
 	}
 
+	// Clear resourceVersion before CREATE - it may have been set by a previous
+	// failed attempt that got AlreadyExists and then retried.
+	u.SetResourceVersion("")
+
 	upserted, err := client.Resource(m.Resource).Namespace(u.GetNamespace()).Create(ctx, u, metav1.CreateOptions{})
 	if err != nil {
 		if apierrors.IsAlreadyExists(err) {

--- a/pkg/reconciler/dynamicrestmapper/defaultrestmapper_kcp.go
+++ b/pkg/reconciler/dynamicrestmapper/defaultrestmapper_kcp.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KCP Authors.
+Copyright 2026 The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary
This replaces #3980 and includes the codegen fix. THis should also unblock any other backports we shy'ed away from just because of the inconvenient codegen stuff. ^^

## What Type of PR Is This?
/kind bug

## Release Notes
```release-note
Fix external cache bootstrapping issues that sometimes prevented shards from bootstrapping successfully.
```
