### PR TITLE
flake: skip TestCachedResourceVirtualWorkspace until fixed

### DIFF
--- a/test/e2e/virtual/replication/virtualworkspace_test.go
+++ b/test/e2e/virtual/replication/virtualworkspace_test.go
@@ -58,6 +58,8 @@ import (
 )
 
 func TestCachedResourceVirtualWorkspace(t *testing.T) {
+	t.Skip("TestCachedResourceVirtualWorkspace is flaking (ref https://github.com/kcp-dev/kcp/issues/4026)")
+
 	t.Parallel()
 	framework.Suite(t, "control-plane")
 


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Skip TestCachedResourceVirtualWorkspace because it's flaking.

## What Type of PR Is This?

/kind flake
/kind bug

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Part of https://github.com/kcp-dev/kcp/issues/4026

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
