### PR TITLE
Add metrics for APIBinding and APIExport usage data

### DIFF
--- a/pkg/reconciler/apis/apibinding/apibinding_condition_metrics_test.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_condition_metrics_test.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/kcp-dev/logicalcluster/v3"
 	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
 	conditionsv1alpha1 "github.com/kcp-dev/sdk/apis/third_party/conditions/apis/conditions/v1alpha1"
 )
@@ -32,7 +33,7 @@ func bindingWithConditions(cluster, name string, conds ...conditionsv1alpha1.Con
 	return &apisv1alpha2.APIBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
-			Annotations: map[string]string{"kcp.io/cluster": cluster},
+			Annotations: map[string]string{logicalcluster.AnnotationKey: cluster},
 		},
 		Status: apisv1alpha2.APIBindingStatus{Conditions: conds},
 	}

--- a/pkg/reconciler/apis/apibinding/apibinding_condition_metrics_test.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_condition_metrics_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apibinding
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
+	conditionsv1alpha1 "github.com/kcp-dev/sdk/apis/third_party/conditions/apis/conditions/v1alpha1"
+)
+
+func bindingWithConditions(cluster, name string, conds ...conditionsv1alpha1.Condition) *apisv1alpha2.APIBinding {
+	return &apisv1alpha2.APIBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Annotations: map[string]string{"kcp.io/cluster": cluster},
+		},
+		Status: apisv1alpha2.APIBindingStatus{Conditions: conds},
+	}
+}
+
+func cond(condType conditionsv1alpha1.ConditionType, status corev1.ConditionStatus) conditionsv1alpha1.Condition {
+	return conditionsv1alpha1.Condition{Type: condType, Status: status}
+}
+
+func TestHandleConditionMetricsOnAdd(t *testing.T) {
+	t.Run("conditions are tracked on add", func(t *testing.T) {
+		c := newTestController()
+		b := bindingWithConditions("root:ws", "test",
+			cond(apisv1alpha2.APIExportValid, corev1.ConditionTrue),
+			cond(apisv1alpha2.InitialBindingCompleted, corev1.ConditionFalse),
+		)
+		c.handleConditionMetricsOnAdd(b)
+		require.Len(t, c.countedAPIBindingConditions, 1)
+		for _, snapshot := range c.countedAPIBindingConditions {
+			require.Equal(t, string(corev1.ConditionTrue), snapshot[string(apisv1alpha2.APIExportValid)])
+			require.Equal(t, string(corev1.ConditionFalse), snapshot[string(apisv1alpha2.InitialBindingCompleted)])
+		}
+	})
+
+	t.Run("binding with no conditions stores empty snapshot", func(t *testing.T) {
+		c := newTestController()
+		b := bindingWithConditions("root:ws", "test")
+		c.handleConditionMetricsOnAdd(b)
+		require.Len(t, c.countedAPIBindingConditions, 1)
+		for _, snapshot := range c.countedAPIBindingConditions {
+			require.Empty(t, snapshot)
+		}
+	})
+
+	t.Run("duplicate add is a no-op", func(t *testing.T) {
+		c := newTestController()
+		b := bindingWithConditions("root:ws", "test",
+			cond(apisv1alpha2.APIExportValid, corev1.ConditionTrue),
+		)
+		c.handleConditionMetricsOnAdd(b)
+		c.handleConditionMetricsOnAdd(b)
+		require.Len(t, c.countedAPIBindingConditions, 1)
+	})
+}
+
+func TestHandleConditionMetricsOnUpdate(t *testing.T) {
+	t.Run("condition status change is tracked", func(t *testing.T) {
+		c := newTestController()
+		old := bindingWithConditions("root:ws", "test",
+			cond(apisv1alpha2.APIExportValid, corev1.ConditionFalse),
+		)
+		new := bindingWithConditions("root:ws", "test",
+			cond(apisv1alpha2.APIExportValid, corev1.ConditionTrue),
+		)
+		c.handleConditionMetricsOnAdd(old)
+		c.handleConditionMetricsOnUpdate(old, new)
+		for _, snapshot := range c.countedAPIBindingConditions {
+			require.Equal(t, string(corev1.ConditionTrue), snapshot[string(apisv1alpha2.APIExportValid)])
+		}
+	})
+
+	t.Run("new condition added on update", func(t *testing.T) {
+		c := newTestController()
+		old := bindingWithConditions("root:ws", "test",
+			cond(apisv1alpha2.APIExportValid, corev1.ConditionTrue),
+		)
+		new := bindingWithConditions("root:ws", "test",
+			cond(apisv1alpha2.APIExportValid, corev1.ConditionTrue),
+			cond(apisv1alpha2.InitialBindingCompleted, corev1.ConditionTrue),
+		)
+		c.handleConditionMetricsOnAdd(old)
+		c.handleConditionMetricsOnUpdate(old, new)
+		for _, snapshot := range c.countedAPIBindingConditions {
+			require.Len(t, snapshot, 2)
+		}
+	})
+
+	t.Run("removed condition is cleaned up on update", func(t *testing.T) {
+		c := newTestController()
+		old := bindingWithConditions("root:ws", "test",
+			cond(apisv1alpha2.APIExportValid, corev1.ConditionTrue),
+			cond(apisv1alpha2.InitialBindingCompleted, corev1.ConditionTrue),
+		)
+		new := bindingWithConditions("root:ws", "test",
+			cond(apisv1alpha2.APIExportValid, corev1.ConditionTrue),
+		)
+		c.handleConditionMetricsOnAdd(old)
+		c.handleConditionMetricsOnUpdate(old, new)
+		for _, snapshot := range c.countedAPIBindingConditions {
+			require.Len(t, snapshot, 1)
+			require.NotContains(t, snapshot, string(apisv1alpha2.InitialBindingCompleted))
+		}
+	})
+}
+
+func TestHandleConditionMetricsOnDelete(t *testing.T) {
+	t.Run("delete removes all condition tracking", func(t *testing.T) {
+		c := newTestController()
+		b := bindingWithConditions("root:ws", "test",
+			cond(apisv1alpha2.APIExportValid, corev1.ConditionTrue),
+		)
+		c.handleConditionMetricsOnAdd(b)
+		require.Len(t, c.countedAPIBindingConditions, 1)
+		c.handleConditionMetricsOnDelete(b)
+		require.Empty(t, c.countedAPIBindingConditions)
+	})
+
+	t.Run("delete of unknown binding is a no-op", func(t *testing.T) {
+		c := newTestController()
+		b := bindingWithConditions("root:ws", "unknown",
+			cond(apisv1alpha2.APIExportValid, corev1.ConditionTrue),
+		)
+		require.NotPanics(t, func() { c.handleConditionMetricsOnDelete(b) })
+	})
+}

--- a/pkg/reconciler/apis/apibinding/apibinding_controller.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_controller.go
@@ -628,6 +628,9 @@ func (c *controller) handlePhaseMetricsOnUpdate(oldBinding, newBinding *apisv1al
 		if newPhase != "" {
 			kcpmetrics.IncrementAPIBindingPhase(newPhase)
 		}
+		if newPhase == string(apisv1alpha2.APIBindingPhaseBound) {
+			kcpmetrics.ObserveAPIBindingReadyDuration(newBinding.CreationTimestamp.Time)
+		}
 		c.countedAPIBindings[key] = newPhase
 	}
 }

--- a/pkg/reconciler/apis/apibinding/apibinding_controller.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_controller.go
@@ -198,7 +198,8 @@ func NewController(
 			kcpClusterClient.ApisV1alpha2().APIBindings(),
 			ControllerName,
 		),
-		countedAPIBindings: make(map[string]string),
+		countedAPIBindings:          make(map[string]string),
+		countedAPIBindingConditions: make(map[string]map[string]string),
 	}
 
 	logger := logging.WithReconciler(klog.Background(), ControllerName)
@@ -209,16 +210,20 @@ func NewController(
 			binding := tombstone.Obj[*apisv1alpha2.APIBinding](obj)
 			c.enqueueAPIBinding(binding, logger, "")
 			c.handlePhaseMetricsOnAdd(binding)
+			c.handleConditionMetricsOnAdd(binding)
 		},
 		UpdateFunc: func(oldObj, obj interface{}) {
 			binding := tombstone.Obj[*apisv1alpha2.APIBinding](obj)
+			old := tombstone.Obj[*apisv1alpha2.APIBinding](oldObj)
 			c.enqueueAPIBinding(binding, logger, "")
-			c.handlePhaseMetricsOnUpdate(tombstone.Obj[*apisv1alpha2.APIBinding](oldObj), binding)
+			c.handlePhaseMetricsOnUpdate(old, binding)
+			c.handleConditionMetricsOnUpdate(old, binding)
 		},
 		DeleteFunc: func(obj interface{}) {
 			binding := tombstone.Obj[*apisv1alpha2.APIBinding](obj)
 			c.enqueueAPIBinding(binding, logger, "")
 			c.handlePhaseMetricsOnDelete(binding)
+			c.handleConditionMetricsOnDelete(binding)
 		},
 	})
 
