### PR TITLE
TokenReview in sharded setups

### DIFF
--- a/config/root/clusterrole-tenancy-maximal-permission-policy.yaml
+++ b/config/root/clusterrole-tenancy-maximal-permission-policy.yaml
@@ -7,6 +7,7 @@ rules:
   verbs: ["*"]
   resources:
   - workspaces
+  - workspaceauthenticationconfigurations
   - workspacetypes
 - apiGroups: ["tenancy.kcp.io"]
   verbs: ["list","watch","get"]

--- a/pkg/authentication/authentication_controller.go
+++ b/pkg/authentication/authentication_controller.go
@@ -59,7 +59,7 @@ type Controller struct {
 	queue workqueue.TypedRateLimitingInterface[string]
 
 	clientGetter ClusterClientGetter
-	authIndex    state
+	authIndex    eagerIndex
 
 	shardIndexer cache.Indexer
 	shardLister  corev1alpha1listers.ShardLister
@@ -246,7 +246,7 @@ func (c *Controller) Lookup(wsType logicalcluster.Path) (authenticator.Request, 
 }
 
 type shardWatcher struct {
-	state                       *state
+	eagerIndex                  *eagerIndex
 	workspaceTypeInformer       cache.SharedIndexInformer
 	workspaceAuthConfigInformer cache.SharedIndexInformer
 	cancel                      context.CancelFunc
@@ -256,24 +256,24 @@ func NewShardWatcher(
 	ctx context.Context,
 	shardName string,
 	shardClient kcpclientset.ClusterInterface,
-	state *state,
+	eagerIndex *eagerIndex,
 ) (*shardWatcher, error) {
 	wacInformer := tenancyv1alpha1informers.NewWorkspaceAuthenticationConfigurationClusterInformer(shardClient, resyncPeriod, nil)
 	_, err := wacInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			wac := obj.(*tenancyv1alpha1.WorkspaceAuthenticationConfiguration)
-			state.UpsertWorkspaceAuthenticationConfiguration(shardName, wac)
+			eagerIndex.UpsertWorkspaceAuthenticationConfiguration(shardName, wac)
 		},
 		UpdateFunc: func(old, obj interface{}) {
 			wac := obj.(*tenancyv1alpha1.WorkspaceAuthenticationConfiguration)
-			state.UpsertWorkspaceAuthenticationConfiguration(shardName, wac)
+			eagerIndex.UpsertWorkspaceAuthenticationConfiguration(shardName, wac)
 		},
 		DeleteFunc: func(obj interface{}) {
 			if final, ok := obj.(cache.DeletedFinalStateUnknown); ok {
 				obj = final.Obj
 			}
 			wac := obj.(*tenancyv1alpha1.WorkspaceAuthenticationConfiguration)
-			state.DeleteWorkspaceAuthenticationConfiguration(shardName, wac)
+			eagerIndex.DeleteWorkspaceAuthenticationConfiguration(shardName, wac)
 		},
 	})
 	if err != nil {
@@ -284,18 +284,18 @@ func NewShardWatcher(
 	_, err = wtInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			wt := obj.(*tenancyv1alpha1.WorkspaceType)
-			state.UpsertWorkspaceType(shardName, wt)
+			eagerIndex.UpsertWorkspaceType(shardName, wt)
 		},
 		UpdateFunc: func(old, obj interface{}) {
 			wt := obj.(*tenancyv1alpha1.WorkspaceType)
-			state.UpsertWorkspaceType(shardName, wt)
+			eagerIndex.UpsertWorkspaceType(shardName, wt)
 		},
 		DeleteFunc: func(obj interface{}) {
 			if final, ok := obj.(cache.DeletedFinalStateUnknown); ok {
 				obj = final.Obj
 			}
 			wt := obj.(*tenancyv1alpha1.WorkspaceType)
-			state.DeleteWorkspaceType(shardName, wt)
+			eagerIndex.DeleteWorkspaceType(shardName, wt)
 		},
 	})
 	if err != nil {
@@ -305,7 +305,7 @@ func NewShardWatcher(
 	ctx, cancel := context.WithCancel(ctx)
 
 	watcher := &shardWatcher{
-		state:                       state,
+		eagerIndex:                  eagerIndex,
 		workspaceTypeInformer:       wtInformer,
 		workspaceAuthConfigInformer: wacInformer,
 		cancel:                      cancel,
@@ -327,5 +327,5 @@ func (w *shardWatcher) Stop() {
 }
 
 func (w *shardWatcher) Lookup(wsType logicalcluster.Path) (authenticator.Request, bool) {
-	return w.state.Lookup(wsType)
+	return w.eagerIndex.Lookup(wsType)
 }

--- a/pkg/authentication/authentication_controller.go
+++ b/pkg/authentication/authentication_controller.go
@@ -59,7 +59,7 @@ type Controller struct {
 	queue workqueue.TypedRateLimitingInterface[string]
 
 	clientGetter ClusterClientGetter
-	authIndex    eagerIndex
+	authIndex    *eagerIndex
 
 	shardIndexer cache.Indexer
 	shardLister  corev1alpha1listers.ShardLister
@@ -85,7 +85,7 @@ func NewController(
 		queue: queue,
 
 		clientGetter: clientGetter,
-		authIndex:    *NewIndex(ctx, baseAudiences),
+		authIndex:    NewIndex(ctx, baseAudiences),
 
 		shardIndexer: shardInformer.Informer().GetIndexer(),
 		shardLister:  shardInformer.Lister(),
@@ -218,7 +218,7 @@ func (c *Controller) process(ctx context.Context, key string) error {
 			return err
 		}
 
-		watcher, err := NewShardWatcher(ctx, shard.Name, client, &c.authIndex)
+		watcher, err := NewShardWatcher(ctx, shard.Name, client, c.authIndex)
 		if err != nil {
 			return fmt.Errorf("failed to start shard watcher: %w", err)
 		}

--- a/pkg/authentication/index.go
+++ b/pkg/authentication/index.go
@@ -54,6 +54,7 @@ var (
 	errCauseDelete      = errors.New("authentication configuration has been deleted")
 	errCauseDeleteShard = errors.New("shard has been deleted")
 	errCauseEmpty       = errors.New("no valid authentication methods configured")
+	errCauseEvict       = errors.New("cache entry evicted")
 )
 
 func getAuthConfigKey(authConfig *tenancyv1alpha1.WorkspaceAuthenticationConfiguration) authenticatorKey {
@@ -92,4 +93,18 @@ func buildAuthenticator(
 	}
 
 	return authenticatorState{cancel: cancel, authenticator: authn}, nil
+}
+
+// wrapWithSecurityFilters wraps an authenticator with security filters
+// that prevent workspace-local auth from escalating to system-level access.
+func wrapWithSecurityFilters(authn authenticator.Request) authenticator.Request {
+	authn = ForbidSystemUsernames(authn)
+	groupFiltered := &GroupFilter{
+		Authenticator:     authn,
+		DropGroupPrefixes: []string{"system:"},
+	}
+	return &ExtraFilter{
+		Authenticator:        groupFiltered,
+		DropExtraKeyContains: []string{"kcp.io"},
+	}
 }

--- a/pkg/authentication/index.go
+++ b/pkg/authentication/index.go
@@ -19,8 +19,11 @@ package authentication
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/klog/v2"
+	kubeauthenticator "k8s.io/kubernetes/pkg/kubeapiserver/authenticator"
 
 	"github.com/kcp-dev/logicalcluster/v3"
 	"github.com/kcp-dev/sdk/apis/core"
@@ -58,4 +61,35 @@ func getAuthConfigKey(authConfig *tenancyv1alpha1.WorkspaceAuthenticationConfigu
 		cluster: logicalcluster.From(authConfig),
 		name:    authConfig.Name,
 	}
+}
+
+// buildAuthenticator builds a JWT authenticator from the provided WAC.
+func buildAuthenticator(
+	lifecycleCtx context.Context,
+	baseAudiences authenticator.Audiences,
+	wac *tenancyv1alpha1.WorkspaceAuthenticationConfiguration,
+) (authenticatorState, error) {
+	kubeAuthConfig := kubeauthenticator.Config{
+		AuthenticationConfig: convertAuthenticationConfiguration(wac),
+		APIAudiences:         baseAudiences,
+	}
+
+	ctx, cancel := context.WithCancelCause(lifecycleCtx)
+
+	authn, _, _, _, err := kubeAuthConfig.New(ctx)
+	if err != nil {
+		logger := klog.FromContext(ctx).WithValues("controller", controllerName)
+		logger.Error(err, "Failed to start workspace authenticator.")
+
+		cancel(fmt.Errorf("authenticator failed to start: %w", err))
+		return authenticatorState{}, err
+	}
+
+	// nil is returned whenever no valid individual auth method is configured.
+	if authn == nil {
+		cancel(errCauseEmpty)
+		return authenticatorState{}, errCauseEmpty
+	}
+
+	return authenticatorState{cancel: cancel, authenticator: authn}, nil
 }

--- a/pkg/authentication/index.go
+++ b/pkg/authentication/index.go
@@ -19,13 +19,8 @@ package authentication
 import (
 	"context"
 	"errors"
-	"fmt"
-	"sync"
 
 	"k8s.io/apiserver/pkg/authentication/authenticator"
-	authenticatorunion "k8s.io/apiserver/pkg/authentication/request/union"
-	"k8s.io/klog/v2"
-	kubeauthenticator "k8s.io/kubernetes/pkg/kubeapiserver/authenticator"
 
 	"github.com/kcp-dev/logicalcluster/v3"
 	"github.com/kcp-dev/sdk/apis/core"
@@ -35,20 +30,6 @@ import (
 // AuthenticatorIndex implements a mapping from workspace type to authenticator.Request.
 type AuthenticatorIndex interface {
 	Lookup(wsType logicalcluster.Path) (authenticator.Request, bool)
-}
-
-// state keeps track of authenticators for each workspace type.
-type state struct {
-	lock sync.RWMutex
-	// This component's job is to hand the application's long-lived context to new,
-	// ad-hoc started goroutines, so it must store the context here. The context
-	// available for a reconciliation will be cancelled too early and is not suitable
-	// for authenticators.
-	//nolint:containedctx
-	lifecycleCtx                context.Context
-	baseAudiences               authenticator.Audiences
-	workspaceTypeAuthenticators map[string]map[logicalcluster.Path][]authenticatorKey
-	authConfigAuthenticators    map[string]map[authenticatorKey]authenticatorState
 }
 
 type authenticatorKey struct {
@@ -61,51 +42,8 @@ type authenticatorState struct {
 	authenticator authenticator.Request
 }
 
-func NewIndex(lifecycleCtx context.Context, baseAudiences authenticator.Audiences) *state {
-	return &state{
-		lifecycleCtx:                lifecycleCtx,
-		workspaceTypeAuthenticators: map[string]map[logicalcluster.Path][]authenticatorKey{},
-		authConfigAuthenticators:    map[string]map[authenticatorKey]authenticatorState{},
-		baseAudiences:               baseAudiences,
-	}
-}
-
-func (c *state) UpsertWorkspaceType(shard string, wst *tenancyv1alpha1.WorkspaceType) {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-
-	clusterName := logicalcluster.From(wst)
-
-	authenticators := make([]authenticatorKey, 0, len(wst.Spec.AuthenticationConfigurations))
-	for _, authConfig := range wst.Spec.AuthenticationConfigurations {
-		authenticators = append(authenticators, authenticatorKey{
-			cluster: clusterName,
-			name:    authConfig.Name,
-		})
-	}
-
-	wstKey := getWorkspaceTypeKey(wst)
-
-	if c.workspaceTypeAuthenticators[shard] == nil {
-		c.workspaceTypeAuthenticators[shard] = map[logicalcluster.Path][]authenticatorKey{}
-	}
-	c.workspaceTypeAuthenticators[shard][wstKey] = authenticators
-}
-
 func getWorkspaceTypeKey(wst *tenancyv1alpha1.WorkspaceType) logicalcluster.Path {
 	return logicalcluster.NewPath(wst.Annotations[core.LogicalClusterPathAnnotationKey]).Join(wst.Name)
-}
-
-func (c *state) DeleteWorkspaceType(shard string, wst *tenancyv1alpha1.WorkspaceType) {
-	wstKey := getWorkspaceTypeKey(wst)
-
-	c.lock.Lock()
-	defer c.lock.Unlock()
-
-	delete(c.workspaceTypeAuthenticators[shard], wstKey)
-	if len(c.workspaceTypeAuthenticators[shard]) == 0 {
-		delete(c.workspaceTypeAuthenticators, shard)
-	}
 }
 
 var (
@@ -115,137 +53,9 @@ var (
 	errCauseEmpty       = errors.New("no valid authentication methods configured")
 )
 
-func (c *state) UpsertWorkspaceAuthenticationConfiguration(shard string, authConfig *tenancyv1alpha1.WorkspaceAuthenticationConfiguration) {
-	mapKey := getAuthConfigKey(authConfig)
-
-	// Stop and delete the old authenticator; do not lock for the entire duration of this function
-	// because initializing the authenticator later might be comparatively slow.
-	c.lock.Lock()
-	c.stopAuthenticator(shard, mapKey, errCauseUpsert)
-	c.lock.Unlock()
-
-	// build new authenticator
-	kubeAuthConfig := kubeauthenticator.Config{
-		AuthenticationConfig: convertAuthenticationConfiguration(authConfig),
-		APIAudiences:         c.baseAudiences,
-	}
-
-	ctx, cancel := context.WithCancelCause(c.lifecycleCtx)
-
-	authn, _, _, _, err := kubeAuthConfig.New(ctx)
-	if err != nil {
-		logger := klog.FromContext(ctx).WithValues("controller", controllerName)
-		logger.Error(err, "Failed to start workspace authenticator.")
-
-		cancel(fmt.Errorf("authenticator failed to start: %w", err))
-		return
-	}
-
-	// nil is returned whenever no valid individual auth method is configured.
-	if authn == nil {
-		cancel(errCauseEmpty)
-		return
-	}
-
-	c.lock.Lock()
-	defer c.lock.Unlock()
-
-	if c.authConfigAuthenticators[shard] == nil {
-		c.authConfigAuthenticators[shard] = map[authenticatorKey]authenticatorState{}
-	}
-	c.authConfigAuthenticators[shard][mapKey] = authenticatorState{
-		cancel:        cancel,
-		authenticator: authn,
-	}
-}
-
 func getAuthConfigKey(authConfig *tenancyv1alpha1.WorkspaceAuthenticationConfiguration) authenticatorKey {
 	return authenticatorKey{
 		cluster: logicalcluster.From(authConfig),
 		name:    authConfig.Name,
 	}
-}
-
-func (c *state) stopAuthenticator(shard string, key authenticatorKey, cause error) {
-	authenticator, ok := c.authConfigAuthenticators[shard][key]
-	if ok {
-		authenticator.cancel(cause)
-		delete(c.authConfigAuthenticators[shard], key)
-		if len(c.authConfigAuthenticators[shard]) == 0 {
-			delete(c.authConfigAuthenticators, shard)
-		}
-	}
-}
-
-func (c *state) DeleteWorkspaceAuthenticationConfiguration(shard string, authConfig *tenancyv1alpha1.WorkspaceAuthenticationConfiguration) {
-	mapKey := getAuthConfigKey(authConfig)
-
-	// Stop and delete the old authenticator
-	c.lock.Lock()
-	defer c.lock.Unlock()
-
-	c.stopAuthenticator(shard, mapKey, errCauseDelete)
-}
-
-func (c *state) DeleteShard(shardName string) {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-
-	// stop all authenticators on this shard
-	for key := range c.authConfigAuthenticators[shardName] {
-		c.stopAuthenticator(shardName, key, errCauseDeleteShard)
-	}
-
-	delete(c.workspaceTypeAuthenticators, shardName)
-	delete(c.authConfigAuthenticators, shardName)
-}
-
-func (c *state) Lookup(wsType logicalcluster.Path) (authenticator.Request, bool) {
-	var (
-		shard             string
-		authenticatorKeys []authenticatorKey
-	)
-
-	c.lock.RLock()
-	defer c.lock.RUnlock()
-
-	for shardKey, authenticatorsMap := range c.workspaceTypeAuthenticators {
-		var found bool
-		authenticatorKeys, found = authenticatorsMap[wsType]
-		if found {
-			shard = shardKey
-			break
-		}
-	}
-
-	if len(authenticatorKeys) == 0 {
-		return nil, false
-	}
-
-	var authenticators []authenticator.Request
-	for _, key := range authenticatorKeys {
-		authenticator, ok := c.authConfigAuthenticators[shard][key]
-		if ok {
-			authenticators = append(authenticators, authenticator.authenticator)
-		}
-	}
-
-	if len(authenticators) == 0 {
-		return nil, false
-	}
-
-	authenticator := authenticatorunion.New(authenticators...)
-
-	// ensure that per-workspace auth cannot be used to become a system: user/group
-	authenticator = ForbidSystemUsernames(authenticator)
-	groupFiltered := &GroupFilter{
-		Authenticator:     authenticator,
-		DropGroupPrefixes: []string{"system:"},
-	}
-	extraFiltered := &ExtraFilter{
-		Authenticator:        groupFiltered,
-		DropExtraKeyContains: []string{"kcp.io"},
-	}
-
-	return extraFiltered, true
 }

--- a/pkg/authentication/index_eager.go
+++ b/pkg/authentication/index_eager.go
@@ -179,18 +179,5 @@ func (i *eagerIndex) Lookup(wsType logicalcluster.Path) (authenticator.Request, 
 		return nil, false
 	}
 
-	authenticator := authenticatorunion.New(authenticators...)
-
-	// ensure that per-workspace auth cannot be used to become a system: user/group
-	authenticator = ForbidSystemUsernames(authenticator)
-	groupFiltered := &GroupFilter{
-		Authenticator:     authenticator,
-		DropGroupPrefixes: []string{"system:"},
-	}
-	extraFiltered := &ExtraFilter{
-		Authenticator:        groupFiltered,
-		DropExtraKeyContains: []string{"kcp.io"},
-	}
-
-	return extraFiltered, true
+	return wrapWithSecurityFilters(authenticatorunion.New(authenticators...)), true
 }

--- a/pkg/authentication/index_eager.go
+++ b/pkg/authentication/index_eager.go
@@ -18,13 +18,10 @@ package authentication
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	authenticatorunion "k8s.io/apiserver/pkg/authentication/request/union"
-	"k8s.io/klog/v2"
-	kubeauthenticator "k8s.io/kubernetes/pkg/kubeapiserver/authenticator"
 
 	"github.com/kcp-dev/logicalcluster/v3"
 	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
@@ -96,26 +93,12 @@ func (i *eagerIndex) UpsertWorkspaceAuthenticationConfiguration(shard string, au
 	i.stopAuthenticator(shard, mapKey, errCauseUpsert)
 	i.lock.Unlock()
 
-	// build new authenticator
-	kubeAuthConfig := kubeauthenticator.Config{
-		AuthenticationConfig: convertAuthenticationConfiguration(authConfig),
-		APIAudiences:         i.baseAudiences,
-	}
-
-	ctx, cancel := context.WithCancelCause(i.lifecycleCtx)
-
-	authn, _, _, _, err := kubeAuthConfig.New(ctx)
+	state, err := buildAuthenticator(i.lifecycleCtx, i.baseAudiences, authConfig)
 	if err != nil {
-		logger := klog.FromContext(ctx).WithValues("controller", controllerName)
-		logger.Error(err, "Failed to start workspace authenticator.")
-
-		cancel(fmt.Errorf("authenticator failed to start: %w", err))
-		return
-	}
-
-	// nil is returned whenever no valid individual auth method is configured.
-	if authn == nil {
-		cancel(errCauseEmpty)
+		// TODO(ntnn): If an authenticator fails to build this will just
+		// quietly go stale with no reattempts. Arguably - if an
+		// authenticator fails to build off of a WAC it's likely
+		// a configuration issue.
 		return
 	}
 
@@ -125,10 +108,7 @@ func (i *eagerIndex) UpsertWorkspaceAuthenticationConfiguration(shard string, au
 	if i.authConfigAuthenticators[shard] == nil {
 		i.authConfigAuthenticators[shard] = map[authenticatorKey]authenticatorState{}
 	}
-	i.authConfigAuthenticators[shard][mapKey] = authenticatorState{
-		cancel:        cancel,
-		authenticator: authn,
-	}
+	i.authConfigAuthenticators[shard][mapKey] = state
 }
 
 func (i *eagerIndex) stopAuthenticator(shard string, key authenticatorKey, cause error) {

--- a/pkg/authentication/index_eager.go
+++ b/pkg/authentication/index_eager.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authentication
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	authenticatorunion "k8s.io/apiserver/pkg/authentication/request/union"
+	"k8s.io/klog/v2"
+	kubeauthenticator "k8s.io/kubernetes/pkg/kubeapiserver/authenticator"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
+)
+
+// eagerIndex keeps track of authenticators for each workspace type.
+type eagerIndex struct {
+	lock sync.RWMutex
+	// This component's job is to hand the application's long-lived context to new,
+	// ad-hoc started goroutines, so it must store the context here. The context
+	// available for a reconciliation will be cancelled too early and is not suitable
+	// for authenticators.
+	//nolint:containedctx
+	lifecycleCtx                context.Context
+	baseAudiences               authenticator.Audiences
+	workspaceTypeAuthenticators map[string]map[logicalcluster.Path][]authenticatorKey
+	authConfigAuthenticators    map[string]map[authenticatorKey]authenticatorState
+}
+
+func NewIndex(lifecycleCtx context.Context, baseAudiences authenticator.Audiences) *eagerIndex {
+	return &eagerIndex{
+		lifecycleCtx:                lifecycleCtx,
+		workspaceTypeAuthenticators: map[string]map[logicalcluster.Path][]authenticatorKey{},
+		authConfigAuthenticators:    map[string]map[authenticatorKey]authenticatorState{},
+		baseAudiences:               baseAudiences,
+	}
+}
+
+func (i *eagerIndex) UpsertWorkspaceType(shard string, wst *tenancyv1alpha1.WorkspaceType) {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+
+	clusterName := logicalcluster.From(wst)
+
+	authenticators := make([]authenticatorKey, 0, len(wst.Spec.AuthenticationConfigurations))
+	for _, authConfig := range wst.Spec.AuthenticationConfigurations {
+		authenticators = append(authenticators, authenticatorKey{
+			cluster: clusterName,
+			name:    authConfig.Name,
+		})
+	}
+
+	wstKey := getWorkspaceTypeKey(wst)
+
+	if i.workspaceTypeAuthenticators[shard] == nil {
+		i.workspaceTypeAuthenticators[shard] = map[logicalcluster.Path][]authenticatorKey{}
+	}
+	i.workspaceTypeAuthenticators[shard][wstKey] = authenticators
+}
+
+func (i *eagerIndex) DeleteWorkspaceType(shard string, wst *tenancyv1alpha1.WorkspaceType) {
+	wstKey := getWorkspaceTypeKey(wst)
+
+	i.lock.Lock()
+	defer i.lock.Unlock()
+
+	delete(i.workspaceTypeAuthenticators[shard], wstKey)
+	if len(i.workspaceTypeAuthenticators[shard]) == 0 {
+		delete(i.workspaceTypeAuthenticators, shard)
+	}
+}
+
+func (i *eagerIndex) UpsertWorkspaceAuthenticationConfiguration(shard string, authConfig *tenancyv1alpha1.WorkspaceAuthenticationConfiguration) {
+	mapKey := getAuthConfigKey(authConfig)
+
+	// Stop and delete the old authenticator; do not lock for the entire duration of this function
+	// because initializing the authenticator later might be comparatively slow.
+	i.lock.Lock()
+	i.stopAuthenticator(shard, mapKey, errCauseUpsert)
+	i.lock.Unlock()
+
+	// build new authenticator
+	kubeAuthConfig := kubeauthenticator.Config{
+		AuthenticationConfig: convertAuthenticationConfiguration(authConfig),
+		APIAudiences:         i.baseAudiences,
+	}
+
+	ctx, cancel := context.WithCancelCause(i.lifecycleCtx)
+
+	authn, _, _, _, err := kubeAuthConfig.New(ctx)
+	if err != nil {
+		logger := klog.FromContext(ctx).WithValues("controller", controllerName)
+		logger.Error(err, "Failed to start workspace authenticator.")
+
+		cancel(fmt.Errorf("authenticator failed to start: %w", err))
+		return
+	}
+
+	// nil is returned whenever no valid individual auth method is configured.
+	if authn == nil {
+		cancel(errCauseEmpty)
+		return
+	}
+
+	i.lock.Lock()
+	defer i.lock.Unlock()
+
+	if i.authConfigAuthenticators[shard] == nil {
+		i.authConfigAuthenticators[shard] = map[authenticatorKey]authenticatorState{}
+	}
+	i.authConfigAuthenticators[shard][mapKey] = authenticatorState{
+		cancel:        cancel,
+		authenticator: authn,
+	}
+}
+
+func (i *eagerIndex) stopAuthenticator(shard string, key authenticatorKey, cause error) {
+	authenticator, ok := i.authConfigAuthenticators[shard][key]
+	if ok {
+		authenticator.cancel(cause)
+		delete(i.authConfigAuthenticators[shard], key)
+		if len(i.authConfigAuthenticators[shard]) == 0 {
+			delete(i.authConfigAuthenticators, shard)
+		}
+	}
+}
+
+func (i *eagerIndex) DeleteWorkspaceAuthenticationConfiguration(shard string, authConfig *tenancyv1alpha1.WorkspaceAuthenticationConfiguration) {
+	mapKey := getAuthConfigKey(authConfig)
+
+	// Stop and delete the old authenticator
+	i.lock.Lock()
+	defer i.lock.Unlock()
+
+	i.stopAuthenticator(shard, mapKey, errCauseDelete)
+}
+
+func (i *eagerIndex) DeleteShard(shardName string) {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+
+	// stop all authenticators on this shard
+	for key := range i.authConfigAuthenticators[shardName] {
+		i.stopAuthenticator(shardName, key, errCauseDeleteShard)
+	}
+
+	delete(i.workspaceTypeAuthenticators, shardName)
+	delete(i.authConfigAuthenticators, shardName)
+}
+
+func (i *eagerIndex) Lookup(wsType logicalcluster.Path) (authenticator.Request, bool) {
+	var (
+		shard             string
+		authenticatorKeys []authenticatorKey
+	)
+
+	i.lock.RLock()
+	defer i.lock.RUnlock()
+
+	for shardKey, authenticatorsMap := range i.workspaceTypeAuthenticators {
+		var found bool
+		authenticatorKeys, found = authenticatorsMap[wsType]
+		if found {
+			shard = shardKey
+			break
+		}
+	}
+
+	if len(authenticatorKeys) == 0 {
+		return nil, false
+	}
+
+	var authenticators []authenticator.Request
+	for _, key := range authenticatorKeys {
+		authenticator, ok := i.authConfigAuthenticators[shard][key]
+		if ok {
+			authenticators = append(authenticators, authenticator.authenticator)
+		}
+	}
+
+	if len(authenticators) == 0 {
+		return nil, false
+	}
+
+	authenticator := authenticatorunion.New(authenticators...)
+
+	// ensure that per-workspace auth cannot be used to become a system: user/group
+	authenticator = ForbidSystemUsernames(authenticator)
+	groupFiltered := &GroupFilter{
+		Authenticator:     authenticator,
+		DropGroupPrefixes: []string{"system:"},
+	}
+	extraFiltered := &ExtraFilter{
+		Authenticator:        groupFiltered,
+		DropExtraKeyContains: []string{"kcp.io"},
+	}
+
+	return extraFiltered, true
+}

--- a/pkg/authentication/index_lazy.go
+++ b/pkg/authentication/index_lazy.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authentication
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	authenticatorunion "k8s.io/apiserver/pkg/authentication/request/union"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
+
+	"github.com/kcp-dev/kcp/pkg/indexers"
+	"github.com/kcp-dev/kcp/pkg/shardlookup"
+)
+
+// lazyIndex, like eagerIndex, keeps track of authenticators for
+// workspace types - but only builds them on demand and caches them for
+// a fixed duration.
+//
+// Authenticators are very expensive, so it is not reasonable to keep
+// authenticators running on shards (that are very busy anyhow) for an
+// indefinite period of time. At the same time shards must be able to
+// handle per-workspace authentication and authorization to handle
+// requests like TokenReviews and similar requests coming through
+// virtual workspaces.
+type lazyIndex struct {
+	lifecycleCtx  context.Context //nolint:containedctx
+	baseAudiences authenticator.Audiences
+
+	localWSTIndexer cache.Indexer
+	cacheWSTIndexer cache.Indexer
+
+	getWAC func(clusterName logicalcluster.Name, name string) (*tenancyv1alpha1.WorkspaceAuthenticationConfiguration, error)
+
+	authenticators *shardlookup.TTLCache[authenticatorState]
+}
+
+// NewLazyIndex creates an AuthenticatorIndex that builds authenticators on demand and caches them with a TTL.
+//
+// localWSTIndexer and cacheWSTIndexer are informer indexers for
+// WorkspaceType objects (local shard and cache server respectively).
+//
+// getWAC retrieves a WorkspaceAuthenticationConfiguration by logical
+// cluster name and object name.
+func NewLazyIndex(
+	lifecycleCtx context.Context,
+	baseAudiences authenticator.Audiences,
+	localWSTIndexer, cacheWSTIndexer cache.Indexer,
+	getWAC func(logicalcluster.Name, string) (*tenancyv1alpha1.WorkspaceAuthenticationConfiguration, error),
+) AuthenticatorIndex {
+	idx := &lazyIndex{
+		lifecycleCtx:    lifecycleCtx,
+		baseAudiences:   baseAudiences,
+		localWSTIndexer: localWSTIndexer,
+		cacheWSTIndexer: cacheWSTIndexer,
+		getWAC:          getWAC,
+		authenticators: shardlookup.NewTTLCacheWithOptions[authenticatorState](shardlookup.TTLOptions{
+			// TODO(ntnn): Make the TTLs configurable via flags? On busy
+			// instances with established patterns it might be
+			// preferable to increase the SuccessTTL to not waste cycles
+			// rebuilding the same authenticators every 2h.
+			SuccessTTL: 2 * time.Hour,
+			FailureTTL: 10 * time.Second,
+		}),
+	}
+	idx.authenticators.OnEviction(func(state authenticatorState) {
+		if state.cancel != nil {
+			state.cancel(errCauseEvict)
+		}
+	})
+	idx.authenticators.Start()
+	return idx
+}
+
+func (idx *lazyIndex) Lookup(wsType logicalcluster.Path) (authenticator.Request, bool) {
+	clusterPath, wstName := wsType.Split()
+	if clusterPath.Empty() {
+		return nil, false
+	}
+
+	state, err := idx.authenticators.Get(wsType.String(), func() (authenticatorState, error) {
+		return idx.buildUnionAuthenticator(clusterPath, wstName)
+	})
+	if err != nil {
+		if errors.Is(err, errCauseEmpty) {
+			return nil, false
+		}
+		logger := klog.Background().WithValues("controller", controllerName, "workspaceType", wsType)
+		logger.Error(err, "Failed to start workspace authenticator.")
+		return nil, false
+	}
+
+	return state.authenticator, true
+}
+
+// buildUnionAuthenticator builds new authenticators for each referenced
+// WAC and then returns a union of all of them.
+//
+// The authenticators cannot be shared because if three WorkspaceTypes
+// share _some_ WSTs but get cached on one shard at different times what
+// could happen is that the first WorkspaceType builds authenticators
+// for all WACs it uses.
+// Then and hour later the second WST is cached and reuses some of the
+// running authenticators from the WACs both WSTs use. Then the first
+// WST gets evicted, cancels its authenticators the union
+// authenticators of the second WST is borked.
+//
+// Caching the authenticators from the WACs in a similar way has the
+// same problem and keeping the authenticators alive would either
+// require tracking which authenticator is used where _and_ keeping them
+// alive longer than the intended TTL.
+//
+// All things considered not a good or ideal solution, but considering
+// the constraints this is ok for now.
+//
+// NOTE(ntnn): If this comes back with a vengeance other avenues can be
+// explored. However the other avenues are all ~~terrible~~ less optimal:
+//  1. Letting front-proxy handle TokenReview -> Doesn't fix requests
+//     coming through virtual workspaces
+//  2. Redirecting per-workspace auth entirely to front-proxy just loads
+//     more things off to the front-proxy, leading to more single point
+//     of failure
+//  3. Caching WACs in the cache server: Also leads to more single point
+//     of failure and pushes even more resources into the cache server.
+//
+// The only option I could somewhat see is an informer that can watch
+// and update only requested resources. Then a shard could simply setup
+// the pull-first informer per shard and build authenticators on demand.
+// Then the watches for the WACs are set up and when these change the
+// authenticator could be invalidated and rebuild.
+func (idx *lazyIndex) buildUnionAuthenticator(clusterPath logicalcluster.Path, wstName string) (authenticatorState, error) {
+	wst, err := indexers.ByPathAndNameWithFallback[*tenancyv1alpha1.WorkspaceType](
+		tenancyv1alpha1.Resource("workspacetypes"),
+		idx.localWSTIndexer, idx.cacheWSTIndexer,
+		clusterPath, wstName,
+	)
+	if err != nil {
+		return authenticatorState{}, err
+	}
+	if len(wst.Spec.AuthenticationConfigurations) == 0 {
+		return authenticatorState{}, errCauseEmpty
+	}
+
+	parentCtx, parentCancel := context.WithCancelCause(idx.lifecycleCtx)
+
+	clusterName := logicalcluster.From(wst)
+	var authenticators []authenticator.Request
+
+	for _, ref := range wst.Spec.AuthenticationConfigurations {
+		wac, err := idx.getWAC(clusterName, ref.Name)
+		if err != nil {
+			err = fmt.Errorf("error getting WorkspaceAuthenticationConfiguration %q from %q: %w", ref.Name, clusterName, err)
+			parentCancel(err)
+			return authenticatorState{}, err
+		}
+
+		state, err := buildAuthenticator(parentCtx, idx.baseAudiences, wac)
+		if err != nil {
+			err = fmt.Errorf("error building authenticator for WorkspaceAuthenticationConfiguration %q from %q: %w", ref.Name, clusterName, err)
+			parentCancel(err)
+			return authenticatorState{}, err
+		}
+		authenticators = append(authenticators, state.authenticator)
+	}
+
+	return authenticatorState{
+		cancel:        parentCancel,
+		authenticator: wrapWithSecurityFilters(authenticatorunion.New(authenticators...)),
+	}, nil
+}

--- a/pkg/authentication/index_lazy.go
+++ b/pkg/authentication/index_lazy.go
@@ -89,7 +89,7 @@ func NewLazyIndex(
 			state.cancel(errCauseEvict)
 		}
 	})
-	idx.authenticators.Start()
+	idx.authenticators.StartWithContext(lifecycleCtx)
 	return idx
 }
 

--- a/pkg/authorization/bootstrap/policy.go
+++ b/pkg/authorization/bootstrap/policy.go
@@ -118,6 +118,13 @@ func clusterRoles() []rbacv1.ClusterRole {
 				rbacv1helpers.NewRule("get", "list", "watch").Groups(cache.GroupName).Resources("cachedresourceendpointslices").RuleOrDie(),
 			},
 		},
+		{
+			// Allow shards to retrieve WACs from other shards for per-workspace authentication.
+			ObjectMeta: metav1.ObjectMeta{Name: SystemExternalLogicalClusterAdmin},
+			Rules: []rbacv1.PolicyRule{
+				rbacv1helpers.NewRule("get").Groups(tenancy.GroupName).Resources("workspaceauthenticationconfigurations").RuleOrDie(),
+			},
+		},
 	}
 }
 

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -479,7 +479,7 @@ func NewConfig(ctx context.Context, opts kcpserveroptions.CompletedOptions) (*Co
 		}
 
 		wacCache := shardlookup.NewTTLCache[*tenancyv1alpha1.WorkspaceAuthenticationConfiguration]()
-		wacCache.Start()
+		wacCache.StartWithContext(ctx)
 		wacLookup := shardlookup.NewLookup(
 			wacCache,
 			func(clusterName logicalcluster.Name, _, _ string) bool {

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -26,8 +26,10 @@ import (
 	"net/url"
 	"os"
 	"sync"
+	"time"
 
 	apiextensionsapiserver "k8s.io/apiextensions-apiserver/pkg/apiserver"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/admission"
@@ -57,6 +59,8 @@ import (
 	"github.com/kcp-dev/embeddedetcd"
 	"github.com/kcp-dev/logicalcluster/v3"
 	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
+	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
+	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
 	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
 	kcpinformers "github.com/kcp-dev/sdk/client/informers/externalversions"
 
@@ -76,6 +80,7 @@ import (
 	kcpserveroptions "github.com/kcp-dev/kcp/pkg/server/options"
 	"github.com/kcp-dev/kcp/pkg/server/options/batteries"
 	"github.com/kcp-dev/kcp/pkg/server/virtualresources"
+	"github.com/kcp-dev/kcp/pkg/shardlookup"
 
 	_ "net/http/pprof"
 )
@@ -457,15 +462,49 @@ func NewConfig(ctx context.Context, opts kcpserveroptions.CompletedOptions) (*Co
 	// an error.
 	var authIndex authentication.AuthenticatorIndex
 	if kcpfeatures.DefaultFeatureGate.Enabled(kcpfeatures.WorkspaceAuthentication) {
-		// Start an index and a shard watcher to fill this index;
-		// the shard watcher's lifetime is tied to the given context.
-		authIndexState := authentication.NewIndex(ctx, c.GenericConfig.Authentication.APIAudiences)
-		_, err := authentication.NewShardWatcher(ctx, c.Options.Extra.ShardName, c.KcpClusterClient, authIndexState)
+		localWSTIndexer := c.KcpSharedInformerFactory.Tenancy().V1alpha1().WorkspaceTypes().Informer().GetIndexer()
+		_ = localWSTIndexer.AddIndexers(cache.Indexers{
+			indexers.ByLogicalClusterPathAndName: indexers.IndexByLogicalClusterPathAndName,
+		})
+		cacheWSTIndexer := c.CacheKcpSharedInformerFactory.Tenancy().V1alpha1().WorkspaceTypes().Informer().GetIndexer()
+		_ = cacheWSTIndexer.AddIndexers(cache.Indexers{
+			indexers.ByLogicalClusterPathAndName: indexers.IndexByLogicalClusterPathAndName,
+		})
+
+		logicalClusterLister := c.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters().Lister()
+		wacLister := c.KcpSharedInformerFactory.Tenancy().V1alpha1().WorkspaceAuthenticationConfigurations().Lister()
+		externalKcpClient, err := kcpclientset.NewForConfig(c.ExternalLogicalClusterAdminConfig)
 		if err != nil {
-			return nil, fmt.Errorf("failed to start shard watcher: %w", err)
+			return nil, fmt.Errorf("failed to create external kcp client for workspace authentication: %w", err)
 		}
 
-		authIndex = authIndexState
+		wacCache := shardlookup.NewTTLCache[*tenancyv1alpha1.WorkspaceAuthenticationConfiguration]()
+		wacCache.Start()
+		wacLookup := shardlookup.NewLookup(
+			wacCache,
+			func(clusterName logicalcluster.Name, _, _ string) bool {
+				_, err := logicalClusterLister.Cluster(clusterName).Get(corev1alpha1.LogicalClusterName)
+				return err == nil
+			},
+			func(clusterName logicalcluster.Name, _, name string) (*tenancyv1alpha1.WorkspaceAuthenticationConfiguration, error) {
+				return wacLister.Cluster(clusterName).Get(name)
+			},
+			func(clusterName logicalcluster.Name, _, name string) (*tenancyv1alpha1.WorkspaceAuthenticationConfiguration, error) {
+				// Enforce a timeout in case the front-proxy or targeted shard do not answer.
+				ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+				defer cancel()
+				return externalKcpClient.TenancyV1alpha1().WorkspaceAuthenticationConfigurations().Cluster(clusterName.Path()).Get(ctx, name, metav1.GetOptions{})
+			},
+		)
+
+		authIndex = authentication.NewLazyIndex(
+			ctx,
+			c.GenericConfig.Authentication.APIAudiences,
+			localWSTIndexer, cacheWSTIndexer,
+			func(clusterName logicalcluster.Name, name string) (*tenancyv1alpha1.WorkspaceAuthenticationConfiguration, error) {
+				return wacLookup.Get(clusterName, "", name)
+			},
+		)
 	}
 
 	// preHandlerChainMux is called before the actual handler chain. Note that BuildHandlerChainFunc below

--- a/pkg/shardlookup/ttl_cache.go
+++ b/pkg/shardlookup/ttl_cache.go
@@ -89,6 +89,15 @@ func (c *TTLCache[V]) Stop() {
 	c.ttl.Stop()
 }
 
+// StartWithContext calls .Start and calls .Stop when the context is canceled.
+func (c *TTLCache[V]) StartWithContext(ctx context.Context) {
+	c.Start()
+	go func() {
+		<-ctx.Done()
+		c.Stop()
+	}()
+}
+
 // OnEviction registers a callback that is called when an entry is
 // evicted from the cache. The callback runs on a separate goroutine.
 // The returned function can be called to unsubscribe.

--- a/test/e2e/authentication/workspace_test.go
+++ b/test/e2e/authentication/workspace_test.go
@@ -35,6 +35,7 @@ import (
 	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
 	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
 	kcptesting "github.com/kcp-dev/sdk/testing"
+	kcptestinghelpers "github.com/kcp-dev/sdk/testing/helpers"
 
 	"github.com/kcp-dev/kcp/pkg/authorization/bootstrap"
 	"github.com/kcp-dev/kcp/test/e2e/fixtures/authfixtures"
@@ -620,13 +621,13 @@ func TestWorkspaceOIDCTokenReview(t *testing.T) {
 	}
 
 	var response *authenticationv1.TokenReview
-	require.Eventually(t, func() bool {
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
 		var err error
-
 		response, err = kubeClusterClient.Cluster(teamPath).AuthenticationV1().TokenReviews().Create(t.Context(), review, metav1.CreateOptions{})
-		require.NoError(t, err)
-
-		return response.Status.Authenticated
+		if err != nil {
+			return false, err.Error()
+		}
+		return response.Status.Authenticated, response.Status.Error
 	}, wait.ForeverTestTimeout, 500*time.Millisecond)
 
 	require.Contains(t, response.Status.Audiences, kcpDefaultAudience)

--- a/test/e2e/authentication/workspace_test.go
+++ b/test/e2e/authentication/workspace_test.go
@@ -568,10 +568,6 @@ func TestWorkspaceOIDCTokenReview(t *testing.T) {
 	// start kcp and setup clients
 	server := kcptesting.SharedKcpServer(t)
 
-	if len(server.ShardNames()) > 1 {
-		t.Skip("This feature currently does not support multi shards because AuthConfigs are not replicated yet.")
-	}
-
 	baseWsPath, _ := kcptesting.NewWorkspaceFixture(t, server, logicalcluster.NewPath("root"), kcptesting.WithNamePrefix("workspace-auth-token-review"))
 
 	kcpConfig := server.BaseConfig(t)


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

TokenReview in sharded setups did not always work in sharded setups as WorkspaceAuthenticationConfiguration are not replicated.

There are three options to handle this, they are discussed in a comment in `pkg/authentication`:

```go
// NOTE(ntnn): If this comes back with a vengeance other avenues can be
// explored. However the other avenues are all ~~terrible~~ less optimal:
//  1. Letting front-proxy handle TokenReview -> Doesn't fix requests
//     coming through virtual workspaces
//  2. Redirecting per-workspace authz entirely to front-proxy just loads
//     more things off to the front-proxy, leading to more single point
//     of failure
//  3. Caching WACs in the cache server: Also leads to more single point
//     of failure and pushes even more resources into the cache server.
//
// The only option I could somewhat see is an informer that can watch
// and update only requested resources. Then a shard could simply setup
// the pull-first informer per shard and build authenticators on demand.
// Then the watches for the WACs are set up and when these change the
// authenticator could be invalidated and rebuild.
```

Similar to the SA cache WorkspaceAuthenticationConfigurations are cached in a TTLCache. The built authenticators are also cached but for a whole 2h as authenticators are expensive. 

I think we'll have to see how this behaves in production use and then reevaluate the approach.

## What Type of PR Is This?

/kind bug

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #4061 

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Add a local-or-remote lookup cache for WorkspaceAuthenticationConfiguration so per-workspace auth with e.g. TokenReview works on shards
```
