### PR TITLE
fix: WorkspaceType admission rejecting forward-referenced APIExports

### DIFF
--- a/pkg/admission/workspacetype/admission.go
+++ b/pkg/admission/workspacetype/admission.go
@@ -208,6 +208,15 @@ func (o *workspacetype) checkDefaultAPIBindingsPermissions(ctx context.Context, 
 			path := logicalcluster.NewPath(exportPath)
 			export, err := o.getAPIExport(path, exportName)
 			if err != nil {
+				if apierrors.IsNotFound(err) {
+					// APIExport does not exist (yet). The default-apibinding-
+					// controller will only create a binding once it appears,
+					// and without it we have no cluster to authorize against.
+					// Skipping the entry preserves the declarative ordering
+					// use case (WorkspaceType created ahead of its exports)
+					// that pre-dated this admission check.
+					continue
+				}
 				return forbidden
 			}
 			exportClusterName = logicalcluster.From(export)

--- a/pkg/admission/workspacetype/admission_test.go
+++ b/pkg/admission/workspacetype/admission_test.go
@@ -208,13 +208,15 @@ func TestValidate_DefaultAPIBindings(t *testing.T) {
 			decision: authorizer.DecisionAllow,
 		},
 		{
-			name: "create denied when referenced APIExport cannot be resolved",
+			name: "create allowed when referenced APIExport cannot be resolved",
 			op:   admission.Create,
 			newWT: newWorkspaceType(tenantCluster, "z",
 				tenancyv1alpha1.APIExportReference{Path: "some:other:cluster", Export: "missing"},
 			),
-			decision:   authorizer.DecisionAllow,
-			wantForbid: true,
+			// Decision is intentionally Deny: when the APIExport is not found
+			// we should skip the SAR entirely, so even a denying authorizer
+			// must not produce a forbidden result.
+			decision: authorizer.DecisionDeny,
 		},
 		{
 			name: "create with non-root path uses cluster from resolved APIExport",


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Fixes a regression in 0.31.2 where creating a `WorkspaceType` referencing an APIExport that doesn't exist yet is rejected with `no permission to bind to export ...`, even for admins.

The bind-permission check (added in #4082) treats a NotFound on the APIExport lookup the same as a permission denial. This breaks the common flow of creating a `WorkspaceType` before its APIExports.

Now: if the APIExport isn't found, skip the SAR for that entry. The check still runs whenever the APIExport exists.

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind bug
/kind regression

## Related Issue(s)

Fixes #4145

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Fix a regression in WorkspaceType admission that rejected creates referencing an APIExport that did not yet exist, even for admins. Such forward references are allowed again; the bind-permission check still applies when the APIExport exists.
```
