### PR TITLE
Terser authentication logic in front-proxy

### DIFF
--- a/pkg/proxy/config.go
+++ b/pkg/proxy/config.go
@@ -50,9 +50,8 @@ type ExtraConfig struct {
 	RootShardConfig   *rest.Config
 	ShardsConfig      *rest.Config
 
-	AuthenticationInfo    genericapiserver.AuthenticationInfo
-	ServingInfo           *genericapiserver.SecureServingInfo
-	AdditionalAuthEnabled bool
+	AuthenticationInfo genericapiserver.AuthenticationInfo
+	ServingInfo        *genericapiserver.SecureServingInfo
 }
 
 type CompletedConfig struct {
@@ -102,8 +101,6 @@ func NewConfig(ctx context.Context, opts *proxyoptions.Options) (*Config, error)
 		return nil, fmt.Errorf("failed to load shard kubeconfig: %w", err)
 	}
 	c.ShardsConfig.Wrap(kcpShardIdentityRoundTripper)
-
-	c.AdditionalAuthEnabled = c.Options.Authentication.AdditionalAuthEnabled()
 
 	return c, nil
 }

--- a/pkg/proxy/filters/filters.go
+++ b/pkg/proxy/filters/filters.go
@@ -27,57 +27,44 @@ import (
 	authenticatorunion "k8s.io/apiserver/pkg/authentication/request/union"
 	genericapifilters "k8s.io/apiserver/pkg/endpoints/filters"
 	"k8s.io/apiserver/pkg/endpoints/request"
-	"k8s.io/klog/v2"
 
 	"github.com/kcp-dev/kcp/pkg/authentication"
 )
 
