### PR TITLE
Add aditional validation for WST

### DIFF
--- a/pkg/admission/workspacetype/admission.go
+++ b/pkg/admission/workspacetype/admission.go
@@ -18,6 +18,7 @@ package workspacetype
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
@@ -26,13 +27,32 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/admission"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
 
+	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
+	"github.com/kcp-dev/logicalcluster/v3"
+	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
 	"github.com/kcp-dev/sdk/apis/core"
 	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
+	kcpinformers "github.com/kcp-dev/sdk/client/informers/externalversions"
+
+	apibindingadmission "github.com/kcp-dev/kcp/pkg/admission/apibinding"
+	kcpinitializers "github.com/kcp-dev/kcp/pkg/admission/initializers"
+	"github.com/kcp-dev/kcp/pkg/authorization/delegated"
+	"github.com/kcp-dev/kcp/pkg/indexers"
 )
 
 // Validate WorkspaceTypes creation and updates for
-//  - "organization" type is only created in root workspace.
+//   - the "root" WorkspaceType can only be created in the root cluster.
+//   - .spec.defaultChildWorkspaceType.path, .spec.limitAllowedChildren.types[*].path,
+//     and .spec.limitAllowedParents.types[*].path must be set when their parent
+//     fields are present.
+//   - the user has the "bind" verb on every APIExport listed in
+//     spec.defaultAPIBindings (newly added entries on update). This prevents
+//     a privilege escalation where unprivileged users would otherwise cause
+//     the default-apibinding-controller to create APIBindings on their behalf
+//     to APIExports they cannot bind directly.
 
 const (
 	PluginName = "tenancy.kcp.io/WorkspaceType"
@@ -41,18 +61,36 @@ const (
 func Register(plugins *admission.Plugins) {
 	plugins.Register(PluginName,
 		func(_ io.Reader) (admission.Interface, error) {
-			return &workspacetype{
-				Handler: admission.NewHandler(admission.Create, admission.Update),
-			}, nil
+			p := &workspacetype{
+				Handler:          admission.NewHandler(admission.Create, admission.Update),
+				createAuthorizer: delegated.NewDelegatedAuthorizer,
+			}
+			p.getAPIExport = func(path logicalcluster.Path, name string) (*apisv1alpha2.APIExport, error) {
+				return indexers.ByPathAndNameWithFallback[*apisv1alpha2.APIExport](apisv1alpha2.Resource("apiexports"), p.apiExportIndexer, p.cacheAPIExportIndexer, path, name)
+			}
+			return p, nil
 		})
 }
 
 type workspacetype struct {
 	*admission.Handler
+
+	getAPIExport func(path logicalcluster.Path, name string) (*apisv1alpha2.APIExport, error)
+
+	apiExportIndexer      cache.Indexer
+	cacheAPIExportIndexer cache.Indexer
+
+	deepSARClient    kcpkubernetesclientset.ClusterInterface
+	createAuthorizer delegated.DelegatedAuthorizerFactory
 }
 
 // Ensure that the required admission interfaces are implemented.
-var _ = admission.ValidationInterface(&workspacetype{})
+var (
+	_ = admission.ValidationInterface(&workspacetype{})
+	_ = admission.InitializationValidator(&workspacetype{})
+	_ = kcpinitializers.WantsKcpInformers(&workspacetype{})
+	_ = kcpinitializers.WantsDeepSARClient(&workspacetype{})
+)
 
 func (o *workspacetype) Validate(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) (err error) {
 	clusterName, err := genericapirequest.ClusterNameFrom(ctx)
@@ -97,5 +135,132 @@ func (o *workspacetype) Validate(ctx context.Context, a admission.Attributes, _ 
 		}
 	}
 
+	return o.checkDefaultAPIBindingsPermissions(ctx, a, clusterName, wt)
+}
+
+// checkDefaultAPIBindingsPermissions ensures the user creating or updating the
+// WorkspaceType has the "bind" verb on every APIExport newly added to
+// spec.defaultAPIBindings. The default-apibinding-controller later creates
+// APIBindings to these exports using its own (system) credentials, so without
+// this check unprivileged users could indirectly bind APIExports they have no
+// "bind" permission on.
+func (o *workspacetype) checkDefaultAPIBindingsPermissions(ctx context.Context, a admission.Attributes, clusterName logicalcluster.Name, wt *tenancyv1alpha1.WorkspaceType) error {
+	if len(wt.Spec.DefaultAPIBindings) == 0 {
+		return nil
+	}
+
+	if !o.WaitForReady() {
+		return admission.NewForbidden(a, errors.New("not yet ready to handle request"))
+	}
+
+	// `grandfathered` holds the entries that should be skipped by the permission
+	// check below.
+	//
+	//   * On Create: stays nil. Reads from a nil map return (zero, false), so
+	//     nothing is skipped and *every* binding in wt.Spec.DefaultAPIBindings
+	//     is checked. This is the primary entry point for the permission gate.
+	//
+	//   * On Update: populated from the old object's bindings. Entries present
+	//     in the old object are "grandfathered" — they were already validated
+	//     when the WorkspaceType was created (or, for objects predating this
+	//     check, predate it entirely). Only newly added bindings are checked,
+	//     so a user without bind permission on an unrelated existing entry can
+	//     still perform legitimate updates.
+	var grandfathered map[tenancyv1alpha1.APIExportReference]struct{}
+	if a.GetOperation() == admission.Update {
+		oldU, ok := a.GetOldObject().(*unstructured.Unstructured)
+		if !ok {
+			return fmt.Errorf("unexpected type %T", a.GetOldObject())
+		}
+		oldWT := &tenancyv1alpha1.WorkspaceType{}
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(oldU.Object, oldWT); err != nil {
+			return fmt.Errorf("failed to convert old unstructured to WorkspaceType: %w", err)
+		}
+		grandfathered = make(map[tenancyv1alpha1.APIExportReference]struct{}, len(oldWT.Spec.DefaultAPIBindings))
+		for _, ref := range oldWT.Spec.DefaultAPIBindings {
+			grandfathered[ref] = struct{}{}
+		}
+	}
+
+	for _, ref := range wt.Spec.DefaultAPIBindings {
+		// Skip grandfathered entries on Update; on Create the map is nil so this
+		// is always false and every entry falls through to the permission check.
+		if _, ok := grandfathered[ref]; ok {
+			continue
+		}
+
+		exportPath := ref.Path
+		exportName := ref.Export
+
+		// unified forbidden error that does not leak workspace existence
+		forbidden := admission.NewForbidden(a, fmt.Errorf("unable to create or update WorkspaceType: no permission to bind to export %s",
+			logicalcluster.NewPath(exportPath).Join(exportName).String()))
+
+		// Resolve the APIExport's cluster. An empty path means the same cluster
+		// as the WorkspaceType being admitted (matching the reconciler's behavior).
+		var exportClusterName logicalcluster.Name
+		switch {
+		case exportPath == "":
+			exportClusterName = clusterName
+		case exportPath == core.RootCluster.String():
+			exportClusterName = core.RootCluster
+		default:
+			path := logicalcluster.NewPath(exportPath)
+			export, err := o.getAPIExport(path, exportName)
+			if err != nil {
+				return forbidden
+			}
+			exportClusterName = logicalcluster.From(export)
+		}
+
+		if err := o.checkAPIExportAccess(ctx, a, exportClusterName, exportName); err != nil {
+			return forbidden
+		}
+	}
+
 	return nil
+}
+
+func (o *workspacetype) checkAPIExportAccess(ctx context.Context, a admission.Attributes, apiExportClusterName logicalcluster.Name, apiExportName string) error {
+	logger := klog.FromContext(ctx)
+	authz, err := o.createAuthorizer(apiExportClusterName, o.deepSARClient, delegated.Options{})
+	if err != nil {
+		logger.Error(err, "error creating authorizer from delegating authorizer config")
+		return errors.New("unable to authorize request")
+	}
+	return apibindingadmission.CheckAPIExportAccess(ctx, a.GetUserInfo(), apiExportName, authz)
+}
+
+func (o *workspacetype) ValidateInitialization() error {
+	if o.deepSARClient == nil {
+		return fmt.Errorf(PluginName + " plugin needs a deepSARClient")
+	}
+	if o.apiExportIndexer == nil {
+		return fmt.Errorf(PluginName + " plugin needs an APIExport indexer")
+	}
+	if o.cacheAPIExportIndexer == nil {
+		return fmt.Errorf(PluginName + " plugin needs a cache APIExport indexer")
+	}
+	return nil
+}
+
+func (o *workspacetype) SetDeepSARClient(client kcpkubernetesclientset.ClusterInterface) {
+	o.deepSARClient = client
+}
+
+func (o *workspacetype) SetKcpInformers(local, global kcpinformers.SharedInformerFactory) {
+	apiExportsReady := local.Apis().V1alpha2().APIExports().Informer().HasSynced
+	cacheAPIExportsReady := global.Apis().V1alpha2().APIExports().Informer().HasSynced
+	o.SetReadyFunc(func() bool {
+		return apiExportsReady() && cacheAPIExportsReady()
+	})
+	o.apiExportIndexer = local.Apis().V1alpha2().APIExports().Informer().GetIndexer()
+	o.cacheAPIExportIndexer = global.Apis().V1alpha2().APIExports().Informer().GetIndexer()
+
+	indexers.AddIfNotPresentOrDie(local.Apis().V1alpha2().APIExports().Informer().GetIndexer(), cache.Indexers{
+		indexers.ByLogicalClusterPathAndName: indexers.IndexByLogicalClusterPathAndName,
+	})
+	indexers.AddIfNotPresentOrDie(global.Apis().V1alpha2().APIExports().Informer().GetIndexer(), cache.Indexers{
+		indexers.ByLogicalClusterPathAndName: indexers.IndexByLogicalClusterPathAndName,
+	})
 }

--- a/pkg/admission/workspacetype/admission_test.go
+++ b/pkg/admission/workspacetype/admission_test.go
@@ -1,0 +1,238 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workspacetype
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
+	"github.com/kcp-dev/logicalcluster/v3"
+	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
+	"github.com/kcp-dev/sdk/apis/core"
+	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
+
+	"github.com/kcp-dev/kcp/pkg/authorization/delegated"
+)
+
+func toUnstructured(t *testing.T, obj runtime.Object) *unstructured.Unstructured {
+	t.Helper()
+	raw, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		t.Fatalf("failed to convert to unstructured: %v", err)
+	}
+	return &unstructured.Unstructured{Object: raw}
+}
+
+func makeAttr(t *testing.T, op admission.Operation, newWT, oldWT *tenancyv1alpha1.WorkspaceType, userInfo user.Info) admission.Attributes {
+	t.Helper()
+	var oldObj runtime.Object
+	if oldWT != nil {
+		oldObj = toUnstructured(t, oldWT)
+	}
+	if userInfo == nil {
+		userInfo = &user.DefaultInfo{Name: "alice"}
+	}
+	return admission.NewAttributesRecord(
+		toUnstructured(t, newWT),
+		oldObj,
+		tenancyv1alpha1.Kind("WorkspaceType").WithVersion("v1alpha1"),
+		"",
+		newWT.Name,
+		tenancyv1alpha1.Resource("workspacetypes").WithVersion("v1alpha1"),
+		"",
+		op,
+		&metav1.CreateOptions{},
+		false,
+		userInfo,
+	)
+}
+
+func newWorkspaceType(cluster logicalcluster.Name, name string, refs ...tenancyv1alpha1.APIExportReference) *tenancyv1alpha1.WorkspaceType {
+	wt := &tenancyv1alpha1.WorkspaceType{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: tenancyv1alpha1.SchemeGroupVersion.String(),
+			Kind:       "WorkspaceType",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Annotations: map[string]string{logicalcluster.AnnotationKey: cluster.String()},
+		},
+	}
+	if len(refs) > 0 {
+		wt.Spec.DefaultAPIBindings = refs
+	}
+	return wt
+}
+
+type fakeAuthorizer struct {
+	decision authorizer.Decision
+	err      error
+}
+
+func (a *fakeAuthorizer) Authorize(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+	return a.decision, "", a.err
+}
+
+func newPlugin(decision authorizer.Decision, exports ...*apisv1alpha2.APIExport) *workspacetype {
+	exportMap := make(map[string]*apisv1alpha2.APIExport, len(exports))
+	for _, e := range exports {
+		exportMap[logicalcluster.From(e).String()+"/"+e.Name] = e
+	}
+
+	p := &workspacetype{
+		Handler: admission.NewHandler(admission.Create, admission.Update),
+		createAuthorizer: func(clusterName logicalcluster.Name, client kcpkubernetesclientset.ClusterInterface, opts delegated.Options) (authorizer.Authorizer, error) {
+			return &fakeAuthorizer{decision: decision}, nil
+		},
+		getAPIExport: func(path logicalcluster.Path, name string) (*apisv1alpha2.APIExport, error) {
+			if e, ok := exportMap[path.String()+"/"+name]; ok {
+				return e, nil
+			}
+			return nil, apierrors.NewNotFound(apisv1alpha2.Resource("apiexports"), name)
+		},
+	}
+	p.SetReadyFunc(func() bool { return true })
+	return p
+}
+
+func newAPIExport(cluster logicalcluster.Name, name string) *apisv1alpha2.APIExport {
+	return &apisv1alpha2.APIExport{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: apisv1alpha2.SchemeGroupVersion.String(),
+			Kind:       "APIExport",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Annotations: map[string]string{logicalcluster.AnnotationKey: cluster.String()},
+		},
+	}
+}
+
+func TestValidate_DefaultAPIBindings(t *testing.T) {
+	cowboys := newAPIExport(core.RootCluster, "cowboys")
+	tenantCluster := logicalcluster.Name("root-test")
+
+	tests := []struct {
+		name         string
+		op           admission.Operation
+		newWT        *tenancyv1alpha1.WorkspaceType
+		oldWT        *tenancyv1alpha1.WorkspaceType
+		decision     authorizer.Decision
+		exports      []*apisv1alpha2.APIExport
+		wantForbid   bool
+		wantContains string
+	}{
+		{
+			name:  "create without defaultAPIBindings is allowed",
+			op:    admission.Create,
+			newWT: newWorkspaceType(tenantCluster, "ok"),
+		},
+		{
+			name: "create with defaultAPIBindings allowed when user has bind",
+			op:   admission.Create,
+			newWT: newWorkspaceType(tenantCluster, "good",
+				tenancyv1alpha1.APIExportReference{Path: "root", Export: "cowboys"},
+			),
+			decision: authorizer.DecisionAllow,
+			exports:  []*apisv1alpha2.APIExport{cowboys},
+		},
+		{
+			name: "create with defaultAPIBindings denied when user lacks bind",
+			op:   admission.Create,
+			newWT: newWorkspaceType(tenantCluster, "bad",
+				tenancyv1alpha1.APIExportReference{Path: "root", Export: "cowboys"},
+			),
+			decision:     authorizer.DecisionDeny,
+			exports:      []*apisv1alpha2.APIExport{cowboys},
+			wantForbid:   true,
+			wantContains: "no permission to bind to export root:cowboys",
+		},
+		{
+			name:  "update adding new defaultAPIBinding requires bind on new entry",
+			op:    admission.Update,
+			oldWT: newWorkspaceType(tenantCluster, "x"),
+			newWT: newWorkspaceType(tenantCluster, "x",
+				tenancyv1alpha1.APIExportReference{Path: "root", Export: "cowboys"},
+			),
+			decision:   authorizer.DecisionDeny,
+			exports:    []*apisv1alpha2.APIExport{cowboys},
+			wantForbid: true,
+		},
+		{
+			name: "update keeping existing defaultAPIBinding does not re-check",
+			op:   admission.Update,
+			oldWT: newWorkspaceType(tenantCluster, "x",
+				tenancyv1alpha1.APIExportReference{Path: "root", Export: "cowboys"},
+			),
+			newWT: newWorkspaceType(tenantCluster, "x",
+				tenancyv1alpha1.APIExportReference{Path: "root", Export: "cowboys"},
+			),
+			// Even with deny, this should pass because the entry is preexisting.
+			decision: authorizer.DecisionDeny,
+			exports:  []*apisv1alpha2.APIExport{cowboys},
+		},
+		{
+			name: "create with empty path resolves to current cluster",
+			op:   admission.Create,
+			newWT: newWorkspaceType(tenantCluster, "y",
+				tenancyv1alpha1.APIExportReference{Export: "local"},
+			),
+			decision: authorizer.DecisionAllow,
+		},
+		{
+			name: "create denied when referenced APIExport cannot be resolved",
+			op:   admission.Create,
+			newWT: newWorkspaceType(tenantCluster, "z",
+				tenancyv1alpha1.APIExportReference{Path: "some:other:cluster", Export: "missing"},
+			),
+			decision:   authorizer.DecisionAllow,
+			wantForbid: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPlugin(tt.decision, tt.exports...)
+			attr := makeAttr(t, tt.op, tt.newWT, tt.oldWT, nil)
+			ctx := request.WithCluster(context.Background(), request.Cluster{Name: tenantCluster})
+			err := p.Validate(ctx, attr, nil)
+			if tt.wantForbid {
+				if err == nil {
+					t.Fatal("expected forbidden error, got nil")
+				}
+				if tt.wantContains != "" && !strings.Contains(err.Error(), tt.wantContains) {
+					t.Fatalf("expected error to contain %q, got %q", tt.wantContains, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/admission/workspacetype/admission_test.go
+++ b/pkg/admission/workspacetype/admission_test.go
@@ -98,26 +98,28 @@ func (a *fakeAuthorizer) Authorize(ctx context.Context, attr authorizer.Attribut
 	return a.decision, "", a.err
 }
 
-func newPlugin(decision authorizer.Decision, exports ...*apisv1alpha2.APIExport) *workspacetype {
+func newPlugin(decision authorizer.Decision, exports ...*apisv1alpha2.APIExport) (*workspacetype, *logicalcluster.Name) {
 	exportMap := make(map[string]*apisv1alpha2.APIExport, len(exports))
 	for _, e := range exports {
-		exportMap[logicalcluster.From(e).String()+"/"+e.Name] = e
+		exportMap[e.Name] = e
 	}
 
+	var capturedCluster logicalcluster.Name
 	p := &workspacetype{
 		Handler: admission.NewHandler(admission.Create, admission.Update),
 		createAuthorizer: func(clusterName logicalcluster.Name, client kcpkubernetesclientset.ClusterInterface, opts delegated.Options) (authorizer.Authorizer, error) {
+			capturedCluster = clusterName
 			return &fakeAuthorizer{decision: decision}, nil
 		},
 		getAPIExport: func(path logicalcluster.Path, name string) (*apisv1alpha2.APIExport, error) {
-			if e, ok := exportMap[path.String()+"/"+name]; ok {
+			if e, ok := exportMap[name]; ok {
 				return e, nil
 			}
 			return nil, apierrors.NewNotFound(apisv1alpha2.Resource("apiexports"), name)
 		},
 	}
 	p.SetReadyFunc(func() bool { return true })
-	return p
+	return p, &capturedCluster
 }
 
 func newAPIExport(cluster logicalcluster.Name, name string) *apisv1alpha2.APIExport {
@@ -138,14 +140,15 @@ func TestValidate_DefaultAPIBindings(t *testing.T) {
 	tenantCluster := logicalcluster.Name("root-test")
 
 	tests := []struct {
-		name         string
-		op           admission.Operation
-		newWT        *tenancyv1alpha1.WorkspaceType
-		oldWT        *tenancyv1alpha1.WorkspaceType
-		decision     authorizer.Decision
-		exports      []*apisv1alpha2.APIExport
-		wantForbid   bool
-		wantContains string
+		name                  string
+		op                    admission.Operation
+		newWT                 *tenancyv1alpha1.WorkspaceType
+		oldWT                 *tenancyv1alpha1.WorkspaceType
+		decision              authorizer.Decision
+		exports               []*apisv1alpha2.APIExport
+		wantForbid            bool
+		wantContains          string
+		wantAuthorizerCluster logicalcluster.Name
 	}{
 		{
 			name:  "create without defaultAPIBindings is allowed",
@@ -213,11 +216,23 @@ func TestValidate_DefaultAPIBindings(t *testing.T) {
 			decision:   authorizer.DecisionAllow,
 			wantForbid: true,
 		},
+		{
+			name: "create with non-root path uses cluster from resolved APIExport",
+			op:   admission.Create,
+			newWT: newWorkspaceType(tenantCluster, "remote",
+				tenancyv1alpha1.APIExportReference{Path: "some:other:path", Export: "cowboys-remote"},
+			),
+			decision: authorizer.DecisionAllow,
+			exports: []*apisv1alpha2.APIExport{
+				newAPIExport(logicalcluster.Name("actual-export-cluster"), "cowboys-remote"),
+			},
+			wantAuthorizerCluster: logicalcluster.Name("actual-export-cluster"),
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := newPlugin(tt.decision, tt.exports...)
+			p, capturedCluster := newPlugin(tt.decision, tt.exports...)
 			attr := makeAttr(t, tt.op, tt.newWT, tt.oldWT, nil)
 			ctx := request.WithCluster(context.Background(), request.Cluster{Name: tenantCluster})
 			err := p.Validate(ctx, attr, nil)
@@ -232,6 +247,9 @@ func TestValidate_DefaultAPIBindings(t *testing.T) {
 			}
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantAuthorizerCluster != "" && *capturedCluster != tt.wantAuthorizerCluster {
+				t.Fatalf("expected authorizer cluster %q, got %q", tt.wantAuthorizerCluster, *capturedCluster)
 			}
 		})
 	}

--- a/test/e2e/apibinding/default_apibinding_admission_test.go
+++ b/test/e2e/apibinding/default_apibinding_admission_test.go
@@ -1,0 +1,241 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apibinding
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+	"k8s.io/utils/ptr"
+
+	kcpdynamic "github.com/kcp-dev/client-go/dynamic"
+	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
+	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
+	"github.com/kcp-dev/sdk/apis/core"
+	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
+	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
+	kcptesting "github.com/kcp-dev/sdk/testing"
+	kcptestinghelpers "github.com/kcp-dev/sdk/testing/helpers"
+
+	"github.com/kcp-dev/kcp/config/helpers"
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+)
+
+// TestDefaultAPIBindingsBindPermission verifies that creating or updating a
+// WorkspaceType with spec.defaultAPIBindings requires the user to hold the
+// "bind" verb on each referenced APIExport.
+//
+// Without this check, an unprivileged user with permission to create
+// WorkspaceTypes and Workspaces could cause the default-apibinding-controller
+// (which runs with system credentials) to create APIBindings to APIExports the
+// user has no "bind" permission on. See pkg/admission/workspacetype.
+func TestDefaultAPIBindingsBindPermission(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "control-plane")
+
+	server := kcptesting.SharedKcpServer(t)
+
+	cfg := server.BaseConfig(t)
+
+	kcpClusterClient, err := kcpclientset.NewForConfig(cfg)
+	require.NoError(t, err, "failed to construct kcp cluster client")
+
+	dynamicClusterClient, err := kcpdynamic.NewForConfig(cfg)
+	require.NoError(t, err, "failed to construct dynamic cluster client")
+
+	kubeClusterClient, err := kcpkubernetesclientset.NewForConfig(cfg)
+	require.NoError(t, err, "failed to construct kube cluster client")
+
+	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
+
+	// Provider workspace owns the cowboys APIExport. user-1 has NO permissions here.
+	providerPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)
+	t.Logf("provider workspace: %s", providerPath)
+
+	// Tenant workspace is where user-1 has cluster-admin and tries to create the
+	// malicious WorkspaceType. This mirrors the PoC in the security report.
+	tenantPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)
+	t.Logf("tenant workspace: %s", tenantPath)
+
+	t.Logf("Install cowboys APIResourceSchema into provider workspace %q", providerPath)
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(kcpClusterClient.Cluster(providerPath).Discovery()))
+	err = helpers.CreateResourceFromFS(t.Context(), dynamicClusterClient.Cluster(providerPath), mapper, nil, "apiresourceschema_cowboys.yaml", testFiles)
+	require.NoError(t, err)
+
+	t.Logf("Create cowboys APIExport in provider workspace %q", providerPath)
+	cowboysAPIExport := &apisv1alpha2.APIExport{
+		ObjectMeta: metav1.ObjectMeta{Name: "today-cowboys"},
+		Spec: apisv1alpha2.APIExportSpec{
+			Resources: []apisv1alpha2.ResourceSchema{
+				{
+					Name:   "cowboys",
+					Group:  "wildwest.dev",
+					Schema: "today.cowboys.wildwest.dev",
+					Storage: apisv1alpha2.ResourceSchemaStorage{
+						CRD: &apisv1alpha2.ResourceSchemaStorageCRD{},
+					},
+				},
+			},
+		},
+	}
+	_, err = kcpClusterClient.Cluster(providerPath).ApisV1alpha2().APIExports().Create(t.Context(), cowboysAPIExport, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("Grant user-1 cluster-admin in tenant workspace %q (matches PoC)", tenantPath)
+	framework.AdmitWorkspaceAccess(t.Context(), t, kubeClusterClient, tenantPath, []string{"user-1"}, nil, true)
+
+	user1Cfg := framework.StaticTokenUserConfig("user-1", rest.CopyConfig(cfg))
+	user1KcpClient, err := kcpclientset.NewForConfig(user1Cfg)
+	require.NoError(t, err, "failed to construct kcp cluster client for user-1")
+
+	providerPathStr := providerPath.String()
+
+	t.Run("create denied without bind permission", func(t *testing.T) {
+		// user-1 has no "bind" permission on cowboys. Creating a WorkspaceType
+		// in the tenant workspace that references the cowboys APIExport in
+		// defaultAPIBindings must be rejected by admission.
+		wt := &tenancyv1alpha1.WorkspaceType{
+			ObjectMeta: metav1.ObjectMeta{Name: "bad"},
+			Spec: tenancyv1alpha1.WorkspaceTypeSpec{
+				Extend: tenancyv1alpha1.WorkspaceTypeExtension{
+					With: []tenancyv1alpha1.WorkspaceTypeReference{{Name: "universal", Path: "root"}},
+				},
+				DefaultAPIBindings: []tenancyv1alpha1.APIExportReference{
+					{Path: providerPathStr, Export: cowboysAPIExport.Name},
+				},
+				DefaultAPIBindingLifecycle: ptr.To(tenancyv1alpha1.APIBindingLifecycleModeMaintain),
+			},
+		}
+
+		// The bind-permission check is the only gate that lets this Create
+		// through; user-1 has no bind on the APIExport, so it MUST fail every
+		// time. We retry only because admission may transiently return a
+		// generic "not yet ready to handle request" forbidden until its
+		// informers sync — once ready, the message is the deterministic
+		// "no permission to bind to export ...". A nil error here would mean
+		// the security check did not fire, which is a regression, so we
+		// hard-fail rather than retry past it.
+		expected := fmt.Sprintf("no permission to bind to export %s:%s", providerPathStr, cowboysAPIExport.Name)
+		kcptestinghelpers.Eventually(t, func() (bool, string) {
+			_, err := user1KcpClient.Cluster(tenantPath).TenancyV1alpha1().WorkspaceTypes().Create(t.Context(), wt, metav1.CreateOptions{})
+			require.Error(t, err, "WorkspaceType create must be denied: user-1 has no bind permission on %s:%s", providerPathStr, cowboysAPIExport.Name)
+			if !strings.Contains(err.Error(), expected) {
+				return false, fmt.Sprintf("waiting for deterministic admission error: want %q, got %q", expected, err.Error())
+			}
+			return true, ""
+		}, wait.ForeverTestTimeout, 250*time.Millisecond, "expected denial of WorkspaceType create with deterministic bind error")
+	})
+
+	t.Run("create allowed when user has bind permission", func(t *testing.T) {
+		t.Logf("Grant user-1 bind on cowboys APIExport in provider workspace %q", providerPath)
+		clusterRole, clusterRoleBinding := createClusterRoleAndBindings(
+			"user-1-bind-cowboys", "user-1", "User",
+			apisv1alpha2.SchemeGroupVersion.Group, "apiexports", cowboysAPIExport.Name,
+			[]string{"bind"},
+		)
+		_, err := kubeClusterClient.Cluster(providerPath).RbacV1().ClusterRoles().Create(t.Context(), clusterRole, metav1.CreateOptions{})
+		require.NoError(t, err)
+		_, err = kubeClusterClient.Cluster(providerPath).RbacV1().ClusterRoleBindings().Create(t.Context(), clusterRoleBinding, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		wt := &tenancyv1alpha1.WorkspaceType{
+			ObjectMeta: metav1.ObjectMeta{Name: "good"},
+			Spec: tenancyv1alpha1.WorkspaceTypeSpec{
+				Extend: tenancyv1alpha1.WorkspaceTypeExtension{
+					With: []tenancyv1alpha1.WorkspaceTypeReference{{Name: "universal", Path: "root"}},
+				},
+				DefaultAPIBindings: []tenancyv1alpha1.APIExportReference{
+					{Path: providerPathStr, Export: cowboysAPIExport.Name},
+				},
+				DefaultAPIBindingLifecycle: ptr.To(tenancyv1alpha1.APIBindingLifecycleModeMaintain),
+			},
+		}
+
+		// Wait for the SAR cache + informers to observe the new RBAC.
+		kcptestinghelpers.Eventually(t, func() (bool, string) {
+			_, err := user1KcpClient.Cluster(tenantPath).TenancyV1alpha1().WorkspaceTypes().Create(t.Context(), wt, metav1.CreateOptions{})
+			if err == nil {
+				return true, ""
+			}
+			return false, err.Error()
+		}, wait.ForeverTestTimeout, 250*time.Millisecond, "expected WorkspaceType create to succeed once user-1 has bind")
+	})
+
+	t.Run("update adding new defaultAPIBinding requires bind", func(t *testing.T) {
+		t.Logf("Create empty WorkspaceType as user-1")
+		wt := &tenancyv1alpha1.WorkspaceType{
+			ObjectMeta: metav1.ObjectMeta{Name: "later"},
+			Spec: tenancyv1alpha1.WorkspaceTypeSpec{
+				Extend: tenancyv1alpha1.WorkspaceTypeExtension{
+					With: []tenancyv1alpha1.WorkspaceTypeReference{{Name: "universal", Path: "root"}},
+				},
+			},
+		}
+		created, err := user1KcpClient.Cluster(tenantPath).TenancyV1alpha1().WorkspaceTypes().Create(t.Context(), wt, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		t.Logf("Create a second APIExport user-1 has no bind on")
+		secondExport := &apisv1alpha2.APIExport{
+			ObjectMeta: metav1.ObjectMeta{Name: "no-bind-export"},
+			Spec: apisv1alpha2.APIExportSpec{
+				Resources: []apisv1alpha2.ResourceSchema{
+					{
+						Name:   "cowboys",
+						Group:  "wildwest.dev",
+						Schema: "today.cowboys.wildwest.dev",
+						Storage: apisv1alpha2.ResourceSchemaStorage{
+							CRD: &apisv1alpha2.ResourceSchemaStorageCRD{},
+						},
+					},
+				},
+			},
+		}
+		_, err = kcpClusterClient.Cluster(providerPath).ApisV1alpha2().APIExports().Create(t.Context(), secondExport, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		t.Logf("user-1 attempts to add the second APIExport to defaultAPIBindings — expect denial")
+		// Same rationale as the create case: user-1 has no bind on
+		// secondExport, so Update MUST fail. Retry only to wait out the
+		// transient "not yet ready" admission response.
+		expected := fmt.Sprintf("no permission to bind to export %s:%s", providerPathStr, secondExport.Name)
+		kcptestinghelpers.Eventually(t, func() (bool, string) {
+			latest, getErr := user1KcpClient.Cluster(tenantPath).TenancyV1alpha1().WorkspaceTypes().Get(t.Context(), created.Name, metav1.GetOptions{})
+			if getErr != nil {
+				return false, getErr.Error()
+			}
+			latest.Spec.DefaultAPIBindings = []tenancyv1alpha1.APIExportReference{
+				{Path: providerPathStr, Export: secondExport.Name},
+			}
+			latest.Spec.DefaultAPIBindingLifecycle = ptr.To(tenancyv1alpha1.APIBindingLifecycleModeMaintain)
+			_, err := user1KcpClient.Cluster(tenantPath).TenancyV1alpha1().WorkspaceTypes().Update(t.Context(), latest, metav1.UpdateOptions{})
+			require.Error(t, err, "WorkspaceType update must be denied: user-1 has no bind permission on %s:%s", providerPathStr, secondExport.Name)
+			if !strings.Contains(err.Error(), expected) {
+				return false, fmt.Sprintf("waiting for deterministic admission error: want %q, got %q", expected, err.Error())
+			}
+			return true, ""
+		}, wait.ForeverTestTimeout, 250*time.Millisecond, "expected denial of WorkspaceType update with deterministic bind error")
+	})
+}


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Enhance WorkspaceType permissions admission checking with more in-depth defence.
This could be done in the controller itself, BUT as we are in the middle of refactoring https://github.com/kcp-dev/kcp/issues/4016 this would make it harder to backport, and its moving target. 

Once this is fixed, I will create a follow-up to do a controller-level check once this one is merged, backported and released. 

## What Type of PR Is This?
/kind bug

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Add more in-depth defence on WorkspaceType default APIBindings
```
