### PR TITLE
cli: support a --workspace (-w) flag to override the workspace

### DIFF
--- a/staging/src/github.com/kcp-dev/cli/pkg/base/options.go
+++ b/staging/src/github.com/kcp-dev/cli/pkg/base/options.go
@@ -28,10 +28,14 @@ type Options struct {
 	// OptOutOfDefaultKubectlFlags indicates that the standard kubectl/kubeconfig-related flags should not be bound
 	// by default.
 	OptOutOfDefaultKubectlFlags bool
+	// OptOutOfWorkspaceFlag indicates that the --workspace/-w flag should not be bound.
+	OptOutOfWorkspaceFlag bool
 	// Kubeconfig specifies kubeconfig file(s).
 	Kubeconfig string
 	// KubectlOverrides stores the extra client connection fields, such as context, user, etc.
 	KubectlOverrides *clientcmd.ConfigOverrides
+	// Workspace is an optional workspace path to target, overriding the current workspace in the kubeconfig.
+	Workspace string
 
 	genericclioptions.IOStreams
 
@@ -54,7 +58,15 @@ func (o *Options) BindFlags(cmd *cobra.Command) {
 		return
 	}
 
-	cmd.Flags().StringVar(&o.Kubeconfig, "kubeconfig", o.Kubeconfig, "path to the kubeconfig file")
+	cmd.Flags().StringVar(&o.Kubeconfig, "kubeconfig", o.Kubeconfig, "Path to the kubeconfig file")
+
+	if !o.OptOutOfWorkspaceFlag {
+		cmd.Flags().StringVarP(&o.Workspace, "workspace", "w", o.Workspace,
+			"Workspace path to target. If not specified, the current workspace from the kubeconfig will be used. "+
+				"Use a leading ':' for absolute paths (e.g. ':root:my-ws'), or omit it for relative paths (e.g. 'my-ws'). "+
+				"'.' stays in the current workspace, '..' navigates to the parent workspace.",
+		)
+	}
 
 	// We add only a subset of kubeconfig-related flags to the plugin.
 	// All those with LongName == "" will be ignored.
@@ -76,6 +88,15 @@ func (o *Options) Complete() error {
 		loadingRules.ExplicitPath = o.Kubeconfig
 
 		o.ClientConfig = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, o.KubectlOverrides)
+	}
+
+	// If the workspace flag is set, wrap the given ClientConfig to override
+	// the server URL to point to a specific workspace.
+	if o.Workspace != "" {
+		o.ClientConfig = &workspaceOverrideClientConfig{
+			delegate:  o.ClientConfig,
+			workspace: o.Workspace,
+		}
 	}
 
 	return nil

--- a/staging/src/github.com/kcp-dev/cli/pkg/base/workspaceoverride.go
+++ b/staging/src/github.com/kcp-dev/cli/pkg/base/workspaceoverride.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package base
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	pluginhelpers "github.com/kcp-dev/cli/pkg/helpers"
+	"github.com/kcp-dev/logicalcluster/v3"
+)
+
+// workspaceOverrideClientConfig wraps a ClientConfig and overrides
+// the server URL to point to a specific workspace.
+type workspaceOverrideClientConfig struct {
+	delegate  clientcmd.ClientConfig
+	workspace string
+}
+
+func (c *workspaceOverrideClientConfig) RawConfig() (clientcmdapi.Config, error) {
+	return c.delegate.RawConfig()
+}
+
+func (c *workspaceOverrideClientConfig) Namespace() (string, bool, error) {
+	return c.delegate.Namespace()
+}
+
+func (c *workspaceOverrideClientConfig) ConfigAccess() clientcmd.ConfigAccess {
+	return c.delegate.ConfigAccess()
+}
+
+func (c *workspaceOverrideClientConfig) ClientConfig() (*rest.Config, error) {
+	delegateCfg, err := c.delegate.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	cfg := rest.CopyConfig(delegateCfg)
+
+	u, currentPath, err := pluginhelpers.ParseClusterURL(cfg.Host)
+	if err != nil {
+		return nil, fmt.Errorf("current URL %q does not point to a workspace: %w", cfg.Host, err)
+	}
+
+	name := c.workspace
+	if strings.HasPrefix(name, ":") {
+		name = strings.TrimPrefix(name, ":")
+	} else {
+		name = currentPath.Join(name).String()
+	}
+
+	pth, err := resolveWorkspaceDots(name)
+	if err != nil {
+		return nil, err
+	}
+	if !pth.IsValid() {
+		return nil, fmt.Errorf("invalid workspace path: %s", c.workspace)
+	}
+
+	u.Path = path.Join(u.Path, pth.RequestPath())
+	cfg.Host = u.String()
+	return cfg, nil
+}
+
+// resolveWorkspaceDots resolves "." (stay) and ".." (go to parent) components in a colon-separated workspace path.
+func resolveWorkspaceDots(pth string) (logicalcluster.Path, error) {
+	var ret logicalcluster.Path
+	for _, part := range strings.Split(pth, ":") {
+		switch part {
+		case ".":
+			continue
+		case "..":
+			if ret.Empty() {
+				return logicalcluster.Path{}, errors.New("cannot go above the root workspace")
+			}
+			ret, _ = ret.Parent()
+		default:
+			ret = ret.Join(part)
+		}
+	}
+	return ret, nil
+}

