### PR TITLE
Improve delete of workspaces

### DIFF
--- a/pkg/reconciler/tenancy/workspace/workspace_controller.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_controller.go
@@ -179,7 +179,7 @@ func NewController(
 
 	// Watch LogicalCluster deletions/updates so the owning Workspace is
 	// enqueued immediately, instead of waiting for the phase reconciler's
-	// backoff-based requeue (up to 10 min) to poll the LogicalCluster state.
+	// backoff-based requeue (up to 5 min) to poll the LogicalCluster state.
 	// Handlers are attached to both the local and the cache (replicated)
 	// informers: the local one reacts without any replication lag when the
 	// Workspace and its LogicalCluster live on the same shard, while the

--- a/pkg/reconciler/tenancy/workspace/workspace_controller.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_controller.go
@@ -132,6 +132,7 @@ func NewController(
 	globalShardInformer corev1alpha1informers.ShardClusterInformer,
 	globalWorkspaceTypeInformer tenancyv1alpha1informers.WorkspaceTypeClusterInformer,
 	logicalClusterInformer corev1alpha1informers.LogicalClusterClusterInformer,
+	cacheLogicalClusterInformer corev1alpha1informers.LogicalClusterClusterInformer,
 ) (*Controller, error) {
 	c := &Controller{
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
@@ -174,6 +175,24 @@ func NewController(
 		AddFunc:    func(obj interface{}) { c.enqueueShard(obj) },
 		UpdateFunc: func(obj, _ interface{}) { c.enqueueShard(obj) },
 		DeleteFunc: func(obj interface{}) { c.enqueueShard(obj) },
+	}))
+
+	// Watch LogicalCluster deletions/updates so the owning Workspace is
+	// enqueued immediately, instead of waiting for the phase reconciler's
+	// backoff-based requeue (up to 10 min) to poll the LogicalCluster state.
+	// Handlers are attached to both the local and the cache (replicated)
+	// informers: the local one reacts without any replication lag when the
+	// Workspace and its LogicalCluster live on the same shard, while the
+	// cache one covers the cross-shard case where the LogicalCluster is
+	// only visible via replication.
+	_, _ = logicalClusterInformer.Informer().AddEventHandler(events.WithoutSyncs(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(_, obj interface{}) { c.enqueueLogicalCluster(obj) },
+		DeleteFunc: func(obj interface{}) { c.enqueueLogicalCluster(obj) },
+	}))
+
+	_, _ = cacheLogicalClusterInformer.Informer().AddEventHandler(events.WithoutSyncs(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(_, obj interface{}) { c.enqueueLogicalCluster(obj) },
+		DeleteFunc: func(obj interface{}) { c.enqueueLogicalCluster(obj) },
 	}))
 
 	return c, nil
