### PR TITLE
Fix ws tree with clusters url

### DIFF
--- a/staging/src/github.com/kcp-dev/cli/pkg/workspace/plugin/tree.go
+++ b/staging/src/github.com/kcp-dev/cli/pkg/workspace/plugin/tree.go
@@ -266,37 +266,39 @@ func (o *TreeOptions) populateInteractiveNodeBubble(ctx context.Context, node *t
 			if ws.DeletionTimestamp != nil {
 				continue
 			}
+			// A mounted workspace's content is served by the mount provider, not
+			// by recursive Workspace listing. Represent it as a non-selectable leaf
+			// regardless of whether its proxy URL happens to contain a /clusters/
+			// segment — when it does, that segment typically points back at the
+			// parent cluster, which would cause this recursion to loop forever.
+			if ws.Spec.Mount != nil {
+				childName := ws.Name
+				if o.Full {
+					childName = workspaceName + ":" + childName
+				}
+				// Use the logical parent path + workspace name as an approximation.
+				mountPath := workspace.Join(ws.Name)
+				childWorkspaceInfo := &workspaceInfo{
+					Path:    mountPath,
+					Type:    ws.Spec.Type,
+					Cluster: ws.Spec.Cluster,
+				}
+				childNode := &treeNode{
+					name:           childName + " [m]",
+					path:           mountPath,
+					info:           childWorkspaceInfo,
+					selectable:     false,
+					parent:         node,
+					childrenLoaded: true,
+					apiInfoLoaded:  false,
+					hasChildren:    false,
+				}
+				node.children = append(node.children, childNode)
+				node.hasChildren = true
+				continue
+			}
 			_, childPath, err := pluginhelpers.ParseClusterURL(ws.Spec.URL)
 			if err != nil {
-				if ws.Spec.Mount != nil {
-					// Mounted workspaces use a provider-specific URL that does not
-					// follow the /clusters/ pattern. Represent them as non-selectable
-					// leaf nodes; their content is served by the mount provider.
-					childName := ws.Name
-					if o.Full {
-						childName = workspaceName + ":" + childName
-					}
-					// Use the logical parent path + workspace name as an approximation.
-					mountPath := workspace.Join(ws.Name)
-					childWorkspaceInfo := &workspaceInfo{
-						Path:    mountPath,
-						Type:    ws.Spec.Type,
-						Cluster: ws.Spec.Cluster,
-					}
-					childNode := &treeNode{
-						name:           childName + " [m]",
-						path:           mountPath,
-						info:           childWorkspaceInfo,
-						selectable:     false,
-						parent:         node,
-						childrenLoaded: true,
-						apiInfoLoaded:  false,
-						hasChildren:    false,
-					}
-					node.children = append(node.children, childNode)
-					node.hasChildren = true
-					continue
-				}
 				return fmt.Errorf("workspace URL %q does not point to valid workspace", ws.Spec.URL)
 			}
 
@@ -374,19 +376,21 @@ func (o *TreeOptions) populateBranch(ctx context.Context, tree treeprint.Tree, p
 		if workspace.DeletionTimestamp != nil {
 			continue
 		}
+		// A mounted workspace's content is served by the mount provider, not by
+		// recursive Workspace listing. Render it as a leaf regardless of whether
+		// its proxy URL happens to contain a /clusters/<name>/ segment — when it
+		// does, that segment typically points back at the parent cluster, which
+		// would cause this recursion to loop forever.
+		if workspace.Spec.Mount != nil {
+			name := workspace.Name
+			if o.Full {
+				name = parentName + ":" + name
+			}
+			tree.AddBranch(name + " [m]")
+			continue
+		}
 		_, current, err := pluginhelpers.ParseClusterURL(workspace.Spec.URL)
 		if err != nil {
-			if workspace.Spec.Mount != nil {
-				// Mounted workspaces use a provider-specific URL that does not follow
-				// the /clusters/ pattern. Add them as leaf nodes since their children
-				// (if any) are served by the mount provider, not by the kcp API.
-				name := workspace.Name
-				if o.Full {
-					name = parentName + ":" + name
-				}
-				tree.AddBranch(name + " [m]")
-				continue
-			}
 			return fmt.Errorf("current config context URL %q does not point to workspace", workspace.Spec.URL)
 		}
 		// NOTE(hasheddan): the cluster URL from the Workspace does not use the

--- a/staging/src/github.com/kcp-dev/cli/pkg/workspace/plugin/tree_test.go
+++ b/staging/src/github.com/kcp-dev/cli/pkg/workspace/plugin/tree_test.go
@@ -161,6 +161,46 @@ func TestPopulateBranch_NormalWorkspace(t *testing.T) {
 		"expected normal workspace NOT to be marked as [m]")
 }
 
+// TestPopulateBranch_MountWorkspaceWithClustersURL verifies that a workspace
+// whose Spec.Mount is non-nil but whose Spec.URL still contains a /clusters/
+// segment is rendered as a leaf rather than recursed into. Mount provider URLs
+// often look like /services/<provider>/clusters/<parent>/... — that segment
+// resolves back to the parent cluster, so recursing would loop forever.
+func TestPopulateBranch_MountWorkspaceWithClustersURL(t *testing.T) {
+	// URL contains /clusters/root/, which would otherwise cause populateBranch
+	// to recurse into "root" (the same cluster it was just listing).
+	mountURLWithClusters := "https://localhost:9443/services/edges-proxy/clusters/root/apis/example.io/v1/edges/mounted-ws/k8s"
+
+	mountWS := &tenancyv1alpha1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "mounted-ws",
+			Annotations: map[string]string{logicalcluster.AnnotationKey: "root"},
+		},
+		Spec: tenancyv1alpha1.WorkspaceSpec{
+			URL:   mountURLWithClusters,
+			Mount: &tenancyv1alpha1.Mount{},
+		},
+	}
+
+	out := &bytes.Buffer{}
+	errOut := &bytes.Buffer{}
+	streams := genericclioptions.IOStreams{
+		In:     strings.NewReader(""),
+		Out:    out,
+		ErrOut: errOut,
+	}
+
+	o := newTreeOptions(streams, "https://test/clusters/root", mountWS)
+
+	tree := treeprint.New()
+	err := o.populateBranch(context.Background(), tree, logicalcluster.NewPath("root"), "root")
+	require.NoError(t, err, "populateBranch should not error or loop for a mount workspace whose URL contains /clusters/")
+
+	treeStr := tree.String()
+	require.Contains(t, treeStr, "mounted-ws [m]",
+		"expected mount workspace to be rendered as a '<name> [m]' leaf, not recursed into")
+}
+
 // TestRun_MountContextURL verifies that when the kubeconfig host points to a
 // non-standard (mount) URL, Run does not return an error; instead it prints a
 // message to Out and returns immediately (no fallback to root).


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

`ws tree` gets stuck if the URL contains `/clusters/<name>` and it creates an infinite loop. 

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