--- a/staging/src/github.com/kcp-dev/cli/pkg/base/workspaceoverride_test.go
+++ b/staging/src/github.com/kcp-dev/cli/pkg/base/workspaceoverride_test.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package base
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+)
+
+func TestResolveWorkspaceDots(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "simple name",
+			path: "root",
+			want: "root",
+		},
+		{
+			name: "colon-separated path",
+			path: "root:foo:bar",
+			want: "root:foo:bar",
+		},
+		{
+			name: "dot is a no-op",
+			path: "root:.:foo",
+			want: "root:foo",
+		},
+		{
+			name: "leading dot",
+			path: ".:root:foo",
+			want: "root:foo",
+		},
+		{
+			name: "dot-dot goes up one level",
+			path: "root:foo:..",
+			want: "root",
+		},
+		{
+			name: "dot-dot in the middle",
+			path: "root:foo:..bar",
+			want: "root:foo:..bar",
+		},
+		{
+			name: "multiple dot-dots",
+			path: "root:foo:bar:..:..",
+			want: "root",
+		},
+		{
+			name: "dot-dot then descend",
+			path: "root:foo:bar:..:baz",
+			want: "root:foo:baz",
+		},
+		{
+			name: "dot-dot from single segment yields empty path",
+			path: "root:..",
+			want: "",
+		},
+		{
+			name:    "dot-dot on empty path errors",
+			path:    "..",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveWorkspaceDots(tt.path)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, logicalcluster.NewPath(tt.want), got)
+		})
+	}
+}
+
+func TestWorkspaceOverrideClientConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		baseHost  string
+		workspace string
+		wantHost  string
+		wantErr   bool
+	}{
+		{
+			name:      "absolute path replaces current workspace",
+			baseHost:  "https://host/clusters/root:other",
+			workspace: ":root:my-ws",
+			wantHost:  "https://host/clusters/root:my-ws",
+		},
+		{
+			name:      "relative name appended to current workspace",
+			baseHost:  "https://host/clusters/root",
+			workspace: "my-ws",
+			wantHost:  "https://host/clusters/root:my-ws",
+		},
+		{
+			name:      "relative name appended to nested workspace",
+			baseHost:  "https://host/clusters/root:parent",
+			workspace: "my-ws",
+			wantHost:  "https://host/clusters/root:parent:my-ws",
+		},
+		{
+			name:      "dot-dot navigates to parent",
+			baseHost:  "https://host/clusters/root:parent:child",
+			workspace: "..",
+			wantHost:  "https://host/clusters/root:parent",
+		},
+		{
+			name:      "dot-dot in absolute path",
+			baseHost:  "https://host/clusters/root:other",
+			workspace: ":root:parent:..",
+			wantHost:  "https://host/clusters/root",
+		},
+		{
+			name:      "base URL prefix is preserved",
+			baseHost:  "https://host/prefix/clusters/root:foo",
+			workspace: ":root:bar",
+			wantHost:  "https://host/prefix/clusters/root:bar",
+		},
+		{
+			name:      "host not pointing to a workspace errors",
+			baseHost:  "https://host/not-a-cluster",
+			workspace: "my-ws",
+			wantErr:   true,
+		},
+		{
+			name:      "dot-dot above root errors",
+			baseHost:  "https://host/clusters/root",
+			workspace: ":root:..",
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &workspaceOverrideClientConfig{
+				delegate:  &fakeClientConfig{host: tt.baseHost},
+				workspace: tt.workspace,
+			}
+			cfg, err := c.ClientConfig()
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantHost, cfg.Host)
+		})
+	}
+}
+
+func TestWorkspaceOverrideClientConfigDelegation(t *testing.T) {
+	streams, _, _, _ := genericclioptions.NewTestIOStreams()
+	o := NewOptions(streams)
+	o.Workspace = ":root:ws"
+
+	o.ClientConfig = &fakeClientConfig{host: "https://host/clusters/root"}
+	require.NoError(t, o.Complete())
+
+	_, ok := o.ClientConfig.(*workspaceOverrideClientConfig)
+	require.True(t, ok, "expected ClientConfig to be wrapped in workspaceOverrideClientConfig")
+}
+
+type fakeClientConfig struct {
+	host string
+}
+
+func (f *fakeClientConfig) ClientConfig() (*rest.Config, error) {
+	return &rest.Config{Host: f.host}, nil
+}
+func (f *fakeClientConfig) RawConfig() (clientcmdapi.Config, error) { panic("not implemented") }
+func (f *fakeClientConfig) Namespace() (string, bool, error)        { panic("not implemented") }
+func (f *fakeClientConfig) ConfigAccess() clientcmd.ConfigAccess    { panic("not implemented") }

