### PR TITLE
fix(rbac): allow external-logical-cluster-admin to create SubjectAcce…

### DIFF
--- a/pkg/authorization/bootstrap/policy.go
+++ b/pkg/authorization/bootstrap/policy.go
@@ -109,6 +109,10 @@ func clusterRoles() []rbacv1.ClusterRole {
 				rbacv1helpers.NewRule("delete", "update", "get").Groups(tenancy.GroupName).Resources("workspaces").RuleOrDie(),
 				rbacv1helpers.NewRule("get").Groups("").Resources("serviceaccounts", "secrets").RuleOrDie(),
 				rbacv1helpers.NewRule("access").URLs("/").RuleOrDie(),
+				// Allow the in-process initializing/terminating virtual workspaces to delegate
+				// authorization checks against the workspacetype's cluster via SubjectAccessReview.
+				// The VW resolves access for the requesting user, not the SAR caller itself.
+				rbacv1helpers.NewRule("create").Groups("authorization.k8s.io").Resources("subjectaccessreviews").RuleOrDie(),
 			},
 		},
 		{


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

The in-process `initializing/terminating` virtual workspaces delegate authorization checks against the workspacetype's cluster via SAR using the shard's ExternalLogicalClusterAdminConfig (system:kcp:external-logical-cluster-admin). That group's policy lacked create on subjectaccessreviews, so SAR-backed discovery against `/services/initializingworkspaces/<path>:<initializer>` failed with "forbidden ... at the cluster scope" and watches never started.

## What Type of PR Is This?
/kind bug

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes kcp-dev/kcp#4155

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
