### PR TITLE
:book: docs: clarify WorkspaceType extend and with field semantics

### DIFF
--- a/config/crds/tenancy.kcp.io_workspacetypes.yaml
+++ b/config/crds/tenancy.kcp.io_workspacetypes.yaml
@@ -123,10 +123,14 @@ spec:
                 type: object
               extend:
                 description: |-
-                  extend is a list of other WorkspaceTypes whose initializers and limitAllowedChildren
-                  and limitAllowedParents this WorkspaceType is inheriting. By (transitively) extending
-                  another WorkspaceType, this WorkspaceType will be considered as that
-                  other type in evaluation of limitAllowedChildren and limitAllowedParents constraints.
+                  extend is a list of other WorkspaceTypes whose initializers and
+                  limitAllowedChildren and limitAllowedParents this WorkspaceType inherits.
+                  Extension is additive: by (transitively) extending another WorkspaceType,
+                  this WorkspaceType is considered to be that other type when evaluating
+                  limitAllowedChildren and limitAllowedParents constraints. As a result, a
+                  type that extends multiple types satisfies a constraint that allows any
+                  one of those types, so the effective allowed set is the union of the
+                  extended types and not their intersection.
 
                   A dependency cycle stop this WorkspaceType from being admitted as the type
                   of a Workspace.
@@ -137,8 +141,7 @@ spec:
                   with:
                     description: |-
                       with are WorkspaceTypes whose initializers are added to the list
-                      for the owning type, and for whom the owning type becomes an alias, as long
-                      as all of their required types are not mentioned in without.
+                      for the owning type, and for whom the owning type becomes an alias.
                     items:
                       description: WorkspaceTypeReference is a globally unique, fully
                         qualified reference to a workspace type.

--- a/config/root-phase0/apiexport-tenancy.kcp.io.yaml
+++ b/config/root-phase0/apiexport-tenancy.kcp.io.yaml
@@ -18,7 +18,7 @@ spec:
       crd: {}
   - group: tenancy.kcp.io
     name: workspacetypes
-    schema: v260428-f702a24c5.workspacetypes.tenancy.kcp.io
+    schema: v260519-96f2749.workspacetypes.tenancy.kcp.io
     storage:
       crd: {}
 status: {}

--- a/config/root-phase0/apiresourceschema-workspacetypes.tenancy.kcp.io.yaml
+++ b/config/root-phase0/apiresourceschema-workspacetypes.tenancy.kcp.io.yaml
@@ -1,7 +1,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v260428-f702a24c5.workspacetypes.tenancy.kcp.io
+  name: v260519-96f2749.workspacetypes.tenancy.kcp.io
 spec:
   group: tenancy.kcp.io
   names:
@@ -120,10 +120,14 @@ spec:
               type: object
             extend:
               description: |-
-                extend is a list of other WorkspaceTypes whose initializers and limitAllowedChildren
-                and limitAllowedParents this WorkspaceType is inheriting. By (transitively) extending
-                another WorkspaceType, this WorkspaceType will be considered as that
-                other type in evaluation of limitAllowedChildren and limitAllowedParents constraints.
+                extend is a list of other WorkspaceTypes whose initializers and
+                limitAllowedChildren and limitAllowedParents this WorkspaceType inherits.
+                Extension is additive: by (transitively) extending another WorkspaceType,
+                this WorkspaceType is considered to be that other type when evaluating
+                limitAllowedChildren and limitAllowedParents constraints. As a result, a
+                type that extends multiple types satisfies a constraint that allows any
+                one of those types, so the effective allowed set is the union of the
+                extended types and not their intersection.
 
                 A dependency cycle stop this WorkspaceType from being admitted as the type
                 of a Workspace.
@@ -134,8 +138,7 @@ spec:
                 with:
                   description: |-
                     with are WorkspaceTypes whose initializers are added to the list
-                    for the owning type, and for whom the owning type becomes an alias, as long
-                    as all of their required types are not mentioned in without.
+                    for the owning type, and for whom the owning type becomes an alias.
                   items:
                     description: WorkspaceTypeReference is a globally unique, fully
                       qualified reference to a workspace type.