@@ -366,6 +371,8 @@ type controller struct {
 
 	mu                 sync.Mutex
 	countedAPIBindings map[string]string
+	// countedAPIBindingConditions maps binding key -> (conditionType -> status)
+	countedAPIBindingConditions map[string]map[string]string
 }
 
 // enqueueAPIBinding enqueues an APIBinding .
@@ -640,4 +647,80 @@ func (c *controller) handlePhaseMetricsOnDelete(binding *apisv1alpha2.APIBinding
 			kcpmetrics.DecrementAPIBindingPhase(phase)
 		}
 	}
+}
+
+func (c *controller) handleConditionMetricsOnAdd(binding *apisv1alpha2.APIBinding) {
+	key, err := kcpcache.MetaClusterNamespaceKeyFunc(binding)
+	if err != nil {
+		return
+	}
+
+	snapshot := make(map[string]string, len(binding.Status.Conditions))
+	for _, cond := range binding.Status.Conditions {
+		snapshot[string(cond.Type)] = string(cond.Status)
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if _, exists := c.countedAPIBindingConditions[key]; exists {
+		return
+	}
+	c.countedAPIBindingConditions[key] = snapshot
+	for condType, status := range snapshot {
+		kcpmetrics.IncrementAPIBindingConditionStatus(condType, status)
+	}
+}
+
+func (c *controller) handleConditionMetricsOnUpdate(oldBinding, newBinding *apisv1alpha2.APIBinding) {
+	key, err := kcpcache.MetaClusterNamespaceKeyFunc(newBinding)
+	if err != nil {
+		return
+	}
+
+	newSnapshot := make(map[string]string, len(newBinding.Status.Conditions))
+	for _, cond := range newBinding.Status.Conditions {
+		newSnapshot[string(cond.Type)] = string(cond.Status)
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	oldSnapshot := c.countedAPIBindingConditions[key]
+
+	// Decrement removed or changed conditions.
+	for condType, oldStatus := range oldSnapshot {
+		newStatus, exists := newSnapshot[condType]
+		if !exists || newStatus != oldStatus {
+			kcpmetrics.DecrementAPIBindingConditionStatus(condType, oldStatus)
+		}
+	}
+	// Increment new or changed conditions.
+	for condType, newStatus := range newSnapshot {
+		oldStatus, exists := oldSnapshot[condType]
+		if !exists || oldStatus != newStatus {
+			kcpmetrics.IncrementAPIBindingConditionStatus(condType, newStatus)
+		}
+	}
+
+	c.countedAPIBindingConditions[key] = newSnapshot
+}
+
+func (c *controller) handleConditionMetricsOnDelete(binding *apisv1alpha2.APIBinding) {
+	key, err := kcpcache.MetaClusterNamespaceKeyFunc(binding)
+	if err != nil {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	snapshot, exists := c.countedAPIBindingConditions[key]
+	if !exists {
+		return
+	}
+	for condType, status := range snapshot {
+		kcpmetrics.DecrementAPIBindingConditionStatus(condType, status)
+	}
+	delete(c.countedAPIBindingConditions, key)
 }

--- a/pkg/reconciler/apis/apibinding/apibinding_controller.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -59,6 +60,7 @@ import (
 	"github.com/kcp-dev/kcp/pkg/logging"
 	"github.com/kcp-dev/kcp/pkg/reconciler/committer"
 	"github.com/kcp-dev/kcp/pkg/reconciler/events"
+	kcpmetrics "github.com/kcp-dev/kcp/pkg/server/metrics"
 	"github.com/kcp-dev/kcp/pkg/tombstone"
 )
 
@@ -195,20 +197,28 @@ func NewController(
 		commit: committer.NewSSACommitter[*APIBinding, Patcher, *APIBindingSpec, *APIBindingStatus](
 			kcpClusterClient.ApisV1alpha2().APIBindings(),
 			ControllerName,
-		)}
+		),
+		countedAPIBindings: make(map[string]string),
+	}
 
 	logger := logging.WithReconciler(klog.Background(), ControllerName)
 
 	// APIBinding handlers
 	_, _ = apiBindingInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			c.enqueueAPIBinding(tombstone.Obj[*apisv1alpha2.APIBinding](obj), logger, "")
+			binding := tombstone.Obj[*apisv1alpha2.APIBinding](obj)
+			c.enqueueAPIBinding(binding, logger, "")
+			c.handlePhaseMetricsOnAdd(binding)
 		},
-		UpdateFunc: func(_, obj interface{}) {
-			c.enqueueAPIBinding(tombstone.Obj[*apisv1alpha2.APIBinding](obj), logger, "")
+		UpdateFunc: func(oldObj, obj interface{}) {
+			binding := tombstone.Obj[*apisv1alpha2.APIBinding](obj)
+			c.enqueueAPIBinding(binding, logger, "")
+			c.handlePhaseMetricsOnUpdate(tombstone.Obj[*apisv1alpha2.APIBinding](oldObj), binding)
 		},
 		DeleteFunc: func(obj interface{}) {
-			c.enqueueAPIBinding(tombstone.Obj[*apisv1alpha2.APIBinding](obj), logger, "")
+			binding := tombstone.Obj[*apisv1alpha2.APIBinding](obj)
+			c.enqueueAPIBinding(binding, logger, "")
+			c.handlePhaseMetricsOnDelete(binding)
 		},
 	})
 
@@ -353,6 +363,9 @@ type controller struct {
 
 	deletedCRDTracker *lockedStringSet
 	commit            CommitFunc
+
+	mu                 sync.Mutex
+	countedAPIBindings map[string]string
 }
 
 // enqueueAPIBinding enqueues an APIBinding .
@@ -570,4 +583,61 @@ func InstallIndexers(
 		indexers.APIExportByAPIResourceSchema: indexers.IndexAPIExportByAPIResourceSchema,
 		indexers.APIExportByIdentity:          indexers.IndexAPIExportByIdentity,
 	})
