### PR TITLE
Fix stale Scheduling metrics 

### DIFF
--- a/pkg/reconciler/core/logicalcluster/logicalcluster_reconcile_phase.go
+++ b/pkg/reconciler/core/logicalcluster/logicalcluster_reconcile_phase.go
@@ -29,6 +29,14 @@ type phaseReconciler struct{}
 
 func (r *phaseReconciler) reconcile(ctx context.Context, workspace *corev1alpha1.LogicalCluster) (reconcileStatus, error) {
 	switch workspace.Status.Phase {
+	case "", corev1alpha1.LogicalClusterPhaseScheduling:
+		// A LogicalCluster object's placement is the shard it lives on, so its
+		// existence implies scheduling is complete. Advance to Initializing and
+		// stop so admission can copy Spec.Initializers to Status.Initializers
+		// on the transition; the next reconcile advances to Ready if none
+		// remain.
+		workspace.Status.Phase = corev1alpha1.LogicalClusterPhaseInitializing
+		return reconcileStatusStopAndRequeue, nil
 	case corev1alpha1.LogicalClusterPhaseInitializing:
 		if len(workspace.Status.Initializers) > 0 {
 			conditions.MarkFalse(workspace, tenancyv1alpha1.WorkspaceInitialized, tenancyv1alpha1.WorkspaceInitializedInitializerExists, conditionsv1alpha1.ConditionSeverityInfo, "Initializers still exist: %v", workspace.Status.Initializers)

--- a/pkg/reconciler/core/logicalcluster/logicalcluster_reconcile_phase_test.go
+++ b/pkg/reconciler/core/logicalcluster/logicalcluster_reconcile_phase_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logicalcluster
+
+import (
+	"context"
+	"testing"
+
+	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
+)
+
+func TestPhaseReconcile(t *testing.T) {
+	tests := []struct {
+		name           string
+		logicalCluster *corev1alpha1.LogicalCluster
+		expectedPhase  corev1alpha1.LogicalClusterPhaseType
+	}{
+		{
+			name: "scheduling advances to initializing and stops so admission can populate initializers",
+			logicalCluster: &corev1alpha1.LogicalCluster{
+				Status: corev1alpha1.LogicalClusterStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseScheduling,
+				},
+			},
+			expectedPhase: corev1alpha1.LogicalClusterPhaseInitializing,
+		},
+		{
+			name: "scheduling with initializers advances to initializing",
+			logicalCluster: &corev1alpha1.LogicalCluster{
+				Status: corev1alpha1.LogicalClusterStatus{
+					Phase:        corev1alpha1.LogicalClusterPhaseScheduling,
+					Initializers: []corev1alpha1.LogicalClusterInitializer{"init"},
+				},
+			},
+			expectedPhase: corev1alpha1.LogicalClusterPhaseInitializing,
+		},
+		{
+			name: "empty phase advances to initializing",
+			logicalCluster: &corev1alpha1.LogicalCluster{
+				Status: corev1alpha1.LogicalClusterStatus{},
+			},
+			expectedPhase: corev1alpha1.LogicalClusterPhaseInitializing,
+		},
+		{
+			name: "initializing without initializers advances to ready",
+			logicalCluster: &corev1alpha1.LogicalCluster{
+				Status: corev1alpha1.LogicalClusterStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseInitializing,
+				},
+			},
+			expectedPhase: corev1alpha1.LogicalClusterPhaseReady,
+		},
+		{
+			name: "initializing with initializers stays initializing",
+			logicalCluster: &corev1alpha1.LogicalCluster{
+				Status: corev1alpha1.LogicalClusterStatus{
+					Phase:        corev1alpha1.LogicalClusterPhaseInitializing,
+					Initializers: []corev1alpha1.LogicalClusterInitializer{"init"},
+				},
+			},
+			expectedPhase: corev1alpha1.LogicalClusterPhaseInitializing,
+		},
+		{
+			name: "ready stays ready",
+			logicalCluster: &corev1alpha1.LogicalCluster{
+				Status: corev1alpha1.LogicalClusterStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseReady,
+				},
+			},
+			expectedPhase: corev1alpha1.LogicalClusterPhaseReady,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &phaseReconciler{}
+			if _, err := r.reconcile(context.Background(), tt.logicalCluster); err != nil {
+				t.Fatalf("unexpected reconcile error: %v", err)
+			}
+			if got := tt.logicalCluster.Status.Phase; got != tt.expectedPhase {
+				t.Errorf("phase: got %q, want %q", got, tt.expectedPhase)
+			}
+		})
+	}
+}

--- a/staging/src/github.com/kcp-dev/cli/pkg/workspace/plugin/tree.go
+++ b/staging/src/github.com/kcp-dev/cli/pkg/workspace/plugin/tree.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"text/tabwriter"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
@@ -34,6 +35,7 @@ import (
 	"github.com/kcp-dev/logicalcluster/v3"
 	apisv1alpha1 "github.com/kcp-dev/sdk/apis/apis/v1alpha1"
 	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
+	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
 	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
 )
@@ -55,6 +57,7 @@ type TreeOptions struct {
 
 	Full        bool
 	Interactive bool
+	Wide        bool
 
 	kcpClusterClient kcpclientset.ClusterInterface
 }