--- a/staging/src/github.com/kcp-dev/sdk/apis/tenancy/v1alpha1/types_workspacetype.go
+++ b/staging/src/github.com/kcp-dev/sdk/apis/tenancy/v1alpha1/types_workspacetype.go
@@ -88,10 +88,14 @@ type WorkspaceTypeSpec struct {
 	// +optional
 	Terminator bool `json:"terminator,omitempty"`
 
-	// extend is a list of other WorkspaceTypes whose initializers and limitAllowedChildren
-	// and limitAllowedParents this WorkspaceType is inheriting. By (transitively) extending
-	// another WorkspaceType, this WorkspaceType will be considered as that
-	// other type in evaluation of limitAllowedChildren and limitAllowedParents constraints.
+	// extend is a list of other WorkspaceTypes whose initializers and
+	// limitAllowedChildren and limitAllowedParents this WorkspaceType inherits.
+	// Extension is additive: by (transitively) extending another WorkspaceType,
+	// this WorkspaceType is considered to be that other type when evaluating
+	// limitAllowedChildren and limitAllowedParents constraints. As a result, a
+	// type that extends multiple types satisfies a constraint that allows any
+	// one of those types, so the effective allowed set is the union of the
+	// extended types and not their intersection.
 	//
 	// A dependency cycle stop this WorkspaceType from being admitted as the type
 	// of a Workspace.
@@ -238,8 +242,7 @@ type WorkspaceTypeSelector struct {
 // composed together to add functionality to the owning WorkspaceType.
 type WorkspaceTypeExtension struct {
 	// with are WorkspaceTypes whose initializers are added to the list
-	// for the owning type, and for whom the owning type becomes an alias, as long
-	// as all of their required types are not mentioned in without.
+	// for the owning type, and for whom the owning type becomes an alias.
 	//
 	// +optional
 	With []WorkspaceTypeReference `json:"with,omitempty"`

--- a/staging/src/github.com/kcp-dev/sdk/client/applyconfiguration/tenancy/v1alpha1/workspacetypeextension.go
+++ b/staging/src/github.com/kcp-dev/sdk/client/applyconfiguration/tenancy/v1alpha1/workspacetypeextension.go
@@ -25,8 +25,7 @@ package v1alpha1
 // composed together to add functionality to the owning WorkspaceType.
 type WorkspaceTypeExtensionApplyConfiguration struct {
 	// with are WorkspaceTypes whose initializers are added to the list
-	// for the owning type, and for whom the owning type becomes an alias, as long
-	// as all of their required types are not mentioned in without.
+	// for the owning type, and for whom the owning type becomes an alias.
 	With []WorkspaceTypeReferenceApplyConfiguration `json:"with,omitempty"`
 }
 

--- a/staging/src/github.com/kcp-dev/sdk/client/applyconfiguration/tenancy/v1alpha1/workspacetypespec.go
+++ b/staging/src/github.com/kcp-dev/sdk/client/applyconfiguration/tenancy/v1alpha1/workspacetypespec.go
@@ -48,10 +48,14 @@ type WorkspaceTypeSpecApplyConfiguration struct {
 	// WorkspaceType `example` is created in the `root:org` workspace, the implicit
 	// terminator name is `root:org:example`.
 	Terminator *bool `json:"terminator,omitempty"`
-	// extend is a list of other WorkspaceTypes whose initializers and limitAllowedChildren
-	// and limitAllowedParents this WorkspaceType is inheriting. By (transitively) extending
-	// another WorkspaceType, this WorkspaceType will be considered as that
-	// other type in evaluation of limitAllowedChildren and limitAllowedParents constraints.
+	// extend is a list of other WorkspaceTypes whose initializers and
+	// limitAllowedChildren and limitAllowedParents this WorkspaceType inherits.
+	// Extension is additive: by (transitively) extending another WorkspaceType,
+	// this WorkspaceType is considered to be that other type when evaluating
+	// limitAllowedChildren and limitAllowedParents constraints. As a result, a
+	// type that extends multiple types satisfies a constraint that allows any
+	// one of those types, so the effective allowed set is the union of the
+	// extended types and not their intersection.
 	//
 	// A dependency cycle stop this WorkspaceType from being admitted as the type
 	// of a Workspace.

--- a/staging/src/github.com/kcp-dev/sdk/openapi/zz_generated.openapi.go
+++ b/staging/src/github.com/kcp-dev/sdk/openapi/zz_generated.openapi.go
@@ -4943,7 +4943,7 @@ func schema_sdk_apis_tenancy_v1alpha1_WorkspaceTypeExtension(ref common.Referenc
 				Properties: map[string]spec.Schema{
 					"with": {
 						SchemaProps: spec.SchemaProps{
-							Description: "with are WorkspaceTypes whose initializers are added to the list for the owning type, and for whom the owning type becomes an alias, as long as all of their required types are not mentioned in without.",
+							Description: "with are WorkspaceTypes whose initializers are added to the list for the owning type, and for whom the owning type becomes an alias.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -5099,7 +5099,7 @@ func schema_sdk_apis_tenancy_v1alpha1_WorkspaceTypeSpec(ref common.ReferenceCall
 					},
 					"extend": {
 						SchemaProps: spec.SchemaProps{
-							Description: "extend is a list of other WorkspaceTypes whose initializers and limitAllowedChildren and limitAllowedParents this WorkspaceType is inheriting. By (transitively) extending another WorkspaceType, this WorkspaceType will be considered as that other type in evaluation of limitAllowedChildren and limitAllowedParents constraints.\n\nA dependency cycle stop this WorkspaceType from being admitted as the type of a Workspace.\n\nA non-existing dependency stop this WorkspaceType from being admitted as the type of a Workspace.",
+							Description: "extend is a list of other WorkspaceTypes whose initializers and limitAllowedChildren and limitAllowedParents this WorkspaceType inherits. Extension is additive: by (transitively) extending another WorkspaceType, this WorkspaceType is considered to be that other type when evaluating limitAllowedChildren and limitAllowedParents constraints. As a result, a type that extends multiple types satisfies a constraint that allows any one of those types, so the effective allowed set is the union of the extended types and not their intersection.\n\nA dependency cycle stop this WorkspaceType from being admitted as the type of a Workspace.\n\nA non-existing dependency stop this WorkspaceType from being admitted as the type of a Workspace.",
 							Default:     map[string]interface{}{},
 							Ref:         ref(tenancyv1alpha1.WorkspaceTypeExtension{}.OpenAPIModelName()),
 						},


### PR DESCRIPTION
## Summary

Improves the godoc on `WorkspaceTypeSpec.extend` and `WorkspaceTypeExtension.with` so the additive nature of extension is explicit. As @sttts noted in #3299, the existing wording does not make clear "is the the new limitAllowedChildren/limitAllowedParents the union or the intersection of those", and the `with` comment kept a leftover "as long as ... in without" reference to a never-merged feature; this states the union behavior and removes the stale clause. Generated CRD and APIResourceSchema YAML regenerated via `make crds`.

## What Type of PR Is This?

/kind documentation

## Related Issue(s)

Fixes #3299

## Release Notes

```release-note
NONE
```