### PR TITLE
Update k8s replacements in virtual-workspace-framework as well

### DIFF
--- a/hack/bump-k8s.sh
+++ b/hack/bump-k8s.sh
@@ -31,14 +31,34 @@ GITHUB_USER=${GITHUB_USER:-kcp-dev}
 GITHUB_REPO=${GITHUB_REPO:-kubernetes}
 BRANCH=${BRANCH:-kcp-1.31.0}
 
-current_version="$( GOPROXY=direct go mod edit -json | jq '.Replace[] | select(.Old.Path=="k8s.io/kubernetes") | .New.Version' --raw-output )"
+bump_root() {
+    local current_version="$( GOPROXY=direct go mod edit -json | jq '.Replace[] | select(.Old.Path=="k8s.io/kubernetes") | .New.Version' --raw-output )"
 
-# equivalent to go mod edit -replace
-is_gnu_sed() { sed --version >/dev/null 2>&1; }
-sed_args=( -i )
-if ! is_gnu_sed; then
-    sed_args+=( "" )
-fi
-sed "${sed_args[@]}" -e "s|${current_version}|${BRANCH}|g" -E -e "s,=> github.com/kcp-dev/kubernetes,=> github.com/${GITHUB_USER}/${GITHUB_REPO},g" go.mod
+    # equivalent to go mod edit -replace
+    is_gnu_sed() { sed --version >/dev/null 2>&1; }
+    local sed_args=( -i )
+    if ! is_gnu_sed; then
+        sed_args+=( "" )
+    fi
+    sed "${sed_args[@]}" -e "s|${current_version}|${BRANCH}|g" -E -e "s,=> github.com/kcp-dev/kubernetes,=> github.com/${GITHUB_USER}/${GITHUB_REPO},g" go.mod
 
-GOPROXY=direct go mod tidy
+    GOPROXY=direct go mod tidy
+}
+
+bump_vw_framework() {
+    go mod edit -json | jq -r '.Replace[] | "\(.Old.Path)=\(.New.Path)@\(.New.Version)"' | grep k8s.io \
+        | while read replace; do
+        go mod edit -modfile=./staging/src/github.com/kcp-dev/virtual-workspace-framework/go.mod -replace "$replace"
+    done
+
+    # `go mod tidy` and `-modfile` with relative replacements fails as
+    # it tries to resolve the relative paths from cwd instead of the
+    # modfile location.
+    (
+        cd staging/src/github.com/kcp-dev/virtual-workspace-framework
+        go mod tidy
+    )
+}
+
+bump_root
+bump_vw_framework


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

This is a followup to #4117 

The new `virtual-workspace-framework` staging directory also needs the replacements for the kube fork.
The `bump-k8s.sh` script now updates the replacements in that module after the versions in the root module have been resolved.

## What Type of PR Is This?

/kind chore

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
