### PR TITLE
🐛 Etcd key poisoning fix

### DIFF
--- a/hack/etcd-list-poisoned-keys.sh
+++ b/hack/etcd-list-poisoned-keys.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The kcp Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# List etcd keys that look like they were corrupted by the workspace-path
+# poisoning bug: the local proxy used to stuff multi-segment workspace paths
+# (e.g. "root:internal-cluster") verbatim into the cluster-name segment of
+# the etcd key, producing rows that are invisible to the normal read path
+# but still consume space and can leak via wildcard partial-metadata lists.
+#
+# This script is READ-ONLY. It never modifies or deletes keys.
+#
+# Usage:
+#   hack/etcd-list-poisoned-keys.sh [--summary]
+#
+# Flags:
+#   -s, --summary   Print counts grouped by poisoned cluster-name segment
+#                   and by <group>/<resource> prefix instead of raw keys.
+#   -h, --help      Show this help.
+#
+# Environment variables (passed through to etcdctl):
+#   ETCDCTL_ENDPOINTS   default: http://localhost:2379
+#   ETCDCTL_CACERT
+#   ETCDCTL_CERT
+#   ETCDCTL_KEY
+#
+# Requires etcdctl v3.4+ (v3 API is the default). Do NOT export
+# ETCDCTL_API=3 on modern etcdctl — it just prints a "unrecognized
+# environment variable" warning.
+#
+# Example against a TLS-protected etcd (generic):
+#   ETCDCTL_ENDPOINTS=https://etcd-0.etcd:2379 \
+#   ETCDCTL_CACERT=/etc/etcd/ca.crt \
+#   ETCDCTL_CERT=/etc/etcd/client.crt \
+#   ETCDCTL_KEY=/etc/etcd/client.key \
+#   hack/etcd-list-poisoned-keys.sh --summary
+#
+# ---------------------------------------------------------------------------
+# Running against a local `kcp start` (embedded etcd)
+# ---------------------------------------------------------------------------
+#
+# `kcp start` runs an embedded etcd whose connection material lives under
+# the kcp --root-directory (default: .kcp in the current working directory).
+# The defaults are:
+#
+#   data dir       <root-dir>/etcd-server/
+#   client URL     https://localhost:<--embedded-etcd-client-port>   (default 2379)
+#   CA cert        <root-dir>/etcd-server/secrets/ca/cert.pem
+#   client cert    <root-dir>/etcd-server/secrets/client/cert.pem
+#   client key     <root-dir>/etcd-server/secrets/client/key.pem
+#
+# The embedded etcd is only reachable while the kcp process is running,
+# and the TLS cert is issued for "localhost" (use https://localhost:PORT,
+# not an IP).
+#
+# First verify the endpoint is alive:
+#
+#   etcdctl \
+#     --endpoints=https://localhost:2379 \
+#     --cacert=.kcp/etcd-server/secrets/ca/cert.pem \
+#     --cert=.kcp/etcd-server/secrets/client/cert.pem \
+#     --key=.kcp/etcd-server/secrets/client/key.pem \
+#     endpoint health
+#
+# Then scan for poisoned keys:
+#
+#   ETCDCTL_ENDPOINTS=https://localhost:2379 \
+#   ETCDCTL_CACERT=.kcp/etcd-server/secrets/ca/cert.pem \
+#   ETCDCTL_CERT=.kcp/etcd-server/secrets/client/cert.pem \
+#   ETCDCTL_KEY=.kcp/etcd-server/secrets/client/key.pem \
+#   hack/etcd-list-poisoned-keys.sh --summary
+#
+# Multi-shard: each shard started by `kcp start --shard=...` runs its own
+# embedded etcd on its own --embedded-etcd-client-port. Run the script
+# once per shard, varying ETCDCTL_ENDPOINTS and the three cert paths to
+# point at that shard's <root-dir>/etcd-server/secrets/.
+#
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+#
+# This script never writes. Only after (1) taking an etcd snapshot and
+# (2) reviewing the list, delete per affected resource:
+#
+#     etcdctl del --prefix /registry/<group>/<resource>/customresources/<seg>/
+#
+# where <seg> is a poisoned cluster-name segment reported by --summary.
+# Do NOT paste the raw output of this script into a delete command.
+
+set -euo pipefail
+
+SUMMARY=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -s|--summary)
+      SUMMARY=1
+      shift
+      ;;
+    -h|--help)
+      sed -n '17,100p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "unknown flag: $1" >&2
+      echo "try: $0 --help" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! command -v etcdctl >/dev/null 2>&1; then
+  echo "etcdctl not found in PATH" >&2
+  exit 1
+fi
+
+# Walk every key under /registry/ and keep only those with at least one
+# path segment that contains a colon and does not start with "system:".
+#
+# kcp's storage key layout is:
+#     /registry/<group>/<resource>/customresources/<cluster>/...
+# None of <group>, <resource>, namespace, or object name can legitimately
+# contain a colon. The only segment that can legitimately contain a colon
+# is a "system:*" cluster name. Any other colon is a poisoned cluster-name
+# segment written by the localproxy bug.
+poisoned=$(
+  etcdctl get --prefix --keys-only /registry/ \
+    | awk -F/ '
+        NF == 0 { next }          # etcdctl prints blank lines between keys
+        {
+          for (i = 1; i <= NF; i++) {
+            seg = $i
+            if (seg == "")                continue
+            if (index(seg, ":") == 0)     continue
+            if (seg ~ /^system:/)         continue
+            print
+            next
+          }
+        }
+      '
+)
+
+if [[ -z "${poisoned}" ]]; then
+  echo "No poisoned keys found."
+  exit 0
+fi
+
+if [[ "${SUMMARY}" -eq 0 ]]; then
+  printf '%s\n' "${poisoned}"
+  exit 0
+fi
+
+total=$(printf '%s\n' "${poisoned}" | wc -l | tr -d ' ')
+echo "Total poisoned keys: ${total}"
+echo
+echo "By poisoned cluster-name segment (count  segment):"
+printf '%s\n' "${poisoned}" \
+  | awk -F/ '
+      {
+        for (i = 1; i <= NF; i++) {
+          if (index($i, ":") > 0 && $i !~ /^system:/) {
+            print $i
+            next
+          }
+        }
+      }
+    ' \
+  | sort | uniq -c | sort -rn
+
+echo
+echo "By resource prefix (count  /registry/<group>/<resource>):"
+printf '%s\n' "${poisoned}" \
+  | awk -F/ '
+      NF >= 4 { print "/" $2 "/" $3 "/" $4 }
+    ' \
+  | sort | uniq -c | sort -rn

