### PR TITLE
[wip]: Attempt to wire in identity into cached resources

### DIFF
--- a/pkg/reconciler/cache/cachedresources/cachedresources_reconcile_replication.go
+++ b/pkg/reconciler/cache/cachedresources/cachedresources_reconcile_replication.go
@@ -27,6 +27,7 @@ import (
 
 	kcpapiextensionsclientset "github.com/kcp-dev/client-go/apiextensions/client"
 	kcpdynamic "github.com/kcp-dev/client-go/dynamic"
+	kcpdynamicinformer "github.com/kcp-dev/client-go/dynamic/dynamicinformer"
 	"github.com/kcp-dev/logicalcluster/v3"
 	cachev1alpha1 "github.com/kcp-dev/sdk/apis/cache/v1alpha1"
 	"github.com/kcp-dev/sdk/apis/third_party/conditions/util/conditions"
@@ -83,12 +84,11 @@ func (r *replication) reconcile(ctx context.Context, cachedResource *cachev1alph
 
 		controllerCtx, cancel := context.WithCancel(ctx)
 
-		global, err := r.globalDiscoveringDynamicKcpInformers.ForResource(gvr)
-		if err != nil {
-			logger.Error(err, "Failed to get global informer for resource", "resource", gvr)
-			cancel()
-			return reconcileStatusStopAndRequeue, err
-		}
+		// The cache server stores replicated objects under resource:identityHash. This
+		// child controller needs to observe that exact cache-side GVR; the shared
+		// cache DDSIF is keyed by plain GVR and can conflate concurrent identities.
+		cacheGVR := replicationcontroller.CacheGVRWithIdentity(gvr, cachedResource.Status.IdentityHash)
+		global := kcpdynamicinformer.NewFilteredDynamicInformer(r.globalDynamicClusterClient, cacheGVR, 0, cache.Indexers{}, nil)
 
 		// Local informer is based on the specific types we want to replicate.
 		local, err := r.localDiscoveringDynamicKcpInformers.ForResource(gvr)

--- a/pkg/reconciler/cache/cachedresources/replication/replication_reconcile.go
+++ b/pkg/reconciler/cache/cachedresources/replication/replication_reconcile.go
@@ -52,8 +52,7 @@ func (c *Controller) reconcile(ctx context.Context, gvrKey string) error {
 	}
 	gvrParts := strings.SplitN(keyParts[0], ".", 3)
 	gvrFromKey := schema.GroupVersionResource{Version: gvrParts[0], Resource: gvrParts[1], Group: gvrParts[2]}
-	gvrWithIdentity := gvrFromKey
-	gvrWithIdentity.Resource += ":" + c.replicated.Identity
+	gvrWithIdentity := CacheGVRWithIdentity(gvrFromKey, c.replicated.Identity)
 
 	// Key will present in the form of namespace/name in the current logical cluster.
 	key := keyParts[1]
@@ -156,6 +155,12 @@ func (c *Controller) reconcile(ctx context.Context, gvrKey string) error {
 	}
 	defer c.requeueSelf()
 	return r.reconcile(ctx, key)
+}
+
+func CacheGVRWithIdentity(gvr schema.GroupVersionResource, identity string) schema.GroupVersionResource {
+	cacheGVR := gvr
+	cacheGVR.Resource += ":" + identity
+	return cacheGVR
 }
 
 type replicationReconciler struct {

--- a/pkg/reconciler/cache/cachedresources/replication/replication_reconcile_test.go
+++ b/pkg/reconciler/cache/cachedresources/replication/replication_reconcile_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package replication
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestCacheGVRWithIdentity(t *testing.T) {
+	t.Parallel()
+
+	gvr := schema.GroupVersionResource{
+		Group:    "wildwest.dev",
+		Version:  "v1alpha1",
+		Resource: "sheriffs",
+	}
+
+	require.Equal(t, schema.GroupVersionResource{
+		Group:    "wildwest.dev",
+		Version:  "v1alpha1",
+		Resource: "sheriffs:identity-hash",
+	}, CacheGVRWithIdentity(gvr, "identity-hash"))
+}

--- a/test/e2e/customresourcedefinition/crd_apiexport_test.go
+++ b/test/e2e/customresourcedefinition/crd_apiexport_test.go
@@ -48,6 +48,7 @@ func TestCRDVirtualWorkspace(t *testing.T) {
 
 	server := kcptesting.SharedKcpServer(t)
 	cfg := server.BaseConfig(t)
+	group := framework.UniqueGroup(".dev")
 
 	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
 
@@ -61,11 +62,11 @@ func TestCRDVirtualWorkspace(t *testing.T) {
 	ctx := context.Background()
 
 	t.Log("Creating cowboys APIExport in provider workspace")
-	apifixtures.CreateSheriffsSchemaAndExport(ctx, t, providerPath, kcpClient, "wildwest.dev", "Wild West API")
+	apifixtures.CreateSheriffsSchemaAndExport(ctx, t, providerPath, kcpClient, group, "Wild West API")
 
 	t.Log("Adding CRD permission claim to APIExport")
 	require.Eventually(t, func() bool {
-		export, err := kcpClient.Cluster(providerPath).ApisV1alpha2().APIExports().Get(ctx, "wildwest.dev", metav1.GetOptions{})
+		export, err := kcpClient.Cluster(providerPath).ApisV1alpha2().APIExports().Get(ctx, group, metav1.GetOptions{})
 		if err != nil {
 			return false
 		}
@@ -111,13 +112,13 @@ func TestCRDVirtualWorkspace(t *testing.T) {
 	t.Log("Binding to cowboys export in consumer workspace with accepted CRD permission claims")
 	binding := &apisv1alpha2.APIBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "wildwest.dev",
+			Name: group,
 		},
 		Spec: apisv1alpha2.APIBindingSpec{
 			Reference: apisv1alpha2.BindingReference{
 				Export: &apisv1alpha2.ExportBindingReference{
 					Path: providerPath.String(),
-					Name: "wildwest.dev",
+					Name: group,
 				},
 			},
 			PermissionClaims: []apisv1alpha2.AcceptablePermissionClaim{
@@ -147,7 +148,7 @@ func TestCRDVirtualWorkspace(t *testing.T) {
 
 	t.Log("Waiting for APIBinding to be bound")
 	require.Eventually(t, func() bool {
-		binding, err := kcpClient.Cluster(consumerPath).ApisV1alpha2().APIBindings().Get(ctx, "wildwest.dev", metav1.GetOptions{})
+		binding, err := kcpClient.Cluster(consumerPath).ApisV1alpha2().APIBindings().Get(ctx, group, metav1.GetOptions{})
 		if err != nil {
 			return false
 		}
@@ -160,7 +161,7 @@ func TestCRDVirtualWorkspace(t *testing.T) {
 	t.Log("Getting virtual workspace URL from APIExportEndpointSlice")
 	var vwURL string
 	require.Eventually(t, func() bool {
-		endpointSlice, err := kcpClient.Cluster(providerPath).ApisV1alpha1().APIExportEndpointSlices().Get(ctx, "wildwest.dev", metav1.GetOptions{})
+		endpointSlice, err := kcpClient.Cluster(providerPath).ApisV1alpha1().APIExportEndpointSlices().Get(ctx, group, metav1.GetOptions{})
 		if err != nil {
 			t.Logf("Failed to get APIExportEndpointSlice: %v", err)
 			return false

--- a/test/e2e/virtual/replication/virtualworkspace_test.go
+++ b/test/e2e/virtual/replication/virtualworkspace_test.go
@@ -58,8 +58,6 @@ import (
 )
 
 func TestCachedResourceVirtualWorkspace(t *testing.T) {
-	t.Skip("TestCachedResourceVirtualWorkspace is flaking (ref https://github.com/kcp-dev/kcp/issues/4026)")
-
 	t.Parallel()
 	framework.Suite(t, "control-plane")
 


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

If I get this right, the fact that the cache server stores with identities, but queries without, we get obj[0], so potentially getting the wrong objects.

So this should wire `  /services/cache/shards/<shard>/clusters/<workspace>/apis/wildwest.dev/v1alpha1/sheriffs:f003...` into the request path and hence remove this.

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
