### PR TITLE
Set shard hash annotation on LC and propagate to Workspace

### DIFF
--- a/config/crds/core.kcp.io_shards.yaml
+++ b/config/crds/core.kcp.io_shards.yaml
@@ -29,6 +29,10 @@ spec:
       jsonPath: .spec.externalURL
       name: External URL
       type: string
+    - description: The shard name hash used in the core.kcp.io/shard annotation
+      jsonPath: .status.hash
+      name: Hash
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -154,6 +158,11 @@ spec:
                   - type
                   type: object
                 type: array
+              hash:
+                description: |-
+                  hash is the shard name hash, the value used as the
+                  core.kcp.io/shard annotation on LogicalClusters scheduled to this shard.
+                type: string
             type: object
         type: object
     served: true

--- a/config/root-phase0/apiexport-shards.core.kcp.io.yaml
+++ b/config/root-phase0/apiexport-shards.core.kcp.io.yaml
@@ -6,7 +6,7 @@ spec:
   resources:
   - group: core.kcp.io
     name: shards
-    schema: v260302-ae9fdd9c1.shards.core.kcp.io
+    schema: v260528-63140f753.shards.core.kcp.io
     storage:
       crd: {}
 status: {}

--- a/config/root-phase0/apiresourceschema-shards.core.kcp.io.yaml
+++ b/config/root-phase0/apiresourceschema-shards.core.kcp.io.yaml
@@ -1,7 +1,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v260302-ae9fdd9c1.shards.core.kcp.io
+  name: v260528-63140f753.shards.core.kcp.io
 spec:
   group: core.kcp.io
   names:
@@ -25,6 +25,10 @@ spec:
     - description: The URL exposed in logical clusters created on that shard
       jsonPath: .spec.externalURL
       name: External URL
+      type: string
+    - description: The shard name hash used in the core.kcp.io/shard annotation
+      jsonPath: .status.hash
+      name: Hash
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
@@ -150,6 +154,11 @@ spec:
                 - type
                 type: object
               type: array
+            hash:
+              description: |-
+                hash is the shard name hash, the value used as the
+                core.kcp.io/shard annotation on LogicalClusters scheduled to this shard.
+              type: string
           type: object
       type: object
     served: true

--- a/pkg/reconciler/core/logicalcluster/logicalcluster_controller.go
+++ b/pkg/reconciler/core/logicalcluster/logicalcluster_controller.go
@@ -32,6 +32,7 @@ import (
 	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v3"
 	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
+	corev1alpha1helper "github.com/kcp-dev/sdk/apis/core/v1alpha1/helper"
 	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
 	corev1alpha1client "github.com/kcp-dev/sdk/client/clientset/versioned/typed/core/v1alpha1"
 	corev1alpha1informers "github.com/kcp-dev/sdk/client/informers/externalversions/core/v1alpha1"
@@ -47,6 +48,7 @@ const (
 )
 
 func NewController(
+	shardName string,
 	shardExternalURL func() string,
 	kcpClusterClient kcpclientset.ClusterInterface,
 	logicalClusterInformer corev1alpha1informers.LogicalClusterClusterInformer,
@@ -59,6 +61,7 @@ func NewController(
 				Name: ControllerName,
 			},
 		),
+		shardHash:             corev1alpha1helper.ShardNameHash(shardName),
 		shardExternalURL:      shardExternalURL,
 		kcpClusterClient:      kcpClusterClient,
 		logicalClusterIndexer: logicalClusterInformer.Informer().GetIndexer(),
@@ -82,6 +85,7 @@ type logicalClusterResource = committer.Resource[*corev1alpha1.LogicalClusterSpe
 type Controller struct {
 	queue workqueue.TypedRateLimitingInterface[string]
 
+	shardHash        string
 	shardExternalURL func() string
 
 	kcpClusterClient kcpclientset.ClusterInterface

--- a/pkg/reconciler/core/logicalcluster/logicalcluster_reconcile.go
+++ b/pkg/reconciler/core/logicalcluster/logicalcluster_reconcile.go
@@ -39,7 +39,7 @@ func (c *Controller) reconcile(ctx context.Context, logicalCluster *corev1alpha1
 	// reconcilers which modify Status should be last
 	// reconcilers which modify ObjectMeta, need to return reconcileStatusStopAndRequeue on change
 	reconcilers := []reconciler{
-		&metaDataReconciler{},
+		&metaDataReconciler{shardHash: c.shardHash},
 		&terminatorReconciler{},
 		&phaseReconciler{clusterContextManager: c.clusterContextManager},
 		&urlReconciler{shardExternalURL: c.shardExternalURL},

--- a/pkg/reconciler/core/logicalcluster/logicalcluster_reconcile_metadata.go
+++ b/pkg/reconciler/core/logicalcluster/logicalcluster_reconcile_metadata.go
@@ -32,6 +32,7 @@ import (
 )
 
 type metaDataReconciler struct {
+	shardHash string
 }
 
 func (r *metaDataReconciler) reconcile(ctx context.Context, logicalCluster *corev1alpha1.LogicalCluster) (reconcileStatus, error) {
@@ -112,6 +113,14 @@ func (r *metaDataReconciler) reconcile(ctx context.Context, logicalCluster *core
 				changed = true
 			}
 		}
+	}
+
+	if got := logicalCluster.Annotations[corev1alpha1.LogicalClusterShardAnnotationKey]; got != r.shardHash {
+		if logicalCluster.Annotations == nil {
+			logicalCluster.Annotations = map[string]string{}
+		}
+		logicalCluster.Annotations[corev1alpha1.LogicalClusterShardAnnotationKey] = r.shardHash
+		changed = true
 	}
 
 	if changed {

--- a/pkg/reconciler/core/logicalcluster/logicalcluster_reconcile_metadata_test.go
+++ b/pkg/reconciler/core/logicalcluster/logicalcluster_reconcile_metadata_test.go
@@ -35,6 +35,7 @@ func TestReconcileMetadata(t *testing.T) {
 
 	for _, testCase := range []struct {
 		name       string
+		shardHash  string
 		input      *corev1alpha1.LogicalCluster
 		expected   metav1.ObjectMeta
 		wantStatus reconcileStatus
@@ -257,9 +258,79 @@ func TestReconcileMetadata(t *testing.T) {
 			},
 			wantStatus: reconcileStatusStopAndRequeue,
 		},
+		{
+			name:      "stamps shard annotation when absent",
+			shardHash: "abcd1234",
+			input: &corev1alpha1.LogicalCluster{
+				Status: corev1alpha1.LogicalClusterStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseReady,
+				},
+			},
+			expected: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"tenancy.kcp.io/phase": "Ready",
+				},
+				Annotations: map[string]string{
+					"core.kcp.io/shard": "abcd1234",
+				},
+			},
+			wantStatus: reconcileStatusStopAndRequeue,
+		},
+		{
+			name:      "overwrites stale shard annotation",
+			shardHash: "abcd1234",
+			input: &corev1alpha1.LogicalCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"tenancy.kcp.io/phase": "Ready",
+					},
+					Annotations: map[string]string{
+						"core.kcp.io/shard": "stalehsh",
+					},
+				},
+				Status: corev1alpha1.LogicalClusterStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseReady,
+				},
+			},
+			expected: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"tenancy.kcp.io/phase": "Ready",
+				},
+				Annotations: map[string]string{
+					"core.kcp.io/shard": "abcd1234",
+				},
+			},
+			wantStatus: reconcileStatusStopAndRequeue,
+		},
+		{
+			name:      "no-op when shard annotation already matches",
+			shardHash: "abcd1234",
+			input: &corev1alpha1.LogicalCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"tenancy.kcp.io/phase": "Ready",
+					},
+					Annotations: map[string]string{
+						"core.kcp.io/shard": "abcd1234",
+					},
+				},
+				Status: corev1alpha1.LogicalClusterStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseReady,
+				},
+			},
+			expected: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"tenancy.kcp.io/phase": "Ready",
+				},
+				Annotations: map[string]string{
+					"core.kcp.io/shard": "abcd1234",
+				},
+			},
+			wantStatus: reconcileStatusContinue,
+		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			reconciler := metaDataReconciler{}
+			reconciler := metaDataReconciler{shardHash: testCase.shardHash}
 			status, err := reconciler.reconcile(context.Background(), testCase.input)
 
 			require.NoError(t, err)

