### PR TITLE
Recover workspaces from Unavailable

### DIFF
--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_phase.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_phase.go
@@ -39,6 +39,11 @@ type phaseReconciler struct {
 	requeueAfter func(workspace *tenancyv1alpha1.Workspace, after time.Duration)
 }
 
+// logicalClusterTimeout is the time limit for a logical cluster to
+// appear for the shard before marking its corresponding Workspace as
+// Unavailable.
+const logicalClusterTimeout = time.Second
+
 func (r *phaseReconciler) reconcile(ctx context.Context, workspace *tenancyv1alpha1.Workspace) (reconcileStatus, error) {
 	logger := klog.FromContext(ctx).WithValues("reconciler", "phase")
 
@@ -61,7 +66,7 @@ func (r *phaseReconciler) reconcile(ctx context.Context, workspace *tenancyv1alp
 				if hasShard {
 					shard, shardErr := r.getShardByHash(shardHash)
 					if shardErr == nil && shard.DeletionTimestamp.IsZero() {
-						if workspace.CreationTimestamp.IsZero() || time.Since(workspace.CreationTimestamp.Time) < 10*time.Second {
+						if workspace.CreationTimestamp.IsZero() || time.Since(workspace.CreationTimestamp.Time) < logicalClusterTimeout {
 							logger.V(3).Info("LogicalCluster not found but shard is alive, requeueing", "shard", shard.Name)
 							r.requeueAfter(workspace, 1*time.Second)
 							return reconcileStatusContinue, nil
@@ -97,6 +102,27 @@ func (r *phaseReconciler) reconcile(ctx context.Context, workspace *tenancyv1alp
 			conditions.MarkTrue(workspace, tenancyv1alpha1.WorkspaceInitialized)
 
 		case corev1alpha1.LogicalClusterPhaseUnavailable:
+			if conditions.IsFalse(workspace, tenancyv1alpha1.WorkspaceInitialized) && conditions.GetReason(workspace, tenancyv1alpha1.WorkspaceInitialized) == tenancyv1alpha1.WorkspaceInitializedWorkspaceDisappeared {
+				shardHash, hasShard := workspace.Annotations[WorkspaceShardHashAnnotationKey]
+				if hasShard {
+					shard, shardErr := r.getShardByHash(shardHash)
+					if shardErr == nil && shard.DeletionTimestamp.IsZero() {
+						_, err := r.getLogicalCluster(ctx, logicalcluster.NewPath(workspace.Spec.Cluster))
+						if apierrors.IsNotFound(err) {
+							return reconcileStatusStopAndRequeue, nil
+						}
+						if err != nil {
+							return reconcileStatusStopAndRequeue, err
+						}
+						// Only resetting the condition. Terminal condition phase will update the phase and the
+						// next reconcile will continue where the workspace left off.
+						logger.V(3).Info("LogicalCluster reappeared, recovering workspace", "cluster", workspace.Spec.Cluster)
+						conditions.MarkTrue(workspace, tenancyv1alpha1.WorkspaceInitialized)
+						// Immediately request requeueing to recover the workspace faster.
+						r.requeueAfter(workspace, time.Second)
+					}
+				}
+			}
 			if updateTerminalConditionPhase(workspace) {
 				return reconcileStatusStopAndRequeue, nil
 			}

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_phase_test.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_phase_test.go
@@ -302,6 +302,117 @@ func TestReconcilePhase(t *testing.T) {
 			wantPhase:  corev1alpha1.LogicalClusterPhaseReady,
 			wantStatus: reconcileStatusStopAndRequeue,
 		},
+		{
+			name: "workspace is unavailable due to disappeared logical cluster and shard is alive - recovers when LC reappears",
+			input: &tenancyv1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						WorkspaceShardHashAnnotationKey: "shard-hash-1",
+					},
+				},
+				Spec: tenancyv1alpha1.WorkspaceSpec{
+					URL:     "http://example.com",
+					Cluster: "cluster-1",
+				},
+				Status: tenancyv1alpha1.WorkspaceStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseUnavailable,
+					Conditions: []conditionsv1alpha1.Condition{
+						{
+							Type:     tenancyv1alpha1.WorkspaceInitialized,
+							Status:   corev1.ConditionFalse,
+							Severity: conditionsv1alpha1.ConditionSeverityError,
+							Reason:   tenancyv1alpha1.WorkspaceInitializedWorkspaceDisappeared,
+							Message:  "LogicalCluster cluster-1 not found",
+						},
+					},
+				},
+			},
+			getLogicalCluster: func(ctx context.Context, cluster logicalcluster.Path) (*corev1alpha1.LogicalCluster, error) {
+				return &corev1alpha1.LogicalCluster{
+					Status: corev1alpha1.LogicalClusterStatus{
+						Initializers: []corev1alpha1.LogicalClusterInitializer{},
+					},
+				}, nil
+			},
+			getShardByHash: func(hash string) (*corev1alpha1.Shard, error) {
+				return &corev1alpha1.Shard{ObjectMeta: metav1.ObjectMeta{Name: "shard-1"}}, nil
+			},
+			wantPhase:  corev1alpha1.LogicalClusterPhaseReady,
+			wantStatus: reconcileStatusStopAndRequeue,
+			wantCondition: conditionsv1alpha1.Condition{
+				Type:   tenancyv1alpha1.WorkspaceInitialized,
+				Status: corev1.ConditionTrue,
+			},
+			wantRequeue: true,
+		},
+		{
+			name: "workspace is unavailable due to disappeared logical cluster and shard is alive - requeues when LC still not found",
+			input: &tenancyv1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						WorkspaceShardHashAnnotationKey: "shard-hash-1",
+					},
+				},
+				Spec: tenancyv1alpha1.WorkspaceSpec{
+					URL:     "http://example.com",
+					Cluster: "cluster-1",
+				},
+				Status: tenancyv1alpha1.WorkspaceStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseUnavailable,
+					Conditions: []conditionsv1alpha1.Condition{
+						{
+							Type:     tenancyv1alpha1.WorkspaceInitialized,
+							Status:   corev1.ConditionFalse,
+							Severity: conditionsv1alpha1.ConditionSeverityError,
+							Reason:   tenancyv1alpha1.WorkspaceInitializedWorkspaceDisappeared,
+							Message:  "LogicalCluster cluster-1 not found",
+						},
+					},
+				},
+			},
+			getLogicalCluster: func(ctx context.Context, cluster logicalcluster.Path) (*corev1alpha1.LogicalCluster, error) {
+				return nil, apierrors.NewNotFound(corev1alpha1.Resource("logicalcluster"), "cluster-1")
+			},
+			getShardByHash: func(hash string) (*corev1alpha1.Shard, error) {
+				return &corev1alpha1.Shard{ObjectMeta: metav1.ObjectMeta{Name: "shard-1"}}, nil
+			},
+			wantPhase:  corev1alpha1.LogicalClusterPhaseUnavailable,
+			wantStatus: reconcileStatusStopAndRequeue,
+		},
+		{
+			name: "workspace is unavailable due to disappeared logical cluster and shard is gone - no recovery",
+			input: &tenancyv1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						WorkspaceShardHashAnnotationKey: "shard-hash-1",
+					},
+				},
+				Spec: tenancyv1alpha1.WorkspaceSpec{
+					URL:     "http://example.com",
+					Cluster: "cluster-1",
+				},
+				Status: tenancyv1alpha1.WorkspaceStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseUnavailable,
+					Conditions: []conditionsv1alpha1.Condition{
+						{
+							Type:     tenancyv1alpha1.WorkspaceInitialized,
+							Status:   corev1.ConditionFalse,
+							Severity: conditionsv1alpha1.ConditionSeverityError,
+							Reason:   tenancyv1alpha1.WorkspaceInitializedWorkspaceDisappeared,
+							Message:  "LogicalCluster cluster-1 not found",
+						},
+					},
+				},
+			},
+			getLogicalCluster: func(ctx context.Context, cluster logicalcluster.Path) (*corev1alpha1.LogicalCluster, error) {
+				return nil, apierrors.NewNotFound(corev1alpha1.Resource("logicalcluster"), "cluster-1")
+			},
+			getShardByHash: func(hash string) (*corev1alpha1.Shard, error) {
+				return nil, apierrors.NewNotFound(corev1alpha1.Resource("shard"), "shard-hash-1")
+			},
+			wantPhase:  corev1alpha1.LogicalClusterPhaseUnavailable,
+			wantStatus: reconcileStatusContinue,
+		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			requeued := false


### PR DESCRIPTION

<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

In high-pressure environments a workspace may be marked unavailable because the 10s timeout is not enough for a logical cluster to be propagated and be known to the shard.

When this happens the workspace never recovers as there is nothing updating the status.

To prevent this:

1. The timeout is increased to one minute via a documented const (so ~60 retries instead of 10)
2. Added reconcile that allows the Workspace to recover from the logical cluster not being visible during initialization

## What Type of PR Is This?

/kind bug
/kind flake

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
