### PR TITLE
Fix: APIBinding read-modify-write race via Server-Side Apply

### DIFF
--- a/pkg/reconciler/apis/apibinding/apibinding_controller.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_controller.go
@@ -63,7 +63,8 @@ import (
 )
 
 const (
-	ControllerName = "kcp-apibinding"
+	ControllerName    = "kcp-apibinding"
+	LocksFieldManager = "apibinding-reconciler-locks"
 )
 
 var (
@@ -165,8 +166,10 @@ func NewController(
 					Kind:       "LogicalCluster",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        lc.Name,
-					Annotations: lc.Annotations,
+					Name: lc.Name,
+					Annotations: map[string]string{
+						ResourceBindingsAnnotationKey: lc.Annotations[ResourceBindingsAnnotationKey],
+					},
 				},
 			}
 			patchBytes, err := json.Marshal(patchObj)
@@ -179,7 +182,7 @@ func NewController(
 				types.ApplyPatchType,
 				patchBytes,
 				metav1.PatchOptions{
-					FieldManager: "apibinding-reconciler-locks",
+					FieldManager: LocksFieldManager,
 					Force:        ptr.To(true),
 				},
 			)

--- a/pkg/reconciler/apis/apibinding/apibinding_controller.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_controller.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 
 	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
 	kcpapiextensionsclientset "github.com/kcp-dev/client-go/apiextensions/client"
