### PR TITLE
Fix CachedResources flakes

### DIFF
--- a/pkg/reconciler/cache/cachedresources/cachedresources_reconcile.go
+++ b/pkg/reconciler/cache/cachedresources/cachedresources_reconcile.go
@@ -76,8 +76,12 @@ func (c *Controller) reconcile(ctx context.Context, cluster logicalcluster.Name,
 			getKind: func(cluster logicalcluster.Name, gvr schema.GroupVersionResource) (schema.GroupVersionKind, error) {
 				return c.dynRESTMapper.ForCluster(cluster).KindFor(gvr)
 			},
-			getRESTScope: func(cluster logicalcluster.Name, kind schema.GroupKind) (meta.RESTScope, error) {
-				m, err := c.dynRESTMapper.ForCluster(cluster).RESTMapping(kind)
+			getRESTScope: func(cluster logicalcluster.Name, gvr schema.GroupVersionResource) (meta.RESTScope, error) {
+				kind, err := c.dynRESTMapper.ForCluster(cluster).KindFor(gvr)
+				if err != nil {
+					return nil, err
+				}
+				m, err := c.dynRESTMapper.ForCluster(cluster).RESTMapping(kind.GroupKind(), kind.Version)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/reconciler/cache/cachedresources/cachedresources_reconcile_annotations.go
+++ b/pkg/reconciler/cache/cachedresources/cachedresources_reconcile_annotations.go
@@ -39,7 +39,7 @@ const (
 // The cache server's CRD lister reads these to synthesize CRDs on demand.
 type reconcileResourceMetadata struct {
 	getKind      func(cluster logicalcluster.Name, gvr schema.GroupVersionResource) (schema.GroupVersionKind, error)
-	getRESTScope func(cluster logicalcluster.Name, kind schema.GroupKind) (meta.RESTScope, error)
+	getRESTScope func(cluster logicalcluster.Name, gvr schema.GroupVersionResource) (meta.RESTScope, error)
 }
 
 func (r *reconcileResourceMetadata) reconcile(ctx context.Context, cachedResource *cachev1alpha1.CachedResource) (reconcileStatus, error) {
@@ -54,7 +54,7 @@ func (r *reconcileResourceMetadata) reconcile(ctx context.Context, cachedResourc
 	if err != nil {
 		return reconcileStatusStopAndRequeue, err
 	}
-	restScope, err := r.getRESTScope(clusterName, kind.GroupKind())
+	restScope, err := r.getRESTScope(clusterName, gvr)
 	if err != nil {
 		return reconcileStatusStopAndRequeue, err
 	}

--- a/pkg/reconciler/cache/cachedresources/cachedresources_reconcile_replication.go
+++ b/pkg/reconciler/cache/cachedresources/cachedresources_reconcile_replication.go
@@ -62,7 +62,6 @@ func (r *replication) reconcile(ctx context.Context, cachedResource *cachev1alph
 		Resource: cachedResource.Spec.Resource,
 	}
 	cluster := logicalcluster.From(cachedResource)
-	cacheGVR := cacheReplicationGVR(cachedResource)
 
 	var resourceLabelSelector labels.Selector
 	if cachedResource.Spec.LabelSelector != nil {
@@ -84,13 +83,9 @@ func (r *replication) reconcile(ctx context.Context, cachedResource *cachev1alph
 
 		controllerCtx, cancel := context.WithCancel(ctx)
 
-		// Replicated objects are stored and addressed on the backing cache API under
-		// resource:identityHash. The global informer must watch that identity-scoped GVR,
-		// otherwise updates can be misclassified as creates and get dropped after an
-		// AlreadyExists response.
-		global, err := r.globalDiscoveringDynamicKcpInformers.ForResource(cacheGVR)
+		global, err := r.globalDiscoveringDynamicKcpInformers.ForResource(gvr)
 		if err != nil {
-			logger.Error(err, "Failed to get global informer for resource", "resource", cacheGVR)
+			logger.Error(err, "Failed to get global informer for resource", "resource", gvr)
 			cancel()
 			return reconcileStatusStopAndRequeue, err
 		}
@@ -176,13 +171,5 @@ func (r *replication) reconcile(ctx context.Context, cachedResource *cachev1alph
 		return reconcileStatusStopAndRequeue, nil
 	default:
 		return reconcileStatusContinue, nil
-	}
-}
-
-func cacheReplicationGVR(cachedResource *cachev1alpha1.CachedResource) schema.GroupVersionResource {
-	return schema.GroupVersionResource{
-		Group:    cachedResource.Spec.Group,
-		Version:  cachedResource.Spec.Version,
-		Resource: cachedResource.Spec.Resource + ":" + cachedResource.Status.IdentityHash,
 	}
 }

--- a/pkg/reconciler/cache/cachedresources/cachedresources_reconcile_replication.go
+++ b/pkg/reconciler/cache/cachedresources/cachedresources_reconcile_replication.go
@@ -62,6 +62,7 @@ func (r *replication) reconcile(ctx context.Context, cachedResource *cachev1alph
 		Resource: cachedResource.Spec.Resource,
 	}
 	cluster := logicalcluster.From(cachedResource)
+	cacheGVR := cacheReplicationGVR(cachedResource)
 
 	var resourceLabelSelector labels.Selector
 	if cachedResource.Spec.LabelSelector != nil {
@@ -83,9 +84,13 @@ func (r *replication) reconcile(ctx context.Context, cachedResource *cachev1alph
 
 		controllerCtx, cancel := context.WithCancel(ctx)
 
-		global, err := r.globalDiscoveringDynamicKcpInformers.ForResource(gvr)
+		// Replicated objects are stored and addressed on the backing cache API under
+		// resource:identityHash. The global informer must watch that identity-scoped GVR,
+		// otherwise updates can be misclassified as creates and get dropped after an
+		// AlreadyExists response.
+		global, err := r.globalDiscoveringDynamicKcpInformers.ForResource(cacheGVR)
 		if err != nil {
-			logger.Error(err, "Failed to get global informer for resource", "resource", gvr)
+			logger.Error(err, "Failed to get global informer for resource", "resource", cacheGVR)
 			cancel()
 			return reconcileStatusStopAndRequeue, err
 		}
@@ -143,16 +148,8 @@ func (r *replication) reconcile(ctx context.Context, cachedResource *cachev1alph
 		go func() {
 			defer cancel()
 
-			// Only require the local informer to sync before starting the controller.
-			// The global (cache) informer may take time to sync because the cache server
-			// needs the CachedResource to be replicated (with annotations and identity hash)
-			// before it can synthesize a CRD and serve the resource. Blocking on global sync
-			// creates a deadlock: the child controller can't start until the cache CRD exists,
-			// but the cache CRD won't be exercised until objects are replicated.
-			// The reconciler handles missing global state gracefully: creates handle AlreadyExists,
-			// and once the global informer eventually syncs, it triggers reconciliation for all objects.
-			if !cache.WaitForCacheSync(controllerCtx.Done(), replicated.Local.HasSynced) {
-				logger.Error(nil, "Local informer failed to sync, removing controller", "controller", controllerName)
+			if !cache.WaitForCacheSync(controllerCtx.Done(), replicated.Local.HasSynced, replicated.Global.HasSynced) {
+				logger.Error(nil, "Informers failed to sync, removing controller", "controller", controllerName)
 				r.controllerRegistry.unregister(controllerName)
 				requeueSelf()
 				return
@@ -179,5 +176,13 @@ func (r *replication) reconcile(ctx context.Context, cachedResource *cachev1alph
 		return reconcileStatusStopAndRequeue, nil
 	default:
 		return reconcileStatusContinue, nil
+	}
+}
+
+func cacheReplicationGVR(cachedResource *cachev1alpha1.CachedResource) schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    cachedResource.Spec.Group,
+		Version:  cachedResource.Spec.Version,
+		Resource: cachedResource.Spec.Resource + ":" + cachedResource.Status.IdentityHash,
 	}
 }

--- a/test/e2e/customresourcedefinition/crd_apiexport_test.go
+++ b/test/e2e/customresourcedefinition/crd_apiexport_test.go
@@ -59,13 +59,14 @@ func TestCRDVirtualWorkspace(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
+	group := framework.UniqueGroup(".dev")
 
 	t.Log("Creating cowboys APIExport in provider workspace")
-	apifixtures.CreateSheriffsSchemaAndExport(ctx, t, providerPath, kcpClient, "wildwest.dev", "Wild West API")
+	apifixtures.CreateSheriffsSchemaAndExport(ctx, t, providerPath, kcpClient, group, "Wild West API")
 
 	t.Log("Adding CRD permission claim to APIExport")
 	require.Eventually(t, func() bool {
-		export, err := kcpClient.Cluster(providerPath).ApisV1alpha2().APIExports().Get(ctx, "wildwest.dev", metav1.GetOptions{})
+		export, err := kcpClient.Cluster(providerPath).ApisV1alpha2().APIExports().Get(ctx, group, metav1.GetOptions{})
 		if err != nil {
 			return false
 		}
@@ -111,13 +112,13 @@ func TestCRDVirtualWorkspace(t *testing.T) {
 	t.Log("Binding to cowboys export in consumer workspace with accepted CRD permission claims")
 	binding := &apisv1alpha2.APIBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "wildwest.dev",
+			Name: group,
 		},
 		Spec: apisv1alpha2.APIBindingSpec{
 			Reference: apisv1alpha2.BindingReference{
 				Export: &apisv1alpha2.ExportBindingReference{
 					Path: providerPath.String(),
-					Name: "wildwest.dev",
+					Name: group,
 				},
 			},
 			PermissionClaims: []apisv1alpha2.AcceptablePermissionClaim{
@@ -147,7 +148,7 @@ func TestCRDVirtualWorkspace(t *testing.T) {
 
 	t.Log("Waiting for APIBinding to be bound")
 	require.Eventually(t, func() bool {
-		binding, err := kcpClient.Cluster(consumerPath).ApisV1alpha2().APIBindings().Get(ctx, "wildwest.dev", metav1.GetOptions{})
+		binding, err := kcpClient.Cluster(consumerPath).ApisV1alpha2().APIBindings().Get(ctx, group, metav1.GetOptions{})
 		if err != nil {
 			return false
 		}
@@ -160,7 +161,7 @@ func TestCRDVirtualWorkspace(t *testing.T) {
 	t.Log("Getting virtual workspace URL from APIExportEndpointSlice")
 	var vwURL string
 	require.Eventually(t, func() bool {
-		endpointSlice, err := kcpClient.Cluster(providerPath).ApisV1alpha1().APIExportEndpointSlices().Get(ctx, "wildwest.dev", metav1.GetOptions{})
+		endpointSlice, err := kcpClient.Cluster(providerPath).ApisV1alpha1().APIExportEndpointSlices().Get(ctx, group, metav1.GetOptions{})
 		if err != nil {
 			t.Logf("Failed to get APIExportEndpointSlice: %v", err)
 			return false

--- a/test/e2e/virtual/replication/virtualworkspace_test.go
+++ b/test/e2e/virtual/replication/virtualworkspace_test.go
@@ -58,8 +58,6 @@ import (
 )
 
 func TestCachedResourceVirtualWorkspace(t *testing.T) {
-	t.Skip("TestCachedResourceVirtualWorkspace is flaking (ref https://github.com/kcp-dev/kcp/issues/4026)")
-
 	t.Parallel()
 	framework.Suite(t, "control-plane")
 

--- a/test/e2e/virtual/replication/virtualworkspace_test.go
+++ b/test/e2e/virtual/replication/virtualworkspace_test.go
@@ -58,6 +58,7 @@ import (
 )
 
 func TestCachedResourceVirtualWorkspace(t *testing.T) {
+	t.Skip("TestCachedResourceVirtualWorkspace is flaking (ref https://github.com/kcp-dev/kcp/issues/4026)")
 	t.Parallel()
 	framework.Suite(t, "control-plane")
 

--- a/test/e2e/virtualresources/cachedresources/vr_cachedresources_test.go
+++ b/test/e2e/virtualresources/cachedresources/vr_cachedresources_test.go
@@ -59,8 +59,6 @@ import (
 )
 
 func TestCachedResources(t *testing.T) {
-	t.Skip("skipping for now because the test is not stable, see https://github.com/kcp-dev/kcp/issues/4026")
-
 	t.Parallel()
 	framework.Suite(t, "control-plane")
 

--- a/test/e2e/virtualresources/cachedresources/vr_cachedresources_test.go
+++ b/test/e2e/virtualresources/cachedresources/vr_cachedresources_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"maps"
-	"reflect"
 	"slices"
 	"sync/atomic"
 	"testing"
@@ -453,37 +452,19 @@ func verifyListAndGet(
 	require.NoError(t, err)
 
 	t.Logf("Listing %s resources in %q via %q client should return one object", resourceName, targetCluster, cfg.Host)
-	kcptestinghelpers.Eventually(t, func() (bool, string) {
-		list, err := dynClient.Cluster(targetCluster.Path()).
-			Resource(wildwestv1alpha1.SchemeGroupVersion.WithResource(resourceName)).
-			List(ctx, metav1.ListOptions{})
-		if err != nil {
-			return false, fmt.Sprintf("failed to list: %v", err)
-		}
-		if len(list.Items) != 1 {
-			return false, fmt.Sprintf("expected 1 item, got %d", len(list.Items))
-		}
-		actual := normalizeUnstructuredMap(list.Items[0].Object)
-		if !reflect.DeepEqual(actual, expected) {
-			return false, fmt.Sprintf("list result mismatch:\n  expected: %v\n  actual:   %v", expected, actual)
-		}
-		return true, ""
-	}, wait.ForeverTestTimeout, time.Millisecond*500, "listing %s in %q via %q", resourceName, targetCluster, cfg.Host)
+	list, err := dynClient.Cluster(targetCluster.Path()).
+		Resource(wildwestv1alpha1.SchemeGroupVersion.WithResource(resourceName)).
+		List(ctx, metav1.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, list.Items, 1, "Unexpected number of items in %s list in %q via %q", resourceName, targetCluster, cfg.Host)
+	require.Equal(t, expected, normalizeUnstructuredMap(list.Items[0].Object))
 
 	t.Logf("Getting a %s resource named %s in %q via %q should return that object", resourceName, objName, targetCluster, cfg.Host)
-	kcptestinghelpers.Eventually(t, func() (bool, string) {
-		obj, err := dynClient.Cluster(targetCluster.Path()).
-			Resource(wildwestv1alpha1.SchemeGroupVersion.WithResource(resourceName)).
-			Get(ctx, objName, metav1.GetOptions{})
-		if err != nil {
-			return false, fmt.Sprintf("failed to get: %v", err)
-		}
-		actual := normalizeUnstructuredMap(obj.Object)
-		if !reflect.DeepEqual(actual, expected) {
-			return false, fmt.Sprintf("get result mismatch:\n  expected: %v\n  actual:   %v", expected, actual)
-		}
-		return true, ""
-	}, wait.ForeverTestTimeout, time.Millisecond*500, "getting %s/%s in %q via %q", resourceName, objName, targetCluster, cfg.Host)
+	obj, err := dynClient.Cluster(targetCluster.Path()).
+		Resource(wildwestv1alpha1.SchemeGroupVersion.WithResource(resourceName)).
+		Get(ctx, objName, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, expected, normalizeUnstructuredMap(obj.Object))
 }
 
 func normalizeUnstructuredMap(origObj map[string]interface{}) map[string]interface{} {

--- a/test/e2e/virtualresources/cachedresources/vr_cachedresources_test.go
+++ b/test/e2e/virtualresources/cachedresources/vr_cachedresources_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"reflect"
 	"slices"
 	"sync/atomic"
 	"testing"
@@ -452,19 +453,37 @@ func verifyListAndGet(
 	require.NoError(t, err)
 
 	t.Logf("Listing %s resources in %q via %q client should return one object", resourceName, targetCluster, cfg.Host)
-	list, err := dynClient.Cluster(targetCluster.Path()).
-		Resource(wildwestv1alpha1.SchemeGroupVersion.WithResource(resourceName)).
-		List(ctx, metav1.ListOptions{})
-	require.NoError(t, err)
-	require.Len(t, list.Items, 1, "Unexpected number of items in %s list in %q via %q", resourceName, targetCluster, cfg.Host)
-	require.Equal(t, expected, normalizeUnstructuredMap(list.Items[0].Object))
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		list, err := dynClient.Cluster(targetCluster.Path()).
+			Resource(wildwestv1alpha1.SchemeGroupVersion.WithResource(resourceName)).
+			List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return false, fmt.Sprintf("failed to list %s in %q via %q: %v", resourceName, targetCluster, cfg.Host, err)
+		}
+		if len(list.Items) != 1 {
+			return false, fmt.Sprintf("unexpected number of items in %s list in %q via %q: got %d, want 1", resourceName, targetCluster, cfg.Host, len(list.Items))
+		}
+		got := normalizeUnstructuredMap(list.Items[0].Object)
+		if !reflect.DeepEqual(expected, got) {
+			return false, fmt.Sprintf("unexpected %s list item in %q via %q:\nexpected: %#v\nactual: %#v", resourceName, targetCluster, cfg.Host, expected, got)
+		}
+		return true, ""
+	}, wait.ForeverTestTimeout, time.Millisecond*500, "waiting for %s list to match expected in %q via %q", resourceName, targetCluster, cfg.Host)
 
 	t.Logf("Getting a %s resource named %s in %q via %q should return that object", resourceName, objName, targetCluster, cfg.Host)
-	obj, err := dynClient.Cluster(targetCluster.Path()).
-		Resource(wildwestv1alpha1.SchemeGroupVersion.WithResource(resourceName)).
-		Get(ctx, objName, metav1.GetOptions{})
-	require.NoError(t, err)
-	require.Equal(t, expected, normalizeUnstructuredMap(obj.Object))
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		obj, err := dynClient.Cluster(targetCluster.Path()).
+			Resource(wildwestv1alpha1.SchemeGroupVersion.WithResource(resourceName)).
+			Get(ctx, objName, metav1.GetOptions{})
+		if err != nil {
+			return false, fmt.Sprintf("failed to get %s/%s in %q via %q: %v", resourceName, objName, targetCluster, cfg.Host, err)
+		}
+		got := normalizeUnstructuredMap(obj.Object)
+		if !reflect.DeepEqual(expected, got) {
+			return false, fmt.Sprintf("unexpected %s/%s in %q via %q:\nexpected: %#v\nactual: %#v", resourceName, objName, targetCluster, cfg.Host, expected, got)
+		}
+		return true, ""
+	}, wait.ForeverTestTimeout, time.Millisecond*500, "waiting for %s/%s to match expected in %q via %q", resourceName, objName, targetCluster, cfg.Host)
 }
 
 func normalizeUnstructuredMap(origObj map[string]interface{}) map[string]interface{} {


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

In general, failures with cached resources were due to multiple tests using the same GK (not GVR), which caused shared informers to get confused. We were getting errors as the wrong schema was being picked up (kcp logs shows "missing namespace on schema" errors). To make it worse, other GVR running in parallel tests were in namespaces. So we had a namespace vs cluster scope clash. 

I will create a follow-up issue as we have to move more of those to identity-based indexing as its an issue not only for cached resources but in general. 

## What Type of PR Is This?
/kind bug
/kind cleanup
<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