@@ -222,6 +241,39 @@ func (c *Controller) enqueue(obj interface{}) {
 	logger := logging.WithQueueKey(logging.WithReconciler(klog.Background(), ControllerName), key)
 	logger.V(4).Info("queueing Workspace")
 	c.queue.Add(key)
+}
+
+// enqueueLogicalCluster enqueues the Workspace (if any) whose spec.cluster
+// matches the LogicalCluster's logical cluster name. Used to react promptly to
+// LogicalCluster deletions so the Workspace does not linger waiting for the
+// phase reconciler's polling interval.
+func (c *Controller) enqueueLogicalCluster(obj interface{}) {
+	logger := logging.WithReconciler(klog.Background(), ControllerName)
+	key, err := kcpcache.DeletionHandlingMetaClusterNamespaceKeyFunc(obj)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+	clusterName, _, _, err := kcpcache.SplitMetaClusterNamespaceKey(key)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+
+	workspaces, err := c.workspaceIndexer.ByIndex(byLogicalCluster, clusterName.String())
+	if err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+	for _, workspace := range workspaces {
+		wsKey, err := kcpcache.MetaClusterNamespaceKeyFunc(workspace)
+		if err != nil {
+			utilruntime.HandleError(err)
+			continue
+		}
+		logging.WithQueueKey(logger, wsKey).V(3).Info("queueing Workspace because of LogicalCluster event", "logicalCluster", clusterName)
+		c.queue.Add(wsKey)
+	}
 }
 
 func (c *Controller) enqueueShard(obj interface{}) {
@@ -358,7 +410,8 @@ func InstallIndexers(
 	globalWorkspaceTypeInformer tenancyv1alpha1informers.WorkspaceTypeClusterInformer,
 ) {
 	indexers.AddIfNotPresentOrDie(workspaceInformer.Informer().GetIndexer(), cache.Indexers{
-		unschedulable: indexUnschedulable,
+		unschedulable:    indexUnschedulable,
+		byLogicalCluster: indexWorkspaceByLogicalCluster,
 	})
 	indexers.AddIfNotPresentOrDie(globalShardInformer.Informer().GetIndexer(), cache.Indexers{
 		byBase36Sha224Name: indexByBase36Sha224Name,

--- a/pkg/reconciler/tenancy/workspace/workspace_controller_test.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_controller_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workspace
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
+	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
+	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
+)
+
+func TestIndexWorkspaceByLogicalCluster(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		obj  *tenancyv1alpha1.Workspace
+		want []string
+	}{
+		{
+			name: "scheduled workspace indexed by spec.cluster",
+			obj: &tenancyv1alpha1.Workspace{
+				Spec: tenancyv1alpha1.WorkspaceSpec{Cluster: "root-foo-bar"},
+			},
+			want: []string{"root-foo-bar"},
+		},
+		{
+			name: "unscheduled workspace yields empty index",
+			obj: &tenancyv1alpha1.Workspace{
+				Spec: tenancyv1alpha1.WorkspaceSpec{Cluster: ""},
+			},
+			want: []string{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := indexWorkspaceByLogicalCluster(tc.obj)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestEnqueueLogicalCluster(t *testing.T) {
+	const (
+		parentCluster  = "root:foo"
+		childCluster   = "root-foo-bar"
+		workspaceName  = "bar"
+		otherWorkspace = "baz"
+	)
+
+	workspaceIndexer := cache.NewIndexer(kcpcache.MetaClusterNamespaceKeyFunc, cache.Indexers{
+		byLogicalCluster: indexWorkspaceByLogicalCluster,
+	})
+
+	// Workspace on shard whose spec.cluster matches the LogicalCluster.
+	matching := &tenancyv1alpha1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        workspaceName,
+			Annotations: map[string]string{"kcp.io/cluster": parentCluster},
+		},
+		Spec: tenancyv1alpha1.WorkspaceSpec{Cluster: childCluster},
+	}
+	// Unrelated workspace that must NOT be enqueued.
+	unrelated := &tenancyv1alpha1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        otherWorkspace,
+			Annotations: map[string]string{"kcp.io/cluster": parentCluster},
+		},
+		Spec: tenancyv1alpha1.WorkspaceSpec{Cluster: "some-other-cluster"},
+	}
+	require.NoError(t, workspaceIndexer.Add(matching))
+	require.NoError(t, workspaceIndexer.Add(unrelated))
+
+	for _, tc := range []struct {
+		name      string
+		lc        *corev1alpha1.LogicalCluster
+		wantItems []string
+	}{
+		{
+			name: "LogicalCluster event enqueues matching workspace only",
+			lc: &corev1alpha1.LogicalCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        corev1alpha1.LogicalClusterName,
+					Annotations: map[string]string{"kcp.io/cluster": childCluster},
+				},
+			},
+			wantItems: []string{"root:foo|bar"},
+		},
+		{
+			name: "LogicalCluster with no matching workspace enqueues nothing",
+			lc: &corev1alpha1.LogicalCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        corev1alpha1.LogicalClusterName,
+					Annotations: map[string]string{"kcp.io/cluster": "orphan-cluster"},
+				},
+			},
+			wantItems: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			queue := workqueue.NewTypedRateLimitingQueueWithConfig(
+				workqueue.DefaultTypedControllerRateLimiter[string](),
+				workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
+			)
+			c := &Controller{
+				queue:            queue,
+				workspaceIndexer: workspaceIndexer,
+			}
+
+			c.enqueueLogicalCluster(tc.lc)
+
+			got := drainQueue(queue)
+			require.ElementsMatch(t, tc.wantItems, got)
+		})
+	}
+}
+
+func drainQueue(q workqueue.TypedRateLimitingInterface[string]) []string {
+	// Give AddAfter/Add a brief moment to land; Add is synchronous, so this
+	// is belt-and-suspenders for any future indirection.
+	deadline := time.Now().Add(100 * time.Millisecond)
+	var items []string
+	for time.Now().Before(deadline) && q.Len() == 0 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	for q.Len() > 0 {
+		item, shutdown := q.Get()
+		if shutdown {
+			break
+		}
+		items = append(items, item)
+		q.Done(item)
+	}
+	return items
+}