@@ -68,11 +69,6 @@ const (
 var (
 	SystemBoundCRDsClusterName = logicalcluster.Name("system:bound-crds")
 )
-
-// boolPtr returns a pointer to a boolean value.
-func boolPtr(b bool) *bool {
-	return &b
-}
 
 // NewController returns a new controller for APIBindings.
 func NewController(
@@ -163,15 +159,17 @@ func NewController(
 			return logicalClusterInformer.Lister().Cluster(name).Get(corev1alpha1.LogicalClusterName)
 		},
 		updateLogicalCluster: func(ctx context.Context, lc *corev1alpha1.LogicalCluster) error {
-			// FIXED: Pass the actual annotations from the LogicalCluster, not an empty map.
-			patchBytes, err := json.Marshal(map[string]interface{}{
-				"apiVersion": "core.kcp.io/v1alpha1",
-				"kind":       "LogicalCluster",
-				"metadata": map[string]interface{}{
-					"name":        lc.Name,
-					"annotations": lc.Annotations,
+			patchObj := &corev1alpha1.LogicalCluster{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: corev1alpha1.SchemeGroupVersion.String(),
+					Kind:       "LogicalCluster",
 				},
-			})
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        lc.Name,
+					Annotations: lc.Annotations,
+				},
+			}
+			patchBytes, err := json.Marshal(patchObj)
 			if err != nil {
 				return err
 			}
@@ -182,7 +180,7 @@ func NewController(
 				patchBytes,
 				metav1.PatchOptions{
 					FieldManager: "apibinding-reconciler-locks",
-					Force:        boolPtr(true),
+					Force:        ptr.To(true),
 				},
 			)
 			return err

--- a/pkg/reconciler/apis/apibinding/apibinding_controller.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_controller.go
@@ -18,6 +18,7 @@ package apibinding
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -28,6 +29,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -66,6 +68,11 @@ const (
 var (
 	SystemBoundCRDsClusterName = logicalcluster.Name("system:bound-crds")
 )
+
+// boolPtr returns a pointer to a boolean value.
+func boolPtr(b bool) *bool {
+	return &b
+}
 
 // NewController returns a new controller for APIBindings.
 func NewController(
@@ -156,12 +163,35 @@ func NewController(
 			return logicalClusterInformer.Lister().Cluster(name).Get(corev1alpha1.LogicalClusterName)
 		},
 		updateLogicalCluster: func(ctx context.Context, lc *corev1alpha1.LogicalCluster) error {
-			_, err := kcpClusterClient.CoreV1alpha1().LogicalClusters().Cluster(logicalcluster.From(lc).Path()).Update(ctx, lc, metav1.UpdateOptions{})
+			// FIXED: Pass the actual annotations from the LogicalCluster, not an empty map.
+			patchBytes, err := json.Marshal(map[string]interface{}{
+				"apiVersion": "core.kcp.io/v1alpha1",
+				"kind":       "LogicalCluster",
+				"metadata": map[string]interface{}{
+					"name":        lc.Name,
+					"annotations": lc.Annotations,
+				},
+			})
+			if err != nil {
+				return err
+			}
+			_, err = kcpClusterClient.CoreV1alpha1().LogicalClusters().Cluster(logicalcluster.From(lc).Path()).Patch(
+				ctx,
+				lc.Name,
+				types.ApplyPatchType,
+				patchBytes,
+				metav1.PatchOptions{
+					FieldManager: "apibinding-reconciler-locks",
+					Force:        boolPtr(true),
+				},
+			)
 			return err
 		},
 		deletedCRDTracker: newLockedStringSet(),
-		commit:            committer.NewCommitter[*APIBinding, Patcher, *APIBindingSpec, *APIBindingStatus](kcpClusterClient.ApisV1alpha2().APIBindings()),
-	}
+		commit: committer.NewSSACommitter[*APIBinding, Patcher, *APIBindingSpec, *APIBindingStatus](
+			kcpClusterClient.ApisV1alpha2().APIBindings(),
+			ControllerName,
+		)}
 
 	logger := logging.WithReconciler(klog.Background(), ControllerName)
 
@@ -492,8 +522,20 @@ func (c *controller) process(ctx context.Context, key string) (bool, error) {
 	}
 
 	// If the object being reconciled changed as a result, update it.
-	oldResource := &Resource{ObjectMeta: old.ObjectMeta, Spec: &old.Spec, Status: &old.Status}
-	newResource := &Resource{ObjectMeta: binding.ObjectMeta, Spec: &binding.Spec, Status: &binding.Status}
+	oldResource := &Resource{
+		APIVersion: "apis.kcp.io/v1alpha2",
+		Kind:       "APIBinding",
+		ObjectMeta: old.ObjectMeta,
+		Spec:       &old.Spec,
+		Status:     &old.Status,
+	}
+	newResource := &Resource{
+		APIVersion: "apis.kcp.io/v1alpha2",
+		Kind:       "APIBinding",
+		ObjectMeta: binding.ObjectMeta,
+		Spec:       &binding.Spec,
+		Status:     &binding.Status,
+	}
 	if err := c.commit(ctx, oldResource, newResource); err != nil {
 		errs = append(errs, err)
 	}

--- a/pkg/reconciler/apis/apibinding/apibinding_controller.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_controller.go
@@ -521,14 +521,14 @@ func (c *controller) process(ctx context.Context, key string) (bool, error) {
 
 	// If the object being reconciled changed as a result, update it.
 	oldResource := &Resource{
-		APIVersion: "apis.kcp.io/v1alpha2",
+		APIVersion: apisv1alpha2.SchemeGroupVersion.String(),
 		Kind:       "APIBinding",
 		ObjectMeta: old.ObjectMeta,
 		Spec:       &old.Spec,
 		Status:     &old.Status,
 	}
 	newResource := &Resource{
-		APIVersion: "apis.kcp.io/v1alpha2",
+		APIVersion: apisv1alpha2.SchemeGroupVersion.String(),
 		Kind:       "APIBinding",
 		ObjectMeta: binding.ObjectMeta,
 		Spec:       &binding.Spec,

--- a/pkg/reconciler/apis/apibinding/apibinding_reconcile.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_reconcile.go
@@ -134,7 +134,8 @@ func (r *newReconciler) reconcile(ctx context.Context, apiBinding *apisv1alpha2.
 		"Waiting for API(s) to be established",
 	)
 
-	return reconcileStatusContinue, nil
+	// FIXED: Stop and requeue so the intent state commits BEFORE dangerous ops begin
+	return reconcileStatusStopAndRequeue, nil
 }
 
 type bindingReconciler struct {

--- a/pkg/reconciler/apis/apibinding/apibinding_reconcile.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_reconcile.go
@@ -134,7 +134,6 @@ func (r *newReconciler) reconcile(ctx context.Context, apiBinding *apisv1alpha2.
 		"Waiting for API(s) to be established",
 	)
 
-	// FIXED: Stop and requeue so the intent state commits BEFORE dangerous ops begin
 	return reconcileStatusStopAndRequeue, nil
 }
 

--- a/pkg/reconciler/apis/apibinding/apibinding_reconcile_test.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_reconcile_test.go
@@ -51,14 +51,25 @@ func TestReconcileNew(t *testing.T) {
 		WithExportReference(logicalcluster.NewPath("org:some-workspace"), "some-export").
 		Build()
 
-	c := &controller{}
+	c := &controller{
+		getAPIExportByPath: func(path logicalcluster.Path, name string) (*apisv1alpha2.APIExport, error) {
+			return nil, apierrors.NewNotFound(apisv1alpha2.SchemeGroupVersion.WithResource("apiexports").GroupResource(), "some-export")
+		},
+	}
 
-	t.Logf("Run only newReconciler because no phase is set")
-	requeue, err := c.reconcile(context.Background(), apiBinding)
+	ctx := context.Background()
+
+	t.Logf("reconcile #1 - fresh binding, no Phase")
+	requeue, err := c.reconcile(ctx, apiBinding)
 	require.NoError(t, err)
-	require.Equal(t, apisv1alpha2.APIBindingPhaseBinding, apiBinding.Status.Phase)
 	require.True(t, requeue)
-	require.False(t, conditions.Has(apiBinding, conditionsv1alpha1.ReadyCondition), "unexpected Ready condition")
+	require.Equal(t, apisv1alpha2.APIBindingPhaseBinding, apiBinding.Status.Phase)
+	require.False(t, conditions.Has(apiBinding, conditionsv1alpha1.ReadyCondition))
+
+	t.Logf("reconcile #2 - same object, simulate the requeue")
+	_, err = c.reconcile(ctx, apiBinding)
+	require.NoError(t, err)
+	require.True(t, conditions.Has(apiBinding, conditionsv1alpha1.ReadyCondition))
 }
 
 func TestReconcileBinding(t *testing.T) {

--- a/pkg/reconciler/apis/apibinding/apibinding_reconcile_test.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_reconcile_test.go
@@ -57,8 +57,8 @@ func TestReconcileNew(t *testing.T) {
 	requeue, err := c.reconcile(context.Background(), apiBinding)
 	require.NoError(t, err)
 	require.Equal(t, apisv1alpha2.APIBindingPhaseBinding, apiBinding.Status.Phase)
-	require.False(t, requeue)
-	requireConditionMatches(t, apiBinding, conditions.FalseCondition(conditionsv1alpha1.ReadyCondition, "", "", ""))
+	require.True(t, requeue)
+	require.False(t, conditions.Has(apiBinding, conditionsv1alpha1.ReadyCondition), "unexpected Ready condition")
 }
 
 func TestReconcileBinding(t *testing.T) {


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

This PR fixes the read-modify-write race condition that causes LogicalCluster and APIBinding conditions to diverge and overwrite each other, especially during crash recovery or concurrent reconciler runs.

Previously, the APIBinding controller relied on JSON Merge Patch and stale informer caches. If the controller crashed mid-flight, or if DefaultAPIBindingLifecycleController updated the cluster concurrently, intermediate conditions would be blindly erased. Furthermore, the reconciler was attempting to lock the cluster and generate CRDs before safely committing its initial Phase: Binding intent to the database.

Building on the infrastructure introduced in the SSA Committer PR, this PR implements the following fixes:

- Migrated APIBinding to SSA: Replaced the legacy MergePatch committer with NewSSACommitter for the APIBinding resource, using an explicit FieldManager.
- Targeted LogicalCluster Locks: Updated updateLogicalCluster to use Server-Side Apply (ApplyPatchType). By explicitly managing the payload, the reconciler now only asserts ownership over its specific locking annotations and conditions, rather than uploading the entire cluster object and wiping out sibling conditions.
- Crash-Proofed State Machine: Modified newReconciler to return reconcileStatusStopAndRequeue immediately after transitioning the object to Phase: Binding. This guarantees the intent is durably committed to etcd before the controller attempts heavy, conflict-prone operations like resource locking or CRD generation.
- Test Updates: Updated apibinding_reconcile_test.go to align with the new state machine expectations (expecting the requeue and appropriately deferring the Ready condition check).   



## What Type of PR Is This?
/kind bug
<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #3926 

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
## Testing Done

- Built and verified KCP locally.
- Created a wildwest-provider workspace and applied the cowboys APIExport and schemas.
- Created a wildwest-consumer workspace and applied the APIBinding.
- Verified that the APIBinding successfully reached phase: Bound and that all status conditions (Ready, APIExportValid, InitialBindingCompleted, PermissionClaimsApplied, etc.) merged flawlessly via SSA without overwriting one another.