### PR TITLE
adopters: add KubeStellar Console

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -5,6 +5,7 @@ Listed below are organizations that have adopted kcp in one way or another. We a
 
 | Organization  | Description | Maturity Level | Further Information |
 | ------------- | ------------- | --- | --- |
+| KubeStellar   | KubeStellar Console integrates kcp workspace management, API browsing, and guided installation missions into an open-source Kubernetes dashboard with AI-assisted operations. | Development | [console.kubestellar.io](https://console.kubestellar.io) |
 | Kubermatic    | Kubermatic is building Kubermatic Developer Platform (KDP), an internal developer platform (IdP) product that uses kcp as its global API control plane.  | Development | [Product Website](https://www.kubermatic.com/products/kubermatic-developer-platform/) |
 | Faros.sh      | Faros is building a control-plane-as-a-service to access & manage multiple Kubernetes clusters across public and private deployments. | Development | - |
 | SAP           | SAP is developing an open reference architecture (ApeiroRA) with a Platform Mesh that leverages kcp as its foundation, enabling service providers to seamlessly connect and interact through unified KRM-based APIs in a cloud-edge continuum. | Development | [Website](https://apeirora.eu/) |


### PR DESCRIPTION
## Summary

Adds KubeStellar Console to the ADOPTERS.md file.

[KubeStellar Console](https://console.kubestellar.io) integrates kcp workspace management, API browsing, and guided installation missions into an open-source Kubernetes dashboard with AI-assisted operations. Maturity level: Development.

## Context

This was approved by @mjudeikis in https://github.com/kcp-dev/kcp/issues/3923#issuecomment-4197227071 ("Adopters - yes").