### PR TITLE
[wip] cached resource flakes

### DIFF
--- a/pkg/reconciler/cache/cachedresources/cachedresources_reconcile_replication.go
+++ b/pkg/reconciler/cache/cachedresources/cachedresources_reconcile_replication.go
@@ -143,16 +143,8 @@ func (r *replication) reconcile(ctx context.Context, cachedResource *cachev1alph
 		go func() {
 			defer cancel()
 
-			// Only require the local informer to sync before starting the controller.
-			// The global (cache) informer may take time to sync because the cache server
-			// needs the CachedResource to be replicated (with annotations and identity hash)
-			// before it can synthesize a CRD and serve the resource. Blocking on global sync
-			// creates a deadlock: the child controller can't start until the cache CRD exists,
-			// but the cache CRD won't be exercised until objects are replicated.
-			// The reconciler handles missing global state gracefully: creates handle AlreadyExists,
-			// and once the global informer eventually syncs, it triggers reconciliation for all objects.
-			if !cache.WaitForCacheSync(controllerCtx.Done(), replicated.Local.HasSynced) {
-				logger.Error(nil, "Local informer failed to sync, removing controller", "controller", controllerName)
+			if !cache.WaitForCacheSync(controllerCtx.Done(), replicated.Local.HasSynced, replicated.Global.HasSynced) {
+				logger.Error(nil, "Informers failed to sync, removing controller", "controller", controllerName)
 				r.controllerRegistry.unregister(controllerName)
 				requeueSelf()
 				return

--- a/staging/src/github.com/kcp-dev/virtual-workspace-framework/pkg/forwardingregistry/store.go
+++ b/staging/src/github.com/kcp-dev/virtual-workspace-framework/pkg/forwardingregistry/store.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -70,6 +71,8 @@ type DynamicClusterClientFunc func(ctx context.Context) (kcpdynamic.ClusterInter
 const (
 	watchListResourceVersionRetryAttempts = 10
 	watchListResourceVersionRetryInterval = 100 * time.Millisecond
+	watchEstablishRetryAttempts           = 5
+	watchEstablishRetryInterval           = 200 * time.Millisecond
 )
 
 func DefaultDynamicDelegatedStoreFuncs(
@@ -303,7 +306,7 @@ func DefaultDynamicDelegatedStoreFuncs(
 			}
 		}()
 
-		return delegate.Watch(watchCtx, v1ListOptions)
+		return watchWithRetry(watchCtx, delegate, v1ListOptions, shouldPrefetchWatchListResourceVersion(apiExportIdentityHash, v1ListOptions))
 	}
 	s.TableConvertorFunc = tableConvertor.ConvertToTable
 	s.CategoriesProviderFunc = func() []string {
@@ -314,12 +317,10 @@ func DefaultDynamicDelegatedStoreFuncs(
 }
 
 func shouldPrefetchWatchListResourceVersion(apiExportIdentityHash string, options metav1.ListOptions) bool {
-	// Pre-fetch whenever we're targeting an identity-hashed (cache server) resource
-	// with an empty ResourceVersion, regardless of SendInitialEvents. The cache
-	// server's watch cache may be behind etcd right after CRD synthesis, so any
-	// empty-RV watch can time out; pre-fetching an RV the cacher has already served
-	// avoids that.
-	return apiExportIdentityHash != "" && options.ResourceVersion == ""
+	return apiExportIdentityHash != "" &&
+		options.SendInitialEvents != nil &&
+		*options.SendInitialEvents &&
+		options.ResourceVersion == ""
 }
 
 func waitForWatchListResourceVersion(ctx context.Context, delegate listerWatcher) (string, error) {
@@ -328,6 +329,7 @@ func waitForWatchListResourceVersion(ctx context.Context, delegate listerWatcher
 
 func waitForWatchListResourceVersionWithRetry(ctx context.Context, delegate listerWatcher, attempts int, retryInterval time.Duration) (string, error) {
 	var lastErr error
+	var retryableOrEmpty bool
 	for i := 0; i < attempts; i++ {
 		list, err := delegate.List(ctx, metav1.ListOptions{Limit: 1})
 		if err == nil {
@@ -335,11 +337,13 @@ func waitForWatchListResourceVersionWithRetry(ctx context.Context, delegate list
 				return resourceVersion, nil
 			}
 			lastErr = fmt.Errorf("empty resourceVersion from list response")
+			retryableOrEmpty = true
 		} else {
 			if !isRetryableWatchListPrefetchError(err) {
 				return "", err
 			}
 			lastErr = err
+			retryableOrEmpty = true
 		}
 
 		if i == attempts-1 {
@@ -358,6 +362,10 @@ func waitForWatchListResourceVersionWithRetry(ctx context.Context, delegate list
 	if lastErr == nil {
 		lastErr = fmt.Errorf("failed to pre-fetch resource version")
 	}
+	if retryableOrEmpty {
+		// Best effort: callers can still proceed with the original watch options.
+		return "", nil
+	}
 	return "", lastErr
 }
 
@@ -366,6 +374,56 @@ func isRetryableWatchListPrefetchError(err error) bool {
 		apierrors.IsServerTimeout(err) ||
 		apierrors.IsTooManyRequests(err) ||
 		apierrors.IsServiceUnavailable(err)
+}
+
+func watchWithRetry(ctx context.Context, delegate listerWatcher, options metav1.ListOptions, refreshResourceVersion bool) (watch.Interface, error) {
+	var lastErr error
+	for i := 0; i < watchEstablishRetryAttempts; i++ {
+		w, err := delegate.Watch(ctx, options)
+		if err == nil {
+			return w, nil
+		}
+		if !isRetryableWatchInitializationError(err) {
+			return nil, err
+		}
+		lastErr = err
+
+		if refreshResourceVersion {
+			if resourceVersion, rvErr := waitForWatchListResourceVersionWithRetry(ctx, delegate, 2, watchEstablishRetryInterval); rvErr == nil {
+				options.ResourceVersion = resourceVersion
+			}
+		}
+
+		if i == watchEstablishRetryAttempts-1 {
+			break
+		}
+
+		timer := time.NewTimer(watchEstablishRetryInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+
+	if lastErr == nil {
+		lastErr = fmt.Errorf("failed to establish watch")
+	}
+	return nil, lastErr
+}
+
+func isRetryableWatchInitializationError(err error) bool {
+	if isRetryableWatchListPrefetchError(err) ||
+		apierrors.IsResourceExpired(err) ||
+		apierrors.HasStatusCause(err, metav1.CauseTypeResourceVersionTooLarge) {
+		return true
+	}
+
+	// This is emitted by the apiserver timeout wrapper and can surface to clients as
+	// a plain error string depending on transport.
+	lowerErr := strings.ToLower(err.Error())
+	return strings.Contains(lowerErr, "timeout or abort while handling")
 }
 
 func clientGetter(dynamicClusterClientFunc DynamicClusterClientFunc, namespaceScoped bool, resource schema.GroupVersionResource, apiExportIdentityHash string) func(ctx context.Context) (dynamic.ResourceInterface, error) {

--- a/staging/src/github.com/kcp-dev/virtual-workspace-framework/pkg/forwardingregistry/store.go
+++ b/staging/src/github.com/kcp-dev/virtual-workspace-framework/pkg/forwardingregistry/store.go
@@ -268,9 +268,28 @@ func DefaultDynamicDelegatedStoreFuncs(
 		if err := metainternalversion.Convert_internalversion_ListOptions_To_v1_ListOptions(options, &v1ListOptions, nil); err != nil {
 			return nil, err
 		}
+
 		delegate, err := listerWatcher(ctx)
 		if err != nil {
 			return nil, err
+		}
+
+		// For API-exported resources with identity hashes, the backend (cache server)
+		// synthesizes CRDs lazily from CachedResource annotations. When the WatchList
+		// feature gate is enabled (k8s 1.35+), SetListOptionsDefaults auto-adds
+		// SendInitialEvents=true for Watch requests with empty ResourceVersion.
+		// The backend's cacher then calls waitUntilFreshAndBlock with the global etcd
+		// revision, but for newly synthesized resource types the watch cache may not
+		// have caught up yet, causing a 3s timeout (TooLargeResourceVersionError).
+		//
+		// Pre-fetch the ResourceVersion via a cheap List so the backend uses a RV its
+		// watch cache has already served, making waitUntilFreshAndBlock succeed immediately.
+		if apiExportIdentityHash != "" && v1ListOptions.SendInitialEvents != nil && *v1ListOptions.SendInitialEvents && v1ListOptions.ResourceVersion == "" {
+			list, err := delegate.List(ctx, metav1.ListOptions{Limit: 1})
+			if err != nil {
+				return nil, fmt.Errorf("failed to pre-fetch resource version for WatchList: %w", err)
+			}
+			v1ListOptions.ResourceVersion = list.GetResourceVersion()
 		}
 
 		watchCtx, cancelFn := context.WithCancel(ctx)

--- a/staging/src/github.com/kcp-dev/virtual-workspace-framework/pkg/forwardingregistry/store.go
+++ b/staging/src/github.com/kcp-dev/virtual-workspace-framework/pkg/forwardingregistry/store.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
@@ -65,6 +66,11 @@ type Strategy interface {
 }
 
 type DynamicClusterClientFunc func(ctx context.Context) (kcpdynamic.ClusterInterface, error)
+
+const (
+	watchListResourceVersionRetryAttempts = 10
+	watchListResourceVersionRetryInterval = 100 * time.Millisecond
+)
 
 func DefaultDynamicDelegatedStoreFuncs(
 	factory FactoryFunc,
@@ -275,21 +281,16 @@ func DefaultDynamicDelegatedStoreFuncs(
 		}
 
 		// For API-exported resources with identity hashes, the backend (cache server)
-		// synthesizes CRDs lazily from CachedResource annotations. When the WatchList
-		// feature gate is enabled (k8s 1.35+), SetListOptionsDefaults auto-adds
-		// SendInitialEvents=true for Watch requests with empty ResourceVersion.
-		// The backend's cacher then calls waitUntilFreshAndBlock with the global etcd
-		// revision, but for newly synthesized resource types the watch cache may not
-		// have caught up yet, causing a 3s timeout (TooLargeResourceVersionError).
-		//
-		// Pre-fetch the ResourceVersion via a cheap List so the backend uses a RV its
-		// watch cache has already served, making waitUntilFreshAndBlock succeed immediately.
-		if apiExportIdentityHash != "" && v1ListOptions.SendInitialEvents != nil && *v1ListOptions.SendInitialEvents && v1ListOptions.ResourceVersion == "" {
-			list, err := delegate.List(ctx, metav1.ListOptions{Limit: 1})
+		// synthesizes CRDs lazily from CachedResource annotations. When WatchList is
+		// enabled, a newly synthesized resource can transiently fail while storage/cacher
+		// becomes ready. Pre-fetching and retrying the list to get a stable RV narrows
+		// that readiness window before opening the watch.
+		if shouldPrefetchWatchListResourceVersion(apiExportIdentityHash, v1ListOptions) {
+			resourceVersion, err := waitForWatchListResourceVersion(ctx, delegate)
 			if err != nil {
 				return nil, fmt.Errorf("failed to pre-fetch resource version for WatchList: %w", err)
 			}
-			v1ListOptions.ResourceVersion = list.GetResourceVersion()
+			v1ListOptions.ResourceVersion = resourceVersion
 		}
 
 		watchCtx, cancelFn := context.WithCancel(ctx)
@@ -310,6 +311,61 @@ func DefaultDynamicDelegatedStoreFuncs(
 	}
 	s.ResetFieldsStrategyFunc = strategy.GetResetFields
 	return s
+}
+
+func shouldPrefetchWatchListResourceVersion(apiExportIdentityHash string, options metav1.ListOptions) bool {
+	// Pre-fetch whenever we're targeting an identity-hashed (cache server) resource
+	// with an empty ResourceVersion, regardless of SendInitialEvents. The cache
+	// server's watch cache may be behind etcd right after CRD synthesis, so any
+	// empty-RV watch can time out; pre-fetching an RV the cacher has already served
+	// avoids that.
+	return apiExportIdentityHash != "" && options.ResourceVersion == ""
+}
+
+func waitForWatchListResourceVersion(ctx context.Context, delegate listerWatcher) (string, error) {
+	return waitForWatchListResourceVersionWithRetry(ctx, delegate, watchListResourceVersionRetryAttempts, watchListResourceVersionRetryInterval)
+}
+
+func waitForWatchListResourceVersionWithRetry(ctx context.Context, delegate listerWatcher, attempts int, retryInterval time.Duration) (string, error) {
+	var lastErr error
+	for i := 0; i < attempts; i++ {
+		list, err := delegate.List(ctx, metav1.ListOptions{Limit: 1})
+		if err == nil {
+			if resourceVersion := list.GetResourceVersion(); resourceVersion != "" {
+				return resourceVersion, nil
+			}
+			lastErr = fmt.Errorf("empty resourceVersion from list response")
+		} else {
+			if !isRetryableWatchListPrefetchError(err) {
+				return "", err
+			}
+			lastErr = err
+		}
+
+		if i == attempts-1 {
+			break
+		}
+
+		timer := time.NewTimer(retryInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return "", ctx.Err()
+		case <-timer.C:
+		}
+	}
+
+	if lastErr == nil {
+		lastErr = fmt.Errorf("failed to pre-fetch resource version")
+	}
+	return "", lastErr
+}
+
+func isRetryableWatchListPrefetchError(err error) bool {
+	return apierrors.IsTimeout(err) ||
+		apierrors.IsServerTimeout(err) ||
+		apierrors.IsTooManyRequests(err) ||
+		apierrors.IsServiceUnavailable(err)
 }
 
 func clientGetter(dynamicClusterClientFunc DynamicClusterClientFunc, namespaceScoped bool, resource schema.GroupVersionResource, apiExportIdentityHash string) func(ctx context.Context) (dynamic.ResourceInterface, error) {

--- a/staging/src/github.com/kcp-dev/virtual-workspace-framework/pkg/forwardingregistry/store_test.go
+++ b/staging/src/github.com/kcp-dev/virtual-workspace-framework/pkg/forwardingregistry/store_test.go
@@ -17,12 +17,18 @@ limitations under the License.
 package forwardingregistry
 
 import (
+	"context"
+	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/watch"
 )
 
 func TestUpdateToCreateOptions(t *testing.T) {
@@ -66,4 +72,100 @@ func TestUpdateToCreateOptions(t *testing.T) {
 		FieldValidation: "Strict",
 	}
 	require.Equalf(t, expectedCreateOptions, co, "CreateOptions should have the same fields as the UpdateOptions")
+}
+
+func TestShouldPrefetchWatchListResourceVersion(t *testing.T) {
+	sendInitialEvents := true
+	require.True(t, shouldPrefetchWatchListResourceVersion("hash", metav1.ListOptions{SendInitialEvents: &sendInitialEvents}))
+	require.False(t, shouldPrefetchWatchListResourceVersion("", metav1.ListOptions{SendInitialEvents: &sendInitialEvents}))
+	require.False(t, shouldPrefetchWatchListResourceVersion("hash", metav1.ListOptions{}))
+	require.False(t, shouldPrefetchWatchListResourceVersion("hash", metav1.ListOptions{
+		SendInitialEvents: &sendInitialEvents,
+		ResourceVersion:   "10",
+	}))
+}
+
+func TestWaitForWatchListResourceVersionWithRetry(t *testing.T) {
+	t.Run("retries transient error", func(t *testing.T) {
+		attempt := 0
+		lw := &fakeListerWatcher{
+			listFn: func() (*unstructured.UnstructuredList, error) {
+				if attempt < 2 {
+					attempt++
+					return nil, apierrors.NewServiceUnavailable("cache not ready")
+				}
+				attempt++
+				return &unstructured.UnstructuredList{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{"resourceVersion": "42"},
+					},
+				}, nil
+			},
+		}
+
+		resourceVersion, err := waitForWatchListResourceVersionWithRetry(context.Background(), lw, 3, 0)
+		require.NoError(t, err)
+		require.Equal(t, "42", resourceVersion)
+		require.Equal(t, 3, lw.listCalls)
+	})
+
+	t.Run("fails fast for non-retryable error", func(t *testing.T) {
+		lw := &fakeListerWatcher{
+			listFn: func() (*unstructured.UnstructuredList, error) {
+				return nil, apierrors.NewBadRequest("invalid list")
+			},
+		}
+
+		_, err := waitForWatchListResourceVersionWithRetry(context.Background(), lw, 3, 0)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid list")
+		require.Equal(t, 1, lw.listCalls)
+	})
+
+	t.Run("fails after retries on empty resourceVersion", func(t *testing.T) {
+		lw := &fakeListerWatcher{
+			listFn: func() (*unstructured.UnstructuredList, error) {
+				return &unstructured.UnstructuredList{}, nil
+			},
+		}
+
+		_, err := waitForWatchListResourceVersionWithRetry(context.Background(), lw, 2, 0)
+		require.EqualError(t, err, "empty resourceVersion from list response")
+		require.Equal(t, 2, lw.listCalls)
+	})
+
+	t.Run("returns context error when canceled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		lw := &fakeListerWatcher{
+			listFn: func() (*unstructured.UnstructuredList, error) {
+				return nil, apierrors.NewTimeoutError("timed out", 1)
+			},
+		}
+
+		_, err := waitForWatchListResourceVersionWithRetry(ctx, lw, 2, time.Second)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+type fakeListerWatcher struct {
+	listFn    func() (*unstructured.UnstructuredList, error)
+	watchFn   func() (watch.Interface, error)
+	listCalls int
+}
+
+func (f *fakeListerWatcher) List(_ context.Context, _ metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	if f.listFn == nil {
+		return nil, fmt.Errorf("listFn must be provided")
+	}
+	f.listCalls++
+	return f.listFn()
+}
+
+func (f *fakeListerWatcher) Watch(_ context.Context, _ metav1.ListOptions) (watch.Interface, error) {
+	if f.watchFn == nil {
+		return watch.NewEmptyWatch(), nil
+	}
+	return f.watchFn()
 }

--- a/staging/src/github.com/kcp-dev/virtual-workspace-framework/pkg/forwardingregistry/store_test.go
+++ b/staging/src/github.com/kcp-dev/virtual-workspace-framework/pkg/forwardingregistry/store_test.go
@@ -122,15 +122,16 @@ func TestWaitForWatchListResourceVersionWithRetry(t *testing.T) {
 		require.Equal(t, 1, lw.listCalls)
 	})
 
-	t.Run("fails after retries on empty resourceVersion", func(t *testing.T) {
+	t.Run("falls back when resourceVersion is empty", func(t *testing.T) {
 		lw := &fakeListerWatcher{
 			listFn: func() (*unstructured.UnstructuredList, error) {
 				return &unstructured.UnstructuredList{}, nil
 			},
 		}
 
-		_, err := waitForWatchListResourceVersionWithRetry(context.Background(), lw, 2, 0)
-		require.EqualError(t, err, "empty resourceVersion from list response")
+		resourceVersion, err := waitForWatchListResourceVersionWithRetry(context.Background(), lw, 2, 0)
+		require.NoError(t, err)
+		require.Empty(t, resourceVersion)
 		require.Equal(t, 2, lw.listCalls)
 	})
 
@@ -149,10 +150,46 @@ func TestWaitForWatchListResourceVersionWithRetry(t *testing.T) {
 	})
 }
 
+func TestWatchWithRetry(t *testing.T) {
+	t.Run("retries transient watch establish error", func(t *testing.T) {
+		attempt := 0
+		lw := &fakeListerWatcher{
+			watchFn: func() (watch.Interface, error) {
+				if attempt < 2 {
+					attempt++
+					return nil, apierrors.NewTimeoutError("timeout or abort while handling", 1)
+				}
+				attempt++
+				return watch.NewEmptyWatch(), nil
+			},
+		}
+
+		w, err := watchWithRetry(context.Background(), lw, metav1.ListOptions{}, false)
+		require.NoError(t, err)
+		require.NotNil(t, w)
+		require.Equal(t, 3, lw.watchCalls)
+		w.Stop()
+	})
+
+	t.Run("fails fast for non-retryable watch error", func(t *testing.T) {
+		lw := &fakeListerWatcher{
+			watchFn: func() (watch.Interface, error) {
+				return nil, apierrors.NewBadRequest("invalid watch")
+			},
+		}
+
+		_, err := watchWithRetry(context.Background(), lw, metav1.ListOptions{}, false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid watch")
+		require.Equal(t, 1, lw.watchCalls)
+	})
+}
+
 type fakeListerWatcher struct {
 	listFn    func() (*unstructured.UnstructuredList, error)
 	watchFn   func() (watch.Interface, error)
 	listCalls int
+	watchCalls int
 }
 
 func (f *fakeListerWatcher) List(_ context.Context, _ metav1.ListOptions) (*unstructured.UnstructuredList, error) {
@@ -164,6 +201,7 @@ func (f *fakeListerWatcher) List(_ context.Context, _ metav1.ListOptions) (*unst
 }
 
 func (f *fakeListerWatcher) Watch(_ context.Context, _ metav1.ListOptions) (watch.Interface, error) {
+	f.watchCalls++
 	if f.watchFn == nil {
 		return watch.NewEmptyWatch(), nil
 	}

--- a/test/e2e/virtual/replication/virtualworkspace_test.go
+++ b/test/e2e/virtual/replication/virtualworkspace_test.go
@@ -58,8 +58,6 @@ import (
 )
 
 func TestCachedResourceVirtualWorkspace(t *testing.T) {
-	t.Skip("TestCachedResourceVirtualWorkspace is flaking (ref https://github.com/kcp-dev/kcp/issues/4026)")
-
 	t.Parallel()
 	framework.Suite(t, "control-plane")
 

--- a/test/e2e/virtualresources/cachedresources/vr_cachedresources_test.go
+++ b/test/e2e/virtualresources/cachedresources/vr_cachedresources_test.go
@@ -340,20 +340,16 @@ func TestCachedResources(t *testing.T) {
 				select {
 				case e, more := <-resultCh:
 					if !more {
+						t.Logf("Watch for consumer workspace %q terminated", consumerPath)
 						return
 					}
-					obj, ok := e.Object.(*unstructured.Unstructured)
-					if !ok {
-						continue
+					if obj, ok := e.Object.(*unstructured.Unstructured); ok {
+						t.Logf("Watch for consumer workspace %q received %s event for %s", consumerPath, e.Type, obj.GetName())
+					} else {
+						t.Logf("Watch for consumer workspace %q received %s event for unexpected object type %T", consumerPath, e.Type, e.Object)
 					}
-					if obj.GetName() != "sheriffs-1" {
-						continue
-					}
-					// The provider helper does a Create followed by UpdateStatus, so depending on
-					// when the watch attaches the first visible event can be either Added or Modified.
-					// We only care that each consumer watch observed the object at least once.
-					if e.Type == watch.Added || e.Type == watch.Modified {
-						atomic.CompareAndSwapInt32(counter, 0, 1)
+					if e.Type == watch.Added {
+						atomic.AddInt32(counter, 1)
 					}
 				case <-ctx.Done():
 					w.Stop()

--- a/test/e2e/virtualresources/cachedresources/vr_cachedresources_test.go
+++ b/test/e2e/virtualresources/cachedresources/vr_cachedresources_test.go
@@ -59,8 +59,6 @@ import (
 )
 
 func TestCachedResources(t *testing.T) {
-	t.Skip("skipping for now because the test is not stable, see https://github.com/kcp-dev/kcp/issues/4026")
-
 	t.Parallel()
 	framework.Suite(t, "control-plane")
 

--- a/test/e2e/virtualresources/cachedresources/vr_cachedresources_test.go
+++ b/test/e2e/virtualresources/cachedresources/vr_cachedresources_test.go
@@ -343,8 +343,10 @@ func TestCachedResources(t *testing.T) {
 					}
 					if obj, ok := e.Object.(*unstructured.Unstructured); ok {
 						t.Logf("Watch for consumer workspace %q received %s event for %s", consumerPath, e.Type, obj.GetName())
+					} else if status, ok := e.Object.(*metav1.Status); ok {
+						t.Logf("Watch for consumer workspace %q received %s event with Status: code=%d reason=%q message=%q details=%+v", consumerPath, e.Type, status.Code, status.Reason, status.Message, status.Details)
 					} else {
-						t.Logf("Watch for consumer workspace %q received %s event for unexpected object type %T", consumerPath, e.Type, e.Object)
+						t.Logf("Watch for consumer workspace %q received %s event for unexpected object type %T: %+v", consumerPath, e.Type, e.Object, e.Object)
 					}
 					if e.Type == watch.Added {
 						atomic.AddInt32(counter, 1)


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Working theory that cache server breaks down on lazy initialized resources and it fails in 3s window for waiting for "state to be up to date" 

This is not the fix - this is to prove theory

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
