### PR TITLE
Add watchcache ring ticker to unblock cacher shrink

### DIFF
--- a/config/shard/watchcache-kicker-clusterrolebinding.yaml
+++ b/config/shard/watchcache-kicker-clusterrolebinding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: watchcache-kicker
+  annotations:
+    "bootstrap.kcp.io/create-only": "true"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:kcp:watchcache-kicker-noop
+subjects: []

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -493,6 +493,7 @@ func (s *Server) Run(ctx context.Context) error {
 		go s.CacheKcpSharedInformerFactory.Apis().V1alpha2().APIExports().Informer().Run(hookContext.Done())
 		go s.CacheKcpSharedInformerFactory.Cache().V1alpha1().CachedResources().Informer().Run(hookContext.Done())
 		go s.CacheKcpSharedInformerFactory.Cache().V1alpha1().CachedResourceEndpointSlices().Informer().Run(hookContext.Done())
+		installWatchCacheKicker(hookCtx, s.KubeClusterClient, s.KcpClusterClient)
 		go s.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters().Informer().Run(hookContext.Done())
 		go s.KcpSharedInformerFactory.Cache().V1alpha1().CachedResources().Informer().Run(hookContext.Done())
 		go s.KcpSharedInformerFactory.Cache().V1alpha1().CachedResourceEndpointSlices().Informer().Run(hookContext.Done())

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -493,7 +493,6 @@ func (s *Server) Run(ctx context.Context) error {
 		go s.CacheKcpSharedInformerFactory.Apis().V1alpha2().APIExports().Informer().Run(hookContext.Done())
 		go s.CacheKcpSharedInformerFactory.Cache().V1alpha1().CachedResources().Informer().Run(hookContext.Done())
 		go s.CacheKcpSharedInformerFactory.Cache().V1alpha1().CachedResourceEndpointSlices().Informer().Run(hookContext.Done())
-		installWatchCacheKicker(hookCtx, s.KubeClusterClient, s.KcpClusterClient)
 		go s.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters().Informer().Run(hookContext.Done())
 		go s.KcpSharedInformerFactory.Cache().V1alpha1().CachedResources().Informer().Run(hookContext.Done())
 		go s.KcpSharedInformerFactory.Cache().V1alpha1().CachedResourceEndpointSlices().Informer().Run(hookContext.Done())
@@ -509,6 +508,8 @@ func (s *Server) Run(ctx context.Context) error {
 			return nil // don't klog.Fatal. This only happens when context is cancelled.
 		}
 		logger.Info("finished starting APIExport, APIBinding and LogicalCluster informers")
+
+		installWatchCacheKicker(hookCtx, s.KubeClusterClient, s.KcpClusterClient)
 
 		if s.Options.Extra.ShardName == corev1alpha1.RootShard {
 			logger.Info("bootstrapping root workspace phase 0")

--- a/pkg/server/watchcache_kicker.go
+++ b/pkg/server/watchcache_kicker.go
@@ -28,9 +28,10 @@ import (
 	"k8s.io/klog/v2"
 
 	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
-	"github.com/kcp-dev/sdk/apis/core"
 	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
+
+	configshard "github.com/kcp-dev/kcp/config/shard"
 )
 
 const (
@@ -44,26 +45,29 @@ const (
 	// watchCacheKickerAnnotation carries a per-tick timestamp on each kicked
 	// object so each patch produces a distinct etcd revision (and therefore
 	// a watch event flowing through the cacher).
-	watchCacheKickerAnnotation = "kcp.io/watchcache-kicker-tick"
+	watchCacheKickerAnnotation = "internal.kcp.io/watchcache-kicker-tick"
 
 	// watchCacheKickerFieldManager makes audit-log filtering trivial.
 	watchCacheKickerFieldManager = "kcp-watchcache-kicker"
 )
 
 // installWatchCacheKicker periodically generates one watch event per target
-// resource by patching a per-resource "kick object" in the root cluster.
+// resource by patching a per-resource "kick object" in the system:shard
+// logical cluster (bootstrapped on every shard, including non-root ones).
 // Works around the upstream watchCache bug where resizeCacheLocked is only
 // called from updateCache(event) and gated on isCacheFullLocked(); without
 // the kick, rings grow during workload bursts and never shrink during idle.
 // See https://github.com/kubernetes/kubernetes/issues/139250.
 //
-// Cost: ~7 metadata patches every 80 s per shard. Each patch sets the same
-// annotation key (only the timestamp value changes), so per-object growth
-// is bounded. Field manager "kcp-watchcache-kicker" is used so the patches
-// can be filtered in audit logs.
+// Each patch sets the same annotation key (only the timestamp value
+// changes), so per-object growth is bounded. Field manager
+// "kcp-watchcache-kicker" is used so the patches can be filtered in audit
+// logs.
 //
-// If a target object is missing (e.g. no APIBindings in the root cluster),
-// that resource is skipped silently — it is not an error.
+// system:shard is bootstrapped with the kick targets the kicker needs that
+// k8s/kcp does not already provide (see config/shard/*.yaml). Resources that
+// may legitimately be empty in system:shard (e.g. CachedResources on a
+// freshly started shard) are kicked via list-first and skipped silently.
 func installWatchCacheKicker(
 	ctx context.Context,
 	kubeClient kcpkubernetesclientset.ClusterInterface,
@@ -88,7 +92,10 @@ func kickAll(
 	ts := time.Now().UTC().Format(time.RFC3339Nano)
 	patch := fmt.Appendf(nil, `{"metadata":{"annotations":{%q:%q}}}`, watchCacheKickerAnnotation, ts)
 	opts := metav1.PatchOptions{FieldManager: watchCacheKickerFieldManager}
-	root := core.RootCluster.Path()
+	// system:shard is bootstrapped on every shard (root and non-root), so the
+	// kicker functions identically on all shards. It hosts a LogicalCluster,
+	// the "default" namespace, and APIBindings for the root APIs.
+	shard := configshard.SystemShardCluster.Path()
 
 	type op struct {
 		resource string
@@ -98,31 +105,23 @@ func kickAll(
 		{
 			resource: "logicalclusters.core.kcp.io",
 			fn: func() error {
-				_, err := kcpClient.Cluster(root).CoreV1alpha1().LogicalClusters().
+				_, err := kcpClient.Cluster(shard).CoreV1alpha1().LogicalClusters().
 					Patch(ctx, corev1alpha1.LogicalClusterName, types.MergePatchType, patch, opts)
-				return err
-			},
-		},
-		{
-			resource: "clusterrolebindings.rbac.authorization.k8s.io",
-			fn: func() error {
-				_, err := kubeClient.Cluster(root).RbacV1().ClusterRoleBindings().
-					Patch(ctx, "system:masters", types.MergePatchType, patch, opts)
 				return err
 			},
 		},
 		{
 			resource: "namespaces",
 			fn: func() error {
-				_, err := kubeClient.Cluster(root).CoreV1().Namespaces().
-					Patch(ctx, "kcp-system", types.MergePatchType, patch, opts)
+				_, err := kubeClient.Cluster(shard).CoreV1().Namespaces().
+					Patch(ctx, "default", types.MergePatchType, patch, opts)
 				return err
 			},
 		},
 		{
 			resource: "serviceaccounts",
 			fn: func() error {
-				_, err := kubeClient.Cluster(root).CoreV1().ServiceAccounts("kcp-system").
+				_, err := kubeClient.Cluster(shard).CoreV1().ServiceAccounts("default").
 					Patch(ctx, "default", types.MergePatchType, patch, opts)
 				return err
 			},
@@ -130,35 +129,34 @@ func kickAll(
 		{
 			resource: "configmaps",
 			fn: func() error {
-				_, err := kubeClient.Cluster(root).CoreV1().ConfigMaps("kcp-system").
+				_, err := kubeClient.Cluster(shard).CoreV1().ConfigMaps("default").
 					Patch(ctx, "kube-root-ca.crt", types.MergePatchType, patch, opts)
 				return err
 			},
 		},
-		// apibindings / workspaces: kick the first one we find, if any.
-		// These resources may legitimately be empty in the root cluster
-		// (esp. in a freshly bootstrapped install), so we list first and
-		// skip silently when empty.
 		{
-			resource: "apibindings.apis.kcp.io",
+			// Bootstrapped via config/shard/watchcache-kicker-clusterrolebinding.yaml
+			// with an empty subjects list, so it grants no permissions.
+			resource: "clusterrolebindings.rbac.authorization.k8s.io",
 			fn: func() error {
-				list, err := kcpClient.Cluster(root).ApisV1alpha2().APIBindings().List(ctx, metav1.ListOptions{Limit: 1})
-				if err != nil || len(list.Items) == 0 {
-					return err
-				}
-				_, err = kcpClient.Cluster(root).ApisV1alpha2().APIBindings().
-					Patch(ctx, list.Items[0].Name, types.MergePatchType, patch, opts)
+				_, err := kubeClient.Cluster(shard).RbacV1().ClusterRoleBindings().
+					Patch(ctx, "watchcache-kicker", types.MergePatchType, patch, opts)
 				return err
 			},
 		},
+		// apibindings, cachedresources and cachedresourceendpointslices: kick
+		// the first one we find on the shard, if any. APIBindings are present
+		// after configshard.Bootstrap binds the root APIs; the cache resources
+		// may legitimately be absent on a freshly started shard, so we list
+		// first and skip silently when empty.
 		{
-			resource: "workspaces.tenancy.kcp.io",
+			resource: "apibindings.apis.kcp.io",
 			fn: func() error {
-				list, err := kcpClient.Cluster(root).TenancyV1alpha1().Workspaces().List(ctx, metav1.ListOptions{Limit: 1})
+				list, err := kcpClient.Cluster(shard).ApisV1alpha2().APIBindings().List(ctx, metav1.ListOptions{Limit: 1})
 				if err != nil || len(list.Items) == 0 {
 					return err
 				}
-				_, err = kcpClient.Cluster(root).TenancyV1alpha1().Workspaces().
+				_, err = kcpClient.Cluster(shard).ApisV1alpha2().APIBindings().
 					Patch(ctx, list.Items[0].Name, types.MergePatchType, patch, opts)
 				return err
 			},

--- a/pkg/server/watchcache_kicker.go
+++ b/pkg/server/watchcache_kicker.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+
+	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
+	"github.com/kcp-dev/sdk/apis/core"
+	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
+	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
+)
+
+const (
+	// watchCacheKickerInterval is just above the upstream apiserver's default
+	// eventFreshDuration (75 s). Ticking at this cadence ensures each kicked
+	// event finds the recent-quarter boundary in any inflated watchCache ring
+	// older than the fresh window — letting upstream's resizeCacheLocked
+	// shrink branch fire.
+	watchCacheKickerInterval = 80 * time.Second
+
+	// watchCacheKickerAnnotation carries a per-tick timestamp on each kicked
+	// object so each patch produces a distinct etcd revision (and therefore
+	// a watch event flowing through the cacher).
+	watchCacheKickerAnnotation = "kcp.io/watchcache-kicker-tick"
+
+	// watchCacheKickerFieldManager makes audit-log filtering trivial.
+	watchCacheKickerFieldManager = "kcp-watchcache-kicker"
+)
+
+// installWatchCacheKicker periodically generates one watch event per target
+// resource by patching a per-resource "kick object" in the root cluster.
+// Works around the upstream watchCache bug where resizeCacheLocked is only
+// called from updateCache(event) and gated on isCacheFullLocked(); without
+// the kick, rings grow during workload bursts and never shrink during idle.
+// See https://github.com/kubernetes/kubernetes/issues/139250.
+//
+// Cost: ~7 metadata patches every 80 s per shard. Each patch sets the same
+// annotation key (only the timestamp value changes), so per-object growth
+// is bounded. Field manager "kcp-watchcache-kicker" is used so the patches
+// can be filtered in audit logs.
+//
+// If a target object is missing (e.g. no APIBindings in the root cluster),
+// that resource is skipped silently — it is not an error.
+func installWatchCacheKicker(
+	ctx context.Context,
+	kubeClient kcpkubernetesclientset.ClusterInterface,
+	kcpClient kcpclientset.ClusterInterface,
+) {
+	logger := klog.FromContext(ctx).WithName("watchcache-kicker")
+	logger.V(2).Info("starting", "interval", watchCacheKickerInterval)
+	go wait.UntilWithContext(ctx, func(ctx context.Context) {
+		kickAll(ctx, logger, kubeClient, kcpClient)
+	}, watchCacheKickerInterval)
+}
+
+// kickAll performs one round of patches across the targeted resources.
+// Per-target errors are logged at V(2) and otherwise ignored — a single
+// missed kick just delays the shrink cascade by one tick.
+func kickAll(
+	ctx context.Context,
+	logger klog.Logger,
+	kubeClient kcpkubernetesclientset.ClusterInterface,
+	kcpClient kcpclientset.ClusterInterface,
+) {
+	ts := time.Now().UTC().Format(time.RFC3339Nano)
+	patch := fmt.Appendf(nil, `{"metadata":{"annotations":{%q:%q}}}`, watchCacheKickerAnnotation, ts)
+	opts := metav1.PatchOptions{FieldManager: watchCacheKickerFieldManager}
+	root := core.RootCluster.Path()
+
+	type op struct {
+		resource string
+		fn       func() error
+	}
+	ops := []op{
+		{
+			resource: "logicalclusters.core.kcp.io",
+			fn: func() error {
+				_, err := kcpClient.Cluster(root).CoreV1alpha1().LogicalClusters().
+					Patch(ctx, corev1alpha1.LogicalClusterName, types.MergePatchType, patch, opts)
+				return err
+			},
+		},
+		{
+			resource: "clusterrolebindings.rbac.authorization.k8s.io",
+			fn: func() error {
+				_, err := kubeClient.Cluster(root).RbacV1().ClusterRoleBindings().
+					Patch(ctx, "system:masters", types.MergePatchType, patch, opts)
+				return err
+			},
+		},
+		{
+			resource: "namespaces",
+			fn: func() error {
+				_, err := kubeClient.Cluster(root).CoreV1().Namespaces().
+					Patch(ctx, "kcp-system", types.MergePatchType, patch, opts)
+				return err
+			},
+		},
+		{
+			resource: "serviceaccounts",
+			fn: func() error {
+				_, err := kubeClient.Cluster(root).CoreV1().ServiceAccounts("kcp-system").
+					Patch(ctx, "default", types.MergePatchType, patch, opts)
+				return err
+			},
+		},
+		{
+			resource: "configmaps",
+			fn: func() error {
+				_, err := kubeClient.Cluster(root).CoreV1().ConfigMaps("kcp-system").
+					Patch(ctx, "kube-root-ca.crt", types.MergePatchType, patch, opts)
+				return err
+			},
+		},
+		// apibindings / workspaces: kick the first one we find, if any.
+		// These resources may legitimately be empty in the root cluster
+		// (esp. in a freshly bootstrapped install), so we list first and
+		// skip silently when empty.
+		{
+			resource: "apibindings.apis.kcp.io",
+			fn: func() error {
+				list, err := kcpClient.Cluster(root).ApisV1alpha2().APIBindings().List(ctx, metav1.ListOptions{Limit: 1})
+				if err != nil || len(list.Items) == 0 {
+					return err
+				}
+				_, err = kcpClient.Cluster(root).ApisV1alpha2().APIBindings().
+					Patch(ctx, list.Items[0].Name, types.MergePatchType, patch, opts)
+				return err
+			},
+		},
+		{
+			resource: "workspaces.tenancy.kcp.io",
+			fn: func() error {
+				list, err := kcpClient.Cluster(root).TenancyV1alpha1().Workspaces().List(ctx, metav1.ListOptions{Limit: 1})
+				if err != nil || len(list.Items) == 0 {
+					return err
+				}
+				_, err = kcpClient.Cluster(root).TenancyV1alpha1().Workspaces().
+					Patch(ctx, list.Items[0].Name, types.MergePatchType, patch, opts)
+				return err
+			},
+		},
+	}
+
+	for _, o := range ops {
+		switch err := o.fn(); {
+		case err == nil:
+			logger.V(4).Info("kicked", "resource", o.resource)
+		case apierrors.IsNotFound(err):
+			logger.V(4).Info("kick target missing — skipping", "resource", o.resource)
+		default:
+			logger.V(2).Info("kick failed", "resource", o.resource, "err", err.Error())
+		}
+	}
+}

--- a/staging/src/github.com/kcp-dev/apimachinery/third_party/informers/shared_informer.go
+++ b/staging/src/github.com/kcp-dev/apimachinery/third_party/informers/shared_informer.go
@@ -333,14 +333,18 @@ func (s *sharedIndexInformer) RunWithContext(ctx context.Context) {
 	defer utilruntime.HandleCrashWithContext(ctx)
 	logger := klog.FromContext(ctx)
 
-	if s.HasStarted() {
-		logger.Info("Warning: the sharedIndexInformer has started, run more than once is not allowed")
-		return
-	}
-
-	func() {
+	// Check-and-set s.started atomically under startedLock. Without this, two
+	// concurrent RunWithContext calls (e.g. an explicit informer.Run plus a
+	// factory.Start that also starts the same informer) can both pass the
+	// guard, both initialize the controller, and both reach the close(s.synced)
+	// goroutine below — panicking with "close of closed channel".
+	alreadyStarted := func() bool {
 		s.startedLock.Lock()
 		defer s.startedLock.Unlock()
+
+		if s.started {
+			return true
+		}
 
 		// kcp: This is almost verbatim the content of newQueueFIFO in controller.go
 		var fifo cache.Queue
@@ -391,7 +395,12 @@ func (s *sharedIndexInformer) RunWithContext(ctx context.Context) {
 		s.controller = kcpreflector.New(cfg)
 		// kcp modification: we removed setting the s.controller.clock here as it's an unexported field we can't access
 		s.started = true
+		return false
 	}()
+	if alreadyStarted {
+		logger.Info("Warning: the sharedIndexInformer has started, run more than once is not allowed")
+		return
+	}
 
 	// Separate stop context because Processor should be stopped strictly after controller.
 	// Cancelation in the parent context is ignored and all values are passed on,


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Upstream's watchCache only calls resizeCacheLocked from updateCache(event) and gates the shrink path on isCacheFullLocked(). During idle periods after a workload burst, no events flow, so inflated rings never shrink and the shard's memory footprint stays elevated until restart. See `https://github.com/kubernetes/kubernetes/issues/139250`.

Install a kicker that, every 80s (just above the upstream eventFreshDuration of 75s), patches a per-resource "kick object" in the root cluster with a tick timestamp. Each patch produces a distinct etcd revision and therefore one watch event per target resource, giving resizeCacheLocked a chance to fire its shrink branch.

Cost is ~7 metadata patches per shard per 80s. The annotation key is fixed so per-object growth is bounded, and the field manager "kcp-watchcache-kicker" makes the patches trivial to filter in audit logs. Missing target objects (e.g. no APIBindings in a freshly bootstrapped root) are skipped silently.

## What Type of PR Is This?
/kind bug

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Add ticker to trigger cache cleanups
```
