### PR TITLE
Add rebase-staging to publishing rules

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -6,6 +6,11 @@ rules:
           branch: main
           dirs:
             - staging/src/github.com/kcp-dev/apimachinery
+      - name: rebase-staging
+        source:
+          branch: rebase-staging
+          dirs:
+            - staging/src/github.com/kcp-dev/apimachinery
       - name: release-0.29
         go: 1.24.13
         source:
@@ -31,6 +36,11 @@ rules:
       - name: main
         source:
           branch: main
+          dirs:
+            - staging/src/github.com/kcp-dev/code-generator
+      - name: rebase-staging
+        source:
+          branch: rebase-staging
           dirs:
             - staging/src/github.com/kcp-dev/code-generator
       - name: release-0.29
@@ -63,6 +73,16 @@ rules:
             branch: main
         source:
           branch: main
+          dirs:
+            - staging/src/github.com/kcp-dev/client-go
+      - name: rebase-staging
+        dependencies:
+          - repository: apimachinery
+            branch: rebase-staging
+          - repository: code-generator
+            branch: rebase-staging
+        source:
+          branch: rebase-staging
           dirs:
             - staging/src/github.com/kcp-dev/client-go
       - name: release-0.29


### PR DESCRIPTION

<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

For the rebase process we need a clean way for the changes for apimachinery and client-go to land in a branch in the staging repositories.

To this end I want the branch `rebase-staging` to be published for these two.

That means a maintainer can update `rebase-staging` to be up to date with main, the person rebasing PRs against this branch, the changes get reviewed, merged and published.

Then the kubernetes fork can be updated targeting the `rebase-staging` branch in the respective repositories.


## What Type of PR Is This?

/kind chore

/hold 

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
