### PR TITLE
Feat: Added SSA commiter

### DIFF
--- a/pkg/reconciler/committer/committer.go
+++ b/pkg/reconciler/committer/committer.go
@@ -35,8 +35,10 @@ import (
 
 // Resource is a generic wrapper around resources so we can generate patches.
 type Resource[Sp any, St any] struct {
+	APIVersion        string `json:"apiVersion,omitempty"`
+	Kind              string `json:"kind,omitempty"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              Sp `json:"spec"`
+	Spec              Sp `json:"spec,omitempty"`
 	Status            St `json:"status,omitempty"`
 }
 
@@ -135,7 +137,7 @@ func generatePatchAndSubResources[Sp any, St any](old, obj *Resource[Sp, St]) ([
 	name := old.Name
 
 	oldForPatch := forPatch(old)
-	// to ensure they appear in the patch as preconditions
+
 	oldForPatch.UID = ""
 	oldForPatch.ResourceVersion = ""
 
@@ -145,7 +147,7 @@ func generatePatchAndSubResources[Sp any, St any](old, obj *Resource[Sp, St]) ([
 	}
 
 	newForPatch := forPatch(obj)
-	// to ensure they appear in the patch as preconditions
+
 	newForPatch.UID = old.UID
 	newForPatch.ResourceVersion = old.ResourceVersion
 
@@ -157,6 +159,94 @@ func generatePatchAndSubResources[Sp any, St any](old, obj *Resource[Sp, St]) ([
 	patchBytes, err := jsonpatch.CreateMergePatch(oldData, newData)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create patch for %s|%s: %w", clusterName, name, err)
+	}
+
+	var subresources []string
+	if statusChanged {
+		subresources = []string{"status"}
+	}
+
+	return patchBytes, subresources, nil
+}
+
+// NewSSACommitter returns a function that can patch instances of R based on meta,
+// spec or status changes using Server-Side Apply (SSA) and a unique field manager.
+// It applies patches with Force=true, which allows the controller to forcefully
+// reclaim field ownership if another manager previously owned the fields. This is
+// critical to preventing read-modify-write races when multiple controllers
+// concurrently update the same object.
+
+func NewSSACommitter[R runtime.Object, P Patcher[R], Sp any, St any](patcher ClusterPatcher[R, P], fieldManager string) CommitFunc[Sp, St] {
+	r := new(R)
+	focusType := fmt.Sprintf("%T", *r)
+	return func(ctx context.Context, old, obj *Resource[Sp, St]) error {
+		return withSSAPatchAndSubResources(ctx, focusType, old, obj, fieldManager,
+			func(patchBytes []byte, subresources []string, opts metav1.PatchOptions) error {
+				clusterName := logicalcluster.From(old)
+				_, err := patcher.Cluster(clusterName.Path()).Patch(ctx, obj.Name, types.ApplyPatchType, patchBytes, opts, subresources...)
+				return err
+			})
+	}
+}
+
+func withSSAPatchAndSubResources[Sp any, St any](ctx context.Context, focusType string, old, obj *Resource[Sp, St], fieldManager string, patch func([]byte, []string, metav1.PatchOptions) error) error {
+	logger := klog.FromContext(ctx)
+	patchBytes, subresources, err := generateSSAPatchAndSubResources(old, obj)
+	if err != nil {
+		return fmt.Errorf("failed to create SSA patch for %s %s: %w", focusType, obj.Name, err)
+	}
+
+	if len(patchBytes) == 0 {
+		return nil
+	}
+
+	force := true
+	opts := metav1.PatchOptions{
+		FieldManager: fieldManager,
+		Force:        &force,
+	}
+
+	logger.V(2).Info(fmt.Sprintf("ssa patching %s", focusType), "patch", string(patchBytes))
+	if err := patch(patchBytes, subresources, opts); err != nil {
+		return fmt.Errorf("failed to ssa patch %s %s: %w", focusType, old.Name, err)
+	}
+	return nil
+}
+
+func generateSSAPatchAndSubResources[Sp any, St any](old, obj *Resource[Sp, St]) ([]byte, []string, error) {
+	objectMetaChanged := !equality.Semantic.DeepEqual(old.ObjectMeta, obj.ObjectMeta)
+	specChanged := !equality.Semantic.DeepEqual(old.Spec, obj.Spec)
+	statusChanged := !equality.Semantic.DeepEqual(old.Status, obj.Status)
+
+	specOrObjectMetaChanged := specChanged || objectMetaChanged
+
+	if specOrObjectMetaChanged && statusChanged {
+		panic(fmt.Sprintf("programmer error: spec and status changed in same reconcile iteration. diff=%s", cmp.Diff(old, obj)))
+	}
+
+	if !specOrObjectMetaChanged && !statusChanged {
+		return nil, nil, nil
+	}
+
+	forPatch := func(r *Resource[Sp, St]) *Resource[Sp, St] {
+		var ret Resource[Sp, St]
+		ret.APIVersion = r.APIVersion
+		ret.Kind = r.Kind
+		ret.Name = r.Name
+
+		if specOrObjectMetaChanged {
+			ret.ObjectMeta = r.ObjectMeta
+			ret.Spec = r.Spec
+		} else {
+			ret.Status = r.Status
+		}
+		return &ret
+	}
+
+	newForPatch := forPatch(obj)
+	patchBytes, err := json.Marshal(newForPatch)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to Marshal new SSA data: %w", err)
 	}
 
 	var subresources []string

--- a/pkg/reconciler/committer/committer_test.go
+++ b/pkg/reconciler/committer/committer_test.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
+	conditionsv1alpha1 "github.com/kcp-dev/sdk/apis/third_party/conditions/apis/conditions/v1alpha1"
 )
 
 func TestGeneratePatchAndSubResourcesMultipleSubresourcesPanic(t *testing.T) {
@@ -126,6 +127,144 @@ func TestGeneratePatchAndSubResources(t *testing.T) {
 		for _, tc := range tt {
 			t.Run(tc.name, func(t *testing.T) {
 				patch, subresources, err := generatePatchAndSubResources(tc.old, tc.new)
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedPatch, string(patch))
+				require.Equal(t, tc.expectedSubResources, subresources)
+			})
+		}
+	}
+}
+
+func TestGenerateSSAPatchAndSubResourcesMultipleSubresourcesPanic(t *testing.T) {
+	// if we change status + either spec or objectmeta, we expect a panic for SSA as well
+	tt := []struct {
+		name string
+		old  *Resource[corev1alpha1.LogicalClusterSpec, corev1alpha1.LogicalClusterStatus]
+		new  *Resource[corev1alpha1.LogicalClusterSpec, corev1alpha1.LogicalClusterStatus]
+	}{
+		{
+			name: "spec and status changed",
+			old: &Resource[corev1alpha1.LogicalClusterSpec, corev1alpha1.LogicalClusterStatus]{
+				Spec:   corev1alpha1.LogicalClusterSpec{DirectlyDeletable: true},
+				Status: corev1alpha1.LogicalClusterStatus{Phase: "old"},
+			},
+			new: &Resource[corev1alpha1.LogicalClusterSpec, corev1alpha1.LogicalClusterStatus]{
+				Spec:   corev1alpha1.LogicalClusterSpec{DirectlyDeletable: false},
+				Status: corev1alpha1.LogicalClusterStatus{Phase: "new"},
+			},
+		},
+		{
+			name: "meta and status changed",
+			old: &Resource[corev1alpha1.LogicalClusterSpec, corev1alpha1.LogicalClusterStatus]{
+				ObjectMeta: metav1.ObjectMeta{Finalizers: []string{}},
+				Status:     corev1alpha1.LogicalClusterStatus{Phase: "old"},
+			},
+			new: &Resource[corev1alpha1.LogicalClusterSpec, corev1alpha1.LogicalClusterStatus]{
+				ObjectMeta: metav1.ObjectMeta{Finalizers: []string{"changed"}},
+				Status:     corev1alpha1.LogicalClusterStatus{Phase: "new"},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Panics(t, func() {
+				_, _, _ = generateSSAPatchAndSubResources(tc.old, tc.new)
+			})
+		})
+	}
+}
+
+func TestGenerateSSAPatchAndSubResources(t *testing.T) {
+	{
+		tt := []struct {
+			name                 string
+			old                  *Resource[corev1alpha1.LogicalClusterSpec, corev1alpha1.LogicalClusterStatus]
+			new                  *Resource[corev1alpha1.LogicalClusterSpec, corev1alpha1.LogicalClusterStatus]
+			expectedPatch        string
+			expectedSubResources []string
+		}{
+			{
+				name: "spec changed",
+				old: &Resource[corev1alpha1.LogicalClusterSpec, corev1alpha1.LogicalClusterStatus]{
+					Spec: corev1alpha1.LogicalClusterSpec{DirectlyDeletable: false},
+				},
+				new: &Resource[corev1alpha1.LogicalClusterSpec, corev1alpha1.LogicalClusterStatus]{
+					APIVersion: "core.kcp.io/v1alpha1",
+					Kind:       "LogicalCluster",
+					ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
+					Spec:       corev1alpha1.LogicalClusterSpec{DirectlyDeletable: true},
+				},
+				expectedPatch:        `{"apiVersion":"core.kcp.io/v1alpha1","kind":"LogicalCluster","metadata":{"name":"test-cluster"},"spec":{"directlyDeletable":true}}`,
+				expectedSubResources: nil,
+			},
+			{
+				name: "status changed",
+				old: &Resource[corev1alpha1.LogicalClusterSpec, corev1alpha1.LogicalClusterStatus]{
+					Status: corev1alpha1.LogicalClusterStatus{Phase: "old"},
+				},
+				new: &Resource[corev1alpha1.LogicalClusterSpec, corev1alpha1.LogicalClusterStatus]{
+					APIVersion: "core.kcp.io/v1alpha1",
+					Kind:       "LogicalCluster",
+					ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
+					Status:     corev1alpha1.LogicalClusterStatus{Phase: "new"},
+				},
+				expectedPatch:        `{"apiVersion":"core.kcp.io/v1alpha1","kind":"LogicalCluster","metadata":{"name":"test-cluster"},"status":{"phase":"new"}}`,
+				expectedSubResources: []string{"status"},
+			},
+			{
+				name: "meta changed",
+				old: &Resource[corev1alpha1.LogicalClusterSpec, corev1alpha1.LogicalClusterStatus]{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Finalizers: []string{}},
+				},
+				new: &Resource[corev1alpha1.LogicalClusterSpec, corev1alpha1.LogicalClusterStatus]{
+					APIVersion: "core.kcp.io/v1alpha1",
+					Kind:       "LogicalCluster",
+					ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Finalizers: []string{"changed"}},
+				},
+				expectedPatch:        `{"apiVersion":"core.kcp.io/v1alpha1","kind":"LogicalCluster","metadata":{"name":"test-cluster","finalizers":["changed"]}}`,
+				expectedSubResources: nil,
+			},
+			{
+				name: "no changes",
+				old: &Resource[corev1alpha1.LogicalClusterSpec, corev1alpha1.LogicalClusterStatus]{
+					ObjectMeta: metav1.ObjectMeta{Finalizers: []string{}},
+				},
+				new: &Resource[corev1alpha1.LogicalClusterSpec, corev1alpha1.LogicalClusterStatus]{
+					ObjectMeta: metav1.ObjectMeta{Finalizers: []string{}},
+				},
+				expectedPatch:        "",
+				expectedSubResources: nil,
+			},
+			{
+				name: "complex status with multiple conditions",
+				old: &Resource[corev1alpha1.LogicalClusterSpec, corev1alpha1.LogicalClusterStatus]{
+					Status: corev1alpha1.LogicalClusterStatus{
+						Phase: corev1alpha1.LogicalClusterPhaseInitializing,
+						Conditions: []conditionsv1alpha1.Condition{
+							{Type: "SomeOldCondition", Status: "True"},
+						},
+					},
+				},
+				new: &Resource[corev1alpha1.LogicalClusterSpec, corev1alpha1.LogicalClusterStatus]{
+					APIVersion: "core.kcp.io/v1alpha1",
+					Kind:       "LogicalCluster",
+					ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
+					Status: corev1alpha1.LogicalClusterStatus{
+						Conditions: []conditionsv1alpha1.Condition{
+							{Type: "WorkspaceAPIBindingsInitialized", Status: "True"},
+							{Type: "WorkspaceAPIBindingsReconciled", Status: "True"},
+						},
+					},
+				},
+				expectedPatch:        `{"apiVersion":"core.kcp.io/v1alpha1","kind":"LogicalCluster","metadata":{"name":"test-cluster"},"status":{"conditions":[{"status":"True","type":"WorkspaceAPIBindingsInitialized"},{"status":"True","type":"WorkspaceAPIBindingsReconciled"}]}}`,
+				expectedSubResources: []string{"status"},
+			},
+		}
+
+		for _, tc := range tt {
+			t.Run(tc.name, func(t *testing.T) {
+				patch, subresources, err := generateSSAPatchAndSubResources(tc.old, tc.new)
 				require.NoError(t, err)
 				require.Equal(t, tc.expectedPatch, string(patch))
 				require.Equal(t, tc.expectedSubResources, subresources)

--- a/pkg/reconciler/committer/committer_test.go
+++ b/pkg/reconciler/committer/committer_test.go
@@ -24,7 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
-	conditionsv1alpha1 "github.com/kcp-dev/sdk/apis/third_party/conditions/apis/conditions/v1alpha1"
 )
 
 func TestGeneratePatchAndSubResourcesMultipleSubresourcesPanic(t *testing.T) {
@@ -145,22 +144,32 @@ func TestGenerateSSAPatchAndSubResourcesMultipleSubresourcesPanic(t *testing.T) 
 		{
 			name: "spec and status changed",
 			old: &Resource[corev1alpha1.LogicalClusterSpec, corev1alpha1.LogicalClusterStatus]{
-				Spec:   corev1alpha1.LogicalClusterSpec{DirectlyDeletable: true},
-				Status: corev1alpha1.LogicalClusterStatus{Phase: "old"},
+				APIVersion: "core.kcp.io/v1alpha1",
+				Kind:       "LogicalCluster",
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
+				Spec:       corev1alpha1.LogicalClusterSpec{DirectlyDeletable: true},
+				Status:     corev1alpha1.LogicalClusterStatus{Phase: "old"},
 			},
 			new: &Resource[corev1alpha1.LogicalClusterSpec, corev1alpha1.LogicalClusterStatus]{
-				Spec:   corev1alpha1.LogicalClusterSpec{DirectlyDeletable: false},
-				Status: corev1alpha1.LogicalClusterStatus{Phase: "new"},
+				APIVersion: "core.kcp.io/v1alpha1",
+				Kind:       "LogicalCluster",
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
+				Spec:       corev1alpha1.LogicalClusterSpec{DirectlyDeletable: false},
+				Status:     corev1alpha1.LogicalClusterStatus{Phase: "new"},
 			},
 		},
 		{
 			name: "meta and status changed",
 			old: &Resource[corev1alpha1.LogicalClusterSpec, corev1alpha1.LogicalClusterStatus]{
-				ObjectMeta: metav1.ObjectMeta{Finalizers: []string{}},
+				APIVersion: "core.kcp.io/v1alpha1",
+				Kind:       "LogicalCluster",
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Finalizers: []string{}},
 				Status:     corev1alpha1.LogicalClusterStatus{Phase: "old"},
 			},
 			new: &Resource[corev1alpha1.LogicalClusterSpec, corev1alpha1.LogicalClusterStatus]{
-				ObjectMeta: metav1.ObjectMeta{Finalizers: []string{"changed"}},
+				APIVersion: "core.kcp.io/v1alpha1",
+				Kind:       "LogicalCluster",
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Finalizers: []string{"changed"}},
 				Status:     corev1alpha1.LogicalClusterStatus{Phase: "new"},
 			},
 		},
@@ -187,7 +196,10 @@ func TestGenerateSSAPatchAndSubResources(t *testing.T) {
 			{
 				name: "spec changed",
 				old: &Resource[corev1alpha1.LogicalClusterSpec, corev1alpha1.LogicalClusterStatus]{
-					Spec: corev1alpha1.LogicalClusterSpec{DirectlyDeletable: false},
+					APIVersion: "core.kcp.io/v1alpha1",
+					Kind:       "LogicalCluster",
+					ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
+					Spec:       corev1alpha1.LogicalClusterSpec{DirectlyDeletable: false},
 				},
 				new: &Resource[corev1alpha1.LogicalClusterSpec, corev1alpha1.LogicalClusterStatus]{
 					APIVersion: "core.kcp.io/v1alpha1",
@@ -195,13 +207,16 @@ func TestGenerateSSAPatchAndSubResources(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
 					Spec:       corev1alpha1.LogicalClusterSpec{DirectlyDeletable: true},
 				},
-				expectedPatch:        `{"apiVersion":"core.kcp.io/v1alpha1","kind":"LogicalCluster","metadata":{"name":"test-cluster"},"spec":{"directlyDeletable":true}}`,
+				expectedPatch:        `{"apiVersion":"core.kcp.io/v1alpha1","kind":"LogicalCluster","metadata":{"name":"test-cluster"},"spec":{"directlyDeletable":true},"status":{}}`,
 				expectedSubResources: nil,
 			},
 			{
 				name: "status changed",
 				old: &Resource[corev1alpha1.LogicalClusterSpec, corev1alpha1.LogicalClusterStatus]{
-					Status: corev1alpha1.LogicalClusterStatus{Phase: "old"},
+					APIVersion: "core.kcp.io/v1alpha1",
+					Kind:       "LogicalCluster",
+					ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
+					Status:     corev1alpha1.LogicalClusterStatus{Phase: "old"},
 				},
 				new: &Resource[corev1alpha1.LogicalClusterSpec, corev1alpha1.LogicalClusterStatus]{
 					APIVersion: "core.kcp.io/v1alpha1",
@@ -209,12 +224,14 @@ func TestGenerateSSAPatchAndSubResources(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
 					Status:     corev1alpha1.LogicalClusterStatus{Phase: "new"},
 				},
-				expectedPatch:        `{"apiVersion":"core.kcp.io/v1alpha1","kind":"LogicalCluster","metadata":{"name":"test-cluster"},"status":{"phase":"new"}}`,
+				expectedPatch:        `{"apiVersion":"core.kcp.io/v1alpha1","kind":"LogicalCluster","metadata":{"name":"test-cluster"},"spec":{},"status":{"phase":"new"}}`,
 				expectedSubResources: []string{"status"},
 			},
 			{
 				name: "meta changed",
 				old: &Resource[corev1alpha1.LogicalClusterSpec, corev1alpha1.LogicalClusterStatus]{
+					APIVersion: "core.kcp.io/v1alpha1",
+					Kind:       "LogicalCluster",
 					ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Finalizers: []string{}},
 				},
 				new: &Resource[corev1alpha1.LogicalClusterSpec, corev1alpha1.LogicalClusterStatus]{
@@ -222,28 +239,32 @@ func TestGenerateSSAPatchAndSubResources(t *testing.T) {
 					Kind:       "LogicalCluster",
 					ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Finalizers: []string{"changed"}},
 				},
-				expectedPatch:        `{"apiVersion":"core.kcp.io/v1alpha1","kind":"LogicalCluster","metadata":{"name":"test-cluster","finalizers":["changed"]}}`,
+				expectedPatch:        `{"apiVersion":"core.kcp.io/v1alpha1","kind":"LogicalCluster","metadata":{"name":"test-cluster","finalizers":["changed"]},"spec":{},"status":{}}`,
 				expectedSubResources: nil,
 			},
 			{
 				name: "no changes",
 				old: &Resource[corev1alpha1.LogicalClusterSpec, corev1alpha1.LogicalClusterStatus]{
+					APIVersion: "core.kcp.io/v1alpha1",
+					Kind:       "LogicalCluster",
 					ObjectMeta: metav1.ObjectMeta{Finalizers: []string{}},
 				},
 				new: &Resource[corev1alpha1.LogicalClusterSpec, corev1alpha1.LogicalClusterStatus]{
+					APIVersion: "core.kcp.io/v1alpha1",
+					Kind:       "LogicalCluster",
 					ObjectMeta: metav1.ObjectMeta{Finalizers: []string{}},
 				},
 				expectedPatch:        "",
 				expectedSubResources: nil,
 			},
 			{
-				name: "complex status with multiple conditions",
+				name: "complex status with multiple values",
 				old: &Resource[corev1alpha1.LogicalClusterSpec, corev1alpha1.LogicalClusterStatus]{
+					APIVersion: "core.kcp.io/v1alpha1",
+					Kind:       "LogicalCluster",
+					ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
 					Status: corev1alpha1.LogicalClusterStatus{
 						Phase: corev1alpha1.LogicalClusterPhaseInitializing,
-						Conditions: []conditionsv1alpha1.Condition{
-							{Type: "SomeOldCondition", Status: "True"},
-						},
 					},
 				},
 				new: &Resource[corev1alpha1.LogicalClusterSpec, corev1alpha1.LogicalClusterStatus]{
@@ -251,13 +272,14 @@ func TestGenerateSSAPatchAndSubResources(t *testing.T) {
 					Kind:       "LogicalCluster",
 					ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
 					Status: corev1alpha1.LogicalClusterStatus{
-						Conditions: []conditionsv1alpha1.Condition{
-							{Type: "WorkspaceAPIBindingsInitialized", Status: "True"},
-							{Type: "WorkspaceAPIBindingsReconciled", Status: "True"},
+						Phase: corev1alpha1.LogicalClusterPhaseReady,
+						Initializers: []corev1alpha1.LogicalClusterInitializer{
+							"kcp.io/apibinder",
+							"kcp.io/workspaces",
 						},
 					},
 				},
-				expectedPatch:        `{"apiVersion":"core.kcp.io/v1alpha1","kind":"LogicalCluster","metadata":{"name":"test-cluster"},"status":{"conditions":[{"status":"True","type":"WorkspaceAPIBindingsInitialized"},{"status":"True","type":"WorkspaceAPIBindingsReconciled"}]}}`,
+				expectedPatch:        `{"apiVersion":"core.kcp.io/v1alpha1","kind":"LogicalCluster","metadata":{"name":"test-cluster"},"spec":{},"status":{"phase":"Ready","initializers":["kcp.io/apibinder","kcp.io/workspaces"]}}`,
 				expectedSubResources: []string{"status"},
 			},
 		}


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary
This PR introduces Server-Side Apply (SSA) support to the committer package by adding a new NewSSACommitter utility.

Currently, KCP controllers rely heavily on JSON Merge Patch (types.MergePatchType) for status updates. When multiple controllers update different status conditions on the same object concurrently based on a stale cache read, it results in a read-modify-write race where conditions are blindly overwritten.
## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes https://github.com/kcp-dev/kcp/issues/3926

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