+}
+
+func (c *controller) handlePhaseMetricsOnAdd(binding *apisv1alpha2.APIBinding) {
+	key, err := kcpcache.MetaClusterNamespaceKeyFunc(binding)
+	if err != nil {
+		return
+	}
+	phase := string(binding.Status.Phase)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if _, exists := c.countedAPIBindings[key]; !exists {
+		c.countedAPIBindings[key] = phase
+		if phase != "" {
+			kcpmetrics.IncrementAPIBindingPhase(phase)
+		}
+	}
+}
+
+func (c *controller) handlePhaseMetricsOnUpdate(oldBinding, newBinding *apisv1alpha2.APIBinding) {
+	key, err := kcpcache.MetaClusterNamespaceKeyFunc(newBinding)
+	if err != nil {
+		return
+	}
+	oldPhase := string(oldBinding.Status.Phase)
+	newPhase := string(newBinding.Status.Phase)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if oldPhase != newPhase {
+		if oldPhase != "" {
+			kcpmetrics.DecrementAPIBindingPhase(oldPhase)
+		}
+		if newPhase != "" {
+			kcpmetrics.IncrementAPIBindingPhase(newPhase)
+		}
+		c.countedAPIBindings[key] = newPhase
+	}
+}
+
+func (c *controller) handlePhaseMetricsOnDelete(binding *apisv1alpha2.APIBinding) {
+	key, err := kcpcache.MetaClusterNamespaceKeyFunc(binding)
+	if err != nil {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if phase, exists := c.countedAPIBindings[key]; exists {
+		delete(c.countedAPIBindings, key)
+		if phase != "" {
+			kcpmetrics.DecrementAPIBindingPhase(phase)
+		}
+	}
 }

--- a/pkg/reconciler/apis/apibinding/apibinding_controller.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_controller.go
@@ -86,6 +86,7 @@ func NewController(
 	globalAPIResourceSchemaInformer apisv1alpha1informers.APIResourceSchemaClusterInformer,
 	globalAPIConversionInformer apisv1alpha1informers.APIConversionClusterInformer,
 	crdInformer kcpapiextensionsv1informers.CustomResourceDefinitionClusterInformer,
+	shardName string,
 ) (*controller, error) {
 	c := &controller{
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
@@ -96,6 +97,7 @@ func NewController(
 		),
 		crdClusterClient: crdClusterClient,
 		kcpClusterClient: kcpClusterClient,
+		shardName:        shardName,
 
 		listAPIBindings: func(clusterName logicalcluster.Name) ([]*apisv1alpha2.APIBinding, error) {
 			return apiBindingInformer.Lister().Cluster(clusterName).List(labels.Everything())
@@ -344,6 +346,7 @@ type CommitFunc = func(context.Context, *Resource, *Resource) error
 type controller struct {
 	queue workqueue.TypedRateLimitingInterface[string]
 
+	shardName        string
 	crdClusterClient kcpapiextensionsclientset.ClusterInterface
 	kcpClusterClient kcpclientset.ClusterInterface
 
@@ -369,8 +372,9 @@ type controller struct {
 	deletedCRDTracker *lockedStringSet
 	commit            CommitFunc
 
-	mu                 sync.Mutex
-	countedAPIBindings map[string]string
+	// countedAPIBindingsLock protects countedAPIBindings and countedAPIBindingConditions.
+	countedAPIBindingsLock sync.Mutex
+	countedAPIBindings     map[string]string
 	// countedAPIBindingConditions maps binding key -> (conditionType -> status)
 	countedAPIBindingConditions map[string]map[string]string
 }
@@ -599,13 +603,13 @@ func (c *controller) handlePhaseMetricsOnAdd(binding *apisv1alpha2.APIBinding) {
 	}
 	phase := string(binding.Status.Phase)
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.countedAPIBindingsLock.Lock()
+	defer c.countedAPIBindingsLock.Unlock()
 
 	if _, exists := c.countedAPIBindings[key]; !exists {
 		c.countedAPIBindings[key] = phase
 		if phase != "" {
-			kcpmetrics.IncrementAPIBindingPhase(phase)
+			kcpmetrics.IncrementAPIBindingPhase(c.shardName, phase)
 		}
 	}
 }
@@ -618,18 +622,18 @@ func (c *controller) handlePhaseMetricsOnUpdate(oldBinding, newBinding *apisv1al
 	oldPhase := string(oldBinding.Status.Phase)
 	newPhase := string(newBinding.Status.Phase)
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.countedAPIBindingsLock.Lock()
+	defer c.countedAPIBindingsLock.Unlock()
 
 	if oldPhase != newPhase {
 		if oldPhase != "" {
-			kcpmetrics.DecrementAPIBindingPhase(oldPhase)
+			kcpmetrics.DecrementAPIBindingPhase(c.shardName, oldPhase)
 		}
 		if newPhase != "" {
-			kcpmetrics.IncrementAPIBindingPhase(newPhase)
+			kcpmetrics.IncrementAPIBindingPhase(c.shardName, newPhase)
 		}
 		if newPhase == string(apisv1alpha2.APIBindingPhaseBound) {
-			kcpmetrics.ObserveAPIBindingReadyDuration(newBinding.CreationTimestamp.Time)
+			kcpmetrics.ObserveAPIBindingReadyDuration(c.shardName, newBinding.CreationTimestamp.Time)
 		}
 		c.countedAPIBindings[key] = newPhase
 	}
@@ -641,13 +645,13 @@ func (c *controller) handlePhaseMetricsOnDelete(binding *apisv1alpha2.APIBinding
 		return
 	}
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.countedAPIBindingsLock.Lock()
+	defer c.countedAPIBindingsLock.Unlock()
 
 	if phase, exists := c.countedAPIBindings[key]; exists {
 		delete(c.countedAPIBindings, key)
 		if phase != "" {
-			kcpmetrics.DecrementAPIBindingPhase(phase)
+			kcpmetrics.DecrementAPIBindingPhase(c.shardName, phase)
 		}
 	}
 }
@@ -663,15 +667,15 @@ func (c *controller) handleConditionMetricsOnAdd(binding *apisv1alpha2.APIBindin
 		snapshot[string(cond.Type)] = string(cond.Status)
 	}
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.countedAPIBindingsLock.Lock()
+	defer c.countedAPIBindingsLock.Unlock()
 
 	if _, exists := c.countedAPIBindingConditions[key]; exists {
 		return
 	}
 	c.countedAPIBindingConditions[key] = snapshot
 	for condType, status := range snapshot {
-		kcpmetrics.IncrementAPIBindingConditionStatus(condType, status)
+		kcpmetrics.IncrementAPIBindingConditionStatus(c.shardName, condType, status)
 	}
 }
 
@@ -686,8 +690,8 @@ func (c *controller) handleConditionMetricsOnUpdate(oldBinding, newBinding *apis
 		newSnapshot[string(cond.Type)] = string(cond.Status)
 	}
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.countedAPIBindingsLock.Lock()
+	defer c.countedAPIBindingsLock.Unlock()
 
 	oldSnapshot := c.countedAPIBindingConditions[key]
 
@@ -695,14 +699,14 @@ func (c *controller) handleConditionMetricsOnUpdate(oldBinding, newBinding *apis
 	for condType, oldStatus := range oldSnapshot {
 		newStatus, exists := newSnapshot[condType]
 		if !exists || newStatus != oldStatus {
-			kcpmetrics.DecrementAPIBindingConditionStatus(condType, oldStatus)
+			kcpmetrics.DecrementAPIBindingConditionStatus(c.shardName, condType, oldStatus)
 		}
 	}
 	// Increment new or changed conditions.
 	for condType, newStatus := range newSnapshot {
 		oldStatus, exists := oldSnapshot[condType]
 		if !exists || oldStatus != newStatus {
-			kcpmetrics.IncrementAPIBindingConditionStatus(condType, newStatus)
+			kcpmetrics.IncrementAPIBindingConditionStatus(c.shardName, condType, newStatus)
 		}
 	}
 
@@ -715,15 +719,15 @@ func (c *controller) handleConditionMetricsOnDelete(binding *apisv1alpha2.APIBin
 		return
 	}
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.countedAPIBindingsLock.Lock()
+	defer c.countedAPIBindingsLock.Unlock()
 
 	snapshot, exists := c.countedAPIBindingConditions[key]
 	if !exists {
 		return
 	}
 	for condType, status := range snapshot {
-		kcpmetrics.DecrementAPIBindingConditionStatus(condType, status)
+		kcpmetrics.DecrementAPIBindingConditionStatus(c.shardName, condType, status)
 	}
 	delete(c.countedAPIBindingConditions, key)
 }

--- a/pkg/reconciler/apis/apibinding/apibinding_phase_metrics_test.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_phase_metrics_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apibinding
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
+)
+
+func newTestController() *controller {
+	return &controller{
+		countedAPIBindings: make(map[string]string),
+	}
+}
+
+func binding(cluster, name string, phase apisv1alpha2.APIBindingPhaseType) *apisv1alpha2.APIBinding {
+	return &apisv1alpha2.APIBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Annotations: map[string]string{"kcp.io/cluster": cluster},
+		},
+		Status: apisv1alpha2.APIBindingStatus{Phase: phase},
+	}
+}
+
+func TestHandlePhaseMetricsOnAdd(t *testing.T) {
+	t.Run("new binding with non-empty phase is tracked", func(t *testing.T) {
+		c := newTestController()
+		b := binding("root:ws", "test", apisv1alpha2.APIBindingPhaseBound)
+		c.handlePhaseMetricsOnAdd(b)
+		require.Len(t, c.countedAPIBindings, 1)
+		for _, v := range c.countedAPIBindings {
+			require.Equal(t, string(apisv1alpha2.APIBindingPhaseBound), v)
+		}
+	})
+
+	t.Run("new binding with empty phase is tracked but metric not emitted", func(t *testing.T) {
+		c := newTestController()
+		b := binding("root:ws", "test", "")
+		c.handlePhaseMetricsOnAdd(b)
+		require.Len(t, c.countedAPIBindings, 1)
+		for _, v := range c.countedAPIBindings {
+			require.Equal(t, "", v)
+		}
+	})
+
+	t.Run("duplicate add is ignored", func(t *testing.T) {
+		c := newTestController()
+		b := binding("root:ws", "test", apisv1alpha2.APIBindingPhaseBinding)
+		c.handlePhaseMetricsOnAdd(b)
+		c.handlePhaseMetricsOnAdd(b) // second add should be a no-op
+		require.Len(t, c.countedAPIBindings, 1)
+	})
+}
+
+func TestHandlePhaseMetricsOnUpdate(t *testing.T) {
+	t.Run("phase change updates tracked state", func(t *testing.T) {
+		c := newTestController()
+		old := binding("root:ws", "test", apisv1alpha2.APIBindingPhaseBinding)
+		new := binding("root:ws", "test", apisv1alpha2.APIBindingPhaseBound)
+		c.handlePhaseMetricsOnAdd(old)
+		c.handlePhaseMetricsOnUpdate(old, new)
+		for _, v := range c.countedAPIBindings {
+			require.Equal(t, string(apisv1alpha2.APIBindingPhaseBound), v)
+		}
+	})
+
+	t.Run("no-op when phase unchanged", func(t *testing.T) {
+		c := newTestController()
+		b := binding("root:ws", "test", apisv1alpha2.APIBindingPhaseBound)
+		c.handlePhaseMetricsOnAdd(b)
+		c.handlePhaseMetricsOnUpdate(b, b)
+		for _, v := range c.countedAPIBindings {
+			require.Equal(t, string(apisv1alpha2.APIBindingPhaseBound), v)
+		}
+	})
+}
+
+func TestHandlePhaseMetricsOnDelete(t *testing.T) {
+	t.Run("delete removes tracked binding", func(t *testing.T) {
+		c := newTestController()
+		b := binding("root:ws", "test", apisv1alpha2.APIBindingPhaseBound)
+		c.handlePhaseMetricsOnAdd(b)
+		require.Len(t, c.countedAPIBindings, 1)
+		c.handlePhaseMetricsOnDelete(b)
+		require.Empty(t, c.countedAPIBindings)
+	})
+
+	t.Run("delete of unknown binding is a no-op", func(t *testing.T) {
+		c := newTestController()
+		b := binding("root:ws", "unknown", apisv1alpha2.APIBindingPhaseBound)
+		require.NotPanics(t, func() { c.handlePhaseMetricsOnDelete(b) })
+		require.Empty(t, c.countedAPIBindings)
+	})
+}
+
+func TestHandlePhaseMetricsConcurrency(t *testing.T) {
+	c := newTestController()
+	var wg sync.WaitGroup
+	for i := range 50 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			name := "binding-" + string(rune('a'+i%26))
+			b := binding("root:ws", name, apisv1alpha2.APIBindingPhaseBinding)
+			c.handlePhaseMetricsOnAdd(b)
+		}(i)
+	}
+	wg.Wait()
+}

