### PR TITLE
Fixup openapi schema serving in VW

### DIFF
--- a/staging/src/github.com/kcp-dev/virtual-workspace-framework/pkg/dynamic/apiserver/openapi.go
+++ b/staging/src/github.com/kcp-dev/virtual-workspace-framework/pkg/dynamic/apiserver/openapi.go
@@ -163,13 +163,20 @@ func (o *openAPIHandler) handleOpenAPIRequest(apiSet apidefinition.APIDefinition
 	// If we found the struct, and the channel is closed, and the spec was generated successfully, serve the already
 	// generated spec, otherwise regenerate it.
 	if ok {
+		cached := entry.(*openAPIServiceItem)
+		// Wait for the previous attempt outside the key lock so concurrent
+		// requests can proceed; we still hold the key lock for the cache miss
+		// path below, so only one regeneration runs at a time per key.
 		_ = o.servicesLock.UnlockKey(key) // error is always nil
-		item = entry.(*openAPIServiceItem)
-		<-item.done
-		if item.err == nil {
+		<-cached.done
+		if cached.err == nil {
 			log.V(7).Info("Reusing OpenAPI v3 service from cache")
-			return item.service, nil
+			return cached.service, nil
 		}
+		// Cached entry recorded an error — reacquire the key lock so we can
+		// regenerate. Without this we'd fall through and call UnlockKey again
+		// on an unlocked mutex, panicking sync.Mutex.
+		o.servicesLock.LockKey(key)
 	}
 
 	doneCh := make(chan struct{})
@@ -246,10 +253,15 @@ func (o *openAPIHandler) handleOpenAPIRequest(apiSet apidefinition.APIDefinition
 		routeSpecs[groupPath] = []*spec3.OpenAPI{spec}
 	}
 
-	// Build OpenAPI v3 specs for /apis/<group>/<version>, i.e. build OpenAPI v3 specs for each APIDefinition
+	// Build OpenAPI v3 specs for /apis/<group>/<version>, i.e. build OpenAPI v3 specs for each APIDefinition.
+	// We pass the GVR's version so a multi-version APIResourceSchema (e.g. built-in apibindings carrying
+	// both v1alpha1 and v1alpha2) emits a spec only for the version this apiSet entry is keyed on.
+	// Otherwise the same APIResourceSchema referenced from two apiSet entries (one per version) would
+	// yield duplicate specs that addSpecs then tries to merge, which trips the strict component-name
+	// conflict check.
 	resourceSpecs := make([]map[string][]*spec3.OpenAPI, 0, len(apiSet))
-	for _, apiDefinition := range apiSet {
-		specs, err := apiResourceSchemaToSpec(apiDefinition.GetAPIResourceSchema())
+	for gvr, apiDefinition := range apiSet {
+		specs, err := apiResourceSchemaToSpec(apiDefinition.GetAPIResourceSchema(), gvr.Version)
 		if err != nil {
 			item.err = err
 			return nil, err
@@ -278,11 +290,19 @@ func (o *openAPIHandler) handleOpenAPIRequest(apiSet apidefinition.APIDefinition
 	return item.service, nil
 }
 
-func apiResourceSchemaToSpec(apiResourceSchema *apisv1alpha1.APIResourceSchema) (map[string][]*spec3.OpenAPI, error) {
+// apiResourceSchemaToSpec builds the OpenAPI v3 spec for the given APIResourceSchema.
+// If onlyVersion is non-empty, only that single version is emitted; this lets callers
+// avoid duplicate specs when the same multi-version APIResourceSchema is reached via
+// multiple per-version apiSet entries.
+func apiResourceSchemaToSpec(apiResourceSchema *apisv1alpha1.APIResourceSchema, onlyVersion string) (map[string][]*spec3.OpenAPI, error) {
 	specs := map[string][]*spec3.OpenAPI{}
 	versions := make([]apiextensionsv1.CustomResourceDefinitionVersion, 0, len(apiResourceSchema.Spec.Versions))
+	srcVersions := make([]apisv1alpha1.APIResourceVersion, 0, len(apiResourceSchema.Spec.Versions))
 
 	for _, ver := range apiResourceSchema.Spec.Versions {
+		if onlyVersion != "" && ver.Name != onlyVersion {
+			continue
+		}
 		verSchema, err := ver.GetSchema()
 		if err != nil {
 			return nil, err
@@ -295,6 +315,7 @@ func apiResourceSchemaToSpec(apiResourceSchema *apisv1alpha1.APIResourceSchema) 
 			},
 			Subresources: &ver.Subresources,
 		})
+		srcVersions = append(srcVersions, ver)
 	}
 
 	crd := &apiextensionsv1.CustomResourceDefinition{
@@ -313,7 +334,7 @@ func apiResourceSchemaToSpec(apiResourceSchema *apisv1alpha1.APIResourceSchema) 
 		}
 
 		if isCRDResource(crd) {
-			patchCRDSchemaForOpenAPI(spec, &apiResourceSchema.Spec.Versions[i])
+			patchCRDSchemaForOpenAPI(spec, &srcVersions[i])
 		}
 
 		gv := schema.GroupVersion{Group: crd.Spec.Group, Version: ver.Name}
@@ -427,7 +448,10 @@ func addSpecs(service *handler3.OpenAPIService, routeSpecs map[string][]*spec3.O
 
 	for _, apiDefSpec := range apiDefSpecs {
 		for gvPath, spec := range apiDefSpec {
-			byGroupVersionSpecs[gvPath] = spec
+			// Append rather than assign: multiple APIDefinitions may produce
+			// specs for the same group/version (e.g. several Kinds bound under
+			// one GV via an APIExport). MergeSpecsV3 below merges the slice.
+			byGroupVersionSpecs[gvPath] = append(byGroupVersionSpecs[gvPath], spec...)
 		}
 	}
 
@@ -435,7 +459,7 @@ func addSpecs(service *handler3.OpenAPIService, routeSpecs map[string][]*spec3.O
 	for gvPath, specs := range byGroupVersionSpecs {
 		log.V(6).Info("Merging OpenAPI v3 specs", "gvPath", gvPath)
 
-		gvSpec, err := builder.MergeSpecsV3(specs...)
+		gvSpec, err := mergeSpecsV3Tolerant(specs)
 		if err != nil {
 			return fmt.Errorf("failed to merge specs: %v", err)
 		}
@@ -444,6 +468,60 @@ func addSpecs(service *handler3.OpenAPIService, routeSpecs map[string][]*spec3.O
 	}
 
 	return nil
+}
+
+// mergeSpecsV3Tolerant merges OpenAPI v3 specs that share a group/version.
+//
+// Unlike apiextensions-apiserver's builder.MergeSpecsV3 it does NOT error on
+// shared component-schema names: when several CRDs are bound under the same
+// group/version (the case this handler is built for), every CRD's spec
+// re-emits common helper types (meta.v1.*, autoscaling.v1.*, and kcp-specific
+// types like apis.v1alpha1.APIBinding). The strict merge treats those as
+// conflicts. Here we keep the first definition we see — they're semantically
+// the same regardless of which CRD emitted them.
+//
+// Paths from later specs override earlier ones with the same key, which is
+// the natural behavior: each path lives on exactly one resource.
+func mergeSpecsV3Tolerant(specs []*spec3.OpenAPI) (*spec3.OpenAPI, error) {
+	merged := &spec3.OpenAPI{}
+	if len(specs) > 0 {
+		merged.Version = specs[0].Version
+		merged.Info = specs[0].Info
+	}
+	for _, s := range specs {
+		if s == nil {
+			continue
+		}
+		if s.Components != nil {
+			if merged.Components == nil {
+				merged.Components = &spec3.Components{}
+			}
+			if merged.Components.Schemas == nil {
+				merged.Components.Schemas = map[string]*spec.Schema{}
+			}
+			for k, v := range s.Components.Schemas {
+				if _, exists := merged.Components.Schemas[k]; exists {
+					// keep first; common helper types may differ slightly
+					// across per-CRD specs (e.g. description ordering) but
+					// are semantically equivalent.
+					continue
+				}
+				merged.Components.Schemas[k] = v
+			}
+		}
+		if s.Paths != nil {
+			if merged.Paths == nil {
+				merged.Paths = &spec3.Paths{}
+			}
+			if merged.Paths.Paths == nil {
+				merged.Paths.Paths = map[string]*spec3.Path{}
+			}
+			for k, v := range s.Paths.Paths {
+				merged.Paths.Paths[k] = v
+			}
+		}
+	}
+	return merged, nil
 }
 
 func apiConfigurationKey(apiDefs apidefinition.APIDefinitionSet) (string, error) {

--- a/test/e2e/virtual/apiexport/apiresourceschema_sheriffs.yaml
+++ b/test/e2e/virtual/apiexport/apiresourceschema_sheriffs.yaml
@@ -1,0 +1,40 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIResourceSchema
+metadata:
+  name: today.sheriffs.wildwest.dev
+spec:
+  group: wildwest.dev
+  names:
+    kind: Sheriff
+    listKind: SheriffList
+    plural: sheriffs
+    singular: sheriff
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      description: Sheriff is part of the wild west
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: SheriffSpec holds the desired state of the Sheriff.
+          properties:
+            badge:
+              type: string
+          type: object
+        status:
+          description: SheriffStatus communicates the observed state of the Sheriff.
+          properties:
+            ok:
+              type: boolean
+          type: object
+      type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/test/e2e/virtual/apiexport/openapi_test.go
+++ b/test/e2e/virtual/apiexport/openapi_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package apiexport
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -26,17 +27,21 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
 	"k8s.io/kube-openapi/pkg/util/sets"
 
 	kcpdynamic "github.com/kcp-dev/client-go/dynamic"
 	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
 	"github.com/kcp-dev/logicalcluster/v3"
+	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
 	"github.com/kcp-dev/sdk/apis/core"
 	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
 	kcptesting "github.com/kcp-dev/sdk/testing"
 	kcptestinghelpers "github.com/kcp-dev/sdk/testing/helpers"
 
+	"github.com/kcp-dev/kcp/config/helpers"
 	wildwestclientset "github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/client/clientset/versioned/cluster"
 	"github.com/kcp-dev/kcp/test/e2e/framework"
 )
@@ -110,4 +115,132 @@ func TestAPIExportOpenAPI(t *testing.T) {
 		}
 		return true, "found OpenAPI URLs"
 	}, wait.ForeverTestTimeout, time.Millisecond*100)
+}
+
+// TestAPIExportOpenAPI_MultipleKinds verifies that when an APIExport binds
+// multiple Kinds under the same group/version, the APIExport virtual workspace's
+// /openapi/v3/apis/<group>/<version> document contains schemas for ALL of those
+// Kinds — not just one. This used to fail because per-CRD OpenAPI was cached
+// individually on each shard and a single request would only surface one Kind.
+func TestAPIExportOpenAPI_MultipleKinds(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "control-plane")
+
+	server := kcptesting.SharedKcpServer(t)
+	cfg := server.BaseConfig(t)
+
+	kcpClients, err := kcpclientset.NewForConfig(cfg)
+	require.NoError(t, err, "failed to construct kcp cluster client for server")
+
+	dynamicClusterClient, err := kcpdynamic.NewForConfig(cfg)
+	require.NoError(t, err, "failed to construct dynamic cluster client for server")
+
+	kubeClusterClient, err := kcpkubernetesclientset.NewForConfig(cfg)
+	require.NoError(t, err, "failed to construct kube cluster client for server")
+
+	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
+	serviceProviderPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)
+	consumerPath, consumerWorkspace := kcptesting.NewWorkspaceFixture(t, server, orgPath)
+	consumerClusterName := logicalcluster.Name(consumerWorkspace.Spec.Cluster)
+
+	framework.AdmitWorkspaceAccess(t.Context(), t, kubeClusterClient, serviceProviderPath, []string{"user-1"}, nil, false)
+
+	// Install BOTH cowboys and sheriffs APIResourceSchemas under wildwest.dev/v1alpha1.
+	t.Logf("Install cowboys and sheriffs APIResourceSchemas into %q", serviceProviderPath)
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(
+		kcpClients.Cluster(serviceProviderPath).Discovery(),
+	))
+	require.NoError(t, helpers.CreateResourceFromFS(t.Context(), dynamicClusterClient.Cluster(serviceProviderPath), mapper, nil, "apiresourceschema_cowboys.yaml", testFiles))
+	require.NoError(t, helpers.CreateResourceFromFS(t.Context(), dynamicClusterClient.Cluster(serviceProviderPath), mapper, nil, "apiresourceschema_sheriffs.yaml", testFiles))
+
+	t.Logf("Create an APIExport referencing both Kinds in the same group/version")
+	export := &apisv1alpha2.APIExport{
+		ObjectMeta: metav1.ObjectMeta{Name: "wildwest-multi"},
+		Spec: apisv1alpha2.APIExportSpec{
+			Resources: []apisv1alpha2.ResourceSchema{
+				{Name: "cowboys", Group: "wildwest.dev", Schema: "today.cowboys.wildwest.dev", Storage: apisv1alpha2.ResourceSchemaStorage{CRD: &apisv1alpha2.ResourceSchemaStorageCRD{}}},
+				{Name: "sheriffs", Group: "wildwest.dev", Schema: "today.sheriffs.wildwest.dev", Storage: apisv1alpha2.ResourceSchemaStorage{CRD: &apisv1alpha2.ResourceSchemaStorageCRD{}}},
+			},
+		},
+	}
+	_, err = kcpClients.Cluster(serviceProviderPath).ApisV1alpha2().APIExports().Create(t.Context(), export, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("Bind consumer %q to %q", consumerPath, serviceProviderPath)
+	binding := &apisv1alpha2.APIBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "wildwest-multi"},
+		Spec: apisv1alpha2.APIBindingSpec{
+			Reference: apisv1alpha2.BindingReference{
+				Export: &apisv1alpha2.ExportBindingReference{Path: serviceProviderPath.String(), Name: "wildwest-multi"},
+			},
+		},
+	}
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		_, err := kcpClients.Cluster(consumerPath).ApisV1alpha2().APIBindings().Create(t.Context(), binding, metav1.CreateOptions{})
+		return err == nil || apierrors.IsAlreadyExists(err), fmt.Sprintf("creating APIBinding: %v", err)
+	}, wait.ForeverTestTimeout, time.Millisecond*100)
+
+	t.Logf("Resolve APIExport VW URL for consumer %q", consumerWorkspace.Name)
+	apiExportVWCfg := rest.CopyConfig(cfg)
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		slice, err := kcpClients.Cluster(serviceProviderPath).ApisV1alpha1().APIExportEndpointSlices().Get(t.Context(), "wildwest-multi", metav1.GetOptions{})
+		if kcptestinghelpers.TolerateOrFail(t, err, apierrors.IsNotFound) {
+			return false, fmt.Sprintf("waiting for APIExportEndpointSlice: %v", err)
+		}
+		var found bool
+		apiExportVWCfg.Host, found, err = framework.VirtualWorkspaceURL(t.Context(), kcpClients, consumerWorkspace, framework.ExportVirtualWorkspaceURLs(slice))
+		require.NoError(t, err)
+		return found, fmt.Sprintf("waiting for VW URL: %v", slice.Status.APIExportEndpoints)
+	}, wait.ForeverTestTimeout, time.Millisecond*100)
+
+	wildwestVCClusterClient, err := wildwestclientset.NewForConfig(apiExportVWCfg)
+	require.NoError(t, err)
+
+	// The bug: a single fetch of /openapi/v3/apis/wildwest.dev/v1alpha1 returns
+	// only ONE of the two Kinds (whichever the answering shard pod has cached).
+	// A correct merged document must contain BOTH Cowboy and Sheriff.
+	t.Logf("Fetch /openapi/v3 for wildwest.dev/v1alpha1 — must include all bound Kinds in a single response")
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		openAPIV3 := wildwestVCClusterClient.Cluster(consumerClusterName.Path()).Discovery().OpenAPIV3()
+		paths, err := openAPIV3.Paths()
+		if err != nil {
+			return false, fmt.Sprintf("fetching OpenAPI v3 paths: %v", err)
+		}
+		gv, ok := paths["apis/wildwest.dev/v1alpha1"]
+		if !ok {
+			return false, fmt.Sprintf("path apis/wildwest.dev/v1alpha1 not in OpenAPI paths: %v", paths)
+		}
+		raw, err := gv.Schema("application/json")
+		if err != nil {
+			return false, fmt.Sprintf("fetching schema: %v", err)
+		}
+		var doc struct {
+			Components struct {
+				Schemas map[string]struct {
+					GVKs []struct {
+						Group   string `json:"group"`
+						Version string `json:"version"`
+						Kind    string `json:"kind"`
+					} `json:"x-kubernetes-group-version-kind"`
+				} `json:"schemas"`
+			} `json:"components"`
+		}
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			return false, fmt.Sprintf("unmarshalling schema: %v", err)
+		}
+		got := sets.NewString()
+		for _, s := range doc.Components.Schemas {
+			for _, gvk := range s.GVKs {
+				if gvk.Group == "wildwest.dev" && gvk.Version == "v1alpha1" {
+					got.Insert(gvk.Kind)
+				}
+			}
+		}
+		expected := sets.NewString("Cowboy", "Sheriff")
+		missing := expected.Difference(got)
+		if missing.Len() > 0 {
+			return false, fmt.Sprintf("OpenAPI for wildwest.dev/v1alpha1 missing Kinds %v (got %v)", missing.List(), got.List())
+		}
+		return true, ""
+	}, wait.ForeverTestTimeout, time.Millisecond*200)
 }


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