--- a/pkg/reconciler/tenancy/workspace/workspace_indexes.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_indexes.go
@@ -30,6 +30,7 @@ import (
 const (
 	byBase36Sha224Name = "byBase36Sha224Name"
 	unschedulable      = "unschedulable"
+	byLogicalCluster   = "byLogicalCluster"
 )
 
 func indexUnschedulable(obj interface{}) ([]string, error) {
@@ -38,6 +39,18 @@ func indexUnschedulable(obj interface{}) ([]string, error) {
 		return []string{"true"}, nil
 	}
 	return []string{}, nil
+}
+
+// indexWorkspaceByLogicalCluster indexes Workspaces by their spec.cluster (the
+// logical cluster name of the underlying LogicalCluster). This lets the
+// controller quickly find the Workspace tied to a given LogicalCluster when a
+// LogicalCluster event fires.
+func indexWorkspaceByLogicalCluster(obj interface{}) ([]string, error) {
+	workspace := obj.(*tenancyv1alpha1.Workspace)
+	if workspace.Spec.Cluster == "" {
+		return []string{}, nil
+	}
+	return []string{workspace.Spec.Cluster}, nil
 }
 
 func indexByBase36Sha224Name(obj interface{}) ([]string, error) {

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_phase.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_phase.go
@@ -119,7 +119,7 @@ func (r *phaseReconciler) reconcile(ctx context.Context, workspace *tenancyv1alp
 
 				if !conditions.IsTrue(workspace, tenancyv1alpha1.WorkspaceContentDeleted) {
 					after := time.Since(logicalCluster.CreationTimestamp.Time) / 5
-					if max := time.Minute * 10; after > max {
+					if max := time.Minute * 5; after > max {
 						after = max
 					}
 					cond := conditions.Get(logicalCluster, tenancyv1alpha1.WorkspaceContentDeleted)

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_phase.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_phase.go
@@ -118,6 +118,14 @@ func (r *phaseReconciler) reconcile(ctx context.Context, workspace *tenancyv1alp
 				}
 
 				if !conditions.IsTrue(workspace, tenancyv1alpha1.WorkspaceContentDeleted) {
+					// Adaptive requeue: poll at 1/5 of the LogicalCluster's age, capped at 5 minutes.
+					// Young clusters get checked quickly (fast feedback when deletion finishes),
+					// older/stuck ones back off to reduce reconciler load.
+					// If the LogicalCluster never finishes deleting, the workspace stays in this
+					// branch indefinitely, requeuing every 5 minutes. There is no timeout or
+					// force-delete path here: exit only happens when getLogicalCluster returns
+					// NotFound, or something else sets WorkspaceContentDeleted=True. The mirrored
+					// condition reason/message below is the only signal of why it's stuck.
 					after := time.Since(logicalCluster.CreationTimestamp.Time) / 5
 					if max := time.Minute * 5; after > max {
 						after = max

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -536,6 +536,7 @@ func (s *Server) installWorkspaceScheduler(ctx context.Context, config *rest.Con
 		s.CacheKcpSharedInformerFactory.Core().V1alpha1().Shards(),
 		s.CacheKcpSharedInformerFactory.Tenancy().V1alpha1().WorkspaceTypes(),
 		s.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters(),
+		s.CacheKcpSharedInformerFactory.Core().V1alpha1().LogicalClusters(),
 	)
 	if err != nil {
 		return err
@@ -548,7 +549,8 @@ func (s *Server) installWorkspaceScheduler(ctx context.Context, config *rest.Con
 				return s.KcpSharedInformerFactory.Tenancy().V1alpha1().Workspaces().Informer().HasSynced() &&
 					s.CacheKcpSharedInformerFactory.Core().V1alpha1().Shards().Informer().HasSynced() &&
 					s.CacheKcpSharedInformerFactory.Tenancy().V1alpha1().WorkspaceTypes().Informer().HasSynced() &&
-					s.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters().Informer().HasSynced(), nil
+					s.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters().Informer().HasSynced() &&
+					s.CacheKcpSharedInformerFactory.Core().V1alpha1().LogicalClusters().Informer().HasSynced(), nil
 			})
 		},
 		Runner: func(ctx context.Context) {


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Currently, workspace deletion is based on pooling. 
This will wire informer-based deletes and index for logicalClusters.

In addition, reduce pooling to 5 mins from the previous 10.

This should improve the speed at which workspaces are deleted when logicalcluster goes away.

## What Type of PR Is This?
/kind feature

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes https://github.com/kcp-dev/kcp/issues/4012

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Improve workspace deletion after LogicalCluster is deleted
```
