### PR TITLE
Use both lookup.ClusterNameFrom and request.ClusterNameFrom to retreive cluster name

### DIFF
--- a/pkg/authentication/authenticators.go
+++ b/pkg/authentication/authenticators.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apiserver/pkg/authentication/group"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/klog/v2"
 
 	"github.com/kcp-dev/kcp/pkg/index"
 	"github.com/kcp-dev/kcp/pkg/proxy/lookup"
@@ -33,7 +34,8 @@ func NewStandaloneWorkspaceAuthenticator(clusterIndex *index.State, authIndex Au
 	return authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
 		clusterName, err := request.ClusterNameFrom(req.Context())
 		if err != nil {
-			return nil, false, fmt.Errorf("request has no cluster context: %w", err)
+			klog.FromContext(req.Context()).V(4).Info("standalone workspace authenticator skipped: request has no cluster context", "path", req.URL.Path, "err", err)
+			return nil, false, nil
 		}
 
 		result, found := clusterIndex.Lookup(clusterName.Path())
@@ -74,22 +76,43 @@ func NewWorkspaceAuthenticator() authenticator.Request {
 func withClusterScope(delegate authenticator.Request) authenticator.Request {
 	return authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
 		response, authenticated, ok := delegate.AuthenticateRequest(req)
-		if authenticated {
-			cluster := lookup.ClusterNameFrom(req.Context())
+		if !authenticated {
+			return response, authenticated, ok
+		}
 
-			extra := response.User.GetExtra()
-			if extra == nil {
-				extra = map[string][]string{}
+		// withClusterScope is used both in the front-proxy and shards.
+		// Both set the cluster name on different context keys due to
+		// differing handler chains and middlewares.
+		//
+		// On top of that, synthetic requests like a TokenReview may
+		// pass through the authentication chain with the cluster only on
+		// the context key from the request package, not the lookup
+		// package.
+		//
+		// To handle both front-proxy and shards both .ClusterNameFrom
+		// functions are checked.
+		cluster := lookup.ClusterNameFrom(req.Context())
+		if cluster.Empty() {
+			var err error
+			cluster, err = request.ClusterNameFrom(req.Context())
+			if err != nil {
+				klog.FromContext(req.Context()).Error(err, "withClusterScope: no cluster name found in lookup or request context; skipping scope extras")
+				return response, authenticated, ok
 			}
-			extra["authentication.kcp.io/scopes"] = append(extra["authentication.kcp.io/scopes"], fmt.Sprintf("cluster:%s", cluster))
-			extra["authentication.kcp.io/cluster-name"] = []string{cluster.String()}
+		}
 
-			response.User = &user.DefaultInfo{
-				Name:   response.User.GetName(),
-				UID:    response.User.GetUID(),
-				Groups: response.User.GetGroups(),
-				Extra:  extra,
-			}
+		extra := response.User.GetExtra()
+		if extra == nil {
+			extra = map[string][]string{}
+		}
+		extra["authentication.kcp.io/scopes"] = append(extra["authentication.kcp.io/scopes"], fmt.Sprintf("cluster:%s", cluster))
+		extra["authentication.kcp.io/cluster-name"] = []string{cluster.String()}
+
+		response.User = &user.DefaultInfo{
+			Name:   response.User.GetName(),
+			UID:    response.User.GetUID(),
+			Groups: response.User.GetGroups(),
+			Extra:  extra,
 		}
 
 		return response, authenticated, ok

--- a/test/e2e/authentication/workspace_test.go
+++ b/test/e2e/authentication/workspace_test.go
@@ -585,7 +585,7 @@ func TestWorkspaceOIDCTokenReview(t *testing.T) {
 
 	// create a new workspace with our new type
 	t.Log("Creating Workspaces...")
-	teamPath, _ := kcptesting.NewWorkspaceFixture(t, server, baseWsPath, kcptesting.WithName("team-a"), kcptesting.WithType(baseWsPath, tenancyv1alpha1.WorkspaceTypeName(wsType)))
+	teamPath, teamWs := kcptesting.NewWorkspaceFixture(t, server, baseWsPath, kcptesting.WithName("team-a"), kcptesting.WithType(baseWsPath, tenancyv1alpha1.WorkspaceTypeName(wsType)))
 
 	var (
 		userName       = "peter"
@@ -630,4 +630,14 @@ func TestWorkspaceOIDCTokenReview(t *testing.T) {
 	}, wait.ForeverTestTimeout, 500*time.Millisecond)
 
 	require.Contains(t, response.Status.Audiences, kcpDefaultAudience)
+
+	// Ensure the correct clusters are mentioned in the TokenReview.
+	require.Equal(t,
+		authenticationv1.ExtraValue{teamWs.Spec.Cluster},
+		response.Status.User.Extra["authentication.kcp.io/cluster-name"],
+	)
+	require.Contains(t,
+		response.Status.User.Extra["authentication.kcp.io/scopes"],
+		fmt.Sprintf("cluster:%s", teamWs.Spec.Cluster),
+	)
 }


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

withClusterScope is used both in the front-proxy and shards.
Both set the cluster name on different context keys due to
differing handler chains and middlewares.

On top of that synthetic requests like a TokenReview only
pass the authentication chain only have the cluster on the
context key from the request package - not from the lookup
package.

Related: #4061

## What Type of PR Is This?

/kind bug

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