--- a/pkg/reconciler/core/shard/shard_controller.go
+++ b/pkg/reconciler/core/shard/shard_controller.go
@@ -32,6 +32,7 @@ import (
 	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v3"
 	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
+	corev1alpha1helper "github.com/kcp-dev/sdk/apis/core/v1alpha1/helper"
 	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
 	corev1alpha1client "github.com/kcp-dev/sdk/client/clientset/versioned/typed/core/v1alpha1"
 	corev1alpha1informers "github.com/kcp-dev/sdk/client/informers/externalversions/core/v1alpha1"
@@ -182,6 +183,9 @@ func (c *Controller) process(ctx context.Context, key string) error {
 	return utilerrors.NewAggregate(errs)
 }
 
-func (c *Controller) reconcile(ctx context.Context, workspaceShard *corev1alpha1.Shard) error {
+func (c *Controller) reconcile(ctx context.Context, shard *corev1alpha1.Shard) error {
+	if hash := corev1alpha1helper.ShardNameHash(shard.Name); shard.Status.Hash != hash {
+		shard.Status.Hash = hash
+	}
 	return nil
 }

--- a/pkg/reconciler/tenancy/initialization/apibinder_initializer_reconcile.go
+++ b/pkg/reconciler/tenancy/initialization/apibinder_initializer_reconcile.go
@@ -18,9 +18,7 @@ package initialization
 
 import (
 	"context"
-	"crypto/sha256"
 	"fmt"
-	"math/big"
 	"sort"
 	"strings"
 
@@ -30,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/klog/v2"
 
+	kcpcrypto "github.com/kcp-dev/apimachinery/v2/pkg/util/crypto"
 	"github.com/kcp-dev/logicalcluster/v3"
 	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
 	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
@@ -280,7 +279,7 @@ func generateAPIBindingName(clusterName logicalcluster.Name, exportPath, exportN
 
 	exportNamePrefix := exportName[:maxLen]
 
-	hash := toBase36Sha224(
+	hash := kcpcrypto.Base62Sha224.String(
 		clusterName.String() + "|" + exportPath + "|" + exportName,
 	)
 
@@ -289,16 +288,6 @@ func generateAPIBindingName(clusterName logicalcluster.Name, exportPath, exportN
 	hash = strings.ToLower(hash)
 
 	return fmt.Sprintf("%s-%s", exportNamePrefix, hash)
-}
-
-func toBase36(hash [28]byte) string {
-	var i big.Int
-	i.SetBytes(hash[:])
-	return i.Text(62)
-}
-
-func toBase36Sha224(s string) string {
-	return toBase36(sha256.Sum224([]byte(s)))
 }
 
 func hasAcceptedPermissionClaims(binding *apisv1alpha2.APIBinding) bool {

--- a/pkg/reconciler/tenancy/workspace/workspace_indexes.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_indexes.go
@@ -17,8 +17,8 @@ limitations under the License.
 package workspace
 
 import (
-	kcpcrypto "github.com/kcp-dev/apimachinery/v2/pkg/util/crypto"
 	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
+	corev1alpha1helper "github.com/kcp-dev/sdk/apis/core/v1alpha1/helper"
 	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
 	"github.com/kcp-dev/sdk/apis/third_party/conditions/util/conditions"
 )
@@ -51,5 +51,5 @@ func indexWorkspaceByLogicalCluster(obj interface{}) ([]string, error) {
 
 func indexByBase36Sha224Name(obj interface{}) ([]string, error) {
 	s := obj.(*corev1alpha1.Shard)
-	return []string{kcpcrypto.Base36Sha224.StringPad(s.Name)[:8]}, nil
+	return []string{corev1alpha1helper.ShardNameHash(s.Name)}, nil
 }

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile.go
@@ -78,7 +78,12 @@ func (c *Controller) reconcile(ctx context.Context, ws *tenancyv1alpha1.Workspac
 	}
 
 	reconcilers := []reconciler{
-		&metaDataReconciler{},
+		&metaDataReconciler{
+			getLogicalCluster: func(ctx context.Context, cluster logicalcluster.Path) (*corev1alpha1.LogicalCluster, error) {
+				return c.kcpExternalClient.Cluster(cluster).CoreV1alpha1().LogicalClusters().Get(ctx, corev1alpha1.LogicalClusterName, metav1.GetOptions{})
+			},
+			getShardByHash: getShardByName,
+		},
 		&deletionReconciler{
 			getLogicalCluster: func(ctx context.Context, cluster logicalcluster.Path) (*corev1alpha1.LogicalCluster, error) {
 				return c.kcpExternalClient.Cluster(cluster).CoreV1alpha1().LogicalClusters().Get(ctx, corev1alpha1.LogicalClusterName, metav1.GetOptions{})

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_deletion.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_deletion.go
@@ -75,7 +75,7 @@ func (r *deletionReconciler) reconcile(ctx context.Context, workspace *tenancyv1
 		// try again with a direct connection. It might be that the front-proxy
 		// does not know about the logical cluster. We don't want to leak, so
 		// try extra hard.
-		shardNameHash, hasShard := workspace.Annotations[WorkspaceShardHashAnnotationKey]
+		shardNameHash, hasShard := workspaceShardHash(workspace)
 		if !hasShard {
 			// nothing we can do beyond retrying
 			return reconcileStatusStopAndRequeue, getErr

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_metadata.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_metadata.go
@@ -21,13 +21,17 @@ import (
 	"encoding/json"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
 
+	"github.com/kcp-dev/logicalcluster/v3"
 	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
 )
 
 type metaDataReconciler struct {
+	getLogicalCluster func(ctx context.Context, cluster logicalcluster.Path) (*corev1alpha1.LogicalCluster, error)
+	getShardByHash    func(hash string) (*corev1alpha1.Shard, error)
 }
 
 func (r *metaDataReconciler) reconcile(ctx context.Context, workspace *tenancyv1alpha1.Workspace) (reconcileStatus, error) {
@@ -67,6 +71,40 @@ func (r *metaDataReconciler) reconcile(ctx context.Context, workspace *tenancyv1
 				changed = true
 			} else if value != string(userOnlyValue) {
 				workspace.Annotations[tenancyv1alpha1.ExperimentalWorkspaceOwnerAnnotationKey] = string(userOnlyValue)
+				changed = true
+			}
+		}
+	}
+
+	// If the shard annotation between the LC and the Workspace has drifted then the LC moved to another shard.
+	if workspace.DeletionTimestamp.IsZero() && workspace.Spec.Cluster != "" {
+		// Only check for drift if there is an annotation on the workspace.
+		if wsShardHash, ok := workspaceShardHash(workspace); ok {
+			lc, err := r.getLogicalCluster(ctx, logicalcluster.NewPath(workspace.Spec.Cluster))
+			if err != nil {
+				if !apierrors.IsNotFound(err) {
+					return reconcileStatusContinue, nil
+				}
+				// If the annotation exists we should only proceed if we see the LC.
+				return reconcileStatusStopAndRequeue, err
+			}
+
+			lcShardHash := lc.Annotations[corev1alpha1.LogicalClusterShardAnnotationKey]
+			if lcShardHash == "" {
+				// The LC is visible but the annotation is empty, can't proceed without.
+				return reconcileStatusStopAndRequeue, nil
+			}
+
+			if lcShardHash != wsShardHash {
+				newShard, err := r.getShardByHash(lcShardHash)
+				if err != nil {
+					if !apierrors.IsNotFound(err) {
+						return reconcileStatusContinue, err
+					}
+					return reconcileStatusStopAndRequeue, nil
+				}
+				logger.V(2).Info("LogicalCluster shard drift detected, retargeting workspace", "from", wsShardHash, "to", lcShardHash, "shard", newShard.Name)
+				applyShardToWorkspaceMetadata(workspace, newShard)
 				changed = true
 			}
 		}

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_metadata_test.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_metadata_test.go
@@ -24,9 +24,12 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/kcp-dev/logicalcluster/v3"
 	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
+	corev1alpha1helper "github.com/kcp-dev/sdk/apis/core/v1alpha1/helper"
 	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
 )
 
@@ -35,10 +38,14 @@ func TestReconcileMetadata(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, testCase := range []struct {
-		name       string
-		input      *tenancyv1alpha1.Workspace
-		expected   metav1.ObjectMeta
-		wantStatus reconcileStatus
+		name              string
+		input             *tenancyv1alpha1.Workspace
+		getLogicalCluster func(ctx context.Context, cluster logicalcluster.Path) (*corev1alpha1.LogicalCluster, error)
+		getShardByHash    func(hash string) (*corev1alpha1.Shard, error)
+		expected          metav1.ObjectMeta
+		expectedSpec      tenancyv1alpha1.WorkspaceSpec
+		wantStatus        reconcileStatus
+		wantErr           bool
 	}{
 		{
 			name: "removes everything but owner username when ready",
@@ -129,16 +136,195 @@ func TestReconcileMetadata(t *testing.T) {
 			},
 			wantStatus: reconcileStatusStopAndRequeue,
 		},
+		{
+			name: "drift: LogicalCluster shard differs from workspace, restamps annotations",
+			input: &tenancyv1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						corev1alpha1.LogicalClusterShardAnnotationKey: "old-hash",
+						WorkspaceShardHashAnnotationKey:               "old-hash",
+					},
+					Labels: map[string]string{
+						"tenancy.kcp.io/phase": "Ready",
+						"region":               "us-east-1",
+					},
+				},
+				Spec: tenancyv1alpha1.WorkspaceSpec{
+					Cluster: "test-cluster",
+					URL:     "https://old.example.com/clusters/root:ws",
+				},
+				Status: tenancyv1alpha1.WorkspaceStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseReady,
+				},
+			},
+			getLogicalCluster: func(_ context.Context, _ logicalcluster.Path) (*corev1alpha1.LogicalCluster, error) {
+				return &corev1alpha1.LogicalCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							corev1alpha1.LogicalClusterShardAnnotationKey: corev1alpha1helper.ShardNameHash("new-shard"),
+						},
+					},
+				}, nil
+			},
+			getShardByHash: func(hash string) (*corev1alpha1.Shard, error) {
+				return &corev1alpha1.Shard{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "new-shard",
+						Labels: map[string]string{"region": "us-west-2"},
+					},
+				}, nil
+			},
+			expected: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					corev1alpha1.LogicalClusterShardAnnotationKey: corev1alpha1helper.ShardNameHash("new-shard"),
+					WorkspaceShardHashAnnotationKey:               corev1alpha1helper.ShardNameHash("new-shard"),
+				},
+				Labels: map[string]string{
+					"tenancy.kcp.io/phase": "Ready",
+					"region":               "us-west-2",
+				},
+			},
+			expectedSpec: tenancyv1alpha1.WorkspaceSpec{
+				Cluster: "test-cluster",
+				URL:     "https://old.example.com/clusters/root:ws",
+			},
+			wantStatus: reconcileStatusStopAndRequeue,
+		},
+		{
+			name: "no drift: LogicalCluster shard matches workspace shard",
+			input: &tenancyv1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						corev1alpha1.LogicalClusterShardAnnotationKey: "hash-1",
+						WorkspaceShardHashAnnotationKey:               "hash-1",
+					},
+					Labels: map[string]string{
+						"tenancy.kcp.io/phase": "Ready",
+					},
+				},
+				Spec: tenancyv1alpha1.WorkspaceSpec{
+					Cluster: "test-cluster",
+				},
+				Status: tenancyv1alpha1.WorkspaceStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseReady,
+				},
+			},
+			getLogicalCluster: func(_ context.Context, _ logicalcluster.Path) (*corev1alpha1.LogicalCluster, error) {
+				return &corev1alpha1.LogicalCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							corev1alpha1.LogicalClusterShardAnnotationKey: "hash-1",
+						},
+					},
+				}, nil
+			},
+			expected: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					corev1alpha1.LogicalClusterShardAnnotationKey: "hash-1",
+					WorkspaceShardHashAnnotationKey:               "hash-1",
+				},
+				Labels: map[string]string{
+					"tenancy.kcp.io/phase": "Ready",
+				},
+			},
+			expectedSpec: tenancyv1alpha1.WorkspaceSpec{
+				Cluster: "test-cluster",
+			},
+			wantStatus: reconcileStatusContinue,
+		},
+		{
+			name: "LogicalCluster has no shard annotation yet: requeue until stamped",
+			input: &tenancyv1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						corev1alpha1.LogicalClusterShardAnnotationKey: "hash-1",
+						WorkspaceShardHashAnnotationKey:               "hash-1",
+					},
+					Labels: map[string]string{
+						"tenancy.kcp.io/phase": "Ready",
+					},
+				},
+				Spec: tenancyv1alpha1.WorkspaceSpec{
+					Cluster: "test-cluster",
+				},
+				Status: tenancyv1alpha1.WorkspaceStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseReady,
+				},
+			},
+			getLogicalCluster: func(_ context.Context, _ logicalcluster.Path) (*corev1alpha1.LogicalCluster, error) {
+				return &corev1alpha1.LogicalCluster{}, nil
+			},
+			expected: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					corev1alpha1.LogicalClusterShardAnnotationKey: "hash-1",
+					WorkspaceShardHashAnnotationKey:               "hash-1",
+				},
+				Labels: map[string]string{
+					"tenancy.kcp.io/phase": "Ready",
+				},
+			},
+			expectedSpec: tenancyv1alpha1.WorkspaceSpec{
+				Cluster: "test-cluster",
+			},
+			wantStatus: reconcileStatusStopAndRequeue,
+		},
+		{
+			name: "LogicalCluster not found: requeue with error",
+			input: &tenancyv1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						corev1alpha1.LogicalClusterShardAnnotationKey: "hash-1",
+						WorkspaceShardHashAnnotationKey:               "hash-1",
+					},
+					Labels: map[string]string{
+						"tenancy.kcp.io/phase": "Ready",
+					},
+				},
+				Spec: tenancyv1alpha1.WorkspaceSpec{
+					Cluster: "test-cluster",
+				},
+				Status: tenancyv1alpha1.WorkspaceStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseReady,
+				},
+			},
+			getLogicalCluster: func(_ context.Context, _ logicalcluster.Path) (*corev1alpha1.LogicalCluster, error) {
+				return nil, apierrors.NewNotFound(corev1alpha1.Resource("logicalclusters"), "cluster")
+			},
+			expected: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					corev1alpha1.LogicalClusterShardAnnotationKey: "hash-1",
+					WorkspaceShardHashAnnotationKey:               "hash-1",
+				},
+				Labels: map[string]string{
+					"tenancy.kcp.io/phase": "Ready",
+				},
+			},
+			expectedSpec: tenancyv1alpha1.WorkspaceSpec{
+				Cluster: "test-cluster",
+			},
+			wantStatus: reconcileStatusStopAndRequeue,
+			wantErr:    true,
+		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			reconciler := metaDataReconciler{}
+			reconciler := metaDataReconciler{
+				getLogicalCluster: testCase.getLogicalCluster,
+				getShardByHash:    testCase.getShardByHash,
+			}
 			status, err := reconciler.reconcile(context.Background(), testCase.input)
 
