### PR TITLE
Fix noisy logs

### DIFF
--- a/pkg/virtual/initializingworkspaces/builder/forwarding.go
+++ b/pkg/virtual/initializingworkspaces/builder/forwarding.go
@@ -19,6 +19,7 @@ package builder
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -224,10 +225,8 @@ func withUpdateValidation(initializer corev1alpha1.LogicalClusterInitializer) re
 					if len(previous)-len(current) != 1 {
 						return invalidUpdateErr
 					}
-					for _, item := range current {
-						if item == string(initializer) {
-							return invalidUpdateErr
-						}
+					if slices.Contains(current, string(initializer)) {
+						return invalidUpdateErr
 					}
 				}
 				return updateValidation(ctx, obj, old)

--- a/pkg/virtual/initializingworkspaces/builder/forwarding.go
+++ b/pkg/virtual/initializingworkspaces/builder/forwarding.go
@@ -217,12 +217,17 @@ func withUpdateValidation(initializer corev1alpha1.LogicalClusterInitializer) re
 						fmt.Sprintf("only removing the %q initializer is supported", initializer),
 					)},
 				)
-				if len(previous)-len(current) != 1 {
-					return invalidUpdateErr
-				}
-				for _, item := range current {
-					if item == string(initializer) {
+				// Allow updates that don't touch initializers (e.g. condition-only status
+				// updates while bindings are still pending). Otherwise require exactly one
+				// initializer removed and it must be the one this VW is scoped to.
+				if len(previous) != len(current) {
+					if len(previous)-len(current) != 1 {
 						return invalidUpdateErr
+					}
+					for _, item := range current {
+						if item == string(initializer) {
+							return invalidUpdateErr
+						}
 					}
 				}
 				return updateValidation(ctx, obj, old)

--- a/pkg/virtual/terminatingworkspaces/builder/forwarding.go
+++ b/pkg/virtual/terminatingworkspaces/builder/forwarding.go
@@ -221,13 +221,22 @@ func validateTerminatorStatusUpdate(terminator corev1alpha1.LogicalClusterTermin
 		)
 
 		// Allow updates that don't touch terminators (e.g. condition-only status
-		// updates while termination is still pending). Otherwise require exactly one
-		// terminator removed and it must be the one this VW is scoped to.
-		if len(previous) != len(current) {
-			if len(previous)-len(current) != 1 {
-				return invalidUpdateErr
-			}
-			if slices.Contains(current, string(terminator)) {
+		// updates while termination is still pending).
+		if slices.Equal(previous, current) {
+			return nil
+		}
+
+		// Otherwise require exactly one terminator removed and it must be the one
+		// this VW is scoped to.
+		if len(previous)-len(current) != 1 {
+			return invalidUpdateErr
+		}
+		if slices.Contains(current, string(terminator)) {
+			return invalidUpdateErr
+		}
+		// Ensure no new terminators were introduced (current must be a subset of previous).
+		for _, c := range current {
+			if !slices.Contains(previous, c) {
 				return invalidUpdateErr
 			}
 		}

--- a/pkg/virtual/terminatingworkspaces/builder/forwarding.go
+++ b/pkg/virtual/terminatingworkspaces/builder/forwarding.go
@@ -220,11 +220,16 @@ func validateTerminatorStatusUpdate(terminator corev1alpha1.LogicalClusterTermin
 			)},
 		)
 
-		if len(previous)-len(current) != 1 {
-			return invalidUpdateErr
-		}
-		if slices.Contains(current, string(terminator)) {
-			return invalidUpdateErr
+		// Allow updates that don't touch terminators (e.g. condition-only status
+		// updates while termination is still pending). Otherwise require exactly one
+		// terminator removed and it must be the one this VW is scoped to.
+		if len(previous) != len(current) {
+			if len(previous)-len(current) != 1 {
+				return invalidUpdateErr
+			}
+			if slices.Contains(current, string(terminator)) {
+				return invalidUpdateErr
+			}
 		}
 
 		return nil

--- a/pkg/virtual/terminatingworkspaces/builder/forwarding_test.go
+++ b/pkg/virtual/terminatingworkspaces/builder/forwarding_test.go
@@ -78,9 +78,30 @@ func TestValidateOnlyTerminatorChanged(t *testing.T) {
 		},
 		{
 			name:   "no object changes",
-			expErr: true, // we expect an error here, as we always expect the number of terminators to decrease
+			expErr: false, // condition-only status updates that don't touch terminators are allowed
 			old:    &corev1alpha1.LogicalCluster{},
 			new:    &corev1alpha1.LogicalCluster{},
+		},
+		{
+			name:       "no terminator change with terminators present",
+			expErr:     false,
+			terminator: "t1",
+			old: &corev1alpha1.LogicalCluster{
+				Status: corev1alpha1.LogicalClusterStatus{
+					Terminators: []corev1alpha1.LogicalClusterTerminator{
+						"t1",
+						"t2",
+					},
+				},
+			},
+			new: &corev1alpha1.LogicalCluster{
+				Status: corev1alpha1.LogicalClusterStatus{
+					Terminators: []corev1alpha1.LogicalClusterTerminator{
+						"t1",
+						"t2",
+					},
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Fix noise from these:
```
E0505 11:53:36.017686    1919 apibinder_initializer_controller.go:291] "Unhandled Error" err="kcp-apibinder-initializer: failed to sync \"i0wh7p9b1xi5w2t8|cluster\", err: failed to patch *v1alpha1.LogicalCluster cluster: LogicalCluster.tenancy.kcp.io \"cluster\" is invalid: status.initializers: Invalid value: [\"system:apibindings\"]: only removing the \"system:apibindings\" initializer is supported" logger="UnhandledError"
```

## What Type of PR Is This?
/kind chore

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