--- a/pkg/cache/server/config.go
+++ b/pkg/cache/server/config.go
@@ -143,6 +143,10 @@ func NewConfig(opts *cacheserveroptions.CompletedOptions, optionalLocalShardRest
 		apiHandler = genericapiserver.DefaultBuildHandlerChainFromStartToBeforeImpersonation(apiHandler, genericConfig)
 
 		apiHandler = filters.WithAuditEventClusterAnnotation(apiHandler, nil)
+		// Defense-in-depth: after WithClusterScope has put the cluster on the
+		// request context, reject any request whose cluster.Name is path-shaped
+		// so a bogus name cannot leak into etcd keys.
+		apiHandler = filters.WithClusterNameShapeInvariant(apiHandler)
 		apiHandler = filters.WithClusterScope(apiHandler)
 		apiHandler = WithShardScope(apiHandler)
 		apiHandler = WithServiceScope(apiHandler)

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -552,6 +552,11 @@ func NewConfig(ctx context.Context, opts kcpserveroptions.CompletedOptions) (*Co
 		apiHandler = mux
 
 		apiHandler = filters.WithAuditInit(apiHandler) // Must run before any audit annotation is made
+		// Defense-in-depth: after WithLocalProxy has resolved the workspace path to
+		// a logical cluster name, reject any request whose cluster.Name is still
+		// path-shaped. Prevents path strings from leaking into etcd keys if the
+		// localproxy logic ever regresses.
+		apiHandler = kcpfilters.WithClusterNameShapeInvariant(apiHandler)
 		apiHandler, err = WithLocalProxy(apiHandler, opts.Extra.ShardName, opts.Extra.AdditionalMappingsFile, clusterIndex)
 		if err != nil {
 			panic(err) // shouldn't happen due to flag validation

--- a/pkg/server/filters/filters.go
+++ b/pkg/server/filters/filters.go
@@ -176,6 +176,42 @@ func ClusterPathFromAndStrip(req *http.Request) (logicalcluster.Path, *url.URL, 
 	return logicalcluster.Path{}, req.URL, false, nil
 }
 
+// WithClusterNameShapeInvariant verifies that, once some upstream handler has
+// populated the cluster on the request context, the cluster name is a bare
+// logical-cluster name and not a workspace path. A path-shaped cluster name
+// (e.g. "root:internal-cluster") reaching the storage layer would be
+// concatenated verbatim into the etcd key by NoNamespaceKeyRootFunc,
+// producing orphaned rows invisible to the normal read path but still
+// consuming etcd space and leaking via wildcard partial-metadata lists.
+//
+// This is a defense-in-depth check: upstream handlers (WithLocalProxy,
+// WithClusterScope) are expected to either resolve the path to a logical
+// cluster name via the index or reject the request. This filter refuses to
+// forward a request whose invariant was violated, so any future regression
+// fails loudly here instead of silently corrupting etcd.
+//
+// The "system:" prefix is allowed: "system:..." names are legal single-name
+// logical clusters in kcp (see logicalcluster.Path.Name).
+func WithClusterNameShapeInvariant(apiHandler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		cluster := request.ClusterFrom(req.Context())
+		if cluster != nil && !cluster.Wildcard {
+			name := cluster.Name.String()
+			if name != "" && strings.Contains(name, ":") && !strings.HasPrefix(name, "system:") {
+				responsewriters.ErrorNegotiated(
+					apierrors.NewInternalError(fmt.Errorf(
+						"invariant violation: cluster name %q on request context is a workspace path, not a logical cluster name; refusing to forward to storage",
+						name,
+					)),
+					errorCodecs, schema.GroupVersion{}, w, req,
+				)
+				return
+			}
+		}
+		apiHandler.ServeHTTP(w, req)
+	})
+}
+
 // WithAcceptHeader makes the Accept header available for code in the handler chain. It is needed for
 // Wildcard requests, when finding the CRD with a common schema. For PartialObjectMeta requests we cand
 // weaken the schema requirement and allow different schemas across workspaces.

--- a/pkg/server/filters/filters_test.go
+++ b/pkg/server/filters/filters_test.go
@@ -18,6 +18,8 @@ package filters
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -29,6 +31,9 @@ import (
 	"sigs.k8s.io/yaml"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	"github.com/kcp-dev/logicalcluster/v3"
 )
 
 var (
@@ -121,6 +126,89 @@ func TestReCluster(t *testing.T) {
 			if got := reClusterName.MatchString(tt.cluster); got != tt.valid {
 				t.Errorf("reCluster.MatchString(%q) = %v, want %v", tt.cluster, got, tt.valid)
 			}
+		})
+	}
+}
+
+// TestWithClusterNameShapeInvariant verifies that the defense-in-depth filter
+// rejects requests whose context carries a path-shaped cluster name (which
+// would otherwise be concatenated verbatim into the etcd key by
+// NoNamespaceKeyRootFunc, producing orphaned rows), while leaving legitimate
+// bare names, system:* names, wildcard requests, and unset-cluster requests
+// alone.
+func TestWithClusterNameShapeInvariant(t *testing.T) {
+	tests := map[string]struct {
+		cluster    *request.Cluster
+		wantStatus int
+		wantCalled bool
+	}{
+		"no cluster on context": {
+			cluster:    nil,
+			wantStatus: http.StatusOK,
+			wantCalled: true,
+		},
+		"bare logical cluster name (hash)": {
+			cluster:    &request.Cluster{Name: logicalcluster.Name("25t3xbr5iceb0155")},
+			wantStatus: http.StatusOK,
+			wantCalled: true,
+		},
+		"bare human-readable name": {
+			cluster:    &request.Cluster{Name: logicalcluster.Name("root")},
+			wantStatus: http.StatusOK,
+			wantCalled: true,
+		},
+		"system:admin is allowed": {
+			cluster:    &request.Cluster{Name: logicalcluster.Name("system:admin")},
+			wantStatus: http.StatusOK,
+			wantCalled: true,
+		},
+		"system:system-crds is allowed": {
+			cluster:    &request.Cluster{Name: logicalcluster.Name("system:system-crds")},
+			wantStatus: http.StatusOK,
+			wantCalled: true,
+		},
+		"wildcard request passes through even with weird name": {
+			cluster:    &request.Cluster{Wildcard: true, Name: logicalcluster.Name("*")},
+			wantStatus: http.StatusOK,
+			wantCalled: true,
+		},
+		"empty name passes through": {
+			cluster:    &request.Cluster{Name: logicalcluster.Name("")},
+			wantStatus: http.StatusOK,
+			wantCalled: true,
+		},
+		"path-shaped name root:internal-cluster is rejected": {
+			cluster:    &request.Cluster{Name: logicalcluster.Name("root:internal-cluster")},
+			wantStatus: http.StatusInternalServerError,
+			wantCalled: false,
+		},
+		"path-shaped name root:org:ws is rejected": {
+			cluster:    &request.Cluster{Name: logicalcluster.Name("root:org:ws")},
+			wantStatus: http.StatusInternalServerError,
+			wantCalled: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			called := false
+			downstream := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				called = true
+				w.WriteHeader(http.StatusOK)
+			})
+
+			h := WithClusterNameShapeInvariant(downstream)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/default/configmaps", http.NoBody)
+			if tt.cluster != nil {
+				req = req.WithContext(request.WithCluster(req.Context(), *tt.cluster))
+			}
+			rr := httptest.NewRecorder()
+
+			h.ServeHTTP(rr, req)
+
+			require.Equal(t, tt.wantStatus, rr.Code, "status code; body=%s", rr.Body.String())
+			require.Equal(t, tt.wantCalled, called, "downstream called")
 		})
 	}
 }