--- a/pkg/reconciler/apis/apibinding/apibinding_phase_metrics_test.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_phase_metrics_test.go
@@ -24,6 +24,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/kcp-dev/logicalcluster/v3"
 	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
 )
 
@@ -38,7 +39,7 @@ func binding(cluster, name string, phase apisv1alpha2.APIBindingPhaseType) *apis
 	return &apisv1alpha2.APIBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
-			Annotations: map[string]string{"kcp.io/cluster": cluster},
+			Annotations: map[string]string{logicalcluster.AnnotationKey: cluster},
 		},
 		Status: apisv1alpha2.APIBindingStatus{Phase: phase},
 	}
@@ -61,7 +62,7 @@ func TestHandlePhaseMetricsOnAdd(t *testing.T) {
 		c.handlePhaseMetricsOnAdd(b)
 		require.Len(t, c.countedAPIBindings, 1)
 		for _, v := range c.countedAPIBindings {
-			require.Equal(t, "", v)
+			require.Empty(t, v)
 		}
 	})
 

--- a/pkg/reconciler/apis/apibinding/apibinding_phase_metrics_test.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_phase_metrics_test.go
@@ -29,7 +29,8 @@ import (
 
 func newTestController() *controller {
 	return &controller{
-		countedAPIBindings: make(map[string]string),
+		countedAPIBindings:          make(map[string]string),
+		countedAPIBindingConditions: make(map[string]map[string]string),
 	}
 }
 

--- a/pkg/reconciler/apis/apibinding/apibinding_ready_duration_metrics_test.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_ready_duration_metrics_test.go
@@ -24,6 +24,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/kcp-dev/logicalcluster/v3"
 	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
 )
 
@@ -31,7 +32,7 @@ func bindingWithPhaseAndCreation(cluster, name string, phase apisv1alpha2.APIBin
 	return &apisv1alpha2.APIBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              name,
-			Annotations:       map[string]string{"kcp.io/cluster": cluster},
+			Annotations:       map[string]string{logicalcluster.AnnotationKey: cluster},
 			CreationTimestamp: metav1.Time{Time: created},
 		},
 		Status: apisv1alpha2.APIBindingStatus{Phase: phase},

--- a/pkg/reconciler/apis/apibinding/apibinding_ready_duration_metrics_test.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_ready_duration_metrics_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apibinding
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
+)
+
+func bindingWithPhaseAndCreation(cluster, name string, phase apisv1alpha2.APIBindingPhaseType, created time.Time) *apisv1alpha2.APIBinding {
+	return &apisv1alpha2.APIBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Annotations:       map[string]string{"kcp.io/cluster": cluster},
+			CreationTimestamp: metav1.Time{Time: created},
+		},
+		Status: apisv1alpha2.APIBindingStatus{Phase: phase},
+	}
+}
+
+func TestHandleReadyDurationOnUpdate(t *testing.T) {
+	t.Run("transitioning to Bound records duration without panic", func(t *testing.T) {
+		c := newTestController()
+		created := time.Now().Add(-5 * time.Second)
+		old := bindingWithPhaseAndCreation("root:ws", "test", apisv1alpha2.APIBindingPhaseBinding, created)
+		new := bindingWithPhaseAndCreation("root:ws", "test", apisv1alpha2.APIBindingPhaseBound, created)
+		c.handlePhaseMetricsOnAdd(old)
+		require.NotPanics(t, func() { c.handlePhaseMetricsOnUpdate(old, new) })
+	})
+
+	t.Run("transitioning to Binding does not record duration", func(t *testing.T) {
+		c := newTestController()
+		created := time.Now().Add(-2 * time.Second)
+		old := bindingWithPhaseAndCreation("root:ws", "test", "", created)
+		new := bindingWithPhaseAndCreation("root:ws", "test", apisv1alpha2.APIBindingPhaseBinding, created)
+		c.handlePhaseMetricsOnAdd(old)
+		require.NotPanics(t, func() { c.handlePhaseMetricsOnUpdate(old, new) })
+	})
+
+	t.Run("same phase does not record duration", func(t *testing.T) {
+		c := newTestController()
+		created := time.Now().Add(-1 * time.Second)
+		b := bindingWithPhaseAndCreation("root:ws", "test", apisv1alpha2.APIBindingPhaseBound, created)
+		c.handlePhaseMetricsOnAdd(b)
+		require.NotPanics(t, func() { c.handlePhaseMetricsOnUpdate(b, b) })
+	})
+}

--- a/pkg/reconciler/apis/apiexport/apiexport_condition_metrics_test.go
+++ b/pkg/reconciler/apis/apiexport/apiexport_condition_metrics_test.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/kcp-dev/logicalcluster/v3"
 	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
 	conditionsv1alpha1 "github.com/kcp-dev/sdk/apis/third_party/conditions/apis/conditions/v1alpha1"
 )
@@ -32,6 +33,7 @@ import (
 func newTestController() *controller {
 	return &controller{
 		countedAPIExportConditions: make(map[string]map[string]string),
+		readyAPIExports:            make(map[string]struct{}),
 	}
 }
 
@@ -39,7 +41,7 @@ func exportWithConditions(cluster, name string, conds ...conditionsv1alpha1.Cond
 	return &apisv1alpha2.APIExport{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
-			Annotations: map[string]string{"kcp.io/cluster": cluster},
+			Annotations: map[string]string{logicalcluster.AnnotationKey: cluster},
 		},
 		Status: apisv1alpha2.APIExportStatus{Conditions: conds},
 	}

--- a/pkg/reconciler/apis/apiexport/apiexport_condition_metrics_test.go
+++ b/pkg/reconciler/apis/apiexport/apiexport_condition_metrics_test.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiexport
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
+	conditionsv1alpha1 "github.com/kcp-dev/sdk/apis/third_party/conditions/apis/conditions/v1alpha1"
+)
+
+func newTestController() *controller {
+	return &controller{
+		countedAPIExportConditions: make(map[string]map[string]string),
+	}
+}
+
+func exportWithConditions(cluster, name string, conds ...conditionsv1alpha1.Condition) *apisv1alpha2.APIExport {
+	return &apisv1alpha2.APIExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Annotations: map[string]string{"kcp.io/cluster": cluster},
+		},
+		Status: apisv1alpha2.APIExportStatus{Conditions: conds},
+	}
+}
+
+func cond(condType conditionsv1alpha1.ConditionType, status corev1.ConditionStatus) conditionsv1alpha1.Condition {
+	return conditionsv1alpha1.Condition{Type: condType, Status: status}
+}
+
+func TestHandleConditionMetricsOnAdd(t *testing.T) {
+	t.Run("conditions are tracked on add", func(t *testing.T) {
+		c := newTestController()
+		e := exportWithConditions("root:ws", "test",
+			cond(apisv1alpha2.APIExportIdentityValid, corev1.ConditionTrue),
+			cond(apisv1alpha2.APIExportVirtualWorkspaceURLsReady, corev1.ConditionFalse),
+		)
+		c.handleConditionMetricsOnAdd(e)
+		require.Len(t, c.countedAPIExportConditions, 1)
+		for _, snapshot := range c.countedAPIExportConditions {
+			require.Equal(t, string(corev1.ConditionTrue), snapshot[string(apisv1alpha2.APIExportIdentityValid)])
+			require.Equal(t, string(corev1.ConditionFalse), snapshot[string(apisv1alpha2.APIExportVirtualWorkspaceURLsReady)])
+		}
+	})
+
+	t.Run("export with no conditions stores empty snapshot", func(t *testing.T) {
+		c := newTestController()
+		e := exportWithConditions("root:ws", "test")
+		c.handleConditionMetricsOnAdd(e)
+		require.Len(t, c.countedAPIExportConditions, 1)
+		for _, snapshot := range c.countedAPIExportConditions {
+			require.Empty(t, snapshot)
+		}
+	})
+
+	t.Run("duplicate add is a no-op", func(t *testing.T) {
+		c := newTestController()
+		e := exportWithConditions("root:ws", "test",
+			cond(apisv1alpha2.APIExportIdentityValid, corev1.ConditionTrue),
+		)
+		c.handleConditionMetricsOnAdd(e)
+		c.handleConditionMetricsOnAdd(e)
+		require.Len(t, c.countedAPIExportConditions, 1)
+	})
+}
+
+func TestHandleConditionMetricsOnUpdate(t *testing.T) {
+	t.Run("condition status change is tracked", func(t *testing.T) {
+		c := newTestController()
+		old := exportWithConditions("root:ws", "test",
+			cond(apisv1alpha2.APIExportIdentityValid, corev1.ConditionFalse),
+		)
+		new := exportWithConditions("root:ws", "test",
+			cond(apisv1alpha2.APIExportIdentityValid, corev1.ConditionTrue),
+		)
+		c.handleConditionMetricsOnAdd(old)
+		c.handleConditionMetricsOnUpdate(old, new)
+		for _, snapshot := range c.countedAPIExportConditions {
+			require.Equal(t, string(corev1.ConditionTrue), snapshot[string(apisv1alpha2.APIExportIdentityValid)])
+		}
+	})
+
+	t.Run("new condition added on update", func(t *testing.T) {
+		c := newTestController()
+		old := exportWithConditions("root:ws", "test",
+			cond(apisv1alpha2.APIExportIdentityValid, corev1.ConditionTrue),
+		)
+		new := exportWithConditions("root:ws", "test",
+			cond(apisv1alpha2.APIExportIdentityValid, corev1.ConditionTrue),
+			cond(apisv1alpha2.APIExportVirtualWorkspaceURLsReady, corev1.ConditionTrue),
+		)
+		c.handleConditionMetricsOnAdd(old)
+		c.handleConditionMetricsOnUpdate(old, new)
+		for _, snapshot := range c.countedAPIExportConditions {
+			require.Len(t, snapshot, 2)
+		}
+	})
+
+	t.Run("removed condition is cleaned up on update", func(t *testing.T) {
+		c := newTestController()
+		old := exportWithConditions("root:ws", "test",
+			cond(apisv1alpha2.APIExportIdentityValid, corev1.ConditionTrue),
+			cond(apisv1alpha2.APIExportVirtualWorkspaceURLsReady, corev1.ConditionTrue),
+		)
+		new := exportWithConditions("root:ws", "test",
+			cond(apisv1alpha2.APIExportIdentityValid, corev1.ConditionTrue),
+		)
+		c.handleConditionMetricsOnAdd(old)
+		c.handleConditionMetricsOnUpdate(old, new)
+		for _, snapshot := range c.countedAPIExportConditions {
+			require.Len(t, snapshot, 1)
+			require.NotContains(t, snapshot, string(apisv1alpha2.APIExportVirtualWorkspaceURLsReady))
+		}
+	})
+}
+
+func TestHandleConditionMetricsOnDelete(t *testing.T) {
+	t.Run("delete removes all condition tracking", func(t *testing.T) {
+		c := newTestController()
+		e := exportWithConditions("root:ws", "test",
+			cond(apisv1alpha2.APIExportIdentityValid, corev1.ConditionTrue),
+		)
+		c.handleConditionMetricsOnAdd(e)
+		require.Len(t, c.countedAPIExportConditions, 1)
+		c.handleConditionMetricsOnDelete(e)
+		require.Empty(t, c.countedAPIExportConditions)
+	})
+
+	t.Run("delete of unknown export is a no-op", func(t *testing.T) {
+		c := newTestController()
+		e := exportWithConditions("root:ws", "unknown",
+			cond(apisv1alpha2.APIExportIdentityValid, corev1.ConditionTrue),
+		)
+		require.NotPanics(t, func() { c.handleConditionMetricsOnDelete(e) })
+	})
+}
+
+func TestHandleConditionMetricsConcurrency(t *testing.T) {
+	c := newTestController()
+	var wg sync.WaitGroup
+	for i := range 50 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			name := "export-" + string(rune('a'+i%26))
+			e := exportWithConditions("root:ws", name,
+				cond(apisv1alpha2.APIExportIdentityValid, corev1.ConditionTrue),
+			)
+			c.handleConditionMetricsOnAdd(e)
+		}(i)
+	}
+	wg.Wait()
+}