@@ -71,6 +74,7 @@ func (o *TreeOptions) BindFlags(cmd *cobra.Command) {
 	o.Options.BindFlags(cmd)
 	cmd.Flags().BoolVarP(&o.Full, "full", "f", o.Full, "Show full workspace names")
 	cmd.Flags().BoolVarP(&o.Interactive, "interactive", "i", o.Interactive, "Interactive workspace tree browser")
+	cmd.Flags().BoolVar(&o.Wide, "wide", o.Wide, "Show workspace and logical cluster status for each node")
 }
 
 // Complete ensures all dynamically populated fields are initialized.
@@ -110,13 +114,38 @@ func (o *TreeOptions) Run(ctx context.Context) error {
 	if !o.Full {
 		name = name[strings.LastIndex(name, ":")+1:]
 	}
-	branch := tree.AddBranch(name)
+	label := name
+	if o.Wide {
+		label = o.formatWideName(ctx, name, current, "")
+	}
+	branch := tree.AddBranch(label)
 	if err := o.populateBranch(ctx, branch, current, name); err != nil {
 		return err
 	}
 
+	if o.Wide {
+		w := tabwriter.NewWriter(o.Out, 0, 0, 2, ' ', 0)
+		fmt.Fprint(w, tree.String())
+		return w.Flush()
+	}
 	fmt.Println(tree.String())
 	return nil
+}
+
+// formatWideName appends workspace and logical cluster status to the name.
+// workspacePhase is the Phase read from the parent's Workspace list ("" when unknown, e.g. for the root).
+func (o *TreeOptions) formatWideName(ctx context.Context, name string, path logicalcluster.Path, workspacePhase corev1alpha1.LogicalClusterPhaseType) string {
+	lcPhase := corev1alpha1.LogicalClusterPhaseType("Unknown")
+	lc, err := o.kcpClusterClient.Cluster(path).CoreV1alpha1().LogicalClusters().Get(ctx, corev1alpha1.LogicalClusterName, metav1.GetOptions{})
+	if err == nil && lc.Status.Phase != "" {
+		lcPhase = lc.Status.Phase
+	}
+
+	wsPart := "-"
+	if workspacePhase != "" {
+		wsPart = string(workspacePhase)
+	}
+	return fmt.Sprintf("%s\tws=%s\tlc=%s", name, wsPart, lcPhase)
 }
 
 // runInteractive starts the interactive workspace tree browser.
@@ -222,18 +251,9 @@ func (o *TreeOptions) populateInteractiveNodeBubble(ctx context.Context, node *t
 	node.hasChildren = len(results.Items) > 0
 	node.childrenLoaded = false
 
-	shouldLoadChildren := node.expanded
-	if !shouldLoadChildren {
-		if workspace == currentWorkspace {
-			shouldLoadChildren = true
-		} else if currentWorkspace.HasPrefix(workspace) {
-			shouldLoadChildren = true
-		}
-	}
+	shouldLoadChildren := node.expanded || currentWorkspace.HasPrefix(workspace)
 
 	if shouldLoadChildren {
-		loadAllChildren := node.expanded
-
 		for _, ws := range results.Items {
 			// Skip workspaces that are being deleted, as they may no longer be
 			// accessible and listing their children could result in a 403.
@@ -243,12 +263,6 @@ func (o *TreeOptions) populateInteractiveNodeBubble(ctx context.Context, node *t
 			_, childPath, err := pluginhelpers.ParseClusterURL(ws.Spec.URL)
 			if err != nil {
 				return fmt.Errorf("workspace URL %q does not point to valid workspace", ws.Spec.URL)
-			}
-
-			if !loadAllChildren {
-				if !currentWorkspace.HasPrefix(childPath) && childPath != currentWorkspace {
-					continue
-				}
 			}
 
 			childName := ws.Name
@@ -278,7 +292,7 @@ func (o *TreeOptions) populateInteractiveNodeBubble(ctx context.Context, node *t
 
 			node.children = append(node.children, childNode)
 
-			if !loadAllChildren || currentWorkspace.HasPrefix(childPath) || childPath == currentWorkspace {
+			if currentWorkspace.HasPrefix(childPath) {
 				if err := o.populateInteractiveNodeBubble(ctx, childNode, childPath, childName, currentWorkspace, currentNode); err != nil {
 					return err
 				}
@@ -335,7 +349,11 @@ func (o *TreeOptions) populateBranch(ctx context.Context, tree treeprint.Tree, p
 		if o.Full {
 			name = parentName + ":" + name
 		}
-		branch := tree.AddBranch(name)
+		label := name
+		if o.Wide {
+			label = o.formatWideName(ctx, name, current, workspace.Status.Phase)
+		}
+		branch := tree.AddBranch(label)
 		if err := o.populateBranch(ctx, branch, current, name); err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Fix stale Scheduling metrics. 
metric some from system LC, which was bootstrapped via yaml and does not have the right statuses due to an unhandled condition. 

## What Type of PR Is This?
/kind bug
/kind chore

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes https://github.com/kcp-dev/kcp/issues/4010
## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