## What Type of PR Is This?

There are quite a few fixes packaged in this. This came from me debugging https://github.com/platform-mesh/kubernetes-graphql-gateway and how it sometimes serves only ONE resource/KIND from apiexport. In example you have `APIExport` with kinds `Cowboy` and `Sherrif` - OpenAPIV3 will serve only one (at random).

### Bugs in order with details

1. Panic on retry after a failed openapi build
[openapi.go:163](https://github.com/kcp-dev/kcp/blob/main/staging/src/github.com/kcp-dev/virtual-workspace-framework/pkg/dynamic/apiserver/openapi.go#L166)

When a cached entry exists with err != nil, the old code unlocked the key, then fell through to the cache-miss path which calls `UnlockKey` again — `sync.Mutex` panics on "unlock of unlocked mutex". So the first request after a transient build failure crashes the apiserver goroutine. 🤯 

Fix: re-acquire the key lock before falling through, so the regeneration path's `UnlockKey` matches a real `LockKey`.

2. Duplicate specs from multi-version APIResourceSchemas
[openapi.go:246](https://github.com/kcp-dev/kcp/blob/main/staging/src/github.com/kcp-dev/virtual-workspace-framework/pkg/dynamic/apiserver/openapi.go#L281) + apiResourceSchemaToSpec signature change

`apiSet` is keyed by `GVR`. An `APIResourceSchema` with two versions (e.g. `v1alpha1 + v1alpha2`) appears as two entries in `apiSet`. The old loop called `apiResourceSchemaToSpec(schema)` for each entry, and that function emitted all versions every time → each GV got its spec twice. Downstream that produces either a strict-merge error (bug 3) or a malformed doc.

Fix: pass gvr.Version so each apiSet entry only emits its own version.

This is the one that bites `apibindings.apis.kcp.io` — it's a multi-version schema and most VWs surface it. We didnt have those, I got this my accident. 

3. The big one: multiple CRDs under a single GV silently lose all-but-one
[openapi.go:448](https://github.com/kcp-dev/kcp/blob/main/staging/src/github.com/kcp-dev/virtual-workspace-framework/pkg/dynamic/apiserver/openapi.go#L430)

```
- byGroupVersionSpecs[gvPath] = spec        // ← bug
+ byGroupVersionSpecs[gvPath] = append(byGroupVersionSpecs[gvPath], spec...)
```
`apiDefSpecs` is a list per `APIDefinition` (= per `CRD`). Multiple `CRDs` frequently share a group/version — that's the normal shape of an `APIExport` that surfaces several `Kinds`. The old = overwrote previous entries, so the final openapi document only had the last CRD for each GV. **Everything else was silently dropped.**

A GraphQL gateway introspecting that openapi sees one `Kind` per `GV` instead of the real set, generates a schema with most types missing, and proxy calls for those types 404 at the gateway. 

4. Strict merge can't tolerate shared helper types
[openapi.go:459](https://github.com/kcp-dev/kcp/blob/main/staging/src/github.com/kcp-dev/virtual-workspace-framework/pkg/dynamic/apiserver/openapi.go#L438) — new mergeSpecsV3Tolerant

Once bug 3 is fixed, MergeSpecsV3 actually receives the per-CRD specs it should have been receiving all along. apiextensions-apiserver's MergeSpecsV3 is strict: it errors on duplicate component names. But every CRD's openapi re-emits `io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta`, `Time`, `ListMeta`, plus kcp types like `apis.kcp.io.v1alpha1.APIBinding`. With ≥2 CRDs in one GV the merge always errors → the whole VW openapi handler returns 500.

Fix: a local tolerant merger that keeps the first-seen component definition (they're semantically identical across CRDs) and otherwise behaves like the upstream merger.

**So TL:DR:** 

The VW openapi handler had two latent bugs (panic on cached-error retry; wrong indexing) plus two structural bugs that compounded each other: per-CRD specs were overwriting same-GV neighbors, and even when that was fixed, the strict upstream merger refused to combine specs that legitimately share common helper schemas. Practically: any `APIExport` surfacing >1 `Kind` under one GV produced either a 500 or a truncated openapi doc, and clients that consume it — `kubectl-explain`, `client-gen`, kubernetes GraphQL gateway — saw a fictional API surface.

/kind bug

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Fix openAPIv3 partial serving in VirtualWorkspaces
```