--- a/pkg/reconciler/apis/apiexport/apiexport_controller.go
+++ b/pkg/reconciler/apis/apiexport/apiexport_controller.go
@@ -51,6 +51,7 @@ import (
 	"github.com/kcp-dev/kcp/pkg/reconciler/committer"
 	"github.com/kcp-dev/kcp/pkg/reconciler/events"
 	kcpmetrics "github.com/kcp-dev/kcp/pkg/server/metrics"
+	"github.com/kcp-dev/kcp/pkg/tombstone"
 )
 
 const (
@@ -68,6 +69,7 @@ func NewController(
 	kubeClusterClient kcpkubernetesclientset.ClusterInterface,
 	namespaceInformer kcpcorev1informers.NamespaceClusterInformer,
 	secretInformer kcpcorev1informers.SecretClusterInformer,
+	shardName string,
 ) (*controller, error) {
 	c := &controller{
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
@@ -77,6 +79,7 @@ func NewController(
 			},
 		),
 
+		shardName:         shardName,
 		kcpClusterClient:  kcpClusterClient,
 		kubeClusterClient: kubeClusterClient,
 
@@ -137,6 +140,7 @@ func NewController(
 		commit: committer.NewCommitter[*APIExport, Patcher, *APIExportSpec, *APIExportStatus](kcpClusterClient.ApisV1alpha2().APIExports()),
 
 		countedAPIExportConditions: make(map[string]map[string]string),
+		readyAPIExports:            make(map[string]struct{}),
 	}
 
 	_, _ = apiExportInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -144,16 +148,19 @@ func NewController(
 			export := obj.(*apisv1alpha2.APIExport)
 			c.enqueueAPIExport(export)
 			c.handleConditionMetricsOnAdd(export)
+			c.handleReadyDurationMetricOnAdd(export)
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			export := newObj.(*apisv1alpha2.APIExport)
 			c.enqueueAPIExport(export)
 			c.handleConditionMetricsOnUpdate(oldObj.(*apisv1alpha2.APIExport), export)
+			c.handleReadyDurationMetricOnUpdate(export)
 		},
 		DeleteFunc: func(obj interface{}) {
-			export := obj.(*apisv1alpha2.APIExport)
+			export := tombstone.Obj[*apisv1alpha2.APIExport](obj)
 			c.enqueueAPIExport(export)
 			c.handleConditionMetricsOnDelete(export)
+			c.handleReadyDurationMetricOnDelete(export)
 		},
 	})
 
@@ -203,6 +210,7 @@ type CommitFunc = func(context.Context, *Resource, *Resource) error
 type controller struct {
 	queue workqueue.TypedRateLimitingInterface[string]
 
+	shardName         string
 	kcpClusterClient  kcpclientset.ClusterInterface
 	kubeClusterClient kcpkubernetesclientset.ClusterInterface
 
@@ -225,8 +233,10 @@ type controller struct {
 
 	commit CommitFunc
 
-	mu                          sync.Mutex
-	countedAPIExportConditions  map[string]map[string]string
+	// metricsMu protects countedAPIExportConditions and readyAPIExports.
+	metricsMu                  sync.Mutex
+	countedAPIExportConditions map[string]map[string]string
+	readyAPIExports            map[string]struct{}
 }
 
 // enqueueAPIExport enqueues an APIExport.
@@ -406,15 +416,15 @@ func (c *controller) handleConditionMetricsOnAdd(export *apisv1alpha2.APIExport)
 		snapshot[string(cond.Type)] = string(cond.Status)
 	}
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.metricsMu.Lock()
+	defer c.metricsMu.Unlock()
 
 	if _, exists := c.countedAPIExportConditions[key]; exists {
 		return
 	}
 	c.countedAPIExportConditions[key] = snapshot
 	for condType, status := range snapshot {
-		kcpmetrics.IncrementAPIExportConditionStatus(condType, status)
+		kcpmetrics.IncrementAPIExportConditionStatus(c.shardName, condType, status)
 	}
 }
 
@@ -429,21 +439,21 @@ func (c *controller) handleConditionMetricsOnUpdate(oldExport, newExport *apisv1
 		newSnapshot[string(cond.Type)] = string(cond.Status)
 	}
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.metricsMu.Lock()
+	defer c.metricsMu.Unlock()
 
 	oldSnapshot := c.countedAPIExportConditions[key]
 
 	for condType, oldStatus := range oldSnapshot {
 		newStatus, exists := newSnapshot[condType]
 		if !exists || newStatus != oldStatus {
-			kcpmetrics.DecrementAPIExportConditionStatus(condType, oldStatus)
+			kcpmetrics.DecrementAPIExportConditionStatus(c.shardName, condType, oldStatus)
 		}
 	}
 	for condType, newStatus := range newSnapshot {
 		oldStatus, exists := oldSnapshot[condType]
 		if !exists || oldStatus != newStatus {
-			kcpmetrics.IncrementAPIExportConditionStatus(condType, newStatus)
+			kcpmetrics.IncrementAPIExportConditionStatus(c.shardName, condType, newStatus)
 		}
 	}
 
@@ -456,15 +466,77 @@ func (c *controller) handleConditionMetricsOnDelete(export *apisv1alpha2.APIExpo
 		return
 	}
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.metricsMu.Lock()
+	defer c.metricsMu.Unlock()
 
 	snapshot, exists := c.countedAPIExportConditions[key]
 	if !exists {
 		return
 	}
 	for condType, status := range snapshot {
-		kcpmetrics.DecrementAPIExportConditionStatus(condType, status)
+		kcpmetrics.DecrementAPIExportConditionStatus(c.shardName, condType, status)
 	}
 	delete(c.countedAPIExportConditions, key)
