### PR TITLE
fix(virtual): shorten DenyCacheTTL for lifecycle VW authorizers

### DIFF
--- a/pkg/virtual/initializingworkspaces/builder/build.go
+++ b/pkg/virtual/initializingworkspaces/builder/build.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"time"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -107,7 +108,20 @@ func BuildVirtualWorkspace(
 		v.Schema.Raw = bs // wipe schemas. We don't want validation here.
 	}
 
-	cachingAuthorizer := delegated.NewCachingAuthorizer(sarKubeClusterClient, authorizerWithCache, delegated.CachingOptions{})
+	// The inner DelegatedAuthorizer caches SAR decisions. Its default
+	// DenyCacheTTL is 30s, which is the same as wait.ForeverTestTimeout and
+	// — more importantly — far longer than the moment between a user being
+	// granted the "initialize" verb and using it. A just-in-time RBAC grant
+	// followed by an immediate request through the VW would otherwise be
+	// rejected for 30s after the first racing SAR returned Deny (e.g. the
+	// shard's RBAC informer hadn't observed the new ClusterRoleBinding yet),
+	// because every subsequent SAR within that window hits the cached Deny.
+	// 5s leaves room to absorb a brief denial loop without hammering the SAR
+	// endpoint on a genuine denial, while keeping fresh grants effective
+	// within one or two poll intervals of typical test/operator workflows.
+	cachingAuthorizer := delegated.NewCachingAuthorizer(sarKubeClusterClient, authorizerWithCache, delegated.CachingOptions{
+		Options: delegated.Options{DenyCacheTTL: 5 * time.Second},
+	})
 	wildcardLogicalClusters := &virtualworkspacesdynamic.DynamicVirtualWorkspace{
 		RootPathResolver: framework.RootPathResolverFunc(func(urlPath string, requestContext context.Context) (accepted bool, prefixToStrip string, completedContext context.Context) {
 			cluster, apiDomain, prefixToStrip, ok := digestUrl(urlPath, rootPathPrefix)

--- a/pkg/virtual/terminatingworkspaces/builder/build.go
+++ b/pkg/virtual/terminatingworkspaces/builder/build.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"time"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -107,7 +108,11 @@ func BuildVirtualWorkspace(
 		v.Schema.Raw = bs // wipe schemas. We don't want validation here.
 	}
 
-	cachingAuthorizer := delegated.NewCachingAuthorizer(sarKubeClusterClient, authorizerWithCache, delegated.CachingOptions{})
+	// See the matching comment in pkg/virtual/initializingworkspaces/builder/build.go
+	// for why DenyCacheTTL is shortened from the 30s default.
+	cachingAuthorizer := delegated.NewCachingAuthorizer(sarKubeClusterClient, authorizerWithCache, delegated.CachingOptions{
+		Options: delegated.Options{DenyCacheTTL: 5 * time.Second},
+	})
 	wildcardLogicalClusters := &virtualworkspacesdynamic.DynamicVirtualWorkspace{
 		RootPathResolver: framework.RootPathResolverFunc(func(urlPath string, requestContext context.Context) (accepted bool, prefixToStrip string, completedContext context.Context) {
 			cluster, apiDomain, prefixToStrip, ok := digestUrl(urlPath, rootPathPrefix)


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

The initializing and terminating VW content proxies authorize every incoming request by issuing a `SubjectAccessReview` for the "initialize" (or "terminate") verb on the underlying WorkspaceType. That SAR is served by a `delegated.NewCachingAuthorizer`, which underneath wraps Kubernetes' webhook authorizer and caches *decisions* in an LRU keyed by (user, attributes). The default DenyCacheTTL inherited from delegated.Options is 30 seconds.

That TTL is too long for these VWs, which are explicitly designed around just-in-time RBAC grants:

  1. An operator (or test) grants user-U the "initialize" verb on workspacetypes/X.
  2. user-U immediately makes a request through the VW.
  3. The VW's SAR races the shard's RBAC informer. If the ClusterRoleBinding has not yet been observed, the SAR returns Deny.
  4. That Deny is cached for 30s. Every subsequent request from user-U within that window — including the test's own EventuallyWithT poll loop — hits the cached Deny without ever re-issuing the SAR. By the time the cache expires, the test has also exhausted wait.ForeverTestTimeout (which is also 30s) and fails with "Condition never satisfied".

Manifested as a flake in `TestInitializingWorkspacesVirtualWorkspace`- `InitializerPermissions` on the sharded e2e job, where the cross-shard RBAC propagation window is wide enough that the first SAR sometimes loses the race.

Shorten DenyCacheTTL to 5s on both lifecycle VW authorizers. Long enough to absorb a brief denial loop without hammering the SAR endpoint; short enough that a fresh "initialize"/"terminate" grant becomes effective within one or two poll intervals of typical test/operator workflows. AllowCacheTTL is left at the 5-minute default — revocation responsiveness in a still-initializing/ terminating workspace is acceptable; the workspace itself is short-lived.



## What Type of PR Is This?
/kind bug
/kind failing-test
/kind flake

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
