### PR TITLE
Add SAR support to VirtualWorkspaces in sharded environments 

### DIFF
--- a/cmd/sharded-test-server/virtual.go
+++ b/cmd/sharded-test-server/virtual.go
@@ -131,6 +131,51 @@ func newVirtualWorkspace(ctx context.Context, index int, servingCA *crypto.CA, h
 		os.Exit(1)
 	}
 
+	// External-logical-cluster-admin kubeconfig: points at the front-proxy
+	// so SAR calls for clusters hosted on other shards reach the shard that
+	// owns them.
+	//
+	// We use the kcp-admin client cert here (system:kcp:admin group bound to
+	// cluster-admin) rather than the VW's local system:masters cert because
+	// the front-proxy strips system:masters from inbound client certs (see
+	// pkg/proxy/options/authentication.go DropGroups). system:kcp:admin
+	// survives the proxy and has the create-subjectaccessreviews permission
+	// the SAR call needs.
+	kcpAdminCertPath, err := filepath.Abs(filepath.Join(workDirPath, ".kcp", "kcp-admin.crt"))
+	if err != nil {
+		return nil, fmt.Errorf("error getting absolute path for kcp-admin.crt: %w", err)
+	}
+	kcpAdminKeyPath, err := filepath.Abs(filepath.Join(workDirPath, ".kcp", "kcp-admin.key"))
+	if err != nil {
+		return nil, fmt.Errorf("error getting absolute path for kcp-admin.key: %w", err)
+	}
+	externalLogicalClusterAdminKubeConfig := clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"front-proxy": {
+				Server:               fmt.Sprintf("https://%s", net.JoinHostPort(hostIP, "6443")),
+				CertificateAuthority: servingCAPath,
+			},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			"front-proxy": {
+				Cluster:  "front-proxy",
+				AuthInfo: "kcp-admin",
+			},
+		},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"kcp-admin": {
+				ClientCertificate: kcpAdminCertPath,
+				ClientKey:         kcpAdminKeyPath,
+			},
+		},
+		CurrentContext: "front-proxy",
+	}
+	externalLogicalClusterAdminKubeconfigPath := filepath.Join(wvDir, "virtualworkspace-external-logical-cluster-admin.kubeconfig")
+	if err := clientcmd.WriteToFile(externalLogicalClusterAdminKubeConfig, externalLogicalClusterAdminKubeconfigPath); err != nil {
+		fmt.Printf("failed to write vw external-logical-cluster-admin kubeconfig: %v", err)
+		os.Exit(1)
+	}
+
 	authenticationKubeconfigPath := filepath.Join(workDirPath, fmt.Sprintf(".kcp-%d", index), "admin.kubeconfig")
 	clientCAFilePath := filepath.Join(workDirPath, ".kcp", "client-ca.crt")
 
@@ -146,6 +191,7 @@ func newVirtualWorkspace(ctx context.Context, index int, servingCA *crypto.CA, h
 
 	args := []string{
 		fmt.Sprintf("--kubeconfig=%s", kubeconfigPath),
+		fmt.Sprintf("--external-logical-cluster-admin-kubeconfig=%s", externalLogicalClusterAdminKubeconfigPath),
 		fmt.Sprintf("--cache-kubeconfig=%s", cacheServerConfigPath),
 		fmt.Sprintf("--authentication-kubeconfig=%s", authenticationKubeconfigPath),
 		fmt.Sprintf("--client-ca-file=%s", clientCAFilePath),

--- a/cmd/virtual-workspaces/command/cmd.go
+++ b/cmd/virtual-workspaces/command/cmd.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/client-go/pkg/version"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	logsapiv1 "k8s.io/component-base/logs/api/v1"
 	"k8s.io/klog/v2"
@@ -96,6 +97,32 @@ func Run(ctx context.Context, o *options.Options) error {
 	cacheConfig, err := o.Cache.RestConfig(defaultCacheClientConfig)
 	if err != nil {
 		return err
+	}
+
+	// parse external-logical-cluster-admin (front-proxy) kubeconfig if
+	// supplied. The VW uses this for SubjectAccessReview against clusters
+	// that may not live on the local shard; otherwise it falls back to the
+	// local kubeconfig.
+	var externalLogicalClusterAdminConfig *rest.Config
+	if o.ExternalLogicalClusterAdminKubeconfigFile != "" {
+		externalKubeConfig, err := readKubeConfig(o.ExternalLogicalClusterAdminKubeconfigFile, o.Context)
+		if err != nil {
+			return err
+		}
+		externalLogicalClusterAdminConfig, err = externalKubeConfig.ClientConfig()
+		if err != nil {
+			return err
+		}
+		externalLogicalClusterAdminConfig.QPS = -1
+
+		// strip any /clusters/... path from the host: the kcp client
+		// adds the cluster prefix itself when the SAR is issued.
+		eu, err := url.Parse(externalLogicalClusterAdminConfig.Host)
+		if err != nil {
+			return err
+		}
+		eu.Path = ""
+		externalLogicalClusterAdminConfig.Host = eu.String()
 	}
 	cacheKcpClusterClient, err := kcpclientset.NewForConfig(cacheConfig)
 	if err != nil {
@@ -187,7 +214,7 @@ func Run(ctx context.Context, o *options.Options) error {
 		return err
 	}
 
-	rootAPIServerConfig.Extra.VirtualWorkspaces, err = o.CoreVirtualWorkspaces.NewVirtualWorkspaces(identityConfig, cacheConfig, o.RootPathPrefix, wildcardKubeInformers, wildcardKcpInformers, cacheKcpInformers)
+	rootAPIServerConfig.Extra.VirtualWorkspaces, err = o.CoreVirtualWorkspaces.NewVirtualWorkspaces(identityConfig, cacheConfig, externalLogicalClusterAdminConfig, o.RootPathPrefix, wildcardKubeInformers, wildcardKcpInformers, cacheKcpInformers)
 	if err != nil {
 		return err
 	}

--- a/cmd/virtual-workspaces/options/options.go
+++ b/cmd/virtual-workspaces/options/options.go
@@ -46,9 +46,10 @@ const DefaultRootPathPrefix string = "/services"
 type Options struct {
 	Output io.Writer
 
-	KubeconfigFile string
-	Context        string
-	RootPathPrefix string
+	KubeconfigFile                            string
+	ExternalLogicalClusterAdminKubeconfigFile string
+	Context                                   string
+	RootPathPrefix                            string
 
 	Cache          cacheoptions.Cache
 	SecureServing  genericapiserveroptions.SecureServingOptions
@@ -103,6 +104,12 @@ func (o *Options) AddFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&o.KubeconfigFile, "kubeconfig", o.KubeconfigFile,
 		"The kubeconfig file of the kcp instance that hosts workspaces.")
 	_ = cobra.MarkFlagRequired(flags, "kubeconfig")
+
+	flags.StringVar(&o.ExternalLogicalClusterAdminKubeconfigFile, "external-logical-cluster-admin-kubeconfig", o.ExternalLogicalClusterAdminKubeconfigFile,
+		"Optional kubeconfig pointing at the front-proxy. Used by virtual workspaces "+
+			"to issue SubjectAccessReview against clusters that may live on a different "+
+			"shard than this VW (e.g. a workspacetype's cluster). When unset, falls back "+
+			"to --kubeconfig, which only works in non-sharded deployments.")
 
 	flags.StringVar(&o.Context, "context", o.Context, "Name of the context in the kubeconfig file to use")
 	flags.StringVar(&o.ProfilerAddress, "profiler-address", "", "[Address]:port to bind the profiler to")

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -801,10 +801,19 @@ func NewConfig(ctx context.Context, opts kcpserveroptions.CompletedOptions) (*Co
 		virtualWorkspacesConfig := rest.CopyConfig(c.GenericConfig.LoopbackClientConfig)
 		virtualWorkspacesConfig = rest.AddUserAgent(virtualWorkspacesConfig, "virtual-workspaces")
 
+		// externalLogicalClusterAdminConfig (front-proxy) is used by VWs that
+		// need to reach clusters hosted on other shards. Defaults to the
+		// loopback when no dedicated kubeconfig was supplied; the SAR will
+		// fall back to local-only resolution which works in single-shard
+		// deployments.
+		externalLogicalClusterAdminConfig := rest.CopyConfig(c.ExternalLogicalClusterAdminConfig)
+		externalLogicalClusterAdminConfig = rest.AddUserAgent(externalLogicalClusterAdminConfig, "virtual-workspaces-external")
+
 		c.OptionalVirtual, err = newVirtualConfig(
 			opts,
 			virtualWorkspacesConfig,
 			cacheClientConfig,
+			externalLogicalClusterAdminConfig,
 			c.KubeSharedInformerFactory,
 			c.KcpSharedInformerFactory,
 			c.CacheKcpSharedInformerFactory,

--- a/pkg/server/virtual.go
+++ b/pkg/server/virtual.go
@@ -56,6 +56,7 @@ func newVirtualConfig(
 	o kcpserveroptions.CompletedOptions,
 	config *rest.Config,
 	cacheConfig *rest.Config,
+	externalLogicalClusterAdminConfig *rest.Config,
 	kubeSharedInformerFactory kcpkubernetesinformers.SharedInformerFactory,
 	kcpSharedInformerFactory, cacheKcpSharedInformerFactory kcpinformers.SharedInformerFactory,
 ) (*VirtualConfig, error) {
@@ -95,6 +96,7 @@ func newVirtualConfig(
 	c.Extra.VirtualWorkspaces, err = o.Virtual.VirtualWorkspaces.NewVirtualWorkspaces(
 		config,
 		cacheConfig,
+		externalLogicalClusterAdminConfig,
 		virtualcommandoptions.DefaultRootPathPrefix,
 		kubeSharedInformerFactory,
 		kcpSharedInformerFactory,

--- a/pkg/virtual/initializingworkspaces/builder/build.go
+++ b/pkg/virtual/initializingworkspaces/builder/build.go
@@ -66,15 +66,28 @@ const (
 	workspaceContentName        = initializingworkspaces.VirtualWorkspaceName + "-workspace-content"
 )
 
+// BuildVirtualWorkspace builds the initializing-workspaces virtual workspaces.
+//
+// externalLogicalClusterAdminClient is used for SubjectAccessReview calls
+// against the workspacetype's logical cluster. In sharded deployments, the
+// workspacetype can live on a different shard than the workspace, so this
+// client must be able to reach any cluster (typically routed through the
+// front-proxy). When nil, kubeClusterClient is used as a fallback, which only
+// works when the workspacetype is co-located with the VW's shard.
 func BuildVirtualWorkspace(
 	cfg *rest.Config,
 	rootPathPrefix string,
 	dynamicClusterClient kcpdynamic.ClusterInterface,
-	kubeClusterClient kcpkubernetesclientset.ClusterInterface,
+	kubeClusterClient, externalLogicalClusterAdminClient kcpkubernetesclientset.ClusterInterface,
 	wildcardKcpInformers kcpinformers.SharedInformerFactory,
 ) ([]rootapiserver.NamedVirtualWorkspace, error) {
 	if !strings.HasSuffix(rootPathPrefix, "/") {
 		rootPathPrefix += "/"
+	}
+
+	sarKubeClusterClient := externalLogicalClusterAdminClient
+	if sarKubeClusterClient == nil {
+		sarKubeClusterClient = kubeClusterClient
 	}
 
 	logicalClusterResource := apisv1alpha1.APIResourceSchema{}
@@ -93,7 +106,7 @@ func BuildVirtualWorkspace(
 		v.Schema.Raw = bs // wipe schemas. We don't want validation here.
 	}
 
-	cachingAuthorizer := delegated.NewCachingAuthorizer(kubeClusterClient, authorizerWithCache, delegated.CachingOptions{})
+	cachingAuthorizer := delegated.NewCachingAuthorizer(sarKubeClusterClient, authorizerWithCache, delegated.CachingOptions{})
 	wildcardLogicalClusters := &virtualworkspacesdynamic.DynamicVirtualWorkspace{
 		RootPathResolver: framework.RootPathResolverFunc(func(urlPath string, requestContext context.Context) (accepted bool, prefixToStrip string, completedContext context.Context) {
 			cluster, apiDomain, prefixToStrip, ok := digestUrl(urlPath, rootPathPrefix)

--- a/pkg/virtual/initializingworkspaces/builder/build_test.go
+++ b/pkg/virtual/initializingworkspaces/builder/build_test.go
@@ -126,7 +126,7 @@ func TestBuildVirtualWorkspace(t *testing.T) {
 	require.NoError(t, err, "ClusterClientSet should not return an error")
 	wildcardKcpInformers := kcpinformers.NewSharedInformerFactory(nil, 0)
 
-	virtualWorkspaces, err := BuildVirtualWorkspace(cfg, rootPathPrefix, dynamicClusterClient, kubeClusterClient, wildcardKcpInformers)
+	virtualWorkspaces, err := BuildVirtualWorkspace(cfg, rootPathPrefix, dynamicClusterClient, kubeClusterClient, nil, wildcardKcpInformers)
 	require.NoError(t, err, "BuildVirtualWorkspace should not return an error")
 
 	assert.Len(t, virtualWorkspaces, 3, "There should be three virtual workspaces")

--- a/pkg/virtual/initializingworkspaces/options/options.go
+++ b/pkg/virtual/initializingworkspaces/options/options.go
@@ -56,6 +56,7 @@ func (o *InitializingWorkspaces) Validate(flagPrefix string) []error {
 func (o *InitializingWorkspaces) NewVirtualWorkspaces(
 	rootPathPrefix string,
 	config *rest.Config,
+	externalLogicalClusterAdminConfig *rest.Config,
 	wildcardKcpInformers kcpinformers.SharedInformerFactory,
 ) (workspaces []rootapiserver.NamedVirtualWorkspace, err error) {
 	config = rest.AddUserAgent(rest.CopyConfig(config), "initializingworkspaces-virtual-workspace")
@@ -68,5 +69,19 @@ func (o *InitializingWorkspaces) NewVirtualWorkspaces(
 		return nil, err
 	}
 
-	return builder.BuildVirtualWorkspace(config, path.Join(rootPathPrefix, initializingworkspaces.VirtualWorkspaceName), dynamicClusterClient, kubeClusterClient, wildcardKcpInformers)
+	// externalLogicalClusterAdminConfig (when set) targets the front-proxy
+	// so SubjectAccessReview calls for the workspacetype's cluster reach the
+	// shard that hosts it instead of the local shard. When unset, the SAR
+	// goes through the local shard's loopback, which only works in
+	// non-sharded deployments or when the workspacetype is co-located.
+	var externalLogicalClusterAdminClient kcpkubernetesclientset.ClusterInterface
+	if externalLogicalClusterAdminConfig != nil {
+		externalCfg := rest.AddUserAgent(rest.CopyConfig(externalLogicalClusterAdminConfig), "initializingworkspaces-virtual-workspace-sar")
+		externalLogicalClusterAdminClient, err = kcpkubernetesclientset.NewForConfig(externalCfg)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return builder.BuildVirtualWorkspace(config, path.Join(rootPathPrefix, initializingworkspaces.VirtualWorkspaceName), dynamicClusterClient, kubeClusterClient, externalLogicalClusterAdminClient, wildcardKcpInformers)
 }

--- a/pkg/virtual/options/options.go
+++ b/pkg/virtual/options/options.go
@@ -70,9 +70,17 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	o.APIResourceSchema.AddFlags(fs, virtualWorkspacesFlagPrefix)
 }
 
+// NewVirtualWorkspaces builds the configured virtual workspaces.
+//
+// externalLogicalClusterAdminConfig is an optional client config that points
+// at the front-proxy and is used by VWs that need to reach clusters hosted on
+// other shards (e.g. for SubjectAccessReview against the workspacetype's
+// cluster). When nil, all VW operations go through config (the local shard
+// loopback), which is correct for non-sharded deployments.
 func (o *Options) NewVirtualWorkspaces(
 	config *rest.Config,
 	cacheConfig *rest.Config,
+	externalLogicalClusterAdminConfig *rest.Config,
 	rootPathPrefix string,
 	wildcardKubeInformers kcpkubernetesinformers.SharedInformerFactory,
 	wildcardKcpInformers, cachedKcpInformers kcpinformers.SharedInformerFactory,
@@ -87,7 +95,7 @@ func (o *Options) NewVirtualWorkspaces(
 		return nil, err
 	}
 
-	initializingworkspaces, err := o.InitializingWorkspaces.NewVirtualWorkspaces(rootPathPrefix, config, wildcardKcpInformers)
+	initializingworkspaces, err := o.InitializingWorkspaces.NewVirtualWorkspaces(rootPathPrefix, config, externalLogicalClusterAdminConfig, wildcardKcpInformers)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +111,7 @@ func (o *Options) NewVirtualWorkspaces(
 		return nil, err
 	}
 
-	terminatingworkspaces, err := o.TerminatingWorkspaces.NewVirtualWorkspaces(rootPathPrefix, config, wildcardKcpInformers)
+	terminatingworkspaces, err := o.TerminatingWorkspaces.NewVirtualWorkspaces(rootPathPrefix, config, externalLogicalClusterAdminConfig, wildcardKcpInformers)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/virtual/terminatingworkspaces/builder/build.go
+++ b/pkg/virtual/terminatingworkspaces/builder/build.go
@@ -58,14 +58,27 @@ const (
 	logicalClustersName         = terminatingworkspaces.VirtualWorkspaceName + "-logicalclusters"
 )
 
+// BuildVirtualWorkspace builds the terminating-workspaces virtual workspaces.
+//
+// externalLogicalClusterAdminClient is used for SubjectAccessReview calls
+// against the workspacetype's logical cluster. In sharded deployments, the
+// workspacetype can live on a different shard than the workspace, so this
+// client must be able to reach any cluster (typically routed through the
+// front-proxy). When nil, kubeClusterClient is used as a fallback, which only
+// works when the workspacetype is co-located with the VW's shard.
 func BuildVirtualWorkspace(
 	cfg *rest.Config,
 	rootPathPrefix string,
 	dynamicClusterClient kcpdynamic.ClusterInterface,
-	kubeClusterClient kcpkubernetesclientset.ClusterInterface,
+	kubeClusterClient, externalLogicalClusterAdminClient kcpkubernetesclientset.ClusterInterface,
 ) ([]rootapiserver.NamedVirtualWorkspace, error) {
 	if !strings.HasSuffix(rootPathPrefix, "/") {
 		rootPathPrefix += "/"
+	}
+
+	sarKubeClusterClient := externalLogicalClusterAdminClient
+	if sarKubeClusterClient == nil {
+		sarKubeClusterClient = kubeClusterClient
 	}
 
 	logicalClusterResource := apisv1alpha1.APIResourceSchema{}
@@ -84,7 +97,7 @@ func BuildVirtualWorkspace(
 		v.Schema.Raw = bs // wipe schemas. We don't want validation here.
 	}
 
-	cachingAuthorizer := delegated.NewCachingAuthorizer(kubeClusterClient, authorizerWithCache, delegated.CachingOptions{})
+	cachingAuthorizer := delegated.NewCachingAuthorizer(sarKubeClusterClient, authorizerWithCache, delegated.CachingOptions{})
 	wildcardLogicalClusters := &virtualworkspacesdynamic.DynamicVirtualWorkspace{
 		RootPathResolver: framework.RootPathResolverFunc(func(urlPath string, requestContext context.Context) (accepted bool, prefixToStrip string, completedContext context.Context) {
 			cluster, apiDomain, prefixToStrip, ok := digestUrl(urlPath, rootPathPrefix)

--- a/pkg/virtual/terminatingworkspaces/options/options.go
+++ b/pkg/virtual/terminatingworkspaces/options/options.go
@@ -56,6 +56,7 @@ func (o *TerminatingWorkspaces) Validate(flagPrefix string) []error {
 func (o *TerminatingWorkspaces) NewVirtualWorkspaces(
 	rootPathPrefix string,
 	config *rest.Config,
+	externalLogicalClusterAdminConfig *rest.Config,
 	wildcardKcpInformers kcpinformers.SharedInformerFactory,
 ) (workspaces []rootapiserver.NamedVirtualWorkspace, err error) {
 	config = rest.AddUserAgent(rest.CopyConfig(config), "terminatingworkspaces-virtual-workspace")
@@ -68,5 +69,19 @@ func (o *TerminatingWorkspaces) NewVirtualWorkspaces(
 		return nil, err
 	}
 
-	return builder.BuildVirtualWorkspace(config, path.Join(rootPathPrefix, terminatingworkspaces.VirtualWorkspaceName), dynamicClusterClient, kubeClusterClient)
+	// externalLogicalClusterAdminConfig (when set) targets the front-proxy
+	// so SubjectAccessReview calls for the workspacetype's cluster reach the
+	// shard that hosts it instead of the local shard. When unset, the SAR
+	// goes through the local shard's loopback, which only works in
+	// non-sharded deployments or when the workspacetype is co-located.
+	var externalLogicalClusterAdminClient kcpkubernetesclientset.ClusterInterface
+	if externalLogicalClusterAdminConfig != nil {
+		externalCfg := rest.AddUserAgent(rest.CopyConfig(externalLogicalClusterAdminConfig), "terminatingworkspaces-virtual-workspace-sar")
+		externalLogicalClusterAdminClient, err = kcpkubernetesclientset.NewForConfig(externalCfg)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return builder.BuildVirtualWorkspace(config, path.Join(rootPathPrefix, terminatingworkspaces.VirtualWorkspaceName), dynamicClusterClient, kubeClusterClient, externalLogicalClusterAdminClient)
 }


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

This enables SAR requests using new FrontProxy cached SAR client. 


## What Type of PR Is This?
/kind bug

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Add --external-logical-cluster-admin for the virtualworkspaces framework for SAR request support 
```
