### PR TITLE
Always serve latest docs version

### DIFF
--- a/docs/scripts/deploy-docs.sh
+++ b/docs/scripts/deploy-docs.sh
@@ -52,7 +52,10 @@ if [[ -n "${BRANCH:-}" ]]; then
   MIKE_OPTIONS+=(--branch "$BRANCH")
 fi
 
-LATEST=$(git describe --tags --match="v[0-9]*" `git rev-list --tags --max-count=1` | grep -o '^v[0-9]\+\.[0-9]\+')
+# Find the highest stable release as vMAJOR.MINOR: list all v* tags, filter to
+# exact vMAJOR.MINOR.PATCH (excludes pre-releases like v0.31.0-alpha.1), strip
+# the patch segment, sort by version, and take the last (highest) entry.
+LATEST=$(git tag --list 'v[0-9]*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | grep -o '^v[0-9]\+\.[0-9]\+' | sort -V | tail -n1)
 if [[ "${LATEST:-}" == "${VERSION:-}" ]]; then
   MIKE_DEPLOY_OPTIONS+=(--update-aliases)
   MIKE_ALIASES+=(latest)


### PR DESCRIPTION
## Summary

Fix `LATEST` version detection in `deploy-docs.sh`.

The previous command used `git rev-list --tags --max-count=1` to find the most recently *created* tag, then derived the version from it. This returns the tag by creation timestamp, not by semantic version — so a patch release like `v0.29.3` tagged after `v0.30.0` would cause `LATEST` to resolve to `v0.29` instead of `v0.30`, skipping the `latest` alias for the actual latest minor version.

The new command lists all tags matching `v*`, filters to stable releases only (exact `vMAJOR.MINOR.PATCH`, excluding pre-releases like `v0.31.0-alpha.1`), strips the patch segment, and picks the highest by semantic version sort. This correctly identifies the latest stable minor version regardless of tag creation order.

## What Type of PR Is This?

/kind bug

## Release Notes
```release-note
NONE
```

/assign @mjudeikis @ntnn @xrstf 