### PR TITLE
load test allow supplying an external config

### DIFF
--- a/test/load/Readme.md
+++ b/test/load/Readme.md
@@ -38,6 +38,12 @@ ensures that all files get generated using unified timestamps in a `.loadtest-re
 ./suite.sh TestExample
 ```
 
+Additionally you can also overwrite default parameters, by supplying a custom config file:
+
+```sh
+./suite.sh --config config.example.json TestExample
+```
+
 The script will show live output and is safe to run in jumphost environments where connectivity might
 break.
 

--- a/test/load/config.example.json
+++ b/test/load/config.example.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "you can override default parameters defined in params.go",
+  "params": {
+    "workspaceCount": 100,
+    "workspaceDepth": 5,
+    "workspaceTreeType": "symmetric",
+    "createWorkspaceQPS": 2.0,
+    "crudConfigMapQPS": 150,
+    "providerWorkspacesCount": 10,
+    "consumerWorkspacesCount": 90
+  }
+}

--- a/test/load/setup/values/cert-manager.yaml
+++ b/test/load/setup/values/cert-manager.yaml
@@ -2,3 +2,6 @@ crds:
   enabled: true
 nodeSelector:
   $NODEPOOL_SELECTOR: auxiliary
+# set webhook timeout to 5s, since some cloud providers are not happy with the default 15s
+webhook:
+  timeoutSeconds: 5

--- a/test/load/suite.sh
+++ b/test/load/suite.sh
@@ -29,10 +29,22 @@ logdir=".loadtest-results"
 mkdir -p "$logdir"
 
 # parse user input
+configfile=""
+if [[ "${1:-}" == "--config" ]]; then
+  configfile="$(realpath "$2")"
+  shift 2
+fi
+
 testname=${1:-}
 if [[ -z "$testname" ]]; then
-  echo "Usage: $0 <testname>"
+  echo "Usage: $0 [--config config.json] <testname>"
   exit 1
+fi
+
+# build go test args
+go_test_args=(-timeout 2h -test.fullpath=true -run "^${testname}$" -count=1 -v github.com/kcp-dev/kcp/test/load/testing)
+if [[ -n "$configfile" ]]; then
+  go_test_args+=(-args --config="$configfile")
 fi
 
 # execute the test and capture logs
@@ -40,7 +52,7 @@ logfile="$logdir/${testname}_$(date '+%Y-%m-%d-%H:%M:%S').log"
 echo "Executing test: $testname"
 echo "Logs will be saved to: $logfile"
 
-go test -timeout 2h -test.fullpath=true -run "^${testname}$" -count=1 -v github.com/kcp-dev/kcp/test/load/testing &> "$logfile" &
+go test "${go_test_args[@]}" &> "$logfile" &
 test_pid=$!
 
 # on Ctrl+C: stop tailing but keep the test running

--- a/test/load/testing/main_test.go
+++ b/test/load/testing/main_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	configFile := flag.String("config", "", "path to a JSON config file with load test parameters")
+	flag.Parse()
+
+	if err := parseConfig(*configFile); err != nil {
+		fmt.Fprintf(os.Stderr, "Error loading parameters: %v\n", err)
+		os.Exit(1)
+	}
+
+	os.Exit(m.Run())
+}

--- a/test/load/testing/params.go
+++ b/test/load/testing/params.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/kcp-dev/sdk/apis/core"
+
+	"github.com/kcp-dev/kcp/test/load/pkg/tree"
+)
+
+var testConfig Config
+
+// Config is the top-level configuration structure unmarshalled from the
+// JSON config file passed via --config.
+type Config struct {
+	Params Params `json:"params"`
+}
+
+func defaultConfig() Config {
+	return Config{
+		Params: defaultParams(),
+	}
+}
+
+func defaultParams() Params {
+	return Params{
+		WorkspaceCount:          10000,
+		WorkspaceDepth:          5,
+		WorkspaceTreeType:       "symmetric",
+		CreateWorkspaceQPS:      8.0,
+		CRUDConfigMapQPS:        150,
+		ProviderWorkspacesCount: 1000,
+		ConsumerWorkspacesCount: 9000,
+	}
+}
+
+// Params holds all configurable load test parameters. Values can be
+// overridden by passing --config=<path-to-json> to the test binary.
+// Any field not set in the JSON file retains its default value.
+type Params struct {
+	// WorkspaceCount is the total number of workspaces to create.
+	WorkspaceCount int `json:"workspaceCount"`
+
+	// WorkspaceDepth controls how deep the workspace tree is.
+	WorkspaceDepth int `json:"workspaceDepth"`
+
+	// WorkspaceTreeType selects the tree layout: "symmetric" or "flat".
+	WorkspaceTreeType string `json:"workspaceTreeType"`
+
+	// CreateWorkspaceQPS is the rate at which workspace creation requests are sent.
+	CreateWorkspaceQPS float64 `json:"createWorkspaceQPS"`
+
+	// CRUDConfigMapQPS is the rate at which ConfigMap CRUD operations are sent.
+	CRUDConfigMapQPS float64 `json:"crudConfigMapQPS"`
+
+	// ProviderWorkspacesCount is the number of provider workspaces for API sharing tests.
+	ProviderWorkspacesCount int `json:"providerWorkspacesCount"`
+
+	// ConsumerWorkspacesCount is the number of consumer workspaces for API sharing tests.
+	ConsumerWorkspacesCount int `json:"consumerWorkspacesCount"`
+}
+
+// WorkspaceTree returns a workspace tree built from the configured parameters.
+// It panics if WorkspaceTreeType is not "symmetric" or "flat".
+func (p Params) WorkspaceTree() tree.WorkspaceTree {
+	switch p.WorkspaceTreeType {
+	case "symmetric":
+		return tree.NewSymmetricTree(core.RootCluster.Path(), p.WorkspaceCount, p.WorkspaceDepth)
+	case "flat":
+		return tree.NewFlatTree(core.RootCluster.Path(), p.WorkspaceCount)
+	default:
+		return nil
+	}
+}
+
+func parseConfig(configFile string) error {
+	testConfig = defaultConfig()
+
+	if configFile == "" {
+		return nil
+	}
+
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		return fmt.Errorf("failed to read config file %q: %w", configFile, err)
+	}
+
+	if err := json.Unmarshal(data, &testConfig); err != nil {
+		return fmt.Errorf("failed to parse config file %q: %w", configFile, err)
+	}
+
+	return nil
+}

--- a/test/load/testing/workspace_creation_test.go
+++ b/test/load/testing/workspace_creation_test.go
@@ -28,7 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	"github.com/kcp-dev/sdk/apis/core"
 	corev1alpha1kcp "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
 	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
@@ -40,20 +39,17 @@ import (
 	"github.com/kcp-dev/kcp/test/load/pkg/tuningset"
 )
 
-const workspaceCount = 10000
-const workspaceDepth = 5
-const createWorkspaceQPS = 8.0
-
 //nolint:paralleltest // load test against shared kcp cluster, parallel execution would conflict on workspace names and skew timing measurements
 func TestWorkspaceCreation(t *testing.T) {
 	cfg := framework.Require(t, framework.KCPFrontProxyKubeconfig)
+	params := testConfig.Params
 
 	client, err := kcpclientset.NewForConfig(cfg.FrontProxyKubeconfig)
 	require.NoError(t, err)
 
 	sections := []measurement.Section{} //nolint:prealloc
 
-	createSection := createWorkspaces(t, client, createWorkspaceQPS)
+	createSection := createWorkspaces(t, client, params.WorkspaceTree(), params.CreateWorkspaceQPS, params.WorkspaceCount)
 	sections = append(sections, createSection)
 
 	report := NewKCPReport(t, "Workspace Creation", cfg.FrontProxyKubeconfig)
@@ -65,11 +61,10 @@ func TestWorkspaceCreation(t *testing.T) {
 	}
 }
 
-// createWorkspaces creates workspaceCount workspaces under the root workspace
+// createWorkspaces creates workspaces under the root workspace
 // and waits for each to become Ready.
-func createWorkspaces(t *testing.T, client kcpclientset.ClusterInterface, qps float64) measurement.Section {
+func createWorkspaces(t *testing.T, client kcpclientset.ClusterInterface, wt tree.WorkspaceTree, qps float64, count int) measurement.Section {
 	t.Helper()
-	wt := defaultTree()
 
 	section := measurement.Section{
 		Title: "Workspace Creation",
@@ -82,7 +77,7 @@ func createWorkspaces(t *testing.T, client kcpclientset.ClusterInterface, qps fl
 		},
 	}
 
-	ts := tuningset.NewUniformQPS(qps, workspaceCount, 1)
+	ts := tuningset.NewUniformQPS(qps, count, 1)
 	section.Start()
 	action := func(seq int, s measurement.Sink) error {
 		defer measurement.RecordElapsedDurationMS(time.Now(), s)
@@ -125,8 +120,4 @@ func createWorkspaces(t *testing.T, client kcpclientset.ClusterInterface, qps fl
 	section.End()
 
 	return section
-}
-
-func defaultTree() tree.WorkspaceTree {
-	return tree.NewSymmetricTree(core.RootCluster.Path(), workspaceCount, workspaceDepth)
 }

--- a/test/load/testing/workspace_simple_crud_test.go
+++ b/test/load/testing/workspace_simple_crud_test.go
@@ -38,11 +38,10 @@ import (
 	"github.com/kcp-dev/kcp/test/load/pkg/tuningset"
 )
 
-const crudConfigMapQPS = 150 // equivalent to 600, see TODO comment below
-
 //nolint:paralleltest // load test against shared kcp cluster, parallel execution would conflict on workspace names and skew timing measurements
 func TestWorkspaceSimpleCRUD(t *testing.T) {
 	cfg := framework.Require(t, framework.KCPFrontProxyKubeconfig)
+	params := testConfig.Params
 
 	client, err := kcpclientset.NewForConfig(cfg.FrontProxyKubeconfig)
 	require.NoError(t, err)
@@ -52,21 +51,21 @@ func TestWorkspaceSimpleCRUD(t *testing.T) {
 
 	var sections []measurement.Section
 
-	wt := defaultTree()
+	wt := params.WorkspaceTree()
 
 	// Ensure workspaces exist, creating them if necessary.
-	exist, err := workspacesExist(wt, client, workspaceCount)
+	exist, err := workspacesExist(wt, client, params.WorkspaceCount)
 	require.NoError(t, err)
 	if exist {
 		t.Logf("workspaces already exist, skipping creation")
 	} else {
 		t.Logf("Creating required workspaces")
-		createSection := createWorkspaces(t, client, createWorkspaceQPS)
+		createSection := createWorkspaces(t, client, wt, params.CreateWorkspaceQPS, params.WorkspaceCount)
 		sections = append(sections, createSection)
 	}
 
 	t.Logf("Running configmap CRUD operations")
-	crudSection := crudConfigMaps(t, wt, kubeClusterClient, crudConfigMapQPS)
+	crudSection := crudConfigMaps(t, wt, kubeClusterClient, params.CRUDConfigMapQPS, params.WorkspaceCount)
 	sections = append(sections, crudSection)
 
 	report := NewKCPReport(t, "Workspace Simple Configmap CRUD", cfg.FrontProxyKubeconfig)
@@ -80,13 +79,13 @@ func TestWorkspaceSimpleCRUD(t *testing.T) {
 
 // crudConfigMaps performs a Create/Update/Delete cycle for a ConfigMap in each
 // of the workspaces.
-func crudConfigMaps(t *testing.T, wt tree.WorkspaceTree, kubeClusterClient kcpkubernetesclientset.ClusterInterface, qps float64) measurement.Section {
+func crudConfigMaps(t *testing.T, wt tree.WorkspaceTree, kubeClusterClient kcpkubernetesclientset.ClusterInterface, qps float64, count int) measurement.Section {
 	t.Helper()
 
 	section := measurement.Section{
 		Title: "ConfigMap CRUD",
 		Parameters: []measurement.Parameter{
-			{Key: "Workspaces", Value: fmt.Sprintf("%d", workspaceCount)},
+			{Key: "Workspaces", Value: fmt.Sprintf("%d", count)},
 			{Key: "QPS", Value: fmt.Sprintf("%f", qps*4)}, // TODO: for now multiply by 4 because we are doing 4 network calls per action, but this needs to be changed inside the framework next to be precise
 		},
 		Sink: &measurement.Memory{
@@ -94,7 +93,7 @@ func crudConfigMaps(t *testing.T, wt tree.WorkspaceTree, kubeClusterClient kcpku
 		},
 	}
 
-	ts := tuningset.NewUniformQPS(qps, workspaceCount, 1)
+	ts := tuningset.NewUniformQPS(qps, count, 1)
 	section.Start()
 	action := func(seq int, s measurement.Sink) error {
 		cmClient := kubeClusterClient.Cluster(wt.PathForSequenceNumber(seq)).CoreV1().ConfigMaps("default")


### PR DESCRIPTION
Little framework change to allow supplying external configs to loadtest. This makes configuring optional parameters a lot easier.

## Summary

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->
/kind chore

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