--- a/staging/src/github.com/kcp-dev/cli/pkg/crd/plugin/snapshot.go
+++ b/staging/src/github.com/kcp-dev/cli/pkg/crd/plugin/snapshot.go
@@ -54,6 +54,7 @@ func NewSnapshotOptions(streams genericclioptions.IOStreams) *SnapshotOptions {
 	}
 
 	o.OptOutOfDefaultKubectlFlags = true
+	o.OptOutOfWorkspaceFlag = true
 
 	return o
 }

--- a/staging/src/github.com/kcp-dev/cli/pkg/quickstart/plugin/options.go
+++ b/staging/src/github.com/kcp-dev/cli/pkg/quickstart/plugin/options.go
@@ -63,6 +63,7 @@ func NewQuickstartOptions(streams genericiooptions.IOStreams) *QuickstartOptions
 		newKCPDynamicClient: defaultKCPDynamicClient,
 	}
 	o.enterWorkspace = o.defaultEnterWorkspace
+	o.OptOutOfWorkspaceFlag = true
 	return o
 }
 

--- a/staging/src/github.com/kcp-dev/cli/pkg/workspace/plugin/context.go
+++ b/staging/src/github.com/kcp-dev/cli/pkg/workspace/plugin/context.go
@@ -54,8 +54,10 @@ type CreateContextOptions struct {
 
 // NewCreateContextOptions returns a new CreateContextOptions.
 func NewCreateContextOptions(streams genericclioptions.IOStreams) *CreateContextOptions {
+	opts := base.NewOptions(streams)
+	opts.OptOutOfWorkspaceFlag = true
 	return &CreateContextOptions{
-		Options: base.NewOptions(streams),
+		Options: opts,
 
 		modifyConfig: func(configAccess clientcmd.ConfigAccess, newConfig *clientcmdapi.Config) error {
 			return clientcmd.ModifyConfig(configAccess, *newConfig, true)

--- a/staging/src/github.com/kcp-dev/cli/pkg/workspace/plugin/use.go
+++ b/staging/src/github.com/kcp-dev/cli/pkg/workspace/plugin/use.go
@@ -70,8 +70,10 @@ type UseWorkspaceOptions struct {
 
 // NewUseWorkspaceOptions returns a new UseWorkspaceOptions.
 func NewUseWorkspaceOptions(streams genericclioptions.IOStreams) *UseWorkspaceOptions {
+	opts := base.NewOptions(streams)
+	opts.OptOutOfWorkspaceFlag = true
 	return &UseWorkspaceOptions{
-		Options: base.NewOptions(streams),
+		Options: opts,
 
 		newKCPClusterClient: newKCPClusterClient,
 		modifyConfig: func(configAccess clientcmd.ConfigAccess, newConfig *clientcmdapi.Config) error {
@@ -466,8 +468,10 @@ type CurrentWorkspaceOptions struct {
 
 // NewCurrentWorkspaceOptions returns a new CurrentWorkspaceOptions.
 func NewCurrentWorkspaceOptions(streams genericclioptions.IOStreams) *CurrentWorkspaceOptions {
+	opts := base.NewOptions(streams)
+	opts.OptOutOfWorkspaceFlag = true
 	return &CurrentWorkspaceOptions{
-		Options: base.NewOptions(streams),
+		Options: opts,
 	}
 }
 


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

```
If this new flag is passed it will wrap the ClientConfig
(which comes from --kubeconfig) and override the URL
that is set in the file to point to the given workspace.

This allows for usage like:
  kubectl-kcp workspace tree --workspace :root:foo
  kubectl-kcp workspace create my-ws --workspace :root:foo
  ...

Supported for:

kubectl kcp bind apiexport
kubectl kcp workspace create
kubectl kcp workspace tree
kubectl kcp claims

Not supported for (as it doesn't make much sense there):

kubectl kcp workspace use
kubectl kcp workspace current
kubectl kcp workspace create-context
kubectl kcp crd snapshot
kubectl kcp quickstart

Add unit tests for the new logic.
```

## What Type of PR Is This?

/kind feature

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #3911

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
cli: add the '--workspace'('-w') flag to the commands 'kubectl kcp bind apiexport', 'kubectl kcp workspace create', 'kubectl kcp workspace tree', 'kubectl kcp claims'. It can be used to override the current workspace defined in the kubeconfig.
```
