### PR TITLE
Add make verify target to make file.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -442,6 +442,9 @@ modules: ## Run go mod tidy to ensure modules are up to date
 verify-modules: modules  ## Verify go modules are up to date
 	hack/verify-go-modules.sh
 
+.PHONY: verify
+verify: verify-boilerplate verify-codegen verify-imports verify-go-versions verify-modules verify-k8s-deps ## Run all verify checks
+
 .PHONY: clean
 clean: clean-workdir ## Clean all
 	rm -fr $(TOOLS_DIR)


### PR DESCRIPTION
## Summary

Adds a top-level verify target that runs all existing verify-* targets: verify-boilerplate, verify-codegen, verify-imports, verify-go-versions, verify-modules, and verify-k8s-deps.

## What Type of PR Is This?

/kind chore


cc @ntnn @mjudeikis

```release-note
NONE
```