### PR TITLE
Add content proxy for terminating wst

### DIFF
--- a/config/crds/core.kcp.io_logicalclusters.yaml
+++ b/config/crds/core.kcp.io_logicalclusters.yaml
@@ -240,7 +240,7 @@ spec:
                 description: |-
                   Terminators are set on creation by the system and must be cleared
                   by a controller before the logical cluster can be deleted. The LogicalCluster object
-                  will stay in the phase "Terminating" until all terminator are cleared.
+                  will stay in the phase "Terminating" until all terminators are cleared.
                 items:
                   description: |-
                     LogicalClusterTerminator is a unique string corresponding to a logical cluster

--- a/config/crds/core.kcp.io_logicalclusters.yaml
+++ b/config/crds/core.kcp.io_logicalclusters.yaml
@@ -233,12 +233,14 @@ spec:
                 - Initializing
                 - Ready
                 - Unavailable
+                - Terminating
+                - Deleting
                 type: string
               terminators:
                 description: |-
                   Terminators are set on creation by the system and must be cleared
                   by a controller before the logical cluster can be deleted. The LogicalCluster object
-                  will stay in the phase "Deleting" until all terminator are cleared.
+                  will stay in the phase "Terminating" until all terminator are cleared.
                 items:
                   description: |-
                     LogicalClusterTerminator is a unique string corresponding to a logical cluster

--- a/config/crds/core.kcp.io_logicalclusters.yaml
+++ b/config/crds/core.kcp.io_logicalclusters.yaml
@@ -240,7 +240,7 @@ spec:
                 description: |-
                   Terminators are set on creation by the system and must be cleared
                   by a controller before the logical cluster can be deleted. The LogicalCluster object
-                  will stay in the phase "Terminating" until all terminators are cleared.
+                  will stay in the phase "Terminating" until all terminator are cleared.
                 items:
                   description: |-
                     LogicalClusterTerminator is a unique string corresponding to a logical cluster

--- a/config/crds/tenancy.kcp.io_workspaces.yaml
+++ b/config/crds/tenancy.kcp.io_workspaces.yaml
@@ -298,6 +298,8 @@ spec:
                 - Initializing
                 - Ready
                 - Unavailable
+                - Terminating
+                - Deleting
                 type: string
               terminators:
                 description: |-

--- a/config/root-phase0/apiexport-tenancy.kcp.io.yaml
+++ b/config/root-phase0/apiexport-tenancy.kcp.io.yaml
@@ -13,7 +13,7 @@ spec:
       crd: {}
   - group: tenancy.kcp.io
     name: workspaces
-    schema: v251015-1d163d0e5.workspaces.tenancy.kcp.io
+    schema: v260428-d075f2d48.workspaces.tenancy.kcp.io
     storage:
       crd: {}
   - group: tenancy.kcp.io

--- a/config/root-phase0/apiresourceschema-logicalclusters.core.kcp.io.yaml
+++ b/config/root-phase0/apiresourceschema-logicalclusters.core.kcp.io.yaml
@@ -1,7 +1,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v260423-d356919ea.logicalclusters.core.kcp.io
+  name: v260428-d075f2d48.logicalclusters.core.kcp.io
 spec:
   group: core.kcp.io
   names:
@@ -230,12 +230,14 @@ spec:
               - Initializing
               - Ready
               - Unavailable
+              - Terminating
+              - Deleting
               type: string
             terminators:
               description: |-
                 Terminators are set on creation by the system and must be cleared
                 by a controller before the logical cluster can be deleted. The LogicalCluster object
-                will stay in the phase "Deleting" until all terminator are cleared.
+                will stay in the phase "Terminating" until all terminator are cleared.
               items:
                 description: |-
                   LogicalClusterTerminator is a unique string corresponding to a logical cluster

--- a/config/root-phase0/apiresourceschema-workspaces.tenancy.kcp.io.yaml
+++ b/config/root-phase0/apiresourceschema-workspaces.tenancy.kcp.io.yaml
@@ -1,7 +1,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v251015-1d163d0e5.workspaces.tenancy.kcp.io
+  name: v260428-d075f2d48.workspaces.tenancy.kcp.io
 spec:
   group: tenancy.kcp.io
   names:
@@ -295,6 +295,8 @@ spec:
               - Initializing
               - Ready
               - Unavailable
+              - Terminating
+              - Deleting
               type: string
             terminators:
               description: |-

--- a/pkg/authorization/workspace_content_authorizer.go
+++ b/pkg/authorization/workspace_content_authorizer.go
@@ -109,7 +109,12 @@ func (a *workspaceContentAuthorizer) Authorize(ctx context.Context, attr authori
 		return authorizer.DecisionNoOpinion, "error getting LogicalCluster", err
 	}
 
-	if logicalCluster.Status.Phase != corev1alpha1.LogicalClusterPhaseInitializing && logicalCluster.Status.Phase != corev1alpha1.LogicalClusterPhaseReady {
+	switch logicalCluster.Status.Phase {
+	case corev1alpha1.LogicalClusterPhaseInitializing,
+		corev1alpha1.LogicalClusterPhaseReady,
+		corev1alpha1.LogicalClusterPhaseTerminating:
+		// allowed
+	default: // Scheduling, Deleting, Unknown, or any future phases are not allowed to access workspace content
 		return authorizer.DecisionNoOpinion, fmt.Sprintf("not permitted due to phase %q", logicalCluster.Status.Phase), nil
 	}
 

--- a/pkg/authorization/workspace_content_authorizer.go
+++ b/pkg/authorization/workspace_content_authorizer.go
@@ -112,9 +112,13 @@ func (a *workspaceContentAuthorizer) Authorize(ctx context.Context, attr authori
 	switch logicalCluster.Status.Phase {
 	case corev1alpha1.LogicalClusterPhaseInitializing,
 		corev1alpha1.LogicalClusterPhaseReady,
-		corev1alpha1.LogicalClusterPhaseTerminating:
+		// Terminating: registered terminator controllers are running and need to clean up content.
+		// Deleting: terminators are done; standard kube finalization (GC, namespace deletion,
+		// finalizer removal) still needs content access until the LogicalCluster object is gone.
+		corev1alpha1.LogicalClusterPhaseTerminating,
+		corev1alpha1.LogicalClusterPhaseDeleting:
 		// allowed
-	default: // Scheduling, Deleting, Unknown, or any future phases are not allowed to access workspace content
+	default: // Scheduling, Unavailable, Unknown, or any future phases are not allowed to access workspace content
 		return authorizer.DecisionNoOpinion, fmt.Sprintf("not permitted due to phase %q", logicalCluster.Status.Phase), nil
 	}
 

--- a/pkg/reconciler/core/logicalcluster/logicalcluster_reconcile_metadata.go
+++ b/pkg/reconciler/core/logicalcluster/logicalcluster_reconcile_metadata.go
@@ -39,9 +39,6 @@ func (r *metaDataReconciler) reconcile(ctx context.Context, logicalCluster *core
 	changed := false
 
 	expected := string(logicalCluster.Status.Phase)
-	if !logicalCluster.DeletionTimestamp.IsZero() {
-		expected = string(corev1alpha1.LogicalClusterPhaseDeleting)
-	}
 	if got := logicalCluster.Labels[tenancyv1alpha1.WorkspacePhaseLabel]; got != expected {
 		if logicalCluster.Labels == nil {
 			logicalCluster.Labels = map[string]string{}

--- a/pkg/reconciler/core/logicalcluster/logicalcluster_reconcile_metadata_test.go
+++ b/pkg/reconciler/core/logicalcluster/logicalcluster_reconcile_metadata_test.go
@@ -66,13 +66,31 @@ func TestReconcileMetadata(t *testing.T) {
 			wantStatus: reconcileStatusStopAndRequeue,
 		},
 		{
-			name: "shows phase Deleting when deletion timestamp is set",
+			name: "label tracks Terminating phase",
 			input: &corev1alpha1.LogicalCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					DeletionTimestamp: &metav1.Time{Time: date},
 				},
 				Status: corev1alpha1.LogicalClusterStatus{
-					Phase: corev1alpha1.LogicalClusterPhaseReady,
+					Phase: corev1alpha1.LogicalClusterPhaseTerminating,
+				},
+			},
+			expected: metav1.ObjectMeta{
+				DeletionTimestamp: &metav1.Time{Time: date},
+				Labels: map[string]string{
+					"tenancy.kcp.io/phase": string(corev1alpha1.LogicalClusterPhaseTerminating),
+				},
+			},
+			wantStatus: reconcileStatusStopAndRequeue,
+		},
+		{
+			name: "label tracks Deleting phase",
+			input: &corev1alpha1.LogicalCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &metav1.Time{Time: date},
+				},
+				Status: corev1alpha1.LogicalClusterStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseDeleting,
 				},
 			},
 			expected: metav1.ObjectMeta{

--- a/pkg/reconciler/core/logicalcluster/logicalcluster_reconcile_phase.go
+++ b/pkg/reconciler/core/logicalcluster/logicalcluster_reconcile_phase.go
@@ -28,6 +28,26 @@ import (
 type phaseReconciler struct{}
 
 func (r *phaseReconciler) reconcile(ctx context.Context, workspace *corev1alpha1.LogicalCluster) (reconcileStatus, error) {
+	if !workspace.DeletionTimestamp.IsZero() {
+		// terminator controllers operate during the Terminating phase. Once they have all
+		// removed themselves from status.terminators, transition to Deleting so that the
+		// workspace content authorizer stops permitting access and the cluster can be
+		// finalized.
+		switch {
+		case len(workspace.Status.Terminators) > 0:
+			if workspace.Status.Phase != corev1alpha1.LogicalClusterPhaseTerminating {
+				workspace.Status.Phase = corev1alpha1.LogicalClusterPhaseTerminating
+				return reconcileStatusContinue, nil
+			}
+		default:
+			if workspace.Status.Phase != corev1alpha1.LogicalClusterPhaseDeleting {
+				workspace.Status.Phase = corev1alpha1.LogicalClusterPhaseDeleting
+				return reconcileStatusContinue, nil
+			}
+		}
+		return reconcileStatusContinue, nil
+	}
+
 	switch workspace.Status.Phase {
 	case "", corev1alpha1.LogicalClusterPhaseScheduling:
 		// A LogicalCluster object's placement is the shard it lives on, so its

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_metadata.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_metadata.go
@@ -44,9 +44,6 @@ func (r *metaDataReconciler) reconcile(ctx context.Context, workspace *tenancyv1
 	}
 
 	expected := string(workspace.Status.Phase)
-	if !workspace.DeletionTimestamp.IsZero() {
-		expected = "Deleting"
-	}
 	if got := workspace.Labels[tenancyv1alpha1.WorkspacePhaseLabel]; got != expected {
 		if workspace.Labels == nil {
 			workspace.Labels = map[string]string{}

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_metadata_test.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_metadata_test.go
@@ -68,19 +68,37 @@ func TestReconcileMetadata(t *testing.T) {
 			wantStatus: reconcileStatusStopAndRequeue,
 		},
 		{
-			name: "shows phase Deleting when deletion timestamp is set",
+			name: "label tracks Terminating phase",
 			input: &tenancyv1alpha1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					DeletionTimestamp: &metav1.Time{Time: date},
 				},
 				Status: tenancyv1alpha1.WorkspaceStatus{
-					Phase: corev1alpha1.LogicalClusterPhaseReady,
+					Phase: corev1alpha1.LogicalClusterPhaseTerminating,
 				},
 			},
 			expected: metav1.ObjectMeta{
 				DeletionTimestamp: &metav1.Time{Time: date},
 				Labels: map[string]string{
-					"tenancy.kcp.io/phase": "Deleting",
+					"tenancy.kcp.io/phase": string(corev1alpha1.LogicalClusterPhaseTerminating),
+				},
+			},
+			wantStatus: reconcileStatusStopAndRequeue,
+		},
+		{
+			name: "label tracks Deleting phase",
+			input: &tenancyv1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &metav1.Time{Time: date},
+				},
+				Status: tenancyv1alpha1.WorkspaceStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseDeleting,
+				},
+			},
+			expected: metav1.ObjectMeta{
+				DeletionTimestamp: &metav1.Time{Time: date},
+				Labels: map[string]string{
+					"tenancy.kcp.io/phase": string(corev1alpha1.LogicalClusterPhaseDeleting),
 				},
 			},
 			wantStatus: reconcileStatusStopAndRequeue,

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_phase.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_phase.go
@@ -102,7 +102,9 @@ func (r *phaseReconciler) reconcile(ctx context.Context, workspace *tenancyv1alp
 			}
 			return reconcileStatusContinue, nil
 
-		case corev1alpha1.LogicalClusterPhaseReady:
+		case corev1alpha1.LogicalClusterPhaseReady,
+			corev1alpha1.LogicalClusterPhaseTerminating,
+			corev1alpha1.LogicalClusterPhaseDeleting:
 			// On delete we need to wait for the logical cluster to be deleted
 			// before we can mark the workspace as deleted.
 			if !workspace.DeletionTimestamp.IsZero() {
@@ -115,6 +117,15 @@ func (r *phaseReconciler) reconcile(ctx context.Context, workspace *tenancyv1alp
 					logger.Info("LogicalCluster disappeared")
 					conditions.MarkTrue(workspace, tenancyv1alpha1.WorkspaceContentDeleted)
 					return reconcileStatusContinue, nil
+				}
+
+				// mirror phase + terminators from the LogicalCluster so that the user-facing
+				// workspace reflects whether terminators are still running (Terminating) or
+				// the cluster is being finalized (Deleting).
+				workspace.Status.Terminators = logicalCluster.Status.Terminators
+				if logicalCluster.Status.Phase == corev1alpha1.LogicalClusterPhaseTerminating ||
+					logicalCluster.Status.Phase == corev1alpha1.LogicalClusterPhaseDeleting {
+					workspace.Status.Phase = logicalCluster.Status.Phase
 				}
 
 				if !conditions.IsTrue(workspace, tenancyv1alpha1.WorkspaceContentDeleted) {
@@ -159,6 +170,14 @@ func (r *phaseReconciler) reconcile(ctx context.Context, workspace *tenancyv1alp
 // updateTerminalConditionPhase checks if the workspace is ready by checking conditions and sets the phase accordingly.
 // It returns true if the phase was changed, false otherwise.
 func updateTerminalConditionPhase(workspace *tenancyv1alpha1.Workspace) bool {
+	// terminating/deleting workspaces are not subject to Unavailable/Ready transitions;
+	// failing conditions (e.g. WorkspaceContentDeleted=False while waiting on
+	// terminators) are expected during termination.
+	if workspace.Status.Phase == corev1alpha1.LogicalClusterPhaseTerminating ||
+		workspace.Status.Phase == corev1alpha1.LogicalClusterPhaseDeleting {
+		return false
+	}
+
 	var notReady bool
 	for _, c := range workspace.Status.Conditions {
 		if c.Status == v1.ConditionFalse && strings.HasPrefix(string(c.Type), "Workspace") {

--- a/pkg/virtual/terminatingworkspaces/builder/build.go
+++ b/pkg/virtual/terminatingworkspaces/builder/build.go
@@ -21,15 +21,20 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httputil"
 	"net/url"
+	"path"
 	"strings"
 
+	authenticationv1 "k8s.io/api/authentication/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/transport"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 
@@ -40,11 +45,13 @@ import (
 	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 	"github.com/kcp-dev/sdk/apis/tenancy/termination"
 	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
+	kcpinformers "github.com/kcp-dev/sdk/client/informers/externalversions"
 	"github.com/kcp-dev/virtual-workspace-framework/framework"
 	virtualworkspacesdynamic "github.com/kcp-dev/virtual-workspace-framework/pkg/dynamic"
 	"github.com/kcp-dev/virtual-workspace-framework/pkg/dynamic/apidefinition"
 	"github.com/kcp-dev/virtual-workspace-framework/pkg/dynamic/apiserver"
 	dynamiccontext "github.com/kcp-dev/virtual-workspace-framework/pkg/dynamic/context"
+	"github.com/kcp-dev/virtual-workspace-framework/pkg/handler"
 	"github.com/kcp-dev/virtual-workspace-framework/pkg/rootapiserver"
 
 	rootphase0 "github.com/kcp-dev/kcp/config/root-phase0"
@@ -56,6 +63,7 @@ import (
 const (
 	wildcardLogicalClustersName = terminatingworkspaces.VirtualWorkspaceName + "-wildcard-logicalclusters"
 	logicalClustersName         = terminatingworkspaces.VirtualWorkspaceName + "-logicalclusters"
+	workspaceContentName        = terminatingworkspaces.VirtualWorkspaceName + "-workspace-content"
 )
 
 // BuildVirtualWorkspace builds the terminating-workspaces virtual workspaces.
@@ -71,6 +79,7 @@ func BuildVirtualWorkspace(
 	rootPathPrefix string,
 	dynamicClusterClient kcpdynamic.ClusterInterface,
 	kubeClusterClient, externalLogicalClusterAdminClient kcpkubernetesclientset.ClusterInterface,
+	wildcardKcpInformers kcpinformers.SharedInformerFactory,
 ) ([]rootapiserver.NamedVirtualWorkspace, error) {
 	if !strings.HasSuffix(rootPathPrefix, "/") {
 		rootPathPrefix += "/"
@@ -166,10 +175,146 @@ func BuildVirtualWorkspace(
 		},
 	}
 
+	workspaceContentReadyCh := make(chan struct{})
+	workspaceContent := &handler.VirtualWorkspace{
+		RootPathResolver: framework.RootPathResolverFunc(func(urlPath string, requestContext context.Context) (accepted bool, prefixToStrip string, completedContext context.Context) {
+			cluster, apiDomain, prefixToStrip, ok := digestUrl(urlPath, rootPathPrefix)
+			if !ok {
+				return false, "", requestContext
+			}
+
+			if cluster.Wildcard {
+				// content access requires a specific cluster
+				return false, "", requestContext
+			}
+
+			// this proxying server does not handle requests for logicalclusters.core.kcp.io
+			resourceURL := strings.TrimPrefix(urlPath, prefixToStrip)
+			if isLogicalClusterRequest(resourceURL) {
+				return false, "", requestContext
+			}
+
+			// in this case since we're proxying and not consuming this request we *do not* want to strip
+			// the cluster prefix
+			prefixToStrip = strings.TrimSuffix(prefixToStrip, cluster.Name.Path().RequestPath())
+
+			completedContext = genericapirequest.WithCluster(requestContext, cluster)
+			completedContext = dynamiccontext.WithAPIDomainKey(completedContext, apiDomain)
+			return true, prefixToStrip, completedContext
+		}),
+		Authorizer: cachingAuthorizer,
+		ReadyChecker: framework.ReadyFunc(func() error {
+			select {
+			case <-workspaceContentReadyCh:
+				return nil
+			default:
+				return fmt.Errorf("%s virtual workspace controllers are not started", workspaceContentName)
+			}
+		}),
+		HandlerFactory: handler.HandlerFactory(func(rootAPIServerConfig genericapiserver.CompletedConfig) (http.Handler, error) {
+			if err := rootAPIServerConfig.AddPostStartHook(workspaceContentName, func(hookContext genericapiserver.PostStartHookContext) error {
+				defer close(workspaceContentReadyCh)
+
+				for name, informer := range map[string]cache.SharedIndexInformer{
+					"logicalclusters": wildcardKcpInformers.Core().V1alpha1().LogicalClusters().Informer(),
+				} {
+					if !cache.WaitForNamedCacheSync(name, hookContext.Done(), informer.HasSynced) {
+						klog.Background().Error(nil, "informer not synced")
+						return nil
+					}
+				}
+
+				return nil
+			}); err != nil {
+				return nil, err
+			}
+
+			forwardedHost, err := url.Parse(cfg.Host)
+			if err != nil {
+				return nil, err
+			}
+
+			lister := wildcardKcpInformers.Core().V1alpha1().LogicalClusters().Lister()
+			return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				cluster, err := genericapirequest.ClusterNameFrom(request.Context())
+				if err != nil {
+					http.Error(writer, fmt.Sprintf("could not determine cluster for request: %v", err), http.StatusInternalServerError)
+					return
+				}
+				logicalCluster, err := lister.Cluster(cluster).Get(corev1alpha1.LogicalClusterName)
+				if err != nil {
+					http.Error(writer, fmt.Sprintf("error getting logicalcluster %s|%s: %v", cluster, corev1alpha1.LogicalClusterName, err), http.StatusInternalServerError)
+					return
+				}
+
+				terminator := corev1alpha1.LogicalClusterTerminator(dynamiccontext.APIDomainKeyFrom(request.Context()))
+				if logicalCluster.DeletionTimestamp.IsZero() || !termination.TerminatorPresent(terminator, logicalCluster.Status.Terminators) {
+					http.Error(writer, fmt.Sprintf("terminator %q cannot access this workspace", terminator), http.StatusForbidden)
+					return
+				}
+
+				if logicalCluster.Spec.CreatedBy == nil {
+					http.Error(writer, fmt.Sprintf("LogicalCluster %s|%s had no createdBy recorded", cluster, corev1alpha1.LogicalClusterName), http.StatusInternalServerError)
+					return
+				}
+				info := authenticationv1.UserInfo{
+					Username: logicalCluster.Spec.CreatedBy.Username,
+					UID:      logicalCluster.Spec.CreatedBy.UID,
+					Groups:   logicalCluster.Spec.CreatedBy.Groups,
+					Extra:    logicalCluster.Spec.CreatedBy.Extra,
+				}
+				extra := map[string][]string{}
+				for k, v := range info.Extra {
+					extra[k] = v
+				}
+
+				thisCfg := rest.CopyConfig(cfg)
+				thisCfg.Impersonate = rest.ImpersonationConfig{
+					UserName: info.Username,
+					UID:      info.UID,
+					Groups:   info.Groups,
+					Extra:    extra,
+				}
+				authenticatingTransport, err := rest.TransportFor(thisCfg)
+				if err != nil {
+					http.Error(writer, fmt.Sprintf("could create round-tripper: %v", err), http.StatusInternalServerError)
+					return
+				}
+				proxy := &httputil.ReverseProxy{
+					Director: func(request *http.Request) {
+						for _, header := range []string{
+							"Authorization",
+							transport.ImpersonateUserHeader,
+							transport.ImpersonateUIDHeader,
+							transport.ImpersonateGroupHeader,
+						} {
+							request.Header.Del(header)
+						}
+						for key := range request.Header {
+							if strings.HasPrefix(key, transport.ImpersonateUserExtraHeaderPrefix) {
+								request.Header.Del(key)
+							}
+						}
+						request.URL.Scheme = forwardedHost.Scheme
+						request.URL.Host = forwardedHost.Host
+					},
+					Transport: authenticatingTransport,
+				}
+				proxy.ServeHTTP(writer, request)
+			}), nil
+		}),
+	}
+
 	return []rootapiserver.NamedVirtualWorkspace{
 		{Name: wildcardLogicalClustersName, VirtualWorkspace: wildcardLogicalClusters},
 		{Name: logicalClustersName, VirtualWorkspace: logicalClusters},
+		{Name: workspaceContentName, VirtualWorkspace: workspaceContent},
 	}, nil
+}
+
+// URLFor returns the absolute path for the specified terminator.
+func URLFor(terminatorName corev1alpha1.LogicalClusterTerminator) string {
+	return path.Join("/services", terminatingworkspaces.VirtualWorkspaceName, string(terminatorName))
 }
 
 var resolver = requestinfo.NewFactory()

--- a/pkg/virtual/terminatingworkspaces/options/options.go
+++ b/pkg/virtual/terminatingworkspaces/options/options.go
@@ -83,5 +83,5 @@ func (o *TerminatingWorkspaces) NewVirtualWorkspaces(
 		}
 	}
 
-	return builder.BuildVirtualWorkspace(config, path.Join(rootPathPrefix, terminatingworkspaces.VirtualWorkspaceName), dynamicClusterClient, kubeClusterClient, externalLogicalClusterAdminClient)
+	return builder.BuildVirtualWorkspace(config, path.Join(rootPathPrefix, terminatingworkspaces.VirtualWorkspaceName), dynamicClusterClient, kubeClusterClient, externalLogicalClusterAdminClient, wildcardKcpInformers)
 }

--- a/staging/src/github.com/kcp-dev/sdk/apis/core/v1alpha1/logicalcluster_types.go
+++ b/staging/src/github.com/kcp-dev/sdk/apis/core/v1alpha1/logicalcluster_types.go
@@ -60,7 +60,7 @@ const (
 
 // LogicalClusterPhaseType is the type of the current phase of the logical cluster.
 //
-// +kubebuilder:validation:Enum=Scheduling;Initializing;Ready;Unavailable
+// +kubebuilder:validation:Enum=Scheduling;Initializing;Ready;Unavailable;Terminating;Deleting
 type LogicalClusterPhaseType string
 
 const (
@@ -73,7 +73,14 @@ const (
 	// This should be used when we really can't serve the logical cluster content and not some
 	// temporary flakes, like readiness probe failing.
 	LogicalClusterPhaseUnavailable LogicalClusterPhaseType = "Unavailable"
-	LogicalClusterPhaseDeleting    LogicalClusterPhaseType = "Deleting"
+	// LogicalClusterPhaseTerminating phase is used to indicate that the logical cluster has a
+	// DeletionTimestamp set and is waiting on terminator controllers to clean up workspace
+	// content. The cluster is still served (the workspace content authorizer permits access)
+	// so that terminator controllers can act on resources before deletion.
+	LogicalClusterPhaseTerminating LogicalClusterPhaseType = "Terminating"
+	// LogicalClusterPhaseDeleting phase is used to indicate that all terminators have completed
+	// and the logical cluster is being deleted. No content access is permitted in this phase.
+	LogicalClusterPhaseDeleting LogicalClusterPhaseType = "Deleting"
 )
 
 // LogicalClusterInitializer is a unique string corresponding to a logical cluster
@@ -218,7 +225,7 @@ type LogicalClusterStatus struct {
 
 	// Terminators are set on creation by the system and must be cleared
 	// by a controller before the logical cluster can be deleted. The LogicalCluster object
-	// will stay in the phase "Deleting" until all terminator are cleared.
+	// will stay in the phase "Terminating" until all terminator are cleared.
 	//
 	// +optional
 	Terminators []LogicalClusterTerminator `json:"terminators,omitempty"`

--- a/staging/src/github.com/kcp-dev/sdk/apis/tenancy/termination/utils.go
+++ b/staging/src/github.com/kcp-dev/sdk/apis/tenancy/termination/utils.go
@@ -19,6 +19,7 @@ package termination
 import (
 	"crypto/sha256"
 	"fmt"
+	"slices"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -31,6 +32,11 @@ import (
 // TerminatorForType determines the identifier for the implicit terminator associated with the WorkspaceType.
 func TerminatorForType(wt *tenancyv1alpha1.WorkspaceType) corev1alpha1.LogicalClusterTerminator {
 	return corev1alpha1.LogicalClusterTerminator(logicalcluster.From(wt).Path().Join(wt.Name).String())
+}
+
+// TerminatorPresent returns true if the given terminator is in the list of terminators.
+func TerminatorPresent(terminator corev1alpha1.LogicalClusterTerminator, terminators []corev1alpha1.LogicalClusterTerminator) bool {
+	return slices.Contains(terminators, terminator)
 }
 
 // TypeFrom determines the WorkspaceType workspace and name from an terminator name.

--- a/staging/src/github.com/kcp-dev/sdk/client/applyconfiguration/core/v1alpha1/logicalclusterstatus.go
+++ b/staging/src/github.com/kcp-dev/sdk/client/applyconfiguration/core/v1alpha1/logicalclusterstatus.go
@@ -42,7 +42,7 @@ type LogicalClusterStatusApplyConfiguration struct {
 	Initializers []corev1alpha1.LogicalClusterInitializer `json:"initializers,omitempty"`
 	// Terminators are set on creation by the system and must be cleared
 	// by a controller before the logical cluster can be deleted. The LogicalCluster object
-	// will stay in the phase "Deleting" until all terminator are cleared.
+	// will stay in the phase "Terminating" until all terminator are cleared.
 	Terminators []corev1alpha1.LogicalClusterTerminator `json:"terminators,omitempty"`
 }
 

--- a/staging/src/github.com/kcp-dev/sdk/openapi/zz_generated.openapi.go
+++ b/staging/src/github.com/kcp-dev/sdk/openapi/zz_generated.openapi.go
@@ -3827,7 +3827,7 @@ func schema_sdk_apis_core_v1alpha1_LogicalClusterStatus(ref common.ReferenceCall
 					},
 					"terminators": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Terminators are set on creation by the system and must be cleared by a controller before the logical cluster can be deleted. The LogicalCluster object will stay in the phase \"Deleting\" until all terminator are cleared.",
+							Description: "Terminators are set on creation by the system and must be cleared by a controller before the logical cluster can be deleted. The LogicalCluster object will stay in the phase \"Terminating\" until all terminator are cleared.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/test/e2e/virtual/terminatingworkspaces/virtualworkspace_test.go
+++ b/test/e2e/virtual/terminatingworkspaces/virtualworkspace_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -846,4 +847,240 @@ func randSuffix() string {
 		b[i] = characters[rand.Intn(len(characters))]
 	}
 	return string(b)
+}
+
+// TestTerminatingWorkspacesVirtualWorkspaceContentAccess exercises the workspace-content
+// sub-resource of the terminating virtual workspace. It verifies that:
+//
+//   - a controller with the "terminate" verb on the workspacetype can reach workspace
+//     content (configmaps) via the VW's reverse proxy while the workspace is in the
+//     Terminating phase,
+//   - a user without the "terminate" verb is rejected by the VW authorizer,
+//   - once the controller removes its terminator from status.terminators, the workspace
+//     transitions to the Deleting phase and content access is no longer permitted.
+func TestTerminatingWorkspacesVirtualWorkspaceContentAccess(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "control-plane")
+
+	source := kcptesting.SharedKcpServer(t)
+	wsPath, _ := kcptesting.NewWorkspaceFixture(t, source, core.RootCluster.Path())
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	t.Cleanup(cancelFunc)
+
+	sourceConfig := source.BaseConfig(t)
+
+	sourceKcpClusterClient, err := kcpclientset.NewForConfig(sourceConfig)
+	require.NoError(t, err)
+
+	kubeClusterClient, err := kcpkubernetesclientset.NewForConfig(sourceConfig)
+	require.NoError(t, err)
+
+	const username = "user-1"
+	framework.AdmitWorkspaceAccess(ctx, t, kubeClusterClient, wsPath, []string{username}, nil, false)
+
+	t.Log("Create a workspacetype that requires a terminator")
+	wst := &tenancyv1alpha1.WorkspaceType{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "content-" + randSuffix(),
+		},
+		Spec: tenancyv1alpha1.WorkspaceTypeSpec{
+			Terminator: true,
+		},
+	}
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		_, err := sourceKcpClusterClient.TenancyV1alpha1().Cluster(wsPath).WorkspaceTypes().Create(ctx, wst, metav1.CreateOptions{})
+		require.NoError(c, err)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond)
+	source.Artifact(t, func() (runtime.Object, error) {
+		return sourceKcpClusterClient.TenancyV1alpha1().Cluster(wsPath).WorkspaceTypes().Get(ctx, wst.Name, metav1.GetOptions{})
+	})
+
+	t.Log("Wait for WorkspaceType and its virtual workspace URLs to be ready")
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		wst, err = sourceKcpClusterClient.TenancyV1alpha1().Cluster(wsPath).WorkspaceTypes().Get(ctx, wst.Name, metav1.GetOptions{})
+		require.NoError(c, err)
+		require.NotEmpty(c, wst.Status.VirtualWorkspaces)
+		require.True(c, conditions.IsTrue(wst, tenancyv1alpha1.WorkspaceTypeVirtualWorkspaceURLsReady))
+		require.True(c, conditions.IsTrue(wst, conditionsv1alpha1.ReadyCondition))
+	}, wait.ForeverTestTimeout, 100*time.Millisecond)
+
+	t.Log("Create a workspace of that type and wait until it is ready with a terminator in status")
+	ws := workspaceForType(wst, map[string]string{"internal.kcp.io/e2e-test": t.Name()})
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		ws, err = sourceKcpClusterClient.TenancyV1alpha1().Cluster(wsPath).Workspaces().Create(ctx, ws, metav1.CreateOptions{})
+		require.NoError(c, err)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond)
+	source.Artifact(t, func() (runtime.Object, error) {
+		return sourceKcpClusterClient.TenancyV1alpha1().Cluster(wsPath).Workspaces().Get(ctx, ws.Name, metav1.GetOptions{})
+	})
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		ws, err = sourceKcpClusterClient.TenancyV1alpha1().Cluster(wsPath).Workspaces().Get(ctx, ws.Name, metav1.GetOptions{})
+		require.NoError(c, err)
+		require.Contains(c, ws.Annotations, "internal.tenancy.kcp.io/shard")
+		require.Equal(c, corev1alpha1.LogicalClusterPhaseReady, ws.Status.Phase)
+		require.NotEmpty(c, ws.Status.Terminators)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond)
+
+	wsClusterName := logicalcluster.Name(ws.Spec.Cluster)
+
+	t.Log("Create a namespace and a configmap inside the workspace as admin (will be accessed later through the VW)")
+	// A finalizer is needed because once the workspace enters Terminating, GC will
+	// race the test and remove the configmap before the terminator gets to read it.
+	const nsName = "terminator-content-test"
+	const cmName = "terminator-target"
+	const cmFinalizer = "e2e.kcp.io/terminator-content-test"
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		_, err := kubeClusterClient.Cluster(wsClusterName.Path()).CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: nsName},
+		}, metav1.CreateOptions{})
+		if !errors.IsAlreadyExists(err) {
+			require.NoError(c, err)
+		}
+	}, wait.ForeverTestTimeout, 100*time.Millisecond)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		_, err := kubeClusterClient.Cluster(wsClusterName.Path()).CoreV1().ConfigMaps(nsName).Create(ctx, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       cmName,
+				Finalizers: []string{cmFinalizer},
+			},
+			Data: map[string]string{"key": "value"},
+		}, metav1.CreateOptions{})
+		if errors.IsAlreadyExists(err) {
+			return
+		}
+		require.NoError(c, err)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond)
+
+	t.Log("Grant user-1 the terminate verb on the workspacetype")
+	terminator := termination.TerminatorForType(wst)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		_, err := kubeClusterClient.Cluster(wsPath).RbacV1().ClusterRoles().Create(ctx, &rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{Name: string(terminator) + "-terminator"},
+			Rules: []rbacv1.PolicyRule{{
+				Verbs:         []string{"terminate"},
+				Resources:     []string{"workspacetypes"},
+				ResourceNames: []string{wst.Name},
+				APIGroups:     []string{"tenancy.kcp.io"},
+			}},
+		}, metav1.CreateOptions{})
+		if !errors.IsAlreadyExists(err) {
+			require.NoError(c, err)
+		}
+		_, err = kubeClusterClient.Cluster(wsPath).RbacV1().ClusterRoleBindings().Create(ctx, &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: string(terminator) + "-terminator"},
+			RoleRef: rbacv1.RoleRef{
+				Kind:     "ClusterRole",
+				APIGroup: "rbac.authorization.k8s.io",
+				Name:     string(terminator) + "-terminator",
+			},
+			Subjects: []rbacv1.Subject{{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "User",
+				Name:     username,
+			}},
+		}, metav1.CreateOptions{})
+		if !errors.IsAlreadyExists(err) {
+			require.NoError(c, err)
+		}
+	}, wait.ForeverTestTimeout, 100*time.Millisecond)
+
+	t.Log("Trigger termination of the workspace")
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		err := sourceKcpClusterClient.TenancyV1alpha1().Cluster(wsPath).Workspaces().Delete(ctx, ws.Name, metav1.DeleteOptions{})
+		require.NoError(c, err)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond)
+
+	t.Log("Wait until the workspace reaches the Terminating phase with our terminator present")
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		ws, err = sourceKcpClusterClient.TenancyV1alpha1().Cluster(wsPath).Workspaces().Get(ctx, ws.Name, metav1.GetOptions{})
+		require.NoError(c, err)
+		require.False(c, ws.GetDeletionTimestamp().IsZero())
+		require.Equal(c, corev1alpha1.LogicalClusterPhaseTerminating, ws.Status.Phase)
+		require.Contains(c, ws.Status.Terminators, terminator)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond)
+
+	t.Log("Pick the VW URL on the shard the workspace lives on")
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		wst, err = sourceKcpClusterClient.TenancyV1alpha1().Cluster(wsPath).WorkspaceTypes().Get(ctx, wst.Name, metav1.GetOptions{})
+		require.NoError(c, err)
+		require.NotEmpty(c, wst.Status.VirtualWorkspaces)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond)
+
+	vwURLs := []string{}
+	for _, vwURL := range wst.Status.VirtualWorkspaces {
+		if strings.Contains(vwURL.URL, terminatingworkspaces.VirtualWorkspaceName) {
+			vwURLs = append(vwURLs, vwURL.URL)
+		}
+	}
+	require.NotEmpty(t, vwURLs, "expected at least one terminating VW URL on the workspacetype")
+
+	targetVwURL, found, err := framework.VirtualWorkspaceURL(ctx, sourceKcpClusterClient, ws, vwURLs)
+	require.NoError(t, err)
+	require.True(t, found, "no terminating VW URL matched the workspace shard")
+
+	vwConfig := rest.AddUserAgent(rest.CopyConfig(sourceConfig), t.Name()+"-virtual")
+	vwConfig.Host = targetVwURL
+
+	user1VwKubeClient, err := kcpkubernetesclientset.NewForConfig(framework.StaticTokenUserConfig(username, vwConfig))
+	require.NoError(t, err)
+
+	t.Log("Terminator controller (user-1) reads the configmap through the content proxy")
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		cm, err := user1VwKubeClient.Cluster(wsClusterName.Path()).CoreV1().ConfigMaps(nsName).Get(ctx, cmName, metav1.GetOptions{})
+		require.NoError(c, err)
+		require.Equal(c, "value", cm.Data["key"])
+	}, wait.ForeverTestTimeout, 100*time.Millisecond)
+
+	t.Log("Terminator controller can also mutate workspace content (clear the finalizer + delete)")
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		cm, err := user1VwKubeClient.Cluster(wsClusterName.Path()).CoreV1().ConfigMaps(nsName).Get(ctx, cmName, metav1.GetOptions{})
+		require.NoError(c, err)
+		cm.Finalizers = nil
+		_, err = user1VwKubeClient.Cluster(wsClusterName.Path()).CoreV1().ConfigMaps(nsName).Update(ctx, cm, metav1.UpdateOptions{})
+		require.NoError(c, err)
+		err = user1VwKubeClient.Cluster(wsClusterName.Path()).CoreV1().ConfigMaps(nsName).Delete(ctx, cmName, metav1.DeleteOptions{})
+		if !errors.IsNotFound(err) {
+			require.NoError(c, err)
+		}
+	}, wait.ForeverTestTimeout, 100*time.Millisecond)
+
+	t.Log("A user without the terminate verb is rejected by the VW authorizer")
+	user2VwKubeClient, err := kcpkubernetesclientset.NewForConfig(framework.StaticTokenUserConfig("user-2", vwConfig))
+	require.NoError(t, err)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		_, err := user2VwKubeClient.Cluster(wsClusterName.Path()).CoreV1().ConfigMaps(nsName).List(ctx, metav1.ListOptions{})
+		require.True(c, errors.IsForbidden(err), "expected forbidden, got: %v", err)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond)
+
+	t.Log("Remove our terminator via the terminating VW's logicalclusters endpoint so the workspace transitions to Deleting")
+	user1VwKcpClient, err := kcpclientset.NewForConfig(framework.StaticTokenUserConfig(username, vwConfig))
+	require.NoError(t, err)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		lc, err := user1VwKcpClient.Cluster(wsClusterName.Path()).CoreV1alpha1().LogicalClusters().Get(ctx, corev1alpha1.LogicalClusterName, metav1.GetOptions{})
+		require.NoError(c, err)
+		mod := lc.DeepCopy()
+		mod.Status.Terminators = removeByValue(mod.Status.Terminators, terminator)
+		patch, err := generatePatchBytes(lc, mod)
+		require.NoError(c, err)
+		_, err = user1VwKcpClient.Cluster(wsClusterName.Path()).CoreV1alpha1().LogicalClusters().Patch(ctx, corev1alpha1.LogicalClusterName, types.MergePatchType, patch, metav1.PatchOptions{}, "status")
+		require.NoError(c, err)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond)
+
+	t.Log("After removing the terminator the content proxy must reject access")
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		_, err := user1VwKubeClient.Cluster(wsClusterName.Path()).CoreV1().ConfigMaps(nsName).List(ctx, metav1.ListOptions{})
+		require.Error(c, err, "expected an error after terminator removal, got nil")
+		// Either the content proxy rejects the request directly (terminator no longer
+		// in status.terminators), or the workspace has already finished deleting and
+		// the request is rejected by the front proxy / authorizer.
+		require.True(c, errors.IsForbidden(err) || errors.IsNotFound(err) || errors.IsServiceUnavailable(err),
+			"expected forbidden/notfound/unavailable, got: %v", err)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond)
+
+	t.Log("Workspace is eventually fully deleted")
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		_, err := sourceKcpClusterClient.TenancyV1alpha1().Cluster(wsPath).Workspaces().Get(ctx, ws.Name, metav1.GetOptions{})
+		require.True(c, errors.IsNotFound(err), "workspace not deleted yet, err: %v", err)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond)
 }


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

This adds a content proxy for terminating the virtual workspace and adds a new phase, `Terminating`, to indicate that the workspace is being deleted but is locked by the terminator. 

<img width="700" height="394" alt="image" src="https://github.com/user-attachments/assets/9d48c87f-6fcf-41e2-8948-502e089b46f7" />



## What Type of PR Is This?
/kind feature

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes https://github.com/kcp-dev/kcp/issues/4018

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Add a content proxy to the terminating VirtualWorkspace
Add phase Terminating to Workspace and LogicalCluster to indicate terminating state
```