--- a/pkg/server/localproxy.go
+++ b/pkg/server/localproxy.go
@@ -190,10 +190,22 @@ func WithLocalProxy(
 		clusterName, isName := path.Name()
 
 		if !isName && !found {
-			// No rewrite, depend on the handler chain to do the right thing, like 403 or 404.
-			cluster.Name = logicalcluster.Name(path.String())
-			logger.WithValues("cluster", cluster.Name).Info("cluster not found")
-			handler.ServeHTTP(w, req.WithContext(request.WithCluster(ctx, cluster)))
+			// The request targets a workspace path (e.g. root:internal-cluster)
+			// that we cannot resolve to a logical cluster on this shard. Do NOT
+			// forward with the raw path stuffed into cluster.Name: the storage
+			// key builder (NoNamespaceKeyRootFunc) would serialize it into the
+			// etcd key as if it were a real logical cluster name, producing
+			// orphaned rows that are invisible to the normal read path but
+			// still consume space and can leak via wildcard partial-metadata
+			// lists. Reject the request here instead.
+			logger.WithValues("path", path).V(4).Info("cluster path not found on this shard")
+			responsewriters.ErrorNegotiated(
+				apierrors.NewNotFound(
+					schema.GroupResource{Group: tenancyv1alpha1.SchemeGroupVersion.Group, Resource: "workspaces"},
+					path.String(),
+				),
+				errorCodecs, schema.GroupVersion{}, w, req,
+			)
 			return
 		}
 

--- a/pkg/server/localproxy_test.go
+++ b/pkg/server/localproxy_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	"github.com/kcp-dev/kcp/pkg/index"
+)
+
+// TestWithLocalProxy_UnresolvablePathIsRejected is a regression test for an
+// etcd-corruption bug where WithLocalProxy's fallback for an unresolvable
+// multi-segment cluster path ("root:internal-cluster") used to stuff the raw
+// path string into request.Cluster.Name and forward the request. The storage
+// key builder (NoNamespaceKeyRootFunc) then concatenated the path verbatim
+// into the etcd key, producing orphaned rows under e.g.
+// /registry/<group>/<resource>/customresources/root:internal-cluster/...
+// that are invisible to the normal read path but still consume etcd space.
+//
+// The fix rejects such requests with 404 before they ever reach the
+// downstream handler chain.
+func TestWithLocalProxy_UnresolvablePathIsRejected(t *testing.T) {
+	called := false
+	downstream := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		called = true
+		// If we ever get here, verify at least that the poisoned cluster.Name
+		// did not make it onto the context.
+		if cluster := request.ClusterFrom(req.Context()); cluster != nil {
+			if got := cluster.Name.String(); got == "root:internal-cluster" {
+				t.Errorf("downstream received poisoned cluster.Name=%q (the bug is back)", got)
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// An empty index: any path lookup returns found=false, which is exactly
+	// the race condition (cold informer / wrong shard / deleted workspace)
+	// that the original bug exploited.
+	emptyIndex := index.New(nil)
+
+	h, err := WithLocalProxy(downstream, "test-shard", "", emptyIndex)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/clusters/root:internal-cluster/apis/networking.dev/v1/namespaces/proj-x/ipallocations/foo",
+		http.NoBody)
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusNotFound, rr.Code,
+		"expected 404 for unresolvable workspace path, got %d; body=%s", rr.Code, rr.Body.String())
+	require.False(t, called,
+		"downstream handler must NOT be invoked for an unresolvable workspace path; the request must be rejected before it can reach storage")
+}
+
+// TestWithLocalProxy_BareNameIsForwarded makes sure the happy path is
+// unchanged: a single-segment cluster name (a hash) is forwarded through to
+// the downstream handler with cluster.Name set to that name.
+func TestWithLocalProxy_BareNameIsForwarded(t *testing.T) {
+	var gotName string
+	downstream := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if cluster := request.ClusterFrom(req.Context()); cluster != nil {
+			gotName = cluster.Name.String()
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	h, err := WithLocalProxy(downstream, "test-shard", "", index.New(nil))
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/clusters/25t3xbr5iceb0155/apis/networking.dev/v1/namespaces/proj-x/ipallocations/foo",
+		http.NoBody)
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "bare cluster name must be forwarded, got %d", rr.Code)
+	require.Equal(t, "25t3xbr5iceb0155", gotName, "downstream must see the bare cluster name on context")
+}

