### PR TITLE
[release-0.30] simplify Prometheus scrape config management in e2e tests (#3983)

### DIFF
--- a/hack/run-with-prometheus.sh
+++ b/hack/run-with-prometheus.sh
@@ -28,7 +28,7 @@ if ! command -v hack/tools/prometheus 1> /dev/null 2>&1; then
 fi
 
 touch .prometheus-config.yaml
-./hack/tools/prometheus --storage.tsdb.path=".prometheus_data" --config.file=.prometheus-config.yaml --web.enable-lifecycle &
+./hack/tools/prometheus --storage.tsdb.path=".prometheus_data" --config.file=.prometheus-config.yaml --web.enable-lifecycle --log.level=warn &
 PROM_PID=$!
 export PROMETHEUS_URL="http://localhost:9090"
 echo 'Waiting for Prometheus to be ready...'

--- a/staging/src/github.com/kcp-dev/sdk/testing/server/metrics.go
+++ b/staging/src/github.com/kcp-dev/sdk/testing/server/metrics.go
@@ -18,24 +18,18 @@ package server
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"io"
-	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
-	"syscall"
 	"time"
-
-	"github.com/stretchr/testify/require"
-	gopkgyaml "gopkg.in/yaml.v3"
 
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
 
 	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned"
 	kcptestinghelpers "github.com/kcp-dev/sdk/testing/helpers"
+	"github.com/kcp-dev/sdk/testing/server/prometheus"
 )
 
 func gatherMetrics(ctx context.Context, t TestingT, server RunningServer, directory string) {
@@ -66,7 +60,14 @@ func scrapeMetricsForServer(t TestingT, srv RunningServer) {
 		t.Logf("PROMETHEUS_URL environment variable unset, skipping Prometheus scrape config generation")
 		return
 	}
-	jobName := fmt.Sprintf("kcp-%s-%s", srv.Name(), t.Name())
+
+	caFile := filepath.Join(srv.CADirectory(), "apiserver.crt")
+	if _, err := os.Stat(caFile); os.IsNotExist(err) {
+		t.Logf("CA file %s does not exist, skipping Prometheus scrape config for server %s", caFile, srv.Name())
+		return
+	}
+
+	jobName := fmt.Sprintf("kcp-%s-%s-%d", srv.Name(), t.Name(), time.Now().Unix())
 	labels := map[string]string{
 		"server": srv.Name(),
 		"test":   t.Name(),
@@ -75,90 +76,64 @@ func scrapeMetricsForServer(t TestingT, srv RunningServer) {
 	ctx, cancel := context.WithTimeout(context.Background(), wait.ForeverTestTimeout)
 	defer cancel()
 	repoDir, err := kcptestinghelpers.RepositoryDir()
-	require.NoError(t, err)
-	require.NoError(t, ScrapeMetrics(ctx, srv.RootShardSystemMasterBaseConfig(t), promUrl, repoDir, jobName, filepath.Join(srv.CADirectory(), "apiserver.crt"), labels))
+	if err != nil {
+		t.Logf("error getting repository directory for server %s: %v", srv.Name(), err)
+		return
+	}
+
+	if err := ScrapeMetrics(ctx, srv.RootShardSystemMasterBaseConfig(t), promUrl, repoDir, jobName, caFile, labels); err != nil {
+		t.Logf("error configuring Prometheus scraping for server %s: %v", srv.Name(), err)
+	}
+
+	// Clean up Prometheus configuration when test finishes
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := CleanupScrapeMetrics(cleanupCtx, promUrl, repoDir, jobName); err != nil {
+			t.Logf("error cleaning up Prometheus scrape config for server %s: %v", srv.Name(), err)
+		}
+	})
+}
+
+func prometheusConfigFile(cfgDir string) string {
+	return filepath.Join(cfgDir, ".prometheus-config.yaml")
 }
 
 func ScrapeMetrics(ctx context.Context, cfg *rest.Config, promUrl, promCfgDir, jobName, caFile string, labels map[string]string) error {
-	jobName = fmt.Sprintf("%s-%d", jobName, time.Now().Unix())
-	type staticConfigs struct {
-		Targets []string          `yaml:"targets,omitempty"`
-		Labels  map[string]string `yaml:"labels,omitempty"`
-	}
-	type tlsConfig struct {
-		InsecureSkipVerify bool   `yaml:"insecure_skip_verify,omitempty"`
-		CaFile             string `yaml:"ca_file,omitempty"`
-	}
-	type scrapeConfig struct {
-		JobName        string          `yaml:"job_name,omitempty"`
-		ScrapeInterval string          `yaml:"scrape_interval,omitempty"`
-		BearerToken    string          `yaml:"bearer_token,omitempty"`
-		TlsConfig      tlsConfig       `yaml:"tls_config,omitempty"`
-		Scheme         string          `yaml:"scheme,omitempty"`
-		StaticConfigs  []staticConfigs `yaml:"static_configs,omitempty"`
-	}
-	type config struct {
-		ScrapeConfigs []scrapeConfig `yaml:"scrape_configs,omitempty"`
-	}
-	err := func() error {
-		scrapeConfigFile := filepath.Join(promCfgDir, ".prometheus-config.yaml")
-		f, err := os.OpenFile(scrapeConfigFile, os.O_RDWR|os.O_CREATE, 0o644)
-		if err != nil {
-			return err
-		}
-		defer f.Close()
-		// lock config file exclusively, blocks all other producers until unlocked or process (test) exits
-		err = syscall.Flock(int(f.Fd()), syscall.LOCK_EX)
-		if err != nil {
-			return err
-		}
-		promCfg := config{}
-		err = gopkgyaml.NewDecoder(f).Decode(&promCfg)
-		if err != nil && !errors.Is(err, io.EOF) {
-			return err
-		}
-		hostUrl, err := url.Parse(cfg.Host)
-		if err != nil {
-			return err
-		}
-		promCfg.ScrapeConfigs = append(promCfg.ScrapeConfigs, scrapeConfig{
-			JobName:        jobName,
-			ScrapeInterval: (5 * time.Second).String(),
-			BearerToken:    cfg.BearerToken,
-			TlsConfig:      tlsConfig{CaFile: caFile},
-			Scheme:         hostUrl.Scheme,
-			StaticConfigs: []staticConfigs{{
-				Targets: []string{hostUrl.Host},
-				Labels:  labels,
-			}},
-		})
-		err = f.Truncate(0)
-		if err != nil {
-			return err
-		}
-		_, err = f.Seek(0, 0)
-		if err != nil {
-			return err
-		}
-		err = gopkgyaml.NewEncoder(f).Encode(&promCfg)
-		if err != nil {
-			return err
-		}
-		return syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
-	}()
+	hostUrl, err := url.Parse(cfg.Host)
 	if err != nil {
 		return err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, promUrl+"/-/reload", http.NoBody)
-	if err != nil {
-		return err
+	if err := prometheus.EnsureScrapeConfig(prometheusConfigFile(promCfgDir), prometheus.ScrapeConfig{
+		JobName:        jobName,
+		ScrapeInterval: (5 * time.Second).String(),
+		BearerToken:    cfg.BearerToken,
+		TlsConfig:      prometheus.TLSConfig{CaFile: caFile},
+		Scheme:         hostUrl.Scheme,
+		StaticConfigs: []prometheus.StaticConfig{{
+			Targets: []string{hostUrl.Host},
+			Labels:  labels,
+		}},
+	}); err != nil {
+		return fmt.Errorf("failed to update Prometheus configuration file: %w", err)
 	}
-	c := &http.Client{}
-	resp, err := c.Do(req)
-	if err != nil {
-		return err
+
+	if err := prometheus.Reload(ctx, promUrl); err != nil {
+		return fmt.Errorf("error reloading Prometheus: %w", err)
 	}
-	resp.Body.Close()
+
+	return nil
+}
+
+func CleanupScrapeMetrics(ctx context.Context, promUrl, promCfgDir, jobName string) error {
+	if err := prometheus.RemoveScrapeConfig(prometheusConfigFile(promCfgDir), jobName); err != nil {
+		return fmt.Errorf("failed to update Prometheus configuration file: %w", err)
+	}
+
+	if err := prometheus.Reload(ctx, promUrl); err != nil {
+		return fmt.Errorf("error reloading Prometheus: %w", err)
+	}
+
 	return nil
 }

--- a/staging/src/github.com/kcp-dev/sdk/testing/server/prometheus/manager.go
+++ b/staging/src/github.com/kcp-dev/sdk/testing/server/prometheus/manager.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2026 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prometheus
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"slices"
+	"syscall"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Config struct {
+	ScrapeConfigs []ScrapeConfig `yaml:"scrape_configs,omitempty"`
+}
+
+type ScrapeConfig struct {
+	JobName        string         `yaml:"job_name,omitempty"`
+	ScrapeInterval string         `yaml:"scrape_interval,omitempty"`
+	BearerToken    string         `yaml:"bearer_token,omitempty"`
+	TlsConfig      TLSConfig      `yaml:"tls_config,omitempty"`
+	Scheme         string         `yaml:"scheme,omitempty"`
+	StaticConfigs  []StaticConfig `yaml:"static_configs,omitempty"`
+}
+
+type TLSConfig struct {
+	InsecureSkipVerify bool   `yaml:"insecure_skip_verify,omitempty"`
+	CaFile             string `yaml:"ca_file,omitempty"`
+}
+
+type StaticConfig struct {
+	Targets []string          `yaml:"targets,omitempty"`
+	Labels  map[string]string `yaml:"labels,omitempty"`
+}
+
+func EnsureScrapeConfig(configFile string, sc ScrapeConfig) error {
+	return patchConfigFile(configFile, func(cfg *Config) error {
+		for idx, existingSC := range cfg.ScrapeConfigs {
+			if existingSC.JobName == sc.JobName {
+				cfg.ScrapeConfigs[idx] = sc
+				return nil
+			}
+		}
+
+		cfg.ScrapeConfigs = append(cfg.ScrapeConfigs, sc)
+		return nil
+	})
+}
+
+func RemoveScrapeConfig(configFile string, jobName string) error {
+	return patchConfigFile(configFile, func(cfg *Config) error {
+		cfg.ScrapeConfigs = slices.DeleteFunc(cfg.ScrapeConfigs, func(sc ScrapeConfig) bool {
+			return sc.JobName == jobName
+		})
+		return nil
+	})
+}
+
+func Reload(ctx context.Context, promUrl string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, promUrl+"/-/reload", http.NoBody)
+	if err != nil {
+		return err
+	}
+	c := &http.Client{}
+	resp, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
+}
+
+func patchConfigFile(configFile string, patch func(*Config) error) error {
+	f, err := os.OpenFile(configFile, os.O_RDWR|os.O_CREATE, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	fd := int(f.Fd())
+	// lock config file exclusively, blocks all other producers until unlocked or process (test) exits
+	err = syscall.Flock(fd, syscall.LOCK_EX)
+	if err != nil {
+		return err
+	}
+
+	promCfg := Config{}
+	err = yaml.NewDecoder(f).Decode(&promCfg)
+	// ignore EOF because the configFile initially is entirely empty
+	if err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+
+	if err := patch(&promCfg); err != nil {
+		return err
+	}
+
+	err = f.Truncate(0)
+	if err != nil {
+		return err
+	}
+
+	_, err = f.Seek(0, 0)
+	if err != nil {
+		return err
+	}
+
+	encoder := yaml.NewEncoder(f)
+	encoder.SetIndent(2)
+
+	err = encoder.Encode(&promCfg)
+	if err != nil {
+		return err
+	}
+
+	return syscall.Flock(fd, syscall.LOCK_UN)
+}


### PR DESCRIPTION
## Summary
This cherrypicks #3983 into the 0.30 release line. This PR additionally also lowers the Prometheus default verbosity, which is something we've done in the main branch already.

## What Type of PR Is This?
/kind chore

## Release Notes
```release-note
NONE
```
