### PR TITLE
fix(workspacetype): resolve defaultAPIBindings path via LogicalCluster

### DIFF
--- a/pkg/admission/workspacetype/admission.go
+++ b/pkg/admission/workspacetype/admission.go
@@ -192,7 +192,10 @@ func (o *workspacetype) checkDefaultAPIBindingsPermissions(ctx context.Context, 
 		exportPath := ref.Path
 		exportName := ref.Export
 
-		// unified forbidden error that does not leak workspace existence
+		// Single forbidden response for both "cannot resolve the workspace"
+		// and "user lacks bind on the export". Distinguishing the two would
+		// let a caller with WorkspaceType create/update permission probe
+		// for the existence of arbitrary workspaces by reading the error.
 		forbidden := admission.NewForbidden(a, fmt.Errorf("unable to create or update WorkspaceType: no permission to bind to export %s",
 			logicalcluster.NewPath(exportPath).Join(exportName).String()))
 
@@ -213,12 +216,7 @@ func (o *workspacetype) checkDefaultAPIBindingsPermissions(ctx context.Context, 
 			path := logicalcluster.NewPath(exportPath)
 			lc, err := o.getLogicalCluster(path)
 			if err != nil {
-				// Distinguish "workspace not visible" from the bind denial
-				// below: the user might have permission once the workspace
-				// is reachable, but right now we cannot evaluate it.
-				return admission.NewForbidden(a, fmt.Errorf(
-					"unable to create or update WorkspaceType: workspace %q referenced in spec.defaultAPIBindings[].path is not found or not yet visible",
-					exportPath))
+				return forbidden
 			}
 			exportClusterName = logicalcluster.From(lc)
 		}

--- a/pkg/admission/workspacetype/admission.go
+++ b/pkg/admission/workspacetype/admission.go
@@ -32,8 +32,8 @@ import (
 
 	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
 	"github.com/kcp-dev/logicalcluster/v3"
-	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
 	"github.com/kcp-dev/sdk/apis/core"
+	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
 	kcpinformers "github.com/kcp-dev/sdk/client/informers/externalversions"
 
@@ -65,8 +65,8 @@ func Register(plugins *admission.Plugins) {
 				Handler:          admission.NewHandler(admission.Create, admission.Update),
 				createAuthorizer: delegated.NewDelegatedAuthorizer,
 			}
-			p.getAPIExport = func(path logicalcluster.Path, name string) (*apisv1alpha2.APIExport, error) {
-				return indexers.ByPathAndNameWithFallback[*apisv1alpha2.APIExport](apisv1alpha2.Resource("apiexports"), p.apiExportIndexer, p.cacheAPIExportIndexer, path, name)
+			p.getLogicalCluster = func(path logicalcluster.Path) (*corev1alpha1.LogicalCluster, error) {
+				return indexers.ByPathAndNameWithFallback[*corev1alpha1.LogicalCluster](corev1alpha1.Resource("logicalclusters"), p.logicalClusterIndexer, p.cacheLogicalClusterIndexer, path, corev1alpha1.LogicalClusterName)
 			}
 			return p, nil
 		})
@@ -75,10 +75,10 @@ func Register(plugins *admission.Plugins) {
 type workspacetype struct {
 	*admission.Handler
 
-	getAPIExport func(path logicalcluster.Path, name string) (*apisv1alpha2.APIExport, error)
+	getLogicalCluster func(path logicalcluster.Path) (*corev1alpha1.LogicalCluster, error)
 
-	apiExportIndexer      cache.Indexer
-	cacheAPIExportIndexer cache.Indexer
+	logicalClusterIndexer      cache.Indexer
+	cacheLogicalClusterIndexer cache.Indexer
 
 	deepSARClient    kcpkubernetesclientset.ClusterInterface
 	createAuthorizer delegated.DelegatedAuthorizerFactory
@@ -197,7 +197,12 @@ func (o *workspacetype) checkDefaultAPIBindingsPermissions(ctx context.Context, 
 			logicalcluster.NewPath(exportPath).Join(exportName).String()))
 
 		// Resolve the APIExport's cluster. An empty path means the same cluster
-		// as the WorkspaceType being admitted (matching the reconciler's behavior).
+		// as the WorkspaceType being admitted (matching the reconciler's
+		// behavior). Otherwise resolve via LogicalCluster lookup — not via
+		// the APIExport object itself, so that forward references to
+		// not-yet-existing APIExports are accepted as long as the user has
+		// pre-granted bind permission on the named resource (RBAC's
+		// resourceNames matches names that do not yet exist). See #4145.
 		var exportClusterName logicalcluster.Name
 		switch {
 		case exportPath == "":
@@ -206,11 +211,16 @@ func (o *workspacetype) checkDefaultAPIBindingsPermissions(ctx context.Context, 
 			exportClusterName = core.RootCluster
 		default:
 			path := logicalcluster.NewPath(exportPath)
-			export, err := o.getAPIExport(path, exportName)
+			lc, err := o.getLogicalCluster(path)
 			if err != nil {
-				return forbidden
+				// Distinguish "workspace not visible" from the bind denial
+				// below: the user might have permission once the workspace
+				// is reachable, but right now we cannot evaluate it.
+				return admission.NewForbidden(a, fmt.Errorf(
+					"unable to create or update WorkspaceType: workspace %q referenced in spec.defaultAPIBindings[].path is not found or not yet visible",
+					exportPath))
 			}
-			exportClusterName = logicalcluster.From(export)
+			exportClusterName = logicalcluster.From(lc)
 		}
 
 		if err := o.checkAPIExportAccess(ctx, a, exportClusterName, exportName); err != nil {
@@ -235,11 +245,11 @@ func (o *workspacetype) ValidateInitialization() error {
 	if o.deepSARClient == nil {
 		return fmt.Errorf(PluginName + " plugin needs a deepSARClient")
 	}
-	if o.apiExportIndexer == nil {
-		return fmt.Errorf(PluginName + " plugin needs an APIExport indexer")
+	if o.logicalClusterIndexer == nil {
+		return fmt.Errorf(PluginName + " plugin needs a LogicalCluster indexer")
 	}
-	if o.cacheAPIExportIndexer == nil {
-		return fmt.Errorf(PluginName + " plugin needs a cache APIExport indexer")
+	if o.cacheLogicalClusterIndexer == nil {
+		return fmt.Errorf(PluginName + " plugin needs a cache LogicalCluster indexer")
 	}
 	return nil
 }
@@ -249,18 +259,18 @@ func (o *workspacetype) SetDeepSARClient(client kcpkubernetesclientset.ClusterIn
 }
 
 func (o *workspacetype) SetKcpInformers(local, global kcpinformers.SharedInformerFactory) {
-	apiExportsReady := local.Apis().V1alpha2().APIExports().Informer().HasSynced
-	cacheAPIExportsReady := global.Apis().V1alpha2().APIExports().Informer().HasSynced
+	logicalClustersReady := local.Core().V1alpha1().LogicalClusters().Informer().HasSynced
+	cacheLogicalClustersReady := global.Core().V1alpha1().LogicalClusters().Informer().HasSynced
 	o.SetReadyFunc(func() bool {
-		return apiExportsReady() && cacheAPIExportsReady()
+		return logicalClustersReady() && cacheLogicalClustersReady()
 	})
-	o.apiExportIndexer = local.Apis().V1alpha2().APIExports().Informer().GetIndexer()
-	o.cacheAPIExportIndexer = global.Apis().V1alpha2().APIExports().Informer().GetIndexer()
+	o.logicalClusterIndexer = local.Core().V1alpha1().LogicalClusters().Informer().GetIndexer()
+	o.cacheLogicalClusterIndexer = global.Core().V1alpha1().LogicalClusters().Informer().GetIndexer()
 
-	indexers.AddIfNotPresentOrDie(local.Apis().V1alpha2().APIExports().Informer().GetIndexer(), cache.Indexers{
+	indexers.AddIfNotPresentOrDie(local.Core().V1alpha1().LogicalClusters().Informer().GetIndexer(), cache.Indexers{
 		indexers.ByLogicalClusterPathAndName: indexers.IndexByLogicalClusterPathAndName,
 	})
-	indexers.AddIfNotPresentOrDie(global.Apis().V1alpha2().APIExports().Informer().GetIndexer(), cache.Indexers{
+	indexers.AddIfNotPresentOrDie(global.Core().V1alpha1().LogicalClusters().Informer().GetIndexer(), cache.Indexers{
 		indexers.ByLogicalClusterPathAndName: indexers.IndexByLogicalClusterPathAndName,
 	})
 }

--- a/pkg/admission/workspacetype/admission_test.go
+++ b/pkg/admission/workspacetype/admission_test.go
@@ -32,8 +32,7 @@ import (
 
 	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
 	"github.com/kcp-dev/logicalcluster/v3"
-	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
-	"github.com/kcp-dev/sdk/apis/core"
+	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
 
 	"github.com/kcp-dev/kcp/pkg/authorization/delegated"
@@ -98,12 +97,11 @@ func (a *fakeAuthorizer) Authorize(ctx context.Context, attr authorizer.Attribut
 	return a.decision, "", a.err
 }
 
-func newPlugin(decision authorizer.Decision, exports ...*apisv1alpha2.APIExport) (*workspacetype, *logicalcluster.Name) {
-	exportMap := make(map[string]*apisv1alpha2.APIExport, len(exports))
-	for _, e := range exports {
-		exportMap[e.Name] = e
-	}
-
+// newPlugin creates a workspacetype admission plugin where knownPaths maps a
+// workspace path string (e.g. "root:some:path") to the cluster name it
+// resolves to. Lookups for paths absent from the map return NotFound,
+// simulating an unreachable workspace.
+func newPlugin(decision authorizer.Decision, knownPaths map[string]logicalcluster.Name) (*workspacetype, *logicalcluster.Name) {
 	var capturedCluster logicalcluster.Name
 	p := &workspacetype{
 		Handler: admission.NewHandler(admission.Create, admission.Update),
@@ -111,32 +109,24 @@ func newPlugin(decision authorizer.Decision, exports ...*apisv1alpha2.APIExport)
 			capturedCluster = clusterName
 			return &fakeAuthorizer{decision: decision}, nil
 		},
-		getAPIExport: func(path logicalcluster.Path, name string) (*apisv1alpha2.APIExport, error) {
-			if e, ok := exportMap[name]; ok {
-				return e, nil
+		getLogicalCluster: func(path logicalcluster.Path) (*corev1alpha1.LogicalCluster, error) {
+			cluster, ok := knownPaths[path.String()]
+			if !ok {
+				return nil, apierrors.NewNotFound(corev1alpha1.Resource("logicalclusters"), path.String())
 			}
-			return nil, apierrors.NewNotFound(apisv1alpha2.Resource("apiexports"), name)
+			return &corev1alpha1.LogicalCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        corev1alpha1.LogicalClusterName,
+					Annotations: map[string]string{logicalcluster.AnnotationKey: cluster.String()},
+				},
+			}, nil
 		},
 	}
 	p.SetReadyFunc(func() bool { return true })
 	return p, &capturedCluster
 }
 
-func newAPIExport(cluster logicalcluster.Name, name string) *apisv1alpha2.APIExport {
-	return &apisv1alpha2.APIExport{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: apisv1alpha2.SchemeGroupVersion.String(),
-			Kind:       "APIExport",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Annotations: map[string]string{logicalcluster.AnnotationKey: cluster.String()},
-		},
-	}
-}
-
 func TestValidate_DefaultAPIBindings(t *testing.T) {
-	cowboys := newAPIExport(core.RootCluster, "cowboys")
 	tenantCluster := logicalcluster.Name("root-test")
 
 	tests := []struct {
@@ -145,7 +135,7 @@ func TestValidate_DefaultAPIBindings(t *testing.T) {
 		newWT                 *tenancyv1alpha1.WorkspaceType
 		oldWT                 *tenancyv1alpha1.WorkspaceType
 		decision              authorizer.Decision
-		exports               []*apisv1alpha2.APIExport
+		knownPaths            map[string]logicalcluster.Name
 		wantForbid            bool
 		wantContains          string
 		wantAuthorizerCluster logicalcluster.Name
@@ -162,7 +152,6 @@ func TestValidate_DefaultAPIBindings(t *testing.T) {
 				tenancyv1alpha1.APIExportReference{Path: "root", Export: "cowboys"},
 			),
 			decision: authorizer.DecisionAllow,
-			exports:  []*apisv1alpha2.APIExport{cowboys},
 		},
 		{
 			name: "create with defaultAPIBindings denied when user lacks bind",
@@ -171,7 +160,6 @@ func TestValidate_DefaultAPIBindings(t *testing.T) {
 				tenancyv1alpha1.APIExportReference{Path: "root", Export: "cowboys"},
 			),
 			decision:     authorizer.DecisionDeny,
-			exports:      []*apisv1alpha2.APIExport{cowboys},
 			wantForbid:   true,
 			wantContains: "no permission to bind to export root:cowboys",
 		},
@@ -183,7 +171,6 @@ func TestValidate_DefaultAPIBindings(t *testing.T) {
 				tenancyv1alpha1.APIExportReference{Path: "root", Export: "cowboys"},
 			),
 			decision:   authorizer.DecisionDeny,
-			exports:    []*apisv1alpha2.APIExport{cowboys},
 			wantForbid: true,
 		},
 		{
@@ -197,7 +184,6 @@ func TestValidate_DefaultAPIBindings(t *testing.T) {
 			),
 			// Even with deny, this should pass because the entry is preexisting.
 			decision: authorizer.DecisionDeny,
-			exports:  []*apisv1alpha2.APIExport{cowboys},
 		},
 		{
 			name: "create with empty path resolves to current cluster",
@@ -208,31 +194,50 @@ func TestValidate_DefaultAPIBindings(t *testing.T) {
 			decision: authorizer.DecisionAllow,
 		},
 		{
-			name: "create denied when referenced APIExport cannot be resolved",
+			name: "create denied when referenced workspace cannot be resolved",
 			op:   admission.Create,
 			newWT: newWorkspaceType(tenantCluster, "z",
 				tenancyv1alpha1.APIExportReference{Path: "some:other:cluster", Export: "missing"},
 			),
-			decision:   authorizer.DecisionAllow,
-			wantForbid: true,
+			// Even with Allow, denied: we cannot evaluate bind against an
+			// unresolvable workspace, and failing closed avoids leaking an
+			// undefined cluster name into the SAR.
+			decision:     authorizer.DecisionAllow,
+			wantForbid:   true,
+			wantContains: `workspace "some:other:cluster"`,
 		},
 		{
-			name: "create with non-root path uses cluster from resolved APIExport",
+			name: "create with non-root path uses cluster from resolved LogicalCluster",
 			op:   admission.Create,
 			newWT: newWorkspaceType(tenantCluster, "remote",
 				tenancyv1alpha1.APIExportReference{Path: "some:other:path", Export: "cowboys-remote"},
 			),
 			decision: authorizer.DecisionAllow,
-			exports: []*apisv1alpha2.APIExport{
-				newAPIExport(logicalcluster.Name("actual-export-cluster"), "cowboys-remote"),
+			knownPaths: map[string]logicalcluster.Name{
+				"some:other:path": logicalcluster.Name("actual-export-cluster"),
 			},
 			wantAuthorizerCluster: logicalcluster.Name("actual-export-cluster"),
+		},
+		{
+			name: "create allowed for forward reference to APIExport when workspace exists and user has bind",
+			op:   admission.Create,
+			newWT: newWorkspaceType(tenantCluster, "forward",
+				tenancyv1alpha1.APIExportReference{Path: "root:provider", Export: "future-export"},
+			),
+			// APIExport doesn't exist yet, but the workspace at root:provider
+			// does and the user holds bind on apiexports/future-export
+			// (resourceNames in RBAC match nonexistent named resources).
+			decision: authorizer.DecisionAllow,
+			knownPaths: map[string]logicalcluster.Name{
+				"root:provider": logicalcluster.Name("provider-cluster"),
+			},
+			wantAuthorizerCluster: logicalcluster.Name("provider-cluster"),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p, capturedCluster := newPlugin(tt.decision, tt.exports...)
+			p, capturedCluster := newPlugin(tt.decision, tt.knownPaths)
 			attr := makeAttr(t, tt.op, tt.newWT, tt.oldWT, nil)
 			ctx := request.WithCluster(context.Background(), request.Cluster{Name: tenantCluster})
 			err := p.Validate(ctx, attr, nil)

--- a/pkg/admission/workspacetype/admission_test.go
+++ b/pkg/admission/workspacetype/admission_test.go
@@ -199,12 +199,12 @@ func TestValidate_DefaultAPIBindings(t *testing.T) {
 			newWT: newWorkspaceType(tenantCluster, "z",
 				tenancyv1alpha1.APIExportReference{Path: "some:other:cluster", Export: "missing"},
 			),
-			// Even with Allow, denied: we cannot evaluate bind against an
-			// unresolvable workspace, and failing closed avoids leaking an
-			// undefined cluster name into the SAR.
+			// Even with Allow, denied. The error must be byte-identical to
+			// the bind-denied case so admission cannot be used as a
+			// workspace-existence oracle by a caller with WST create perms.
 			decision:     authorizer.DecisionAllow,
 			wantForbid:   true,
-			wantContains: `workspace "some:other:cluster"`,
+			wantContains: "no permission to bind to export some:other:cluster:missing",
 		},
 		{
 			name: "create with non-root path uses cluster from resolved LogicalCluster",

--- a/test/e2e/reconciler/workspace/apibinding_initializer_test.go
+++ b/test/e2e/reconciler/workspace/apibinding_initializer_test.go
@@ -160,19 +160,23 @@ func TestWorkspaceTypesAPIBindingInitialization(t *testing.T) {
 
 	t.Logf("Creating WorkspaceType parent1")
 	// parent1 references an APIExport in cowboys-provider, which lives on a
-	// different shard than universal. The WorkspaceType admission resolves
-	// the path via the (cache-replicated) LogicalCluster of cowboys-provider;
-	// in a sharded setup that replication may lag by a beat, in which case
-	// admission returns a deterministic "workspace ... not found or not yet
-	// visible" error. Retry on exactly that message — any other admission
-	// error is a real bug and is surfaced immediately via require.NoError.
+	// different shard than universal. WorkspaceType admission resolves the
+	// path via the cache-replicated LogicalCluster of cowboys-provider, and
+	// that replication can lag by a beat. While the LC is invisible,
+	// admission cannot evaluate bind and intentionally returns the same
+	// "no permission to bind to export ..." error as a real bind denial —
+	// distinguishing the two would let WST create permission be used to
+	// probe for the existence of arbitrary workspaces. Retry on that
+	// message. The test grants bind via clusterrolebinding_cowboys.yaml,
+	// so once the LC is visible the create succeeds; a real bind regression
+	// will still surface when the Eventually deadline expires.
 	kcptestinghelpers.Eventually(t, func() (bool, string) {
 		_, err := kcpClusterClient.Cluster(universalPath).TenancyV1alpha1().WorkspaceTypes().Create(t.Context(), wtParent1, metav1.CreateOptions{})
 		if err == nil {
 			return true, ""
 		}
-		if strings.Contains(err.Error(), "not found or not yet visible") {
-			return false, fmt.Sprintf("waiting for cross-shard LogicalCluster visibility: %v", err)
+		if strings.Contains(err.Error(), "no permission to bind to export") {
+			return false, fmt.Sprintf("waiting for cross-shard LogicalCluster visibility (or bind permission): %v", err)
 		}
 		require.NoError(t, err, "error creating wt parent1")
 		return true, ""

--- a/test/e2e/reconciler/workspace/apibinding_initializer_test.go
+++ b/test/e2e/reconciler/workspace/apibinding_initializer_test.go
@@ -17,11 +17,15 @@ limitations under the License.
 package workspace
 
 import (
+	"fmt"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/restmapper"
 
@@ -31,6 +35,7 @@ import (
 	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
 	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
 	kcptesting "github.com/kcp-dev/sdk/testing"
+	kcptestinghelpers "github.com/kcp-dev/sdk/testing/helpers"
 
 	"github.com/kcp-dev/kcp/config/helpers"
 	"github.com/kcp-dev/kcp/test/e2e/framework"
@@ -154,8 +159,24 @@ func TestWorkspaceTypesAPIBindingInitialization(t *testing.T) {
 	}
 
 	t.Logf("Creating WorkspaceType parent1")
-	_, err = kcpClusterClient.Cluster(universalPath).TenancyV1alpha1().WorkspaceTypes().Create(t.Context(), wtParent1, metav1.CreateOptions{})
-	require.NoError(t, err, "error creating wt parent1")
+	// parent1 references an APIExport in cowboys-provider, which lives on a
+	// different shard than universal. The WorkspaceType admission resolves
+	// the path via the (cache-replicated) LogicalCluster of cowboys-provider;
+	// in a sharded setup that replication may lag by a beat, in which case
+	// admission returns a deterministic "workspace ... not found or not yet
+	// visible" error. Retry on exactly that message — any other admission
+	// error is a real bug and is surfaced immediately via require.NoError.
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		_, err := kcpClusterClient.Cluster(universalPath).TenancyV1alpha1().WorkspaceTypes().Create(t.Context(), wtParent1, metav1.CreateOptions{})
+		if err == nil {
+			return true, ""
+		}
+		if strings.Contains(err.Error(), "not found or not yet visible") {
+			return false, fmt.Sprintf("waiting for cross-shard LogicalCluster visibility: %v", err)
+		}
+		require.NoError(t, err, "error creating wt parent1")
+		return true, ""
+	}, wait.ForeverTestTimeout, 250*time.Millisecond, "expected wt parent1 create to succeed once cowboys-provider LogicalCluster is visible from universal's shard")
 
 	t.Logf("Creating WorkspaceType parent2")
 	_, err = kcpClusterClient.Cluster(universalPath).TenancyV1alpha1().WorkspaceTypes().Create(t.Context(), wtParent2, metav1.CreateOptions{})


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

The bind-permission check added in 51246a32a ("Add aditional validation for WST") rejected creation of WorkspaceTypes that referenced an APIExport which was not visible to the admitting shard:

```
  workspacetypes.tenancy.kcp.io "X" is forbidden: unable to create or
  update WorkspaceType: no permission to bind to export <path>
```

The lookup served two purposes — checking existence and resolving exportPath into a cluster name for the bind SAR — but it conflated "export is not visible" with "user cannot bind". That regressed two real workflows:

  1. Forward references (#4145). Until 0.31.2 users could create a WorkspaceType whose defaultAPIBindings pointed at an APIExport that did not exist yet. The new check rejected this with a misleading permission error even when admin-issued RBAC granted bind on the named (future) APIExport — and RBAC's resourceNames does match resources that do not exist yet.

  2. Sharded clusters (e2e TestWorkspaceTypesAPIBindingInitialization). When the WorkspaceType is admitted on shard A and the APIExport was just created on shard B, the cache-replicated APIExport may not be visible to shard A's informer yet. Admission failed non-deterministically with the same forbidden error.

Resolve exportPath via the LogicalCluster of the referenced workspace instead of the APIExport object. LogicalClusters are also cache- replicated but are typically established earlier (the workspace must exist for the test/user to reach this code path), and the resolution no longer depends on the APIExport itself existing. The bind SAR is then issued against the resolved cluster with the user's identity, as before, so the permission gate is preserved end-to-end:

```
  - workspace at exportPath not visible    -> forbidden (deterministic
                                              message names the path)
  - workspace visible, user lacks bind     -> forbidden (unchanged)
  - workspace visible, user has bind, but
    APIExport does not exist yet           -> admitted; the default-
                                              apibinding controller
                                              will bind it later
```

Belt-and-suspenders: wrap the parent1 create in the failing e2e in `kcptestinghelpers.Eventually` that retries only on the deterministic "not found or not yet visible" message — any other admission error still surfaces immediately, so a real regression is not masked.

Fixes #4145.

## What Type of PR Is This?

/kind bug

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