+}
+
+func isAPIExportReady(export *apisv1alpha2.APIExport) bool {
+	identityValid := false
+	urlsReady := false
+	for _, cond := range export.Status.Conditions {
+		switch cond.Type {
+		case apisv1alpha2.APIExportIdentityValid:
+			identityValid = cond.Status == corev1.ConditionTrue
+		case apisv1alpha2.APIExportVirtualWorkspaceURLsReady:
+			urlsReady = cond.Status == corev1.ConditionTrue
+		}
+	}
+	return identityValid && urlsReady
+}
+
+func (c *controller) handleReadyDurationMetricOnAdd(export *apisv1alpha2.APIExport) {
+	if !isAPIExportReady(export) {
+		return
+	}
+	key, err := kcpcache.MetaClusterNamespaceKeyFunc(export)
+	if err != nil {
+		return
+	}
+
+	c.metricsMu.Lock()
+	defer c.metricsMu.Unlock()
+
+	// On add (including restarts), just mark the export as already seen so that
+	// a subsequent update does not re-record the ready duration.
+	c.readyAPIExports[key] = struct{}{}
+}
+
+func (c *controller) handleReadyDurationMetricOnUpdate(export *apisv1alpha2.APIExport) {
+	if !isAPIExportReady(export) {
+		return
+	}
+	key, err := kcpcache.MetaClusterNamespaceKeyFunc(export)
+	if err != nil {
+		return
+	}
+
+	c.metricsMu.Lock()
+	defer c.metricsMu.Unlock()
+
+	if _, alreadyObserved := c.readyAPIExports[key]; alreadyObserved {
+		return
+	}
+	c.readyAPIExports[key] = struct{}{}
+	kcpmetrics.ObserveAPIExportReadyDuration(c.shardName, export.CreationTimestamp.Time)
+}
+
+func (c *controller) handleReadyDurationMetricOnDelete(export *apisv1alpha2.APIExport) {
+	key, err := kcpcache.MetaClusterNamespaceKeyFunc(export)
+	if err != nil {
+		return
+	}
+
+	c.metricsMu.Lock()
+	defer c.metricsMu.Unlock()
+
+	delete(c.readyAPIExports, key)
 }

--- a/pkg/reconciler/apis/apiexport/apiexport_controller.go
+++ b/pkg/reconciler/apis/apiexport/apiexport_controller.go
@@ -19,6 +19,7 @@ package apiexport
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -49,6 +50,7 @@ import (
 	"github.com/kcp-dev/kcp/pkg/logging"
 	"github.com/kcp-dev/kcp/pkg/reconciler/committer"
 	"github.com/kcp-dev/kcp/pkg/reconciler/events"
+	kcpmetrics "github.com/kcp-dev/kcp/pkg/server/metrics"
 )
 
 const (
@@ -133,17 +135,25 @@ func NewController(
 		},
 
 		commit: committer.NewCommitter[*APIExport, Patcher, *APIExportSpec, *APIExportStatus](kcpClusterClient.ApisV1alpha2().APIExports()),
+
+		countedAPIExportConditions: make(map[string]map[string]string),
 	}
 
 	_, _ = apiExportInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			c.enqueueAPIExport(obj.(*apisv1alpha2.APIExport))
+			export := obj.(*apisv1alpha2.APIExport)
+			c.enqueueAPIExport(export)
+			c.handleConditionMetricsOnAdd(export)
 		},
-		UpdateFunc: func(_, newObj interface{}) {
-			c.enqueueAPIExport(newObj.(*apisv1alpha2.APIExport))
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			export := newObj.(*apisv1alpha2.APIExport)
+			c.enqueueAPIExport(export)
+			c.handleConditionMetricsOnUpdate(oldObj.(*apisv1alpha2.APIExport), export)
 		},
 		DeleteFunc: func(obj interface{}) {
-			c.enqueueAPIExport(obj.(*apisv1alpha2.APIExport))
+			export := obj.(*apisv1alpha2.APIExport)
+			c.enqueueAPIExport(export)
+			c.handleConditionMetricsOnDelete(export)
 		},
 	})
 
@@ -214,6 +224,9 @@ type controller struct {
 	listShards func() ([]*corev1alpha1.Shard, error)
 
 	commit CommitFunc
+
+	mu                          sync.Mutex
+	countedAPIExportConditions  map[string]map[string]string
 }
 
 // enqueueAPIExport enqueues an APIExport.
@@ -380,4 +393,78 @@ func InstallIndexers(apiExportInformer apisv1alpha2informers.APIExportClusterInf
 			indexers.APIExportBySecret:   indexers.IndexAPIExportBySecret,
 		},
 	)
