### PR TITLE
Fix stale conditions on delete

### DIFF
--- a/pkg/reconciler/apis/apibindingdeletion/apibinding_deletion_controller.go
+++ b/pkg/reconciler/apis/apibindingdeletion/apibinding_deletion_controller.go
@@ -261,6 +261,14 @@ func (c *Controller) process(ctx context.Context, key string) error {
 		return remainingErr
 	}
 
+	// Commit the status update from mutateResourceRemainingStatus first.
+	// The committer rejects simultaneous spec/metadata + status changes, so the
+	// finalizer removal below must go in a separate patch.
+	statusResource := &Resource{ObjectMeta: apibindingCopy.ObjectMeta, Spec: &apibindingCopy.Spec, Status: &apibindingCopy.Status}
+	if err := c.commit(ctx, oldResource, statusResource); err != nil {
+		return err
+	}
+
 	filtered := make([]string, 0, len(apibindingCopy.Finalizers))
 	for i := range apibindingCopy.Finalizers {
 		if apibindingCopy.Finalizers[i] == APIBindingFinalizer {
@@ -271,9 +279,11 @@ func (c *Controller) process(ctx context.Context, key string) error {
 	if len(apibindingCopy.Finalizers) == len(filtered) {
 		return nil
 	}
-	apibindingCopy.Finalizers = filtered
+	finalizersCopy := apibindingCopy.DeepCopy()
+	finalizersCopy.Finalizers = filtered
 	logger.V(2).Info("finalizing APIBinding")
-	newResource := &Resource{ObjectMeta: apibindingCopy.ObjectMeta, Spec: &apibindingCopy.Spec, Status: &apibindingCopy.Status}
+	oldResource = &Resource{ObjectMeta: apibindingCopy.ObjectMeta, Spec: &apibindingCopy.Spec, Status: &apibindingCopy.Status}
+	newResource := &Resource{ObjectMeta: finalizersCopy.ObjectMeta, Spec: &finalizersCopy.Spec, Status: &finalizersCopy.Status}
 	return c.commit(ctx, oldResource, newResource)
 }
 

--- a/pkg/reconciler/apis/apibindingdeletion/apibinding_deletion_controller.go
+++ b/pkg/reconciler/apis/apibindingdeletion/apibinding_deletion_controller.go
@@ -261,7 +261,6 @@ func (c *Controller) process(ctx context.Context, key string) error {
 		return remainingErr
 	}
 
-	apibindingCopy = apibinding.DeepCopy()
 	filtered := make([]string, 0, len(apibindingCopy.Finalizers))
 	for i := range apibindingCopy.Finalizers {
 		if apibindingCopy.Finalizers[i] == APIBindingFinalizer {

--- a/pkg/reconciler/core/logicalclusterdeletion/deletion/logicalcluster_resource_deletor.go
+++ b/pkg/reconciler/core/logicalclusterdeletion/deletion/logicalcluster_resource_deletor.go
@@ -50,6 +50,7 @@ import (
 
 	kcpmetadata "github.com/kcp-dev/client-go/metadata"
 	"github.com/kcp-dev/logicalcluster/v3"
+	"github.com/kcp-dev/sdk/apis/apis"
 	"github.com/kcp-dev/sdk/apis/core"
 	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
@@ -380,11 +381,23 @@ func (d *logicalClusterResourcesDeleter) deleteAllContent(ctx context.Context, w
 			return d.isBoundResource(logicalcluster.From(ws), group, resource)
 		}},
 	}, resources)
-	groupVersionResources, err := groupVersionResources(deletableResources)
+	allGVRs, err := groupVersionResources(deletableResources)
 	if err != nil {
 		// discovery errors are not fatal.  We often have some set of resources we can operate against even if we don't have a complete list
 		errs = append(errs, err)
 		deletionContentSuccessReason = "GroupVersionParsingFailed"
+	}
+
+	// Split GVRs: delete APIBindings last so their schemas remain available
+	// while namespaces cascade-delete bound resources.
+	apiBindingGVRs := map[schema.GroupVersionResource]sets.Set[string]{}
+	nonAPIBindingGVRs := map[schema.GroupVersionResource]sets.Set[string]{}
+	for gvr, verbs := range allGVRs {
+		if gvr.Group == apis.GroupName && gvr.Resource == "apibindings" {
+			apiBindingGVRs[gvr] = verbs
+		} else {
+			nonAPIBindingGVRs[gvr] = verbs
+		}
 	}
 
 	numRemainingTotals := allGVRDeletionMetadata{
@@ -392,7 +405,7 @@ func (d *logicalClusterResourcesDeleter) deleteAllContent(ctx context.Context, w
 		finalizersToNumRemaining: map[string]int{},
 	}
 	deleteContentErrs := []error{}
-	for gvr, verbs := range groupVersionResources {
+	for gvr, verbs := range nonAPIBindingGVRs {
 		gvrDeletionMetadata, err := d.deleteAllContentForGroupVersionResource(ctx, logicalcluster.From(ws), gvr, verbs, clusterDeletedAt)
 		if err != nil {
 			// If there is an error, hold on to it but proceed with all the remaining
@@ -409,6 +422,28 @@ func (d *logicalClusterResourcesDeleter) deleteAllContent(ctx context.Context, w
 					continue
 				}
 				numRemainingTotals.finalizersToNumRemaining[finalizer] += numRemaining
+			}
+		}
+	}
+
+	// Only delete APIBindings after all other resources have been cleaned up.
+	if len(numRemainingTotals.gvrToNumRemaining) == 0 && len(numRemainingTotals.finalizersToNumRemaining) == 0 && len(deleteContentErrs) == 0 {
+		for gvr, verbs := range apiBindingGVRs {
+			gvrDeletionMetadata, err := d.deleteAllContentForGroupVersionResource(ctx, logicalcluster.From(ws), gvr, verbs, clusterDeletedAt)
+			if err != nil {
+				deleteContentErrs = append(deleteContentErrs, err)
+			}
+			if gvrDeletionMetadata.finalizerEstimateSeconds > estimate {
+				estimate = gvrDeletionMetadata.finalizerEstimateSeconds
+			}
+			if gvrDeletionMetadata.numRemaining > 0 {
+				numRemainingTotals.gvrToNumRemaining[gvr] = gvrDeletionMetadata.numRemaining
+				for finalizer, numRemaining := range gvrDeletionMetadata.finalizersToNumRemaining {
+					if numRemaining == 0 {
+						continue
+					}
+					numRemainingTotals.finalizersToNumRemaining[finalizer] += numRemaining
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Prevents stale conditions on logicalcluster by making APIBinding delete to be last. Otherwise, we can get into a situation where apibinding is deleted before other resources, and you see a confusing condition

```
status:
  URL: https://localhost:8443/clusters/2q9x76rwu6vzssmp
  conditions:
  - lastTransitionTime: "2026-04-09T07:11:19Z"
    status: "True"
    type: APIBindingsReconciled
  - lastTransitionTime: "2026-04-09T07:07:49Z"
    message: 'Some resources are remaining: namespaces. has 2 resource instances'
    reason: SomeResourcesRemain
    severity: Info
    status: "False"
    type: WorkspaceContentDeleted
```

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Fix stale condition on LogicalCluster by reordering the delete 
```