-			require.NoError(t, err)
+			if testCase.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
 			require.Equal(t, testCase.wantStatus, status)
 
 			if diff := cmp.Diff(testCase.input.ObjectMeta, testCase.expected); diff != "" {
 				t.Errorf("invalid output after reconciling metadata: %v", diff)
+			}
+			if diff := cmp.Diff(testCase.input.Spec, testCase.expectedSpec); diff != "" {
+				t.Errorf("invalid spec after reconciling metadata: %v", diff)
 			}
 		})
 	}

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_phase.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_phase.go
@@ -62,7 +62,7 @@ func (r *phaseReconciler) reconcile(ctx context.Context, workspace *tenancyv1alp
 			} else if apierrors.IsNotFound(err) {
 				// The LogicalCluster may not be visible through the front-proxy yet
 				// because the shard index hasn't caught up.
-				shardHash, hasShard := workspace.Annotations[WorkspaceShardHashAnnotationKey]
+				shardHash, hasShard := workspaceShardHash(workspace)
 				if hasShard {
 					shard, shardErr := r.getShardByHash(shardHash)
 					if shardErr == nil && shard.DeletionTimestamp.IsZero() {
@@ -103,7 +103,7 @@ func (r *phaseReconciler) reconcile(ctx context.Context, workspace *tenancyv1alp
 
 		case corev1alpha1.LogicalClusterPhaseUnavailable:
 			if conditions.IsFalse(workspace, tenancyv1alpha1.WorkspaceInitialized) && conditions.GetReason(workspace, tenancyv1alpha1.WorkspaceInitialized) == tenancyv1alpha1.WorkspaceInitializedWorkspaceDisappeared {
-				shardHash, hasShard := workspace.Annotations[WorkspaceShardHashAnnotationKey]
+				shardHash, hasShard := workspaceShardHash(workspace)
 				if hasShard {
 					shard, shardErr := r.getShardByHash(shardHash)
 					if shardErr == nil && shard.DeletionTimestamp.IsZero() {

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_scheduling.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_scheduling.go
@@ -55,6 +55,9 @@ import (
 const (
 	// WorkspaceShardHashAnnotationKey keeps track on which shard LogicalCluster must be scheduled. The value
 	// is a base36(sha224) hash of the Shard name.
+	//
+	// Deprecated: use corev1alpha1.LogicalClusterShardAnnotationKey instead.
+	// This key is still updated and read as a fallback for backwards compatibility but will be removed in a future release.
 	WorkspaceShardHashAnnotationKey = "internal.tenancy.kcp.io/shard"
 
 	// workspaceClusterAnnotationKey keeps track of the logical cluster on the shard.
@@ -64,6 +67,33 @@ const (
 	// The annotation is meant to be used by e2e tests that otherwise started a private instance of kcp server.
 	unschedulableAnnotationKey = "experimental.core.kcp.io/unschedulable"
 )
+
+// workspaceShardHash reads the shard hash annotation from a Workspace.
+func workspaceShardHash(ws *tenancyv1alpha1.Workspace) (string, bool) {
+	if v, ok := ws.Annotations[corev1alpha1.LogicalClusterShardAnnotationKey]; ok {
+		return v, true
+	}
+	v, ok := ws.Annotations[WorkspaceShardHashAnnotationKey]
+	return v, ok
+}
+
+// applyShardToWorkspaceMetadata updates a workspaces shard metadata.
+func applyShardToWorkspaceMetadata(ws *tenancyv1alpha1.Workspace, shard *corev1alpha1.Shard) {
+	hash := corev1alpha1helper.ShardNameHash(shard.Name)
+	if ws.Annotations == nil {
+		ws.Annotations = map[string]string{}
+	}
+	ws.Annotations[corev1alpha1.LogicalClusterShardAnnotationKey] = hash
+	ws.Annotations[WorkspaceShardHashAnnotationKey] = hash
+
+	if ws.Labels == nil {
+		ws.Labels = map[string]string{}
+	}
+	delete(ws.Labels, "region")
+	if region, found := shard.Labels["region"]; found {
+		ws.Labels["region"] = region
+	}
+}
 
 type schedulingReconciler struct {
 	generateClusterName func(path logicalcluster.Path) (logicalcluster.Name, error)
@@ -96,7 +126,7 @@ func (r *schedulingReconciler) reconcile(ctx context.Context, workspace *tenancy
 		// This is bit of edge case, but nevertheless we need to check if logical cluster url still matches the workspace url.
 		clusterNameString, hasCluster := workspace.Annotations[workspaceClusterAnnotationKey]
 		clusterName := logicalcluster.Name(clusterNameString)
-		shardNameHash, hasShard := workspace.Annotations[WorkspaceShardHashAnnotationKey]
+		shardNameHash, hasShard := workspaceShardHash(workspace)
 		if !hasShard || !hasCluster {
 			return reconcileStatusContinue, nil
 		}
@@ -110,9 +140,10 @@ func (r *schedulingReconciler) reconcile(ctx context.Context, workspace *tenancy
 		}
 
 		parentThis, err := r.getLogicalCluster(logicalcluster.From(workspace))
-		if err != nil && !apierrors.IsNotFound(err) {
-			return reconcileStatusStopAndRequeue, err
-		} else if apierrors.IsNotFound(err) {
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				return reconcileStatusStopAndRequeue, err
+			}
 			return reconcileStatusStopAndRequeue, nil // wait for parent LogicalCluster to be created
 		}
 
@@ -139,7 +170,7 @@ func (r *schedulingReconciler) reconcile(ctx context.Context, workspace *tenancy
 		conditions.MarkTrue(workspace, tenancyv1alpha1.WorkspaceScheduled)
 		return reconcileStatusContinue, nil
 	case workspace.Spec.URL == "" || workspace.Spec.Cluster == "":
-		shardNameHash, hasShard := workspace.Annotations[WorkspaceShardHashAnnotationKey]
+		shardNameHash, hasShard := workspaceShardHash(workspace)
 		clusterNameString, hasCluster := workspace.Annotations[workspaceClusterAnnotationKey]
 		clusterName := logicalcluster.Name(clusterNameString)
 		hasFinalizer := sets.New[string](workspace.Finalizers...).Has(corev1alpha1.LogicalClusterFinalizerName)
@@ -162,13 +193,7 @@ func (r *schedulingReconciler) reconcile(ctx context.Context, workspace *tenancy
 			}
 			logger.V(2).Info("Chose shard", "shard", shard.Name)
 			shardNameHash = corev1alpha1helper.ShardNameHash(shard.Name)
-			if workspace.Annotations == nil {
-				workspace.Annotations = map[string]string{}
-			}
-			workspace.Annotations[WorkspaceShardHashAnnotationKey] = shardNameHash
-			if region, found := shard.Labels["region"]; found {
-				workspace.Labels["region"] = region
-			}
+			applyShardToWorkspaceMetadata(workspace, shard)
 		}
 		if !hasCluster {
 			cluster, err := r.generateClusterName(logicalcluster.From(workspace).Path().Join(workspace.Name))

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_scheduling.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_scheduling.go
@@ -39,6 +39,7 @@ import (
 	"github.com/kcp-dev/logicalcluster/v3"
 	"github.com/kcp-dev/sdk/apis/core"
 	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
+	corev1alpha1helper "github.com/kcp-dev/sdk/apis/core/v1alpha1/helper"
 	"github.com/kcp-dev/sdk/apis/tenancy/initialization"
 	"github.com/kcp-dev/sdk/apis/tenancy/termination"
 	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
@@ -160,7 +161,7 @@ func (r *schedulingReconciler) reconcile(ctx context.Context, workspace *tenancy
 				return reconcileStatusContinue, nil // retry is automatic when new shards show up
 			}
 			logger.V(2).Info("Chose shard", "shard", shard.Name)
-			shardNameHash = kcpcrypto.Base36Sha224.StringPad(shard.Name)[:8]
+			shardNameHash = corev1alpha1helper.ShardNameHash(shard.Name)
 			if workspace.Annotations == nil {
 				workspace.Annotations = map[string]string{}
 			}

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_scheduling_test.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_scheduling_test.go
@@ -34,13 +34,13 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
-	kcpcrypto "github.com/kcp-dev/apimachinery/v2/pkg/util/crypto"
 	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
 	kcpfakekubeclient "github.com/kcp-dev/client-go/kubernetes/fake"
 	kcpclientgotesting "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/testing"
 	"github.com/kcp-dev/logicalcluster/v3"
 	"github.com/kcp-dev/sdk/apis/core"
 	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
+	corev1alpha1helper "github.com/kcp-dev/sdk/apis/core/v1alpha1/helper"
 	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
 	conditionsapi "github.com/kcp-dev/sdk/apis/third_party/conditions/apis/conditions/v1alpha1"
 	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
@@ -327,7 +327,7 @@ func TestReconcileScheduling(t *testing.T) {
 				},
 				getShardByHash: func(hash string) (*corev1alpha1.Shard, error) {
 					for _, shard := range scenario.initialShards {
-						if shardNameToBase36Sha224(shard.Name) == hash {
+						if corev1alpha1helper.ShardNameHash(shard.Name) == hash {
 							return shard, nil
 						}
 					}
@@ -587,8 +587,4 @@ func actionStrings(actions []kcpclientgotesting.Action) []string {
 		res = append(res, actionString(a))
 	}
 	return res
-}
-
-func shardNameToBase36Sha224(name string) string {
-	return kcpcrypto.Base36Sha224.StringPad(name)[:8]
 }

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_scheduling_test.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_scheduling_test.go
@@ -73,6 +73,7 @@ func TestReconcileScheduling(t *testing.T) {
 				t.Helper()
 
 				initialWS.Annotations["internal.tenancy.kcp.io/cluster"] = "root-foo"
+				initialWS.Annotations[corev1alpha1.LogicalClusterShardAnnotationKey] = "1pfxsevk"
 				initialWS.Annotations["internal.tenancy.kcp.io/shard"] = "1pfxsevk"
 				initialWS.Finalizers = append(initialWS.Finalizers, "core.kcp.io/logicalcluster")
 				if !equality.Semantic.DeepEqual(ws, initialWS) {
@@ -86,7 +87,13 @@ func TestReconcileScheduling(t *testing.T) {
 			initialShards:         []*corev1alpha1.Shard{shard("root")},
 			initialWorkspaceTypes: wellKnownWorkspaceTypes(),
 			targetWorkspace:       wellKnownFooWSForPhaseTwo(),
-			targetLogicalCluster:  &corev1alpha1.LogicalCluster{},
+			targetLogicalCluster: &corev1alpha1.LogicalCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						corev1alpha1.LogicalClusterShardAnnotationKey: "1pfxsevk",
+					},
+				},
+			},
 			validateWorkspace: func(t *testing.T, initialWS, wsAfterReconciliation *tenancyv1alpha1.Workspace) {
 				t.Helper()
 
@@ -119,8 +126,14 @@ func TestReconcileScheduling(t *testing.T) {
 				thisWS.Annotations["kcp.io/cluster"] = "root-foo"
 				return thisWS
 			}()},
-			targetWorkspace:      wellKnownFooWSForPhaseTwo(),
-			targetLogicalCluster: &corev1alpha1.LogicalCluster{},
+			targetWorkspace: wellKnownFooWSForPhaseTwo(),
+			targetLogicalCluster: &corev1alpha1.LogicalCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						corev1alpha1.LogicalClusterShardAnnotationKey: "1pfxsevk",
+					},
+				},
+			},
 			validateWorkspace: func(t *testing.T, initialWS, wsAfterReconciliation *tenancyv1alpha1.Workspace) {
 				t.Helper()
 
@@ -182,8 +195,14 @@ func TestReconcileScheduling(t *testing.T) {
 				thisWS.Annotations["kcp.io/cluster"] = "root-foo"
 				return thisWS
 			}()},
-			targetWorkspace:      wellKnownFooWSForPhaseTwo(),
-			targetLogicalCluster: &corev1alpha1.LogicalCluster{},
+			targetWorkspace: wellKnownFooWSForPhaseTwo(),
+			targetLogicalCluster: &corev1alpha1.LogicalCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						corev1alpha1.LogicalClusterShardAnnotationKey: "1pfxsevk",
+					},
+				},
+			},
 			validateWorkspace: func(t *testing.T, initialWS, wsAfterReconciliation *tenancyv1alpha1.Workspace) {
 				t.Helper()
 
@@ -245,6 +264,7 @@ func TestReconcileScheduling(t *testing.T) {
 				t.Helper()
 
 				initialWS.Annotations["internal.tenancy.kcp.io/cluster"] = "root-foo"
+				initialWS.Annotations[corev1alpha1.LogicalClusterShardAnnotationKey] = "29hdqnv7"
 				initialWS.Annotations["internal.tenancy.kcp.io/shard"] = "29hdqnv7"
 				initialWS.Finalizers = append(initialWS.Finalizers, "core.kcp.io/logicalcluster")
 				if !equality.Semantic.DeepEqual(wsAfterReconciliation, initialWS) {
@@ -272,6 +292,37 @@ func TestReconcileScheduling(t *testing.T) {
 					Status:   corev1.ConditionFalse,
 					Reason:   tenancyv1alpha1.WorkspaceReasonUnschedulable,
 					Message:  "No available shards to schedule the workspace",
+				})
+				if !equality.Semantic.DeepEqual(wsAfterReconciliation, initialWS) {
+					t.Fatalf("unexpected Workspace:\n%s", cmp.Diff(wsAfterReconciliation, initialWS))
+				}
+			},
+			expectedStatus: reconcileStatusContinue,
+		},
+		{
+			name:                  "shard hash changed: workspace URL is rebuilt from the new shard",
+			initialShards:         []*corev1alpha1.Shard{shard("root"), shard("amber")},
+			initialWorkspaceTypes: wellKnownWorkspaceTypes(),
+			targetWorkspace: func() *tenancyv1alpha1.Workspace {
+				ws := wellKnownFooWSForPhaseTwo()
+				// metaDataReconciler has already restamped the shard hash to amber,
+				// but the URL still points at the old (root) shard.
+				ws.Annotations[corev1alpha1.LogicalClusterShardAnnotationKey] = "29hdqnv7"
+				ws.Annotations["internal.tenancy.kcp.io/shard"] = "29hdqnv7"
+				ws.Spec.URL = "https://root/clusters/root:foo"
+				ws.Spec.Cluster = "root-foo"
+				return ws
+			}(),
+			targetLogicalCluster: &corev1alpha1.LogicalCluster{},
+			validateWorkspace: func(t *testing.T, initialWS, wsAfterReconciliation *tenancyv1alpha1.Workspace) {
+				t.Helper()
+
+				clearLastTransitionTimeOnWsConditions(wsAfterReconciliation)
+				initialWS.CreationTimestamp = wsAfterReconciliation.CreationTimestamp
+				initialWS.Spec.URL = "https://amber/clusters/root:foo"
+				initialWS.Status.Conditions = append(initialWS.Status.Conditions, conditionsapi.Condition{
+					Type:   tenancyv1alpha1.WorkspaceScheduled,
+					Status: corev1.ConditionTrue,
 				})
 				if !equality.Semantic.DeepEqual(wsAfterReconciliation, initialWS) {
 					t.Fatalf("unexpected Workspace:\n%s", cmp.Diff(wsAfterReconciliation, initialWS))
@@ -395,6 +446,7 @@ func wellKnownFooWSForPhaseTwo() *tenancyv1alpha1.Workspace {
 	ws := workspace("foo")
 	// since this is part two we can assume the following fields are assigned
 	ws.Annotations["internal.tenancy.kcp.io/cluster"] = "root-foo"
+	ws.Annotations[corev1alpha1.LogicalClusterShardAnnotationKey] = "1pfxsevk"
 	ws.Annotations["internal.tenancy.kcp.io/shard"] = "1pfxsevk"
 	ws.Annotations["experimental.tenancy.kcp.io/owner"] = `{"username":"kcp-admin"}`
 	ws.Finalizers = append(ws.Finalizers, "core.kcp.io/logicalcluster")

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -721,6 +721,7 @@ func (s *Server) installLogicalCluster(ctx context.Context, config *rest.Config)
 	}
 
 	logicalClusterController, err := logicalclusterctrl.NewController(
+		s.Options.Extra.ShardName,
 		s.CompletedConfig.ShardExternalURL,
 		kcpClusterClient,
 		s.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters(),

--- a/staging/src/github.com/kcp-dev/sdk/apis/core/v1alpha1/helper/helper.go
+++ b/staging/src/github.com/kcp-dev/sdk/apis/core/v1alpha1/helper/helper.go
@@ -21,6 +21,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	kcpcrypto "github.com/kcp-dev/apimachinery/v2/pkg/util/crypto"
 	"github.com/kcp-dev/logicalcluster/v3"
 )
 
@@ -32,4 +33,10 @@ func QualifiedObjectName(obj metav1.Object) string {
 		return fmt.Sprintf("%s|%s/%s", logicalcluster.From(obj), obj.GetNamespace(), obj.GetName())
 	}
 	return fmt.Sprintf("%s|%s", logicalcluster.From(obj), obj.GetName())
+}
+
+// ShardNameHash converts a shard name into an opaque hash.
+// This hash is annotated on relevant resources.
+func ShardNameHash(name string) string {
+	return kcpcrypto.Base36Sha224.StringPad(name)[:8]
 }

--- a/staging/src/github.com/kcp-dev/sdk/apis/core/v1alpha1/helper/helper_test.go
+++ b/staging/src/github.com/kcp-dev/sdk/apis/core/v1alpha1/helper/helper_test.go
@@ -51,3 +51,30 @@ func TestQualifiedObjectName(t *testing.T) {
 		})
 	}
 }
+
+// TestShardNameHash ensures that ShardNameHash stays consistent as
+// these values are stored on some resources they cannot change across
+// versions without a migration.
+func TestShardNameHash(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{"", "2n6a5vwp"},
+		{"root", "1pfxsevk"},
+		{"shard-1", "2e1tfbst"},
+		{"shard-2", "quyfennr"},
+		{"shard-3", "2jvdumni"},
+		{"europe-1", "32dpb82e"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ShardNameHash(tt.name); got != tt.want {
+				t.Errorf("ShardNameHash(%q) = %q, want %q", tt.name, got, tt.want)
+			}
+			if got := ShardNameHash(tt.name); len(got) != 8 {
+				t.Errorf("ShardNameHash(%q) length = %d, want 8", tt.name, len(got))
+			}
+		})
+	}
+}

--- a/staging/src/github.com/kcp-dev/sdk/apis/core/v1alpha1/logicalcluster_types.go
+++ b/staging/src/github.com/kcp-dev/sdk/apis/core/v1alpha1/logicalcluster_types.go
@@ -70,6 +70,9 @@ const (
 	//
 	// Deprecated: use LogicalClusterInactiveAnnotationKey.
 	LogicalClusterInactiveAnnotationKeyLegacy = "internal.kcp.io/inactive"
+
+	// LogicalClusterShardAnnotationKey is the hashed shard name the LogicalCluster is scheduled on.
+	LogicalClusterShardAnnotationKey = "core.kcp.io/shard"
 )
 
 // LogicalClusterPhaseType is the type of the current phase of the logical cluster.

--- a/staging/src/github.com/kcp-dev/sdk/apis/core/v1alpha1/shard_types.go
+++ b/staging/src/github.com/kcp-dev/sdk/apis/core/v1alpha1/shard_types.go
@@ -38,6 +38,7 @@ var RootShard = "root"
 // +kubebuilder:printcolumn:name="Region",type=string,JSONPath=`.metadata.labels['region']`,description="The region this workspace is in"
 // +kubebuilder:printcolumn:name="URL",type=string,JSONPath=`.spec.baseURL`,description="Type URL to directly connect to the shard"
 // +kubebuilder:printcolumn:name="External URL",type=string,JSONPath=`.spec.externalURL`,description="The URL exposed in logical clusters created on that shard"
+// +kubebuilder:printcolumn:name="Hash",type=string,JSONPath=`.status.hash`,description="The shard name hash used in the core.kcp.io/shard annotation"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type Shard struct {
 	v1.TypeMeta `json:",inline"`
@@ -106,6 +107,11 @@ type ShardSpec struct {
 
 // ShardStatus communicates the observed state of the Shard.
 type ShardStatus struct {
+	// hash is the shard name hash, the value used as the
+	// core.kcp.io/shard annotation on LogicalClusters scheduled to this shard.
+	// +optional
+	Hash string `json:"hash,omitempty"`
+
 	// Set of integer resources that logical clusters can be scheduled into
 	// +optional
 	Capacity corev1.ResourceList `json:"capacity,omitempty"`

--- a/staging/src/github.com/kcp-dev/sdk/client/applyconfiguration/core/v1alpha1/shardstatus.go
+++ b/staging/src/github.com/kcp-dev/sdk/client/applyconfiguration/core/v1alpha1/shardstatus.go
@@ -29,6 +29,9 @@ import (
 //
 // ShardStatus communicates the observed state of the Shard.
 type ShardStatusApplyConfiguration struct {
+	// hash is the shard name hash, the value used as the
+	// core.kcp.io/shard annotation on LogicalClusters scheduled to this shard.
+	Hash *string `json:"hash,omitempty"`
 	// Set of integer resources that logical clusters can be scheduled into
 	Capacity *v1.ResourceList `json:"capacity,omitempty"`
 	// Current processing state of the Shard.
@@ -39,6 +42,14 @@ type ShardStatusApplyConfiguration struct {
 // apply.
 func ShardStatus() *ShardStatusApplyConfiguration {
 	return &ShardStatusApplyConfiguration{}
+}
+
+// WithHash sets the Hash field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Hash field is set to the value of the last call.
+func (b *ShardStatusApplyConfiguration) WithHash(value string) *ShardStatusApplyConfiguration {
+	b.Hash = &value
+	return b
 }
 
 // WithCapacity sets the Capacity field in the declarative configuration to the given value

--- a/staging/src/github.com/kcp-dev/sdk/openapi/zz_generated.openapi.go
+++ b/staging/src/github.com/kcp-dev/sdk/openapi/zz_generated.openapi.go
@@ -4053,6 +4053,13 @@ func schema_sdk_apis_core_v1alpha1_ShardStatus(ref common.ReferenceCallback) com
 				Description: "ShardStatus communicates the observed state of the Shard.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"hash": {
+						SchemaProps: spec.SchemaProps{
+							Description: "hash is the shard name hash, the value used as the core.kcp.io/shard annotation on LogicalClusters scheduled to this shard.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"capacity": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Set of integer resources that logical clusters can be scheduled into",

--- a/staging/src/github.com/kcp-dev/sdk/testing/workspaces.go
+++ b/staging/src/github.com/kcp-dev/sdk/testing/workspaces.go
@@ -31,11 +31,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 
-	kcpcrypto "github.com/kcp-dev/apimachinery/v2/pkg/util/crypto"
 	"github.com/kcp-dev/logicalcluster/v3"
 	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
 	"github.com/kcp-dev/sdk/apis/core"
 	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
+	corev1alpha1helper "github.com/kcp-dev/sdk/apis/core/v1alpha1/helper"
 	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
 	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
 	kcptestinghelpers "github.com/kcp-dev/sdk/testing/helpers"
@@ -277,7 +277,7 @@ func WorkspaceShard(ctx context.Context, kcpClient kcpclientset.ClusterInterface
 	}
 
 	for i := range shards.Items {
-		if name := shards.Items[i].Name; kcpcrypto.Base36Sha224.StringPad(name)[:8] == hash {
+		if name := shards.Items[i].Name; corev1alpha1helper.ShardNameHash(name) == hash {
 			return &shards.Items[i], nil
 		}
 	}

--- a/test/e2e/reconciler/partitionset/partitionset_test.go
+++ b/test/e2e/reconciler/partitionset/partitionset_test.go
@@ -177,11 +177,19 @@ func TestPartitionSet(t *testing.T) {
 			reflect.DeepEqual(partitions.Items[1].Spec.Selector.MatchLabels, map[string]string{"partition-test-region": "partition-test-region-1"})), "selectors not as expected")
 
 	t.Logf("Moving the second shard to the same region as the first one")
-	shard2.Labels = map[string]string{
-		"partition-test-region": "partition-test-region-1",
-	}
-	_, err = shardClient.Cluster(core.RootCluster.Path()).Update(ctx, shard2, metav1.UpdateOptions{})
-	require.NoError(t, err, "error updating shard")
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		shard2, err = shardClient.Cluster(core.RootCluster.Path()).Get(ctx, shard2.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, fmt.Sprintf("error retrieving shard: %v", err)
+		}
+		shard2.Labels = map[string]string{
+			"partition-test-region": "partition-test-region-1",
+		}
+		if _, err = shardClient.Cluster(core.RootCluster.Path()).Update(ctx, shard2, metav1.UpdateOptions{}); err != nil {
+			return false, fmt.Sprintf("error updating shard: %v", err)
+		}
+		return true, ""
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "expected shard to be updated")
 	kcptestinghelpers.Eventually(t, func() (bool, string) {
 		partitionSet, err = partitionSetClient.Cluster(partitionClusterPath).Get(ctx, partitionSet.Name, metav1.GetOptions{})
 		require.NoError(t, err, "error retrieving partitionSet")
@@ -238,12 +246,20 @@ func TestPartitionSet(t *testing.T) {
 	}, wait.ForeverTestTimeout, 100*time.Millisecond, "expected 2 partitions")
 
 	t.Logf("Excluding the shard of the third region")
-	shard3.Labels = map[string]string{
-		"partition-test-region": "partition-test-region-3",
-		"excluded":              "true",
-	}
-	_, err = shardClient.Cluster(core.RootCluster.Path()).Update(ctx, shard3, metav1.UpdateOptions{})
-	require.NoError(t, err, "error updating shard")
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		shard3, err = shardClient.Cluster(core.RootCluster.Path()).Get(ctx, shard3.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, fmt.Sprintf("error retrieving shard: %v", err)
+		}
+		shard3.Labels = map[string]string{
+			"partition-test-region": "partition-test-region-3",
+			"excluded":              "true",
+		}
+		if _, err = shardClient.Cluster(core.RootCluster.Path()).Update(ctx, shard3, metav1.UpdateOptions{}); err != nil {
+			return false, fmt.Sprintf("error updating shard: %v", err)
+		}
+		return true, ""
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "expected shard to be updated")
 	kcptestinghelpers.Eventually(t, func() (bool, string) {
 		partitionSet, err = partitionSetClient.Cluster(partitionClusterPath).Get(ctx, partitionSet.Name, metav1.GetOptions{})
 		require.NoError(t, err, "error retrieving partitionSet")


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Currently the shard annotation on Workspaces is set once during LC scheduling and then never reevaluated.

With incoming LC migration the shard-relevant fields must be updated depending on where the LC is scheduled.

To this end the following changes are made

1. `core.kcp.io/shard` is made part of the core API
2. `core.kcp.io/shard` is set on the LC by the LC reconciler
3. Workspace reconciler compares the LC annotation with the Workspace annotation and updates on a drift

The `internal.tenancy.kcp.io/shard` annotation is updated as well and marked deprecated.

Drawback is that when an LC isn't visible to the shard reconciling stops - which I think makes sense.

Also added the hash on the Shard status so it is getting printed when getting shards:

<img width="742" height="118" alt="image" src="https://github.com/user-attachments/assets/452012c1-b805-4a2e-ac5f-b1726c7fc18a" />


## What Type of PR Is This?

/kind feature

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
LogicalClusters get the `core.kcp.io/shard` annotation with the value being the hashed name of the shard they are scheduled on
Workspaces derive the `core.kcp.io/shard` annotation from its LogicalCluster
```