--- a/test/e2e/reconciler/workspacedeletion/controller_test.go
+++ b/test/e2e/reconciler/workspacedeletion/controller_test.go
@@ -120,7 +120,18 @@ func TestWorkspaceDeletion(t *testing.T) {
 					return workspace.Status.Phase == corev1alpha1.LogicalClusterPhaseReady, fmt.Sprintf("workspace phase is %s", workspace.Status.Phase)
 				}, wait.ForeverTestTimeout, time.Millisecond*100, "failed to wait for workspace %s to become ready", orgPath.Join(workspace.Name))
 
+				// Re-fetch the workspace so we have an up-to-date Spec.Cluster
+				// (the cluster hash). We need the hash to address the logical
+				// cluster *after* the workspace is hard-deleted: at that point
+				// the workspace path is no longer resolvable via the shard's
+				// local index, but single-segment cluster-name paths still
+				// short-circuit without an index lookup.
+				workspace, err := server.kcpClusterClient.Cluster(orgPath).TenancyV1alpha1().Workspaces().Get(ctx, workspace.Name, metav1.GetOptions{})
+				require.NoError(t, err, "failed to get workspace %s", workspace.Name)
+				require.NotEmpty(t, workspace.Spec.Cluster, "workspace %s has no spec.cluster set", workspace.Name)
+
 				workspaceCluster := orgPath.Join(workspace.Name)
