### PR TITLE
Fix idempotent CachedResources clients

### DIFF
--- a/pkg/admission/cachedresource/admission.go
+++ b/pkg/admission/cachedresource/admission.go
@@ -156,8 +156,15 @@ func (adm *CachedResourceAdmission) validateV1alpha1(ctx context.Context, a admi
 		return err
 	}
 
-	// Make sure there is at most one CachedResource per GVR.
-	if len(existing) > 0 {
+	// Make sure there is at most one CachedResource per GVR. An entry that
+	// matches the incoming object's name is not a real conflict — it is a
+	// re-apply of the same object, which the storage layer will surface
+	// naturally as AlreadyExists. Rejecting here would mask that error
+	// behind a misleading Forbidden and break idempotent client flows.
+	for _, e := range existing {
+		if e.Name == cachedResource.Name {
+			continue
+		}
 		return admission.NewForbidden(a,
 			field.Invalid(
 				field.NewPath("spec"),

--- a/pkg/admission/cachedresource/admission_test.go
+++ b/pkg/admission/cachedresource/admission_test.go
@@ -156,6 +156,30 @@ func TestAdmission(t *testing.T) {
 			),
 			cluster: logicalcluster.Name("cluster-2"),
 		},
+		"SameNameReapply": {
+			attr: createAttr(createCachedResource("wohoo", schema.GroupVersionResource{
+				Group:    "example.org",
+				Version:  "v1",
+				Resource: "objects",
+			})),
+			index: map[logicalcluster.Name]map[schema.GroupVersionResource][]*cachev1alpha1.CachedResource{
+				"cluster-1": {
+					schema.GroupVersionResource{
+						Group:    "example.org",
+						Version:  "v1",
+						Resource: "objects",
+					}: []*cachev1alpha1.CachedResource{
+						createCachedResource("wohoo", schema.GroupVersionResource{
+							Group:    "example.org",
+							Version:  "v1",
+							Resource: "objects",
+						}),
+					},
+				},
+			},
+			wantErr: nil,
+			cluster: logicalcluster.Name("cluster-1"),
+		},
 		"IgnoreIfNotCreate": {
 			attr: updateAttr(createCachedResource("wohoo", schema.GroupVersionResource{
 				Group:    "example.org",


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Fix idempotency for clients for CachedResources. Else on apply it returns Forbidden. 

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Fix idempotency for clients for CachedResources
```