-// WithOptionalAuthentication creates a handler that authenticates a request
-// if a ClientCert is presented but passes through to the next handler if one is
-// not. It will also call the authenticator present in the request context, if
-// any, to support per-workspace authentication.
-// When additionalAuthMethods is true we also attempt to authenticate even when
-// no client cert is detected in the request.
-func WithOptionalAuthentication(handler, failed http.Handler, auth authenticator.Request, additionalAuthMethods bool) http.Handler {
+// WithOptionalAuthentication creates a handler that authenticates
+// a request if credentials are presented but passes through to the next
+// handler if one is not.
+func WithOptionalAuthentication(handler, failed http.Handler, auth authenticator.Request) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		// Do not accidentally modify the variables in the scope of WithOptionalAuthentication().
-		var (
-			authenticator  = auth
-			additionalAuth = additionalAuthMethods
-		)
-
-		// If an authenticator for the workspace exists,
-		// it offers an alternative way to authenticate.
-		reqAuthenticator, ok := authentication.WorkspaceAuthenticatorFrom(req.Context())
-		if ok {
-			if auth != nil {
-				authenticator = authenticatorunion.New(auth, reqAuthenticator)
-			} else {
-				authenticator = reqAuthenticator
-			}
-			additionalAuth = true
+		// Collect all available authenticators: base (client cert, token file, etc.)
+		// plus any per-workspace authenticator resolved earlier in the chain.
+		authenticators := make([]authenticator.Request, 0, 2)
+		if auth != nil {
+			authenticators = append(authenticators, auth)
 		}
 
-		if authenticator == nil {
+		if wsAuth, ok := authentication.WorkspaceAuthenticatorFrom(req.Context()); ok {
+			authenticators = append(authenticators, wsAuth)
+		}
+
+		// No authenticators configured
+		if len(authenticators) == 0 {
 			handler.ServeHTTP(w, req)
 			return
 		}
 
-		if (req.TLS == nil || len(req.TLS.PeerCertificates) == 0) && !additionalAuth {
-			handler.ServeHTTP(w, req)
-			return
+		// Try to authenticate the request
+		combined := authenticatorunion.New(authenticators...)
+		resp, ok, err := combined.AuthenticateRequest(req)
+		if err == nil && ok {
+			// Add identity if authentication passed
+			req = req.WithContext(request.WithUser(req.Context(), resp.User))
+			// If this failed the request has to propagate to the shard.
+			// The request might be made with a static token which the
+			// front-proxy has no knowledge of.
+			// This will be superfluous in the future, see
+			// https://github.com/kcp-dev/kcp/issues/4100
 		}
-
-		resp, ok, err := authenticator.AuthenticateRequest(req)
-		if err != nil || !ok {
-			if err != nil {
-				logger := klog.FromContext(req.Context())
-				logger.Error(err, "Unable to authenticate the request")
-			}
-			failed.ServeHTTP(w, req)
-			return
-		}
-		req = req.WithContext(request.WithUser(req.Context(), resp.User))
 		handler.ServeHTTP(w, req)
 	})
 }

--- a/pkg/proxy/options/authentication.go
+++ b/pkg/proxy/options/authentication.go
@@ -55,7 +55,6 @@ type Authentication struct {
 // NewAuthentication creates a default Authentication.
 func NewAuthentication() *Authentication {
 	auth := &Authentication{
-		// Note: when adding new auth methods, also update AdditionalAuthEnabled below
 		BuiltInOptions: kubeoptions.NewBuiltInAuthenticationOptions().
 			WithClientCert().
 			WithOIDC().
@@ -70,19 +69,6 @@ func NewAuthentication() *Authentication {
 	}
 	auth.BuiltInOptions.ServiceAccounts.Issuers = []string{"https://kcp.default.svc"}
 	return auth
-}
-
-// When configured to enable auth other than ClientCert, this returns true.
-func (c *Authentication) AdditionalAuthEnabled() bool {
-	return c.tokenAuthEnabled() || c.serviceAccountAuthEnabled() || c.oidcAuthEnabled()
-}
-
-func (c *Authentication) oidcAuthEnabled() bool {
-	return c.BuiltInOptions.OIDC != nil && c.BuiltInOptions.OIDC.IssuerURL != ""
-}
-
-func (c *Authentication) tokenAuthEnabled() bool {
-	return c.BuiltInOptions.TokenFile != nil && c.BuiltInOptions.TokenFile.TokenFile != ""
 }
 
 func (c *Authentication) serviceAccountAuthEnabled() bool {

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -100,16 +100,11 @@ func NewServer(ctx context.Context, c CompletedConfig) (*Server, error) {
 		return s, err
 	}
 
-	// The optional auth handler will call the underlying authenticator only if
-	// auth methods are configured directly on the front-proxy *or* if there is
-	// a custom workspace authenticator, i.e. the AdditionalAuthEnabled field
-	// only represents the CLI flag state.
 	failedHandler := frontproxyfilters.NewUnauthorizedHandler()
 	handler = frontproxyfilters.WithOptionalAuthentication(
 		handler,
 		failedHandler,
-		s.completedConfig.AuthenticationInfo.Authenticator,
-		s.CompletedConfig.AdditionalAuthEnabled)
+		s.completedConfig.AuthenticationInfo.Authenticator)
 
 	// Make the per-workspace authenticator available to the previous middleware
 	// by hooking up a handler and a runtime index.


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

That logic never sat right with me and it seems to cause a logic error.

The original error was fixed with https://github.com/kcp-dev/kcp/pull/4125, which moved the front-proxy back to its old behaviour that relies on essentially a race for the test to function:

The root cause of the error was that an authenticated request came through but the authenticator wasn't yet ready, so the original code here: 
https://github.com/kcp-dev/kcp/blob/5a9d2e2518464cb32e9871e543b5db2b38902ede/pkg/proxy/filters/filters.go#L49-L59

Would return `nil, false` from here https://github.com/kcp-dev/kcp/blob/5a9d2e2518464cb32e9871e543b5db2b38902ede/pkg/authentication/filters.go#L67-L73

Because the handler that should add the workspace authenticator in the cotext silently fails here:
https://github.com/kcp-dev/kcp/blob/5a9d2e2518464cb32e9871e543b5db2b38902ede/pkg/authentication/filters.go#L41-L44

Because of the change that validated authenticators before returning them the authenticator was in the index later than the test assumed, turning this into a race.

Anyhow - this doesn't fix that issue. I just noticed this issue because of that.

This fixes another problem that currently isn't tested - if a request with a static token comes in for a workspace that has per-workspace authentication configured the request will get denied.

I skipped writing a test for this because this will be fixed as part of https://github.com/kcp-dev/kcp/issues/4100

## What Type of PR Is This?

/kind bug

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