+				workspaceClusterPath := logicalcluster.Name(workspace.Spec.Cluster).Path()
 
 				t.Logf("Wait for default namespace to be created")
 				kcptestinghelpers.Eventually(t, func() (bool, string) {
@@ -132,7 +143,7 @@ func TestWorkspaceDeletion(t *testing.T) {
 				}, wait.ForeverTestTimeout, 100*time.Millisecond, "default namespace was never created")
 
 				t.Logf("Delete default ns should be forbidden")
-				err := server.kubeClusterClient.Cluster(workspaceCluster).CoreV1().Namespaces().Delete(ctx, metav1.NamespaceDefault, metav1.DeleteOptions{})
+				err = server.kubeClusterClient.Cluster(workspaceCluster).CoreV1().Namespaces().Delete(ctx, metav1.NamespaceDefault, metav1.DeleteOptions{})
 				if !apierrors.IsForbidden(err) {
 					t.Fatalf("expect default namespace deletion to be forbidden")
 				}
@@ -189,14 +200,20 @@ func TestWorkspaceDeletion(t *testing.T) {
 
 				t.Logf("Finally check if all resources has been removed")
 
-				// Note: we have to access the shard direction to access a logical cluster without workspace
+				// Note: we have to access the shard directly to access a
+				// logical cluster without a workspace. We must address it by
+				// the cluster hash (single-segment path), not the workspace
+				// path: once the workspace is hard-deleted, the shard's index
+				// has removed the path -> hash mapping, so path-based access
+				// would be rejected by the local proxy (404).
 				rootShardKubeClusterClient, err := kcpkubernetesclientset.NewForConfig(server.RunningServer.RootShardSystemMasterBaseConfig(t))
+				require.NoError(t, err, "failed to construct root shard client")
 
-				nslist, err := rootShardKubeClusterClient.Cluster(workspaceCluster).CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+				nslist, err := rootShardKubeClusterClient.Cluster(workspaceClusterPath).CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 				require.NoError(t, err, "failed to list namespaces in workspace %s", workspace.Name)
 				require.Empty(t, nslist.Items)
 
-				cmlist, err := rootShardKubeClusterClient.Cluster(workspaceCluster).CoreV1().ConfigMaps(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+				cmlist, err := rootShardKubeClusterClient.Cluster(workspaceClusterPath).CoreV1().ConfigMaps(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 				require.NoError(t, err, "failed to list configmaps in workspace %s", workspace.Name)
 				require.Empty(t, cmlist.Items)
 			},

--- a/test/e2e/workspace/deletion_test.go
+++ b/test/e2e/workspace/deletion_test.go
@@ -112,7 +112,13 @@ func TestWorkspaceLogicalClusterRelationship(t *testing.T) {
 	// the logicalcluster should now be cleaned up successfully
 	kcptestinghelpers.Eventually(t, func() (success bool, reason string) {
 		_, err := clientset.Cluster(testPath).CoreV1alpha1().LogicalClusters().Get(ctx, corev1alpha1.LogicalClusterName, v1.GetOptions{})
-		if apierrors.IsForbidden(err) {
+		// Either Forbidden (LC object is gone but the workspace path still
+		// resolves on the shard) or NotFound (the workspace has been
+		// hard-deleted and the shard's local proxy can no longer resolve
+		// the path) is a valid "logicalcluster is gone" signal. Which one
+		// we observe depends on the race between LC deletion and workspace
+		// hard-deletion.
+		if apierrors.IsForbidden(err) || apierrors.IsNotFound(err) {
 			return true, ""
 		}
 		return false, "logicalcluster still exists"


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Fixes an etcd key-corruption bug in `WithLocalProxy`: when a multi-segment workspace path (e.g. root:internal-cluster) could not be resolved against the shard's local index, the fallback stuffed the raw path string into `request.Cluster.Name` and forwarded the request. For sufficiently privileged callers this reached storage, and `NoNamespaceKeyRootFunc `concatenated the path verbatim into the etcd key, producing orphaned rows like `/registry/<group>/<resource>/customresources/root:internal-cluster/...` next to the legitimate hash-keyed rows. These rows are invisible to normal reads (which resolve path → hash), survive workspace deletion, and leak via wildcard partial-metadata lists. The race is triggered by any cold/stale index state: informer not yet synced after restart, wrong-shard routing, scheduling lag.

### Changes:

- `pkg/server/localproxy.go`: the unresolvable-path fallback now returns 404 NotFound for the workspace instead of forwarding with a poisoned context.
- `pkg/server/filters/filters.go`: new defense-in-depth filter WithClusterNameShapeInvariant that rejects any request whose context carries a path-shaped cluster.Name (bare names, wildcards, and system:* still pass). Wired in after `WithLocalProxy` on the main shard chain and after WithClusterScope on the cache server chain.
- Regression tests for both the localproxy fallback and the new filter.
- No behaviour change on any legitimate request path. Existing orphaned rows must be cleaned up out-of-band with etcdctl.

| Client type                                                              | Canonical path still works?                                                  |
|--------------------------------------------------------------------------|------------------------------------------------------------------------------|
| kubectl / client-go going through the front-proxy                        | Yes, unchanged                                                               |
| kubectl / client-go going directly to the correct shard                  | Yes, unchanged                                                               |
| kubectl / client-go going directly to the wrong shard                    | No (now 404 instead of silent corruption — this was always broken, invisibly)|
| Controller / informer watching a live workspace                          | Yes, unchanged                                                               |
| Controller cleaning up resources in an LC whose Workspace is gone        | Should use the hash; if it used the path, it was relying on the bug          |

related to https://kubernetes.slack.com/archives/C021U8WSAFK/p1775749028395829 

## What Type of PR Is This?
/kind bug
/kind regression
<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Fix an etcd key-corruption bug where an unresolvable multi-segment workspace path in `/clusters/<path>/...` on a shard could cause resources to be written to etcd under a key segment containing the raw workspace path instead of the logical cluster name, producing orphaned rows invisible to the normal API read path. The shard now returns 404 for unresolvable workspace paths, and a new defense-in-depth filter rejects any request whose context carries a path-shaped cluster name before it can reach storage.

```
