### PR TITLE
docs: add KubeStellar Console integration

### DIFF
--- a/docs/content/setup/integrations.md
+++ b/docs/content/setup/integrations.md
@@ -174,3 +174,30 @@ workspaces             ws   tenancy.kcp.io/v1alpha1   false   Workspace
 logicalclusters             core.kcp.io/v1alpha1     false   LogicalCluster
 ...
 ```
+
+## KubeStellar Console
+
+[KubeStellar Console](https://console.kubestellar.io) is an open-source Kubernetes dashboard that provides a web-based interface for kcp. It connects via kubeconfig and works read-only without requiring any cluster-side agent.
+
+Features relevant to kcp users include:
+
+- **Guided kcp installation mission** — a step-by-step workflow that walks you through setting up kcp and creating your first workspaces
+- **Workspace visualization** — browse and navigate the kcp workspace hierarchy
+- **API browsing** — explore API resources exposed by kcp
+- **Multi-tenant observability** — view resources across workspaces from a single pane
+- **AI-assisted operations** — natural-language queries against your kcp environment
+
+### Quick start
+
+Install with a single command:
+
+```sh
+curl -sL https://raw.githubusercontent.com/kubestellar/console/main/install.sh | bash
+```
+
+Or deploy into a Kubernetes cluster — see the [GitHub repository](https://github.com/kubestellar/console) for Helm chart and other installation options.
+
+### Links
+
+- Live demo: [console.kubestellar.io](https://console.kubestellar.io)
+- Source: [github.com/kubestellar/console](https://github.com/kubestellar/console)


### PR DESCRIPTION
## Summary

Adds [KubeStellar Console](https://console.kubestellar.io) as an integration to the kcp docs. KubeStellar Console is an open-source Kubernetes dashboard that provides a web-based interface for kcp, including guided installation missions, workspace visualization, API browsing, and AI-assisted operations.

This was discussed with @mjudeikis in https://github.com/kcp-dev/kcp/issues/3923#issuecomment-4197227071 — he expressed interest in having the console listed as an integration.

## Changes

- Added a new "KubeStellar Console" section to `docs/content/setup/integrations.md`, following the same format as existing integrations (multicluster-runtime, Dex, OpenFGA, Lima)

## Links

- Live demo: https://console.kubestellar.io
- Source: https://github.com/kubestellar/console