### PR TITLE
remove default /services/ mapping in front-proxy during e2e tests

### DIFF
--- a/cmd/sharded-test-server/frontproxy.go
+++ b/cmd/sharded-test-server/frontproxy.go
@@ -70,14 +70,6 @@ func startFrontProxy(
 
 	mappings := []types.PathMapping{
 		{
-			Path: "/services/",
-			// TODO: support multiple virtual workspace backend servers
-			Backend:         fmt.Sprintf("https://localhost:%s", vwPort),
-			BackendServerCA: filepath.Join(workDirPath, ".kcp", "serving-ca.crt"),
-			ProxyClientCert: filepath.Join(workDirPath, ".kcp-front-proxy", "requestheader.crt"),
-			ProxyClientKey:  filepath.Join(workDirPath, ".kcp-front-proxy", "requestheader.key"),
-		},
-		{
 			Path:            "/e2e/clusters/{cluster}/",
 			Backend:         "https://localhost:2443",
 			BackendServerCA: filepath.Join(workDirPath, ".kcp", "serving-ca.crt"),

--- a/pkg/proxy/doc.go
+++ b/pkg/proxy/doc.go
@@ -21,11 +21,6 @@ limitations under the License.
 //
 // An example configuration:
 //
-//   - path: /services/
-//     backend: https://localhost:6444
-//     backend_server_ca: certs/kcp-ca-cert.pem
-//     proxy_client_cert: certs/proxy-client-cert.pem
-//     proxy_client_key: certs/proxy-client-key.pem
 //   - path: /
 //     backend: https://localhost:6443
 //     backend_server_ca: certs/kcp-ca-cert.pem


### PR DESCRIPTION
## Summary
Routing virtual-workspace traffic through the front-proxy is nowadays considered an anti-pattern. To get rid of it, we should first start by making sure none of our own tests rely on that mapping anymore.

The bigger impact will be felt in the kcp-operator, which is usually responsible for creating the front-proxy's ConfigMap. No release note on this PR here because this only affects our tests.

## What Type of PR Is This?
/kind cleanup

## Related Issue(s)
Fixes #3826

## Release Notes
```release-note
NONE
```