+}
+
+func (c *controller) handleConditionMetricsOnAdd(export *apisv1alpha2.APIExport) {
+	key, err := kcpcache.MetaClusterNamespaceKeyFunc(export)
+	if err != nil {
+		return
+	}
+
+	snapshot := make(map[string]string, len(export.Status.Conditions))
+	for _, cond := range export.Status.Conditions {
+		snapshot[string(cond.Type)] = string(cond.Status)
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if _, exists := c.countedAPIExportConditions[key]; exists {
+		return
+	}
+	c.countedAPIExportConditions[key] = snapshot
+	for condType, status := range snapshot {
+		kcpmetrics.IncrementAPIExportConditionStatus(condType, status)
+	}
+}
+
+func (c *controller) handleConditionMetricsOnUpdate(oldExport, newExport *apisv1alpha2.APIExport) {
+	key, err := kcpcache.MetaClusterNamespaceKeyFunc(newExport)
+	if err != nil {
+		return
+	}
+
+	newSnapshot := make(map[string]string, len(newExport.Status.Conditions))
+	for _, cond := range newExport.Status.Conditions {
+		newSnapshot[string(cond.Type)] = string(cond.Status)
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	oldSnapshot := c.countedAPIExportConditions[key]
+
+	for condType, oldStatus := range oldSnapshot {
+		newStatus, exists := newSnapshot[condType]
+		if !exists || newStatus != oldStatus {
+			kcpmetrics.DecrementAPIExportConditionStatus(condType, oldStatus)
+		}
+	}
+	for condType, newStatus := range newSnapshot {
+		oldStatus, exists := oldSnapshot[condType]
+		if !exists || oldStatus != newStatus {
+			kcpmetrics.IncrementAPIExportConditionStatus(condType, newStatus)
+		}
+	}
+
+	c.countedAPIExportConditions[key] = newSnapshot
+}
+
+func (c *controller) handleConditionMetricsOnDelete(export *apisv1alpha2.APIExport) {
+	key, err := kcpcache.MetaClusterNamespaceKeyFunc(export)
+	if err != nil {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	snapshot, exists := c.countedAPIExportConditions[key]
+	if !exists {
+		return
+	}
+	for condType, status := range snapshot {
+		kcpmetrics.DecrementAPIExportConditionStatus(condType, status)
+	}
+	delete(c.countedAPIExportConditions, key)
 }

--- a/pkg/reconciler/apis/apiexport/apiexport_ready_duration_metrics_test.go
+++ b/pkg/reconciler/apis/apiexport/apiexport_ready_duration_metrics_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiexport
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
+	conditionsv1alpha1 "github.com/kcp-dev/sdk/apis/third_party/conditions/apis/conditions/v1alpha1"
+)
+
+func exportWithCreation(cluster, name string, created time.Time, conds ...conditionsv1alpha1.Condition) *apisv1alpha2.APIExport {
+	return &apisv1alpha2.APIExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Annotations:       map[string]string{logicalcluster.AnnotationKey: cluster},
+			CreationTimestamp: metav1.Time{Time: created},
+		},
+		Status: apisv1alpha2.APIExportStatus{Conditions: conds},
+	}
+}
+
+func TestIsAPIExportReady(t *testing.T) {
+	t.Run("ready when both conditions are True", func(t *testing.T) {
+		e := exportWithCreation("root:ws", "test", time.Now(),
+			cond(apisv1alpha2.APIExportIdentityValid, corev1.ConditionTrue),
+			cond(apisv1alpha2.APIExportVirtualWorkspaceURLsReady, corev1.ConditionTrue),
+		)
+		require.True(t, isAPIExportReady(e))
+	})
+
+	t.Run("not ready when identity is False", func(t *testing.T) {
+		e := exportWithCreation("root:ws", "test", time.Now(),
+			cond(apisv1alpha2.APIExportIdentityValid, corev1.ConditionFalse),
+			cond(apisv1alpha2.APIExportVirtualWorkspaceURLsReady, corev1.ConditionTrue),
+		)
+		require.False(t, isAPIExportReady(e))
+	})
+
+	t.Run("not ready when URLs not ready", func(t *testing.T) {
+		e := exportWithCreation("root:ws", "test", time.Now(),
+			cond(apisv1alpha2.APIExportIdentityValid, corev1.ConditionTrue),
+			cond(apisv1alpha2.APIExportVirtualWorkspaceURLsReady, corev1.ConditionFalse),
+		)
+		require.False(t, isAPIExportReady(e))
+	})
+
+	t.Run("not ready with no conditions", func(t *testing.T) {
+		e := exportWithCreation("root:ws", "test", time.Now())
+		require.False(t, isAPIExportReady(e))
+	})
+}
+
+func TestHandleReadyDurationMetricOnUpdate(t *testing.T) {
+	t.Run("first transition to ready records duration without panic", func(t *testing.T) {
+		c := newTestController()
+		created := time.Now().Add(-3 * time.Second)
+		e := exportWithCreation("root:ws", "test", created,
+			cond(apisv1alpha2.APIExportIdentityValid, corev1.ConditionTrue),
+			cond(apisv1alpha2.APIExportVirtualWorkspaceURLsReady, corev1.ConditionTrue),
+		)
+		require.NotPanics(t, func() { c.handleReadyDurationMetricOnUpdate(e) })
+		require.Len(t, c.readyAPIExports, 1)
+	})
+
+	t.Run("second update when already ready does not double-record", func(t *testing.T) {
+		c := newTestController()
+		created := time.Now().Add(-3 * time.Second)
+		e := exportWithCreation("root:ws", "test", created,
+			cond(apisv1alpha2.APIExportIdentityValid, corev1.ConditionTrue),
+			cond(apisv1alpha2.APIExportVirtualWorkspaceURLsReady, corev1.ConditionTrue),
+		)
+		c.handleReadyDurationMetricOnUpdate(e)
+		c.handleReadyDurationMetricOnUpdate(e) // second call should be a no-op
+		require.Len(t, c.readyAPIExports, 1)
+	})
+
+	t.Run("not-ready update does not record", func(t *testing.T) {
+		c := newTestController()
+		e := exportWithCreation("root:ws", "test", time.Now(),
+			cond(apisv1alpha2.APIExportIdentityValid, corev1.ConditionFalse),
+			cond(apisv1alpha2.APIExportVirtualWorkspaceURLsReady, corev1.ConditionTrue),
+		)
+		c.handleReadyDurationMetricOnUpdate(e)
+		require.Empty(t, c.readyAPIExports)
+	})
+}
+
+func TestHandleReadyDurationMetricOnDelete(t *testing.T) {
+	t.Run("delete removes ready tracking", func(t *testing.T) {
+		c := newTestController()
+		created := time.Now().Add(-1 * time.Second)
+		e := exportWithCreation("root:ws", "test", created,
+			cond(apisv1alpha2.APIExportIdentityValid, corev1.ConditionTrue),
+			cond(apisv1alpha2.APIExportVirtualWorkspaceURLsReady, corev1.ConditionTrue),
+		)
+		c.handleReadyDurationMetricOnUpdate(e)
+		require.Len(t, c.readyAPIExports, 1)
+		c.handleReadyDurationMetricOnDelete(e)
+		require.Empty(t, c.readyAPIExports)
+	})
+
+	t.Run("delete of untracked export is a no-op", func(t *testing.T) {
+		c := newTestController()
+		e := exportWithCreation("root:ws", "unknown", time.Now())
+		require.NotPanics(t, func() { c.handleReadyDurationMetricOnDelete(e) })
+	})
+}

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -770,6 +770,7 @@ func (s *Server) installAPIBindingController(ctx context.Context, config *rest.C
 		s.CacheKcpSharedInformerFactory.Apis().V1alpha1().APIResourceSchemas(),
 		s.CacheKcpSharedInformerFactory.Apis().V1alpha1().APIConversions(),
 		s.ApiExtensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions(),
+		s.Options.Extra.ShardName,
 	)
 	if err != nil {
 		return err
@@ -1140,6 +1141,7 @@ func (s *Server) installAPIExportController(ctx context.Context, config *rest.Co
 		kubeClusterClient,
 		s.KubeSharedInformerFactory.Core().V1().Namespaces(),
 		s.KubeSharedInformerFactory.Core().V1().Secrets(),
+		s.Options.Extra.ShardName,
 	)
 	if err != nil {
 		return err

--- a/pkg/server/metrics/metrics.go
+++ b/pkg/server/metrics/metrics.go
@@ -68,6 +68,15 @@ var (
 			Buckets:        []float64{100, 500, 1000, 2500, 5000, 10000, 30000, 60000, 120000, 300000},
 		},
 	)
+
+	apiExportConditionStatus = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Name:           "kcp_apiexport_condition_status",
+			Help:           "Number of APIExports with each condition type and status (True, False, Unknown).",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"condition", "status"},
+	)
 )
 
 func init() {
@@ -76,6 +85,7 @@ func init() {
 	legacyregistry.MustRegister(apiBindingPhase)
 	legacyregistry.MustRegister(apiBindingConditionStatus)
 	legacyregistry.MustRegister(apiBindingReadyDurationMs)
+	legacyregistry.MustRegister(apiExportConditionStatus)
 }
 
 // IncrementLogicalClusterCount increments the count for the given shard and phase.
@@ -121,4 +131,14 @@ func DecrementAPIBindingConditionStatus(conditionType, status string) {
 // ObserveAPIBindingReadyDuration records the duration from creation to Bound phase.
 func ObserveAPIBindingReadyDuration(creationTime time.Time) {
 	apiBindingReadyDurationMs.Observe(float64(time.Since(creationTime).Milliseconds()))
+}
+
+// IncrementAPIExportConditionStatus increments the gauge for the given APIExport condition type and status.
+func IncrementAPIExportConditionStatus(conditionType, status string) {
+	apiExportConditionStatus.WithLabelValues(conditionType, status).Inc()
+}
+
+// DecrementAPIExportConditionStatus decrements the gauge for the given APIExport condition type and status.
+func DecrementAPIExportConditionStatus(conditionType, status string) {
+	apiExportConditionStatus.WithLabelValues(conditionType, status).Dec()
 }

--- a/pkg/server/metrics/metrics.go
+++ b/pkg/server/metrics/metrics.go
@@ -48,7 +48,7 @@ var (
 			Help:           "Number of APIBindings in each phase (Binding, Bound, or empty for newly created).",
 			StabilityLevel: metrics.ALPHA,
 		},
-		[]string{"phase"},
+		[]string{"shard", "phase"},
 	)
 
 	apiBindingConditionStatus = metrics.NewGaugeVec(
@@ -57,16 +57,17 @@ var (
 			Help:           "Number of APIBindings with each condition type and status (True, False, Unknown).",
 			StabilityLevel: metrics.ALPHA,
 		},
-		[]string{"condition", "status"},
+		[]string{"shard", "condition", "status"},
 	)
 
-	apiBindingReadyDurationMs = metrics.NewHistogram(
+	apiBindingReadyDurationMs = metrics.NewHistogramVec(
 		&metrics.HistogramOpts{
 			Name:           "kcp_apibinding_ready_duration_ms",
 			Help:           "Duration in milliseconds from APIBinding creation to reaching the Bound phase.",
 			StabilityLevel: metrics.ALPHA,
 			Buckets:        []float64{100, 500, 1000, 2500, 5000, 10000, 30000, 60000, 120000, 300000},
 		},
+		[]string{"shard"},
 	)
 
 	apiExportConditionStatus = metrics.NewGaugeVec(
@@ -75,7 +76,17 @@ var (
 			Help:           "Number of APIExports with each condition type and status (True, False, Unknown).",
 			StabilityLevel: metrics.ALPHA,
 		},
-		[]string{"condition", "status"},
+		[]string{"shard", "condition", "status"},
+	)
+
+	apiExportReadyDurationMs = metrics.NewHistogramVec(
+		&metrics.HistogramOpts{
+			Name:           "kcp_apiexport_ready_duration_ms",
+			Help:           "Duration in milliseconds from APIExport creation to becoming fully operational (IdentityValid and VirtualWorkspaceURLsReady both True).",
+			StabilityLevel: metrics.ALPHA,
+			Buckets:        []float64{100, 500, 1000, 2500, 5000, 10000, 30000, 60000, 120000, 300000},
+		},
+		[]string{"shard"},
 	)
 )
 
@@ -86,6 +97,7 @@ func init() {
 	legacyregistry.MustRegister(apiBindingConditionStatus)
 	legacyregistry.MustRegister(apiBindingReadyDurationMs)
 	legacyregistry.MustRegister(apiExportConditionStatus)
+	legacyregistry.MustRegister(apiExportReadyDurationMs)
 }
 
 // IncrementLogicalClusterCount increments the count for the given shard and phase.
@@ -109,36 +121,41 @@ func DecrementWorkspaceCount(shardName string, phase string) {
 }
 
 // IncrementAPIBindingPhase increments the gauge for the given APIBinding phase.
-func IncrementAPIBindingPhase(phase string) {
-	apiBindingPhase.WithLabelValues(phase).Inc()
+func IncrementAPIBindingPhase(shardName, phase string) {
+	apiBindingPhase.WithLabelValues(shardName, phase).Inc()
 }
 
 // DecrementAPIBindingPhase decrements the gauge for the given APIBinding phase.
-func DecrementAPIBindingPhase(phase string) {
-	apiBindingPhase.WithLabelValues(phase).Dec()
+func DecrementAPIBindingPhase(shardName, phase string) {
+	apiBindingPhase.WithLabelValues(shardName, phase).Dec()
 }
 
 // IncrementAPIBindingConditionStatus increments the gauge for the given condition type and status.
-func IncrementAPIBindingConditionStatus(conditionType, status string) {
-	apiBindingConditionStatus.WithLabelValues(conditionType, status).Inc()
+func IncrementAPIBindingConditionStatus(shardName, conditionType, status string) {
+	apiBindingConditionStatus.WithLabelValues(shardName, conditionType, status).Inc()
 }
 
 // DecrementAPIBindingConditionStatus decrements the gauge for the given condition type and status.
-func DecrementAPIBindingConditionStatus(conditionType, status string) {
-	apiBindingConditionStatus.WithLabelValues(conditionType, status).Dec()
+func DecrementAPIBindingConditionStatus(shardName, conditionType, status string) {
+	apiBindingConditionStatus.WithLabelValues(shardName, conditionType, status).Dec()
 }
 
 // ObserveAPIBindingReadyDuration records the duration from creation to Bound phase.
-func ObserveAPIBindingReadyDuration(creationTime time.Time) {
-	apiBindingReadyDurationMs.Observe(float64(time.Since(creationTime).Milliseconds()))
+func ObserveAPIBindingReadyDuration(shardName string, creationTime time.Time) {
+	apiBindingReadyDurationMs.WithLabelValues(shardName).Observe(float64(time.Since(creationTime).Milliseconds()))
 }
 
 // IncrementAPIExportConditionStatus increments the gauge for the given APIExport condition type and status.
-func IncrementAPIExportConditionStatus(conditionType, status string) {
-	apiExportConditionStatus.WithLabelValues(conditionType, status).Inc()
+func IncrementAPIExportConditionStatus(shardName, conditionType, status string) {
+	apiExportConditionStatus.WithLabelValues(shardName, conditionType, status).Inc()
 }
 
 // DecrementAPIExportConditionStatus decrements the gauge for the given APIExport condition type and status.
-func DecrementAPIExportConditionStatus(conditionType, status string) {
-	apiExportConditionStatus.WithLabelValues(conditionType, status).Dec()
+func DecrementAPIExportConditionStatus(shardName, conditionType, status string) {
+	apiExportConditionStatus.WithLabelValues(shardName, conditionType, status).Dec()
+}
+
+// ObserveAPIExportReadyDuration records the duration from APIExport creation to fully operational.
+func ObserveAPIExportReadyDuration(shardName string, creationTime time.Time) {
+	apiExportReadyDurationMs.WithLabelValues(shardName).Observe(float64(time.Since(creationTime).Milliseconds()))
 }

--- a/pkg/server/metrics/metrics.go
+++ b/pkg/server/metrics/metrics.go
@@ -39,11 +39,21 @@ var (
 		},
 		[]string{"shard", "phase"},
 	)
+
+	apiBindingPhase = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Name:           "kcp_apibinding_phase",
+			Help:           "Number of APIBindings in each phase (Binding, Bound, or empty for newly created).",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"phase"},
+	)
 )
 
 func init() {
 	legacyregistry.MustRegister(logicalClusterCount)
 	legacyregistry.MustRegister(workspaceCount)
+	legacyregistry.MustRegister(apiBindingPhase)
 }
 
 // IncrementLogicalClusterCount increments the count for the given shard and phase.
@@ -64,4 +74,14 @@ func IncrementWorkspaceCount(shardName string, phase string) {
 // DecrementWorkspaceCount decrements the count for the given shard and phase.
 func DecrementWorkspaceCount(shardName string, phase string) {
 	workspaceCount.WithLabelValues(shardName, phase).Dec()
+}
+
+// IncrementAPIBindingPhase increments the gauge for the given APIBinding phase.
+func IncrementAPIBindingPhase(phase string) {
+	apiBindingPhase.WithLabelValues(phase).Inc()
+}
+
+// DecrementAPIBindingPhase decrements the gauge for the given APIBinding phase.
+func DecrementAPIBindingPhase(phase string) {
+	apiBindingPhase.WithLabelValues(phase).Dec()
 }

--- a/pkg/server/metrics/metrics.go
+++ b/pkg/server/metrics/metrics.go
@@ -48,12 +48,22 @@ var (
 		},
 		[]string{"phase"},
 	)
+
+	apiBindingConditionStatus = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Name:           "kcp_apibinding_condition_status",
+			Help:           "Number of APIBindings with each condition type and status (True, False, Unknown).",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"condition", "status"},
+	)
 )
 
 func init() {
 	legacyregistry.MustRegister(logicalClusterCount)
 	legacyregistry.MustRegister(workspaceCount)
 	legacyregistry.MustRegister(apiBindingPhase)
+	legacyregistry.MustRegister(apiBindingConditionStatus)
 }
 
 // IncrementLogicalClusterCount increments the count for the given shard and phase.
@@ -84,4 +94,14 @@ func IncrementAPIBindingPhase(phase string) {
 // DecrementAPIBindingPhase decrements the gauge for the given APIBinding phase.
 func DecrementAPIBindingPhase(phase string) {
 	apiBindingPhase.WithLabelValues(phase).Dec()
+}
+
+// IncrementAPIBindingConditionStatus increments the gauge for the given condition type and status.
+func IncrementAPIBindingConditionStatus(conditionType, status string) {
+	apiBindingConditionStatus.WithLabelValues(conditionType, status).Inc()
+}
+
+// DecrementAPIBindingConditionStatus decrements the gauge for the given condition type and status.
+func DecrementAPIBindingConditionStatus(conditionType, status string) {
+	apiBindingConditionStatus.WithLabelValues(conditionType, status).Dec()
 }

--- a/pkg/server/metrics/metrics.go
+++ b/pkg/server/metrics/metrics.go
@@ -17,6 +17,8 @@ limitations under the License.
 package metrics
 
 import (
+	"time"
+
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
 )
@@ -57,6 +59,15 @@ var (
 		},
 		[]string{"condition", "status"},
 	)
+
+	apiBindingReadyDurationMs = metrics.NewHistogram(
+		&metrics.HistogramOpts{
+			Name:           "kcp_apibinding_ready_duration_ms",
+			Help:           "Duration in milliseconds from APIBinding creation to reaching the Bound phase.",
+			StabilityLevel: metrics.ALPHA,
+			Buckets:        []float64{100, 500, 1000, 2500, 5000, 10000, 30000, 60000, 120000, 300000},
+		},
+	)
 )
 
 func init() {
@@ -64,6 +75,7 @@ func init() {
 	legacyregistry.MustRegister(workspaceCount)
 	legacyregistry.MustRegister(apiBindingPhase)
 	legacyregistry.MustRegister(apiBindingConditionStatus)
+	legacyregistry.MustRegister(apiBindingReadyDurationMs)
 }
 
 // IncrementLogicalClusterCount increments the count for the given shard and phase.
@@ -104,4 +116,9 @@ func IncrementAPIBindingConditionStatus(conditionType, status string) {
 // DecrementAPIBindingConditionStatus decrements the gauge for the given condition type and status.
 func DecrementAPIBindingConditionStatus(conditionType, status string) {
 	apiBindingConditionStatus.WithLabelValues(conditionType, status).Dec()
+}
+
+// ObserveAPIBindingReadyDuration records the duration from creation to Bound phase.
+func ObserveAPIBindingReadyDuration(creationTime time.Time) {
+	apiBindingReadyDurationMs.Observe(float64(time.Since(creationTime).Milliseconds()))
 }


### PR DESCRIPTION
Implements the metrics proposed in #4041. Adds five new Prometheus metrics to improve
  observability of `APIBinding` and `APIExport` lifecycle and health, following the same
  patterns already used for `kcp_workspace_count` and `kcp_logicalcluster_count`.

  All metrics are system-wide aggregates with no per-resource labels to avoid cardinality
  explosion.

  ### New metrics

  | Metric | Type | Labels | Description |
  |---|---|---|---|
  | `kcp_apibinding_phase` | Gauge | `phase` | Number of APIBindings in each phase (`Binding`, `Bound`, or empty for newly created) |
  | `kcp_apibinding_condition_status` | Gauge | `condition`, `status` | Number of APIBindings with each condition type and status (`True`/`False`/`Unknown`) |
  | `kcp_apibinding_ready_duration_ms` | Histogram | — | Milliseconds from APIBinding creation to reaching the `Bound` phase |
  | `kcp_apiexport_condition_status` | Gauge | `condition`, `status` | Number of APIExports with each condition type and status |
  | `kcp_apiexport_ready_duration_ms` | Histogram | — | Milliseconds from APIExport creation to becoming fully operational (`IdentityValid=True` and `VirtualWorkspaceURLsReady=True`) |

  ### Implementation

  - Phase and condition state is tracked per resource key in a `sync.Mutex`-protected map
    in each controller; on update only the diff is applied to the gauges.
  - Histogram observations are idempotent — each resource contributes exactly one sample
    (guarded by a phase-transition check for bindings, a `readyAPIExports` set for exports)
    so controller restarts do not double-count.
  - Each metric is introduced in its own commit with unit tests covering add, update,
    delete, and concurrency cases.

cc @mjudeikis @ntnn @SimonTheLeg 

/kind feature

```release-note
Add metrics for APIExport and APIBinding usage
```