### PR TITLE
evictor wiring server->clients->cache

### DIFF
--- a/pkg/server/clientcache_evictor.go
+++ b/pkg/server/clientcache_evictor.go
@@ -17,6 +17,8 @@ limitations under the License.
 package server
 
 import (
+	"context"
+
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
@@ -32,7 +34,8 @@ import (
 // Without this, those caches grow monotonically and pin per-cluster REST
 // clients, codec factories, JSON-decoded schemas, etc. for the lifetime of
 // the process. See https://github.com/kcp-dev/kcp/issues/4071.
-func installClientCacheEvictor(informer corev1alpha1informers.LogicalClusterClusterInformer) {
+func installClientCacheEvictor(ctx context.Context, informer corev1alpha1informers.LogicalClusterClusterInformer) {
+	logger := klog.FromContext(ctx)
 	_, _ = informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		DeleteFunc: func(obj any) {
 			lc, ok := obj.(*corev1alpha1.LogicalCluster)
@@ -50,7 +53,7 @@ func installClientCacheEvictor(informer corev1alpha1informers.LogicalClusterClus
 			if name == "" {
 				return
 			}
-			klog.V(4).InfoS("evicting per-cluster client caches", "logicalcluster", name)
+			logger.V(4).Info("evicting per-cluster client caches", "logicalcluster", name)
 			apiclient.EvictCluster(name.Path())
 		},
 	})

--- a/pkg/server/clientcache_evictor.go
+++ b/pkg/server/clientcache_evictor.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	apiclient "github.com/kcp-dev/apimachinery/v2/pkg/client"
+	"github.com/kcp-dev/logicalcluster/v3"
+	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
+	corev1alpha1informers "github.com/kcp-dev/sdk/client/informers/externalversions/core/v1alpha1"
+)
+
+// installClientCacheEvictor registers a LogicalCluster delete handler that
+// notifies apiclient.EvictCluster, which fans out to every per-cluster client
+// cache (kube, sdk, dynamic, metadata, ...) constructed via apiclient.NewCache.
+// Without this, those caches grow monotonically and pin per-cluster REST
+// clients, codec factories, JSON-decoded schemas, etc. for the lifetime of
+// the process. See https://github.com/kcp-dev/kcp/issues/4071.
+func installClientCacheEvictor(informer corev1alpha1informers.LogicalClusterClusterInformer) {
+	_, _ = informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		DeleteFunc: func(obj any) {
+			lc, ok := obj.(*corev1alpha1.LogicalCluster)
+			if !ok {
+				tombstone, tok := obj.(cache.DeletedFinalStateUnknown)
+				if !tok {
+					return
+				}
+				lc, ok = tombstone.Obj.(*corev1alpha1.LogicalCluster)
+				if !ok {
+					return
+				}
+			}
+			name := logicalcluster.From(lc)
+			if name == "" {
+				return
+			}
+			klog.V(4).InfoS("evicting per-cluster client caches", "logicalcluster", name)
+			apiclient.EvictCluster(name.Path())
+		},
+	})
+}

--- a/pkg/server/clientcache_evictor.go
+++ b/pkg/server/clientcache_evictor.go
@@ -18,23 +18,43 @@ package server
 
 import (
 	"context"
+	"sync"
 
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
-	apiclient "github.com/kcp-dev/apimachinery/v2/pkg/client"
 	"github.com/kcp-dev/logicalcluster/v3"
 	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 	corev1alpha1informers "github.com/kcp-dev/sdk/client/informers/externalversions/core/v1alpha1"
 )
 
-// installClientCacheEvictor registers a LogicalCluster delete handler that
-// notifies apiclient.EvictCluster, which fans out to every per-cluster client
-// cache (kube, sdk, dynamic, metadata, ...) constructed via apiclient.NewCache.
-// Without this, those caches grow monotonically and pin per-cluster REST
-// clients, codec factories, JSON-decoded schemas, etc. for the lifetime of
-// the process. See https://github.com/kcp-dev/kcp/issues/4071.
-func installClientCacheEvictor(ctx context.Context, informer corev1alpha1informers.LogicalClusterClusterInformer) {
+type evictable interface {
+	Evict(logicalcluster.Path)
+}
+
+// clientCacheEvictor forwards LogicalCluster deletions to its registered evictables.
+type clientCacheEvictor struct {
+	lock       sync.Mutex
+	evictables []evictable
+}
+
+func newClientCacheEvictor() *clientCacheEvictor {
+	return &clientCacheEvictor{}
+}
+
+// Register adds c to the set notified on LogicalCluster deletion. Safe to
+// call before or after Run.
+func (e *clientCacheEvictor) Register(c evictable) {
+	if c == nil {
+		return
+	}
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	e.evictables = append(e.evictables, c)
+}
+
+// Run starts the clientCacheEvictor process.
+func (e *clientCacheEvictor) Run(ctx context.Context, informer corev1alpha1informers.LogicalClusterClusterInformer) {
 	logger := klog.FromContext(ctx)
 	_, _ = informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		DeleteFunc: func(obj any) {
@@ -54,7 +74,14 @@ func installClientCacheEvictor(ctx context.Context, informer corev1alpha1informe
 				return
 			}
 			logger.V(4).Info("evicting per-cluster client caches", "logicalcluster", name)
-			apiclient.EvictCluster(name.Path())
+			path := name.Path()
+			e.lock.Lock()
+			snapshot := make([]evictable, len(e.evictables))
+			copy(snapshot, e.evictables)
+			e.lock.Unlock()
+			for _, c := range snapshot {
+				c.Evict(path)
+			}
 		},
 	})
 }

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -113,6 +113,9 @@ type ExtraConfig struct {
 	kcpAdminToken, shardAdminToken, userToken string
 	shardAdminTokenHash                       []byte
 
+	// ClientCacheEvictor forwards LogicalCluster deletions to clients.
+	ClientCacheEvictor *clientCacheEvictor
+
 	// clients
 	DynamicClusterClient                kcpdynamic.ClusterInterface
 	KubeClusterClient                   kcpkubernetesclientset.ClusterInterface
@@ -210,6 +213,7 @@ func NewConfig(ctx context.Context, opts kcpserveroptions.CompletedOptions) (*Co
 	c := &Config{
 		Options: opts,
 	}
+	c.ClientCacheEvictor = newClientCacheEvictor()
 
 	if opts.Extra.ProfilerAddress != "" {
 		//nolint:errcheck,gosec
@@ -256,6 +260,7 @@ func NewConfig(ctx context.Context, opts kcpserveroptions.CompletedOptions) (*Co
 	if err != nil {
 		return nil, err
 	}
+	c.ClientCacheEvictor.Register(c.KubeClusterClient)
 	cacheClientConfig, err := c.Options.Cache.Client.RestConfig(rest.CopyConfig(c.GenericConfig.LoopbackClientConfig))
 	if err != nil {
 		return nil, err
@@ -266,10 +271,12 @@ func NewConfig(ctx context.Context, opts kcpserveroptions.CompletedOptions) (*Co
 		return nil, err
 	}
 	c.KcpCacheClusterClient = cacheKcpClusterClient
+	c.ClientCacheEvictor.Register(cacheKcpClusterClient)
 	cacheKubeClusterClient, err := kcpkubernetesclientset.NewForConfig(cacheClientConfig)
 	if err != nil {
 		return nil, err
 	}
+	c.ClientCacheEvictor.Register(cacheKubeClusterClient)
 	c.CacheKcpSharedInformerFactory = kcpinformers.NewSharedInformerFactoryWithOptions(
 		cacheKcpClusterClient,
 		resyncPeriod,
@@ -282,6 +289,7 @@ func NewConfig(ctx context.Context, opts kcpserveroptions.CompletedOptions) (*Co
 	if err != nil {
 		return nil, err
 	}
+	c.ClientCacheEvictor.Register(c.CacheDynamicClient)
 
 	// Setup kcp * informers, but those will need the identities for the APIExports used to make the APIs available.
 	// The identities are not known before we can get them from the APIExports via the loopback client or from the root shard in case this is a non-root shard,
@@ -302,6 +310,7 @@ func NewConfig(ctx context.Context, opts kcpserveroptions.CompletedOptions) (*Co
 		if err != nil {
 			return nil, err
 		}
+		c.ClientCacheEvictor.Register(c.RootShardKcpClusterClient)
 
 		c.IdentityConfig = rest.CopyConfig(c.GenericConfig.LoopbackClientConfig)
 		c.IdentityConfig.Wrap(kcpShardIdentityRoundTripper)
@@ -309,6 +318,7 @@ func NewConfig(ctx context.Context, opts kcpserveroptions.CompletedOptions) (*Co
 		if err != nil {
 			return nil, err
 		}
+		c.ClientCacheEvictor.Register(c.KcpClusterClient)
 	} else {
 		// The informers here are not used before the informers are actually started (i.e. no race).
 
@@ -317,6 +327,7 @@ func NewConfig(ctx context.Context, opts kcpserveroptions.CompletedOptions) (*Co
 		if err != nil {
 			return nil, err
 		}
+		c.ClientCacheEvictor.Register(c.KcpClusterClient)
 		c.RootShardKcpClusterClient = c.KcpClusterClient
 	}
 
@@ -326,6 +337,7 @@ func NewConfig(ctx context.Context, opts kcpserveroptions.CompletedOptions) (*Co
 	if err != nil {
 		return nil, err
 	}
+	c.ClientCacheEvictor.Register(informerKcpClient)
 	c.KcpSharedInformerFactory = kcpinformers.NewSharedInformerFactoryWithOptions(
 		informerKcpClient,
 		resyncPeriod,
@@ -334,6 +346,7 @@ func NewConfig(ctx context.Context, opts kcpserveroptions.CompletedOptions) (*Co
 	if err != nil {
 		return nil, err
 	}
+	c.ClientCacheEvictor.Register(c.DeepSARClient)
 
 	c.LogicalClusterAdminConfig = rest.CopyConfig(c.GenericConfig.LoopbackClientConfig)
 	if len(c.Options.Extra.LogicalClusterAdminKubeconfig) > 0 {
@@ -355,6 +368,7 @@ func NewConfig(ctx context.Context, opts kcpserveroptions.CompletedOptions) (*Co
 	if err != nil {
 		return nil, err
 	}
+	c.ClientCacheEvictor.Register(externalKubeClient)
 	opts.Extra.ServiceAccountCache.SetKubeShardClient(externalKubeClient)
 	opts.Extra.ServiceAccountCache.SetInformers(c.KcpSharedInformerFactory)
 
@@ -363,6 +377,7 @@ func NewConfig(ctx context.Context, opts kcpserveroptions.CompletedOptions) (*Co
 	if err != nil {
 		return nil, err
 	}
+	c.ClientCacheEvictor.Register(c.ApiExtensionsClusterClient)
 	c.ApiExtensionsSharedInformerFactory = kcpapiextensionsinformers.NewSharedInformerFactoryWithOptions(
 		c.ApiExtensionsClusterClient,
 		resyncPeriod,
@@ -372,6 +387,7 @@ func NewConfig(ctx context.Context, opts kcpserveroptions.CompletedOptions) (*Co
 	if err != nil {
 		return nil, err
 	}
+	c.ClientCacheEvictor.Register(c.CacheApiExtensionsClusterClient)
 	c.CacheApiExtensionsSharedInformerFactory = kcpapiextensionsinformers.NewSharedInformerFactoryWithOptions(
 		c.CacheApiExtensionsClusterClient,
 		resyncPeriod,
@@ -382,6 +398,7 @@ func NewConfig(ctx context.Context, opts kcpserveroptions.CompletedOptions) (*Co
 	if err != nil {
 		return nil, err
 	}
+	c.ClientCacheEvictor.Register(c.DynamicClusterClient)
 
 	if err := opts.Authorization.ApplyTo(ctx, c.GenericConfig, c.KubeSharedInformerFactory, c.CacheKubeSharedInformerFactory, c.KcpSharedInformerFactory, c.CacheKcpSharedInformerFactory); err != nil {
 		return nil, err
@@ -406,11 +423,13 @@ func NewConfig(ctx context.Context, opts kcpserveroptions.CompletedOptions) (*Co
 	if err != nil {
 		return nil, err
 	}
+	c.ClientCacheEvictor.Register(c.BootstrapApiExtensionsClusterClient)
 
 	c.BootstrapDynamicClusterClient, err = kcpdynamic.NewForConfig(bootstrapConfig)
 	if err != nil {
 		return nil, err
 	}
+	c.ClientCacheEvictor.Register(c.BootstrapDynamicClusterClient)
 
 	if err := opts.GenericControlPlane.Audit.ApplyTo(c.GenericConfig); err != nil {
 		return nil, err
@@ -479,6 +498,7 @@ func NewConfig(ctx context.Context, opts kcpserveroptions.CompletedOptions) (*Co
 		if err != nil {
 			return nil, fmt.Errorf("failed to create external kcp client for workspace authentication: %w", err)
 		}
+		c.ClientCacheEvictor.Register(externalKcpClient)
 
 		wacCache := shardlookup.NewTTLCache[*tenancyv1alpha1.WorkspaceAuthenticationConfiguration]()
 		wacCache.StartWithContext(ctx)

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -165,6 +165,7 @@ func (s *Server) installClusterRoleAggregationController(ctx context.Context, co
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kubeClient)
 	c := clusterroleaggregation.NewClusterRoleAggregation(
 		s.KubeSharedInformerFactory.Rbac().V1().ClusterRoles(),
 		kubeClient.RbacV1())
@@ -189,10 +190,12 @@ func (s *Server) installKubeNamespaceController(ctx context.Context, config *res
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kubeClient)
 	metadata, err := kcpmetadata.NewForConfig(config)
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(metadata)
 
 	discoverResourcesFn := func(clusterName logicalcluster.Path) ([]*metav1.APIResourceList, error) {
 		logicalClusterConfig := rest.CopyConfig(config)
@@ -238,6 +241,7 @@ func (s *Server) installKubeServiceAccountController(ctx context.Context, config
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kubeClient)
 
 	c, err := serviceaccountcontroller.NewServiceAccountsController(
 		klog.FromContext(ctx).WithValues("controller", controllerName),
@@ -271,6 +275,7 @@ func (s *Server) installKubeServiceAccountTokenController(ctx context.Context, c
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kubeClient)
 
 	serviceAccountKeyFile := s.Options.Controllers.SAController.ServiceAccountKeyFile
 	if len(serviceAccountKeyFile) == 0 {
@@ -333,6 +338,7 @@ func (s *Server) installRootCAConfigMapController(ctx context.Context, config *r
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kubeClient)
 
 	// TODO(jmprusi): We should make the CA loading dynamic when the file changes on disk.
 	caDataPath := s.Options.Controllers.SAController.RootCAFile
@@ -376,6 +382,7 @@ func (s *Server) installKubeValidatingAdmissionPolicyStatusController(_ context.
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kubeClient)
 
 	schemaResolver := resolver.NewDefinitionsSchemaResolver(openapi.GetOpenAPIDefinitions, k8sscheme.Scheme, apiextensionsscheme.Scheme)
 
@@ -386,6 +393,7 @@ func (s *Server) installKubeValidatingAdmissionPolicyStatusController(_ context.
 		if err != nil {
 			return nil, err
 		}
+		s.ClientCacheEvictor.Register(kubeClient)
 
 		discoveryClient := memory.NewMemCacheClient(kubeClient.Cluster(clusterName).Discovery())
 
@@ -435,6 +443,7 @@ func (s *Server) installTenancyLogicalClusterController(ctx context.Context, con
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kubeClusterClient)
 
 	controller := tenancylogicalcluster.NewController(
 		kubeClusterClient,
@@ -464,10 +473,12 @@ func (s *Server) installLogicalClusterDeletionController(ctx context.Context, co
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kcpClusterClient)
 	metadataClusterClient, err := kcpmetadata.NewForConfig(config)
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(metadataClusterClient)
 	discoverResourcesFn := func(clusterName logicalcluster.Path) ([]*metav1.APIResourceList, error) {
 		logicalClusterConfig := rest.CopyConfig(config)
 		logicalClusterConfig.Host += clusterName.RequestPath()
@@ -481,6 +492,7 @@ func (s *Server) installLogicalClusterDeletionController(ctx context.Context, co
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kubeClusterClient)
 
 	logicalClusterDeletionController := logicalclusterdeletion.NewController(
 		kubeClusterClient,
@@ -515,10 +527,12 @@ func (s *Server) installWorkspaceScheduler(ctx context.Context, config *rest.Con
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kcpClusterClient)
 	kubeClusterClient, err := kcpkubernetesclientset.NewForConfig(workspaceConfig)
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kubeClusterClient)
 
 	logicalClusterAdminConfig = rest.CopyConfig(logicalClusterAdminConfig)
 	logicalClusterAdminConfig = rest.AddUserAgent(logicalClusterAdminConfig, workspace.ControllerName+"+"+s.Options.Extra.ShardName)
@@ -566,6 +580,7 @@ func (s *Server) installWorkspaceScheduler(ctx context.Context, config *rest.Con
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kcpClusterClient)
 
 	var workspaceShardController *shard.Controller
 	if s.Options.Extra.ShardName == corev1alpha1.RootShard {
@@ -599,6 +614,7 @@ func (s *Server) installWorkspaceScheduler(ctx context.Context, config *rest.Con
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kcpClusterClient)
 
 	workspaceTypeController, err := workspacetype.NewController(
 		kcpClusterClient,
@@ -634,11 +650,13 @@ func (s *Server) installWorkspaceScheduler(ctx context.Context, config *rest.Con
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(dynamicClusterClient)
 
 	bootstrapKcpClusterClient, err := kcpclientset.NewForConfig(bootstrapConfig)
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(bootstrapKcpClusterClient)
 
 	universalController, err := bootstrap.NewController(
 		dynamicClusterClient,
@@ -678,11 +696,13 @@ func (s *Server) installWorkspaceMountsScheduler(ctx context.Context, config *re
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kcpClusterClient)
 
 	dynamicClusterClient, err := kcpdynamic.NewForConfig(workspaceConfig)
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(dynamicClusterClient)
 
 	workspaceMountsController, err := workspacemounts.NewController(
 		kcpClusterClient,
@@ -719,6 +739,7 @@ func (s *Server) installLogicalCluster(ctx context.Context, config *rest.Config)
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kcpClusterClient)
 
 	logicalClusterController, err := logicalclusterctrl.NewController(
 		s.CompletedConfig.ShardExternalURL,
@@ -752,11 +773,13 @@ func (s *Server) installAPIBindingController(ctx context.Context, config *rest.C
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kcpClusterClient)
 
 	crdClusterClient, err := kcpapiextensionsclientset.NewForConfig(apiBindingConfig)
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(crdClusterClient)
 
 	c, err := apibinding.NewController(
 		crdClusterClient,
@@ -804,10 +827,12 @@ func (s *Server) installAPIBindingController(ctx context.Context, config *rest.C
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kcpClusterClient)
 	dynamicClusterClient, err := kcpdynamic.NewForConfig(permissionClaimLabelConfig)
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(dynamicClusterClient)
 
 	permissionClaimLabelController, err := permissionclaimlabel.NewController(
 		kcpClusterClient,
@@ -844,10 +869,12 @@ func (s *Server) installAPIBindingController(ctx context.Context, config *rest.C
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kcpClusterClient)
 	dynamicClusterClient, err = kcpdynamic.NewForConfig(resourceConfig)
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(dynamicClusterClient)
 	permissionClaimLabelResourceController, err := permissionclaimlabel.NewResourceController(
 		kcpClusterClient,
 		dynamicClusterClient,
@@ -883,10 +910,12 @@ func (s *Server) installAPIBindingController(ctx context.Context, config *rest.C
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kcpClusterClient)
 	metadataClient, err := kcpmetadata.NewForConfig(deletionConfig)
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(metadataClient)
 	apibindingDeletionController := apibindingdeletion.NewController(
 		metadataClient,
 		kcpClusterClient,
@@ -933,6 +962,7 @@ func (s *Server) installDefaultAPIBindingController(ctx context.Context, config 
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kcpClusterClient)
 
 	c, err := defaultapibindinglifecycle.NewDefaultAPIBindingController(
 		kcpClusterClient,
@@ -1003,10 +1033,12 @@ func (s *Server) installAPIBinderController(ctx context.Context, config *rest.Co
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(initializingWorkspacesKcpClusterClient)
 	informerClient, err := kcpclientset.NewForConfig(config)
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(informerClient)
 
 	// This informer factory is created here because it is specifically against the initializing workspaces virtual
 	// workspace.
@@ -1058,6 +1090,7 @@ func (s *Server) installCRDCleanupController(ctx context.Context, config *rest.C
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(crdClusterClient)
 
 	c, err := crdcleanup.NewController(
 		s.ApiExtensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions(),
@@ -1094,6 +1127,7 @@ func (s *Server) installLogicalClusterCleanupController(ctx context.Context, con
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kcpClusterClient)
 
 	c, err := logicalclustercleanup.NewController(
 		kcpClusterClient,
@@ -1127,10 +1161,12 @@ func (s *Server) installAPIExportController(ctx context.Context, config *rest.Co
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kcpClusterClient)
 	kubeClusterClient, err := kcpkubernetesclientset.NewForConfig(config)
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kubeClusterClient)
 
 	c, err := apiexport.NewController(
 		kcpClusterClient,
@@ -1172,6 +1208,7 @@ func (s *Server) installApisReplicateClusterRoleControllers(ctx context.Context,
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kubeClusterClient)
 
 	c := apisreplicateclusterrole.NewController(
 		kubeClusterClient,
@@ -1200,6 +1237,7 @@ func (s *Server) installCoreReplicateClusterRoleControllers(ctx context.Context,
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kubeClusterClient)
 
 	c := coresreplicateclusterrole.NewController(
 		kubeClusterClient,
@@ -1230,6 +1268,7 @@ func (s *Server) installApisReplicateClusterRoleBindingControllers(ctx context.C
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kubeClusterClient)
 
 	c := apisreplicateclusterrolebinding.NewController(
 		kubeClusterClient,
@@ -1258,6 +1297,7 @@ func (s *Server) installApisReplicateLogicalClusterControllers(ctx context.Conte
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kcpClusterClient)
 
 	c := apisreplicatelogicalcluster.NewController(
 		kcpClusterClient,
@@ -1286,6 +1326,7 @@ func (s *Server) installTenancyReplicateLogicalClusterControllers(ctx context.Co
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kcpClusterClient)
 
 	c := tenancyreplicatelogicalcluster.NewController(
 		kcpClusterClient,
@@ -1314,6 +1355,7 @@ func (s *Server) installCoreReplicateClusterRoleBindingControllers(ctx context.C
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kubeClusterClient)
 
 	c := corereplicateclusterrolebinding.NewController(
 		kubeClusterClient,
@@ -1344,6 +1386,7 @@ func (s *Server) installTenancyReplicateClusterRoleControllers(ctx context.Conte
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kubeClusterClient)
 
 	c := tenancyreplicateclusterrole.NewController(
 		kubeClusterClient,
@@ -1372,6 +1415,7 @@ func (s *Server) installTenancyReplicateClusterRoleBindingControllers(ctx contex
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kubeClusterClient)
 
 	c := tenancyreplicateclusterrolebinding.NewController(
 		kubeClusterClient,
@@ -1401,6 +1445,7 @@ func (s *Server) installAPIExportEndpointSliceController(_ context.Context, conf
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kcpClusterClient)
 
 	c, err := apiexportendpointslice.NewController(
 		s.KcpSharedInformerFactory.Apis().V1alpha1().APIExportEndpointSlices(),
@@ -1436,6 +1481,7 @@ func (s *Server) installAPIExportEndpointSliceURLsController(_ context.Context, 
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kcpClusterClient)
 
 	c, err := apiexportendpointsliceurls.NewController(
 		s.Options.Extra.ShardName,
@@ -1476,6 +1522,7 @@ func (s *Server) installPartitionSetController(ctx context.Context, config *rest
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kcpClusterClient)
 
 	c, err := partitionset.NewController(
 		s.KcpSharedInformerFactory.Topology().V1alpha1().PartitionSets(),
@@ -1509,6 +1556,7 @@ func (s *Server) installExtraAnnotationSyncController(ctx context.Context, confi
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kcpClusterClient)
 
 	c, err := extraannotationsync.NewController(kcpClusterClient,
 		s.KcpSharedInformerFactory.Apis().V1alpha2().APIExports(),
@@ -1543,6 +1591,7 @@ func (s *Server) installKubeQuotaController(
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kubeClusterClient)
 
 	// TODO(ncdc): should we make these configurable?
 	const (
@@ -1593,6 +1642,7 @@ func (s *Server) installApiExportIdentityController(ctx context.Context, config 
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kubeClusterClient)
 	c, err := identitycache.NewApiExportIdentityProviderController(kubeClusterClient, s.CacheKcpSharedInformerFactory.Apis().V1alpha2().APIExports(), s.KubeSharedInformerFactory.Core().V1().ConfigMaps())
 	if err != nil {
 		return err
@@ -1644,11 +1694,13 @@ func (s *Server) installGarbageCollectorController(ctx context.Context, config *
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kubeClusterClient)
 
 	metadataClient, err := kcpmetadata.NewForConfig(config)
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(metadataClient)
 
 	// TODO: make it configurable
 	// TODO(ntnn): would be great to scale workers by number of
@@ -1750,6 +1802,7 @@ func (s *Server) installCacheController(ctx context.Context, config *rest.Config
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(cacheDynClient)
 
 	// NOTE: keep `config` unaltered so there isn't cross-use between controllers installed here.
 	workspaceConfig := rest.CopyConfig(config)
@@ -1758,10 +1811,12 @@ func (s *Server) installCacheController(ctx context.Context, config *rest.Config
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kcpClusterClient)
 	dynamicClient, err := kcpdynamic.NewForConfig(workspaceConfig)
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(dynamicClient)
 
 	cachedResourceInformer := s.KcpSharedInformerFactory.Cache().V1alpha1().CachedResources()
 	cachedResourceEndpointSliceInformer := s.KcpSharedInformerFactory.Cache().V1alpha1().CachedResourceEndpointSlices()
@@ -1811,6 +1866,7 @@ func (s *Server) installCachedResourceEndpointSliceController(ctx context.Contex
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kcpClusterClient)
 	c, err := cachedresourceendpointslice.NewController(
 		s.KcpSharedInformerFactory.Cache().V1alpha1().CachedResourceEndpointSlices(),
 		s.CacheKcpSharedInformerFactory.Cache().V1alpha1().CachedResources(),
@@ -1849,6 +1905,7 @@ func (s *Server) installCachedResourceEndpointSliceURLsController(_ context.Cont
 	if err != nil {
 		return err
 	}
+	s.ClientCacheEvictor.Register(kcpClusterClient)
 
 	c, err := cachedresourceendpointsliceurls.NewController(
 		s.Options.Extra.ShardName,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -493,6 +493,7 @@ func (s *Server) Run(ctx context.Context) error {
 		go s.CacheKcpSharedInformerFactory.Apis().V1alpha2().APIExports().Informer().Run(hookContext.Done())
 		go s.CacheKcpSharedInformerFactory.Cache().V1alpha1().CachedResources().Informer().Run(hookContext.Done())
 		go s.CacheKcpSharedInformerFactory.Cache().V1alpha1().CachedResourceEndpointSlices().Informer().Run(hookContext.Done())
+		installClientCacheEvictor(s.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters())
 		go s.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters().Informer().Run(hookContext.Done())
 		go s.KcpSharedInformerFactory.Cache().V1alpha1().CachedResources().Informer().Run(hookContext.Done())
 		go s.KcpSharedInformerFactory.Cache().V1alpha1().CachedResourceEndpointSlices().Informer().Run(hookContext.Done())

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -508,7 +508,7 @@ func (s *Server) Run(ctx context.Context) error {
 			return nil // don't klog.Fatal. This only happens when context is cancelled.
 		}
 		logger.Info("finished starting APIExport, APIBinding and LogicalCluster informers")
-		installClientCacheEvictor(hookCtx, s.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters())
+		s.ClientCacheEvictor.Run(hookCtx, s.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters())
 
 		if s.Options.Extra.ShardName == corev1alpha1.RootShard {
 			logger.Info("bootstrapping root workspace phase 0")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -493,7 +493,7 @@ func (s *Server) Run(ctx context.Context) error {
 		go s.CacheKcpSharedInformerFactory.Apis().V1alpha2().APIExports().Informer().Run(hookContext.Done())
 		go s.CacheKcpSharedInformerFactory.Cache().V1alpha1().CachedResources().Informer().Run(hookContext.Done())
 		go s.CacheKcpSharedInformerFactory.Cache().V1alpha1().CachedResourceEndpointSlices().Informer().Run(hookContext.Done())
-		installClientCacheEvictor(s.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters())
+		installClientCacheEvictor(ctx, s.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters())
 		go s.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters().Informer().Run(hookContext.Done())
 		go s.KcpSharedInformerFactory.Cache().V1alpha1().CachedResources().Informer().Run(hookContext.Done())
 		go s.KcpSharedInformerFactory.Cache().V1alpha1().CachedResourceEndpointSlices().Informer().Run(hookContext.Done())

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -493,7 +493,6 @@ func (s *Server) Run(ctx context.Context) error {
 		go s.CacheKcpSharedInformerFactory.Apis().V1alpha2().APIExports().Informer().Run(hookContext.Done())
 		go s.CacheKcpSharedInformerFactory.Cache().V1alpha1().CachedResources().Informer().Run(hookContext.Done())
 		go s.CacheKcpSharedInformerFactory.Cache().V1alpha1().CachedResourceEndpointSlices().Informer().Run(hookContext.Done())
-		installClientCacheEvictor(hookCtx, s.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters())
 		go s.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters().Informer().Run(hookContext.Done())
 		go s.KcpSharedInformerFactory.Cache().V1alpha1().CachedResources().Informer().Run(hookContext.Done())
 		go s.KcpSharedInformerFactory.Cache().V1alpha1().CachedResourceEndpointSlices().Informer().Run(hookContext.Done())
@@ -509,6 +508,7 @@ func (s *Server) Run(ctx context.Context) error {
 			return nil // don't klog.Fatal. This only happens when context is cancelled.
 		}
 		logger.Info("finished starting APIExport, APIBinding and LogicalCluster informers")
+		installClientCacheEvictor(hookCtx, s.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters())
 
 		if s.Options.Extra.ShardName == corev1alpha1.RootShard {
 			logger.Info("bootstrapping root workspace phase 0")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -493,7 +493,7 @@ func (s *Server) Run(ctx context.Context) error {
 		go s.CacheKcpSharedInformerFactory.Apis().V1alpha2().APIExports().Informer().Run(hookContext.Done())
 		go s.CacheKcpSharedInformerFactory.Cache().V1alpha1().CachedResources().Informer().Run(hookContext.Done())
 		go s.CacheKcpSharedInformerFactory.Cache().V1alpha1().CachedResourceEndpointSlices().Informer().Run(hookContext.Done())
-		installClientCacheEvictor(ctx, s.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters())
+		installClientCacheEvictor(hookCtx, s.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters())
 		go s.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters().Informer().Run(hookContext.Done())
 		go s.KcpSharedInformerFactory.Cache().V1alpha1().CachedResources().Informer().Run(hookContext.Done())
 		go s.KcpSharedInformerFactory.Cache().V1alpha1().CachedResourceEndpointSlices().Informer().Run(hookContext.Done())

--- a/staging/src/github.com/kcp-dev/apimachinery/pkg/client/constructor.go
+++ b/staging/src/github.com/kcp-dev/apimachinery/pkg/client/constructor.go
@@ -19,7 +19,6 @@ package client
 import (
 	"net/http"
 	"sync"
-	"weak"
 
 	"k8s.io/client-go/rest"
 
@@ -35,72 +34,16 @@ type Constructor[R any] struct {
 type Cache[R any] interface {
 	ClusterOrDie(clusterPath logicalcluster.Path) R
 	Cluster(clusterPath logicalcluster.Path) (R, error)
-	// Evict drops the cached client for clusterPath, if any. Used to release
-	// per-cluster client state (REST clients, codec factories, parsed
-	// schemas) when a logical cluster is deleted. Safe to call concurrently
-	// with Cluster / ClusterOrDie. No-op if the path is not cached.
 	Evict(clusterPath logicalcluster.Path)
 }
 
-// evictorRef is the value the registry tracks via a weak pointer. Each
-// clientCache holds its own ref as a struct field, so the ref stays alive
-// exactly as long as the cache does. Once the cache becomes unreachable
-// from outside the registry, ref dies with it and the weak entry can be
-// pruned.
-type evictorRef struct {
-	evict func(clusterPath logicalcluster.Path)
-}
-
-var (
-	evictorsMu sync.Mutex
-	evictors   []weak.Pointer[evictorRef]
-)
-
-// registerEvictor adds ref to the weak registry. The registry must not hold
-// a strong reference to ref — that would re-introduce the leak this whole
-// mechanism exists to avoid.
-func registerEvictor(ref *evictorRef) {
-	evictorsMu.Lock()
-	defer evictorsMu.Unlock()
-	evictors = append(evictors, weak.Make(ref))
-}
-
-// EvictCluster notifies every registered cache that clusterPath has been
-// deleted and its cached client (and everything that client transitively
-// pins — REST client, codec factory, JSON decoder state, OpenAPI schemas)
-// can be released. Wire this to a LogicalCluster delete handler to bound
-// retained memory per workspace lifetime. See
-// https://github.com/kcp-dev/kcp/issues/4071.
-//
-// Dead entries (caches whose only remaining reference was the weak entry
-// in this registry) are pruned in-place during the iteration.
-func EvictCluster(clusterPath logicalcluster.Path) {
-	evictorsMu.Lock()
-	live := evictors[:0]
-	alive := make([]*evictorRef, 0, len(evictors))
-	for _, wp := range evictors {
-		ref := wp.Value()
-		if ref == nil {
-			continue
-		}
-		live = append(live, wp)
-		alive = append(alive, ref)
-	}
-	evictors = live
-	evictorsMu.Unlock()
-	for _, ref := range alive {
-		ref.evict(clusterPath)
-	}
-}
-
 // NewCache creates a new client factory cache using the given constructor.
-// The cache is auto-registered with the package-level EvictCluster fan-out
-// so per-cluster entries can be released when a LogicalCluster is deleted.
-// The registry holds the cache weakly: if all references to the returned
-// Cache are dropped, it becomes eligible for GC and is pruned from the
-// registry lazily.
 func NewCache[R any](cfg *rest.Config, client *http.Client, constructor *Constructor[R]) Cache[R] {
-	c := &clientCache[R]{
+	return newClientCache(cfg, client, constructor)
+}
+
+func newClientCache[R any](cfg *rest.Config, client *http.Client, constructor *Constructor[R]) *clientCache[R] {
+	return &clientCache[R]{
 		cfg:         cfg,
 		client:      client,
 		constructor: constructor,
@@ -109,9 +52,6 @@ func NewCache[R any](cfg *rest.Config, client *http.Client, constructor *Constru
 		clientsByClusterPath: map[logicalcluster.Path]R{},
 		evicted:              map[logicalcluster.Path]struct{}{},
 	}
-	c.evictRef = &evictorRef{evict: c.Evict}
-	registerEvictor(c.evictRef)
-	return c
 }
 
 type clientCache[R any] struct {
@@ -132,12 +72,6 @@ type clientCache[R any] struct {
 	// ~26B map-bucket overhead ≈ ~60B. 100k churned workspaces ≈ ~6MB,
 	// which is bounded and not worth GCing.
 	evicted map[logicalcluster.Path]struct{}
-
-	// evictRef anchors the entry registered in the package-level evictor
-	// registry. The registry holds it weakly, so this field is what keeps
-	// the entry alive: when the cache is GC'd, evictRef dies with it and
-	// the weak entry can be pruned lazily.
-	evictRef *evictorRef
 }
 
 // ClusterOrDie returns a new client scoped to the given logical cluster, or panics if there

--- a/staging/src/github.com/kcp-dev/apimachinery/pkg/client/constructor.go
+++ b/staging/src/github.com/kcp-dev/apimachinery/pkg/client/constructor.go
@@ -34,11 +34,55 @@ type Constructor[R any] struct {
 type Cache[R any] interface {
 	ClusterOrDie(clusterPath logicalcluster.Path) R
 	Cluster(clusterPath logicalcluster.Path) (R, error)
+	// Evict drops the cached client for clusterPath, if any. Used to release
+	// per-cluster client state (REST clients, codec factories, parsed
+	// schemas) when a logical cluster is deleted. Safe to call concurrently
+	// with Cluster / ClusterOrDie. No-op if the path is not cached.
+	Evict(clusterPath logicalcluster.Path)
+}
+
+// Evictor is the non-generic subset of Cache used by EvictCluster to fan
+// eviction out to every registered cache. Every cache returned by NewCache
+// is auto-registered. Callers that wrap or substitute caches may register
+// their own implementation via RegisterEvictor.
+type Evictor interface {
+	Evict(clusterPath logicalcluster.Path)
+}
+
+var (
+	evictorsMu sync.RWMutex
+	evictors   []Evictor
+)
+
+// RegisterEvictor adds e to the set of caches notified by EvictCluster.
+// NewCache calls this automatically.
+func RegisterEvictor(e Evictor) {
+	evictorsMu.Lock()
+	defer evictorsMu.Unlock()
+	evictors = append(evictors, e)
+}
+
+// EvictCluster notifies every registered cache that clusterPath has been
+// deleted and its cached client (and everything that client transitively
+// pins — REST client, codec factory, JSON decoder state, OpenAPI schemas)
+// can be released. Wire this to a LogicalCluster delete handler to bound
+// retained memory per workspace lifetime. See
+// https://github.com/kcp-dev/kcp/issues/4071.
+func EvictCluster(clusterPath logicalcluster.Path) {
+	evictorsMu.RLock()
+	snapshot := make([]Evictor, len(evictors))
+	copy(snapshot, evictors)
+	evictorsMu.RUnlock()
+	for _, e := range snapshot {
+		e.Evict(clusterPath)
+	}
 }
 
 // NewCache creates a new client factory cache using the given constructor.
+// The cache is auto-registered with the package-level EvictCluster fan-out
+// so per-cluster entries can be released when a LogicalCluster is deleted.
 func NewCache[R any](cfg *rest.Config, client *http.Client, constructor *Constructor[R]) Cache[R] {
-	return &clientCache[R]{
+	c := &clientCache[R]{
 		cfg:         cfg,
 		client:      client,
 		constructor: constructor,
@@ -46,6 +90,8 @@ func NewCache[R any](cfg *rest.Config, client *http.Client, constructor *Constru
 		RWMutex:              &sync.RWMutex{},
 		clientsByClusterPath: map[logicalcluster.Path]R{},
 	}
+	RegisterEvictor(c)
+	return c
 }
 
 type clientCache[R any] struct {
@@ -98,4 +144,11 @@ func (c *clientCache[R]) Cluster(clusterPath logicalcluster.Path) (R, error) {
 	c.clientsByClusterPath[clusterPath] = instance
 
 	return instance, nil
+}
+
+// Evict drops the cached client for clusterPath, if any.
+func (c *clientCache[R]) Evict(clusterPath logicalcluster.Path) {
+	c.Lock()
+	defer c.Unlock()
+	delete(c.clientsByClusterPath, clusterPath)
 }

--- a/staging/src/github.com/kcp-dev/apimachinery/pkg/client/constructor.go
+++ b/staging/src/github.com/kcp-dev/apimachinery/pkg/client/constructor.go
@@ -89,6 +89,7 @@ func NewCache[R any](cfg *rest.Config, client *http.Client, constructor *Constru
 
 		RWMutex:              &sync.RWMutex{},
 		clientsByClusterPath: map[logicalcluster.Path]R{},
+		evictGen:             map[logicalcluster.Path]uint64{},
 	}
 	RegisterEvictor(c)
 	return c
@@ -101,6 +102,16 @@ type clientCache[R any] struct {
 
 	*sync.RWMutex
 	clientsByClusterPath map[logicalcluster.Path]R
+	// evictGen is bumped on every Evict(path). A Cluster() build whose captured
+	// generation no longer matches at write time means an eviction raced in
+	// mid-build; the freshly-built client is returned to the caller but not
+	// cached, so we don't resurrect state for a deleted cluster.
+	//
+	// Entries are never deleted, so the map grows with the lifetime set of
+	// evicted paths. Per entry: ~16B string header + ~16-32B path bytes + 8B
+	// uint64 + ~26B map-bucket overhead ≈ ~70B. 100k churned workspaces ≈ ~7MB,
+	// which is bounded and not worth GCing.
+	evictGen map[logicalcluster.Path]uint64
 }
 
 // ClusterOrDie returns a new client scoped to the given logical cluster, or panics if there
@@ -122,6 +133,7 @@ func (c *clientCache[R]) Cluster(clusterPath logicalcluster.Path) (R, error) {
 	var exists bool
 	c.RLock()
 	cachedClient, exists = c.clientsByClusterPath[clusterPath]
+	genAtStart := c.evictGen[clusterPath]
 	c.RUnlock()
 	if exists {
 		return cachedClient, nil
@@ -140,6 +152,12 @@ func (c *clientCache[R]) Cluster(clusterPath logicalcluster.Path) (R, error) {
 	if exists {
 		return cachedClient, nil
 	}
+	if c.evictGen[clusterPath] != genAtStart {
+		// An Evict raced with this build. Hand the freshly-built client to the
+		// caller so its in-flight request can complete, but do not cache it —
+		// the cluster has been signalled as gone.
+		return instance, nil
+	}
 
 	c.clientsByClusterPath[clusterPath] = instance
 
@@ -151,4 +169,5 @@ func (c *clientCache[R]) Evict(clusterPath logicalcluster.Path) {
 	c.Lock()
 	defer c.Unlock()
 	delete(c.clientsByClusterPath, clusterPath)
+	c.evictGen[clusterPath]++
 }

--- a/staging/src/github.com/kcp-dev/apimachinery/pkg/client/constructor.go
+++ b/staging/src/github.com/kcp-dev/apimachinery/pkg/client/constructor.go
@@ -19,6 +19,7 @@ package client
 import (
 	"net/http"
 	"sync"
+	"weak"
 
 	"k8s.io/client-go/rest"
 
@@ -41,25 +42,27 @@ type Cache[R any] interface {
 	Evict(clusterPath logicalcluster.Path)
 }
 
-// Evictor is the non-generic subset of Cache used by EvictCluster to fan
-// eviction out to every registered cache. Every cache returned by NewCache
-// is auto-registered. Callers that wrap or substitute caches may register
-// their own implementation via RegisterEvictor.
-type Evictor interface {
-	Evict(clusterPath logicalcluster.Path)
+// evictorRef is the value the registry tracks via a weak pointer. Each
+// clientCache holds its own ref as a struct field, so the ref stays alive
+// exactly as long as the cache does. Once the cache becomes unreachable
+// from outside the registry, ref dies with it and the weak entry can be
+// pruned.
+type evictorRef struct {
+	evict func(clusterPath logicalcluster.Path)
 }
 
 var (
-	evictorsMu sync.RWMutex
-	evictors   []Evictor
+	evictorsMu sync.Mutex
+	evictors   []weak.Pointer[evictorRef]
 )
 
-// RegisterEvictor adds e to the set of caches notified by EvictCluster.
-// NewCache calls this automatically.
-func RegisterEvictor(e Evictor) {
+// registerEvictor adds ref to the weak registry. The registry must not hold
+// a strong reference to ref — that would re-introduce the leak this whole
+// mechanism exists to avoid.
+func registerEvictor(ref *evictorRef) {
 	evictorsMu.Lock()
 	defer evictorsMu.Unlock()
-	evictors = append(evictors, e)
+	evictors = append(evictors, weak.Make(ref))
 }
 
 // EvictCluster notifies every registered cache that clusterPath has been
@@ -68,19 +71,34 @@ func RegisterEvictor(e Evictor) {
 // can be released. Wire this to a LogicalCluster delete handler to bound
 // retained memory per workspace lifetime. See
 // https://github.com/kcp-dev/kcp/issues/4071.
+//
+// Dead entries (caches whose only remaining reference was the weak entry
+// in this registry) are pruned in-place during the iteration.
 func EvictCluster(clusterPath logicalcluster.Path) {
-	evictorsMu.RLock()
-	snapshot := make([]Evictor, len(evictors))
-	copy(snapshot, evictors)
-	evictorsMu.RUnlock()
-	for _, e := range snapshot {
-		e.Evict(clusterPath)
+	evictorsMu.Lock()
+	live := evictors[:0]
+	alive := make([]*evictorRef, 0, len(evictors))
+	for _, wp := range evictors {
+		ref := wp.Value()
+		if ref == nil {
+			continue
+		}
+		live = append(live, wp)
+		alive = append(alive, ref)
+	}
+	evictors = live
+	evictorsMu.Unlock()
+	for _, ref := range alive {
+		ref.evict(clusterPath)
 	}
 }
 
 // NewCache creates a new client factory cache using the given constructor.
 // The cache is auto-registered with the package-level EvictCluster fan-out
 // so per-cluster entries can be released when a LogicalCluster is deleted.
+// The registry holds the cache weakly: if all references to the returned
+// Cache are dropped, it becomes eligible for GC and is pruned from the
+// registry lazily.
 func NewCache[R any](cfg *rest.Config, client *http.Client, constructor *Constructor[R]) Cache[R] {
 	c := &clientCache[R]{
 		cfg:         cfg,
@@ -89,9 +107,10 @@ func NewCache[R any](cfg *rest.Config, client *http.Client, constructor *Constru
 
 		RWMutex:              &sync.RWMutex{},
 		clientsByClusterPath: map[logicalcluster.Path]R{},
-		evictGen:             map[logicalcluster.Path]uint64{},
+		evicted:              map[logicalcluster.Path]struct{}{},
 	}
-	RegisterEvictor(c)
+	c.evictRef = &evictorRef{evict: c.Evict}
+	registerEvictor(c.evictRef)
 	return c
 }
 
@@ -102,16 +121,23 @@ type clientCache[R any] struct {
 
 	*sync.RWMutex
 	clientsByClusterPath map[logicalcluster.Path]R
-	// evictGen is bumped on every Evict(path). A Cluster() build whose captured
-	// generation no longer matches at write time means an eviction raced in
-	// mid-build; the freshly-built client is returned to the caller but not
-	// cached, so we don't resurrect state for a deleted cluster.
+	// evicted records cluster paths that have been signalled as gone. Once
+	// a path appears here, Cluster() returns freshly-built clients to any
+	// in-flight caller but never re-caches them — caching for a deleted
+	// cluster would reintroduce the leak this whole mechanism exists to
+	// fix.
 	//
 	// Entries are never deleted, so the map grows with the lifetime set of
-	// evicted paths. Per entry: ~16B string header + ~16-32B path bytes + 8B
-	// uint64 + ~26B map-bucket overhead ≈ ~70B. 100k churned workspaces ≈ ~7MB,
+	// evicted paths. Per entry: ~16B string header + ~16-32B path bytes +
+	// ~26B map-bucket overhead ≈ ~60B. 100k churned workspaces ≈ ~6MB,
 	// which is bounded and not worth GCing.
-	evictGen map[logicalcluster.Path]uint64
+	evicted map[logicalcluster.Path]struct{}
+
+	// evictRef anchors the entry registered in the package-level evictor
+	// registry. The registry holds it weakly, so this field is what keeps
+	// the entry alive: when the cache is GC'd, evictRef dies with it and
+	// the weak entry can be pruned lazily.
+	evictRef *evictorRef
 }
 
 // ClusterOrDie returns a new client scoped to the given logical cluster, or panics if there
@@ -129,11 +155,9 @@ func (c *clientCache[R]) ClusterOrDie(clusterPath logicalcluster.Path) R {
 
 // Cluster returns a new client scoped to the given logical cluster.
 func (c *clientCache[R]) Cluster(clusterPath logicalcluster.Path) (R, error) {
-	var cachedClient R
-	var exists bool
 	c.RLock()
-	cachedClient, exists = c.clientsByClusterPath[clusterPath]
-	genAtStart := c.evictGen[clusterPath]
+	cachedClient, exists := c.clientsByClusterPath[clusterPath]
+	_, evicted := c.evicted[clusterPath]
 	c.RUnlock()
 	if exists {
 		return cachedClient, nil
@@ -145,6 +169,12 @@ func (c *clientCache[R]) Cluster(clusterPath logicalcluster.Path) (R, error) {
 		var result R
 		return result, err
 	}
+	if evicted {
+		// The cluster has been signalled as gone. Hand the freshly-built
+		// client to the in-flight caller so its request can complete, but
+		// don't resurrect cached state for a deleted cluster.
+		return instance, nil
+	}
 
 	c.Lock()
 	defer c.Unlock()
@@ -152,10 +182,9 @@ func (c *clientCache[R]) Cluster(clusterPath logicalcluster.Path) (R, error) {
 	if exists {
 		return cachedClient, nil
 	}
-	if c.evictGen[clusterPath] != genAtStart {
-		// An Evict raced with this build. Hand the freshly-built client to the
-		// caller so its in-flight request can complete, but do not cache it —
-		// the cluster has been signalled as gone.
+	if _, evicted := c.evicted[clusterPath]; evicted {
+		// An Evict raced with this build, or completed between our RUnlock
+		// and Lock. Same handling as above — return without caching.
 		return instance, nil
 	}
 
@@ -164,10 +193,11 @@ func (c *clientCache[R]) Cluster(clusterPath logicalcluster.Path) (R, error) {
 	return instance, nil
 }
 
-// Evict drops the cached client for clusterPath, if any.
+// Evict drops the cached client for clusterPath, if any, and records the
+// path so future Cluster() calls do not re-cache for it.
 func (c *clientCache[R]) Evict(clusterPath logicalcluster.Path) {
 	c.Lock()
 	defer c.Unlock()
 	delete(c.clientsByClusterPath, clusterPath)
-	c.evictGen[clusterPath]++
+	c.evicted[clusterPath] = struct{}{}
 }

--- a/staging/src/github.com/kcp-dev/apimachinery/pkg/client/constructor_test.go
+++ b/staging/src/github.com/kcp-dev/apimachinery/pkg/client/constructor_test.go
@@ -18,10 +18,8 @@ package client
 
 import (
 	"net/http"
-	"runtime"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"k8s.io/client-go/rest"
 
@@ -81,98 +79,5 @@ func TestClientCache_EvictDropsAndStopsCaching(t *testing.T) {
 	}
 	if got := builds.Load(); got != 3 {
 		t.Fatalf("expected 3 builds (initial + 2 post-evict), got %d", got)
-	}
-}
-
-func TestEvictCluster_FansOutToAllRegisteredCaches(t *testing.T) {
-	var buildsA, buildsB atomic.Int64
-	cacheA := newFakeCache(t, &buildsA)
-	cacheB := newFakeCache(t, &buildsB)
-	path := logicalcluster.NewPath("ws-fanout")
-
-	if _, err := cacheA.Cluster(path); err != nil {
-		t.Fatalf("cacheA Cluster: %v", err)
-	}
-	if _, err := cacheB.Cluster(path); err != nil {
-		t.Fatalf("cacheB Cluster: %v", err)
-	}
-
-	EvictCluster(path)
-
-	// Both caches should now treat the path as evicted and refuse to
-	// re-cache.
-	a1, _ := cacheA.Cluster(path)
-	a2, _ := cacheA.Cluster(path)
-	if a1 == a2 {
-		t.Fatalf("cacheA: expected re-eviction marker, got cached client")
-	}
-	b1, _ := cacheB.Cluster(path)
-	b2, _ := cacheB.Cluster(path)
-	if b1 == b2 {
-		t.Fatalf("cacheB: expected re-eviction marker, got cached client")
-	}
-}
-
-// TestRegistry_PrunesGCdCaches verifies that caches dropped by their owners
-// don't pin themselves alive through the registry. We can't directly force a
-// weak pointer to nil, so we drop the strong references, force GC, trigger
-// EvictCluster to compact, and assert the registry no longer holds the
-// dropped caches.
-func TestRegistry_PrunesGCdCaches(t *testing.T) {
-	// Drop any caches retained by previous tests in this binary so we start
-	// from a known floor.
-	flushRegistry()
-	if got := registrySize(); got != 0 {
-		t.Fatalf("expected empty registry after flush, got %d entries", got)
-	}
-
-	var builds atomic.Int64
-	// Scope the caches to an inner function so all strong references go
-	// out of scope before we force GC.
-	func() {
-		for range 5 {
-			c := newFakeCache(t, &builds)
-			_, _ = c.Cluster(logicalcluster.NewPath("ws-gc"))
-			_ = c
-		}
-	}()
-
-	if got := registrySize(); got != 5 {
-		t.Fatalf("expected 5 registry entries pre-GC, got %d", got)
-	}
-
-	// Drop our reference to anything that might be holding the caches and
-	// give the GC a chance to reclaim. weak.Pointer reclamation needs the
-	// underlying object to be unreachable AND the GC to have actually swept.
-	const attempts = 50
-	for range attempts {
-		runtime.GC()
-		runtime.GC()
-		EvictCluster(logicalcluster.NewPath("trigger-prune"))
-		if registrySize() == 0 {
-			return
-		}
-		time.Sleep(2 * time.Millisecond)
-	}
-	t.Fatalf("registry did not prune dead entries: still has %d", registrySize())
-}
-
-func registrySize() int {
-	evictorsMu.Lock()
-	defer evictorsMu.Unlock()
-	return len(evictors)
-}
-
-// flushRegistry forces the registry to compact, dropping any entries whose
-// underlying cache has been collected. Test-only helper.
-func flushRegistry() {
-	for range 50 {
-		runtime.GC()
-		runtime.GC()
-		before := registrySize()
-		EvictCluster(logicalcluster.NewPath("flush"))
-		if registrySize() == before {
-			return
-		}
 	}
 }

--- a/staging/src/github.com/kcp-dev/apimachinery/pkg/client/constructor_test.go
+++ b/staging/src/github.com/kcp-dev/apimachinery/pkg/client/constructor_test.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"net/http"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"k8s.io/client-go/rest"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+)
+
+type fakeClient struct{ id int64 }
+
+func newFakeCache(t *testing.T, builds *atomic.Int64) Cache[*fakeClient] {
+	t.Helper()
+	return NewCache(&rest.Config{}, &http.Client{}, &Constructor[*fakeClient]{
+		NewForConfigAndClient: func(_ *rest.Config, _ *http.Client) (*fakeClient, error) {
+			return &fakeClient{id: builds.Add(1)}, nil
+		},
+	})
+}
+
+func TestClientCache_CachesAcrossCalls(t *testing.T) {
+	var builds atomic.Int64
+	cache := newFakeCache(t, &builds)
+	path := logicalcluster.NewPath("ws-a")
+
+	first, err := cache.Cluster(path)
+	if err != nil {
+		t.Fatalf("first Cluster: %v", err)
+	}
+	second, err := cache.Cluster(path)
+	if err != nil {
+		t.Fatalf("second Cluster: %v", err)
+	}
+	if first != second {
+		t.Fatalf("expected cached client to be reused, got %p then %p", first, second)
+	}
+	if got := builds.Load(); got != 1 {
+		t.Fatalf("expected constructor called once, got %d", got)
+	}
+}
+
+func TestClientCache_EvictDropsAndStopsCaching(t *testing.T) {
+	var builds atomic.Int64
+	cache := newFakeCache(t, &builds)
+	path := logicalcluster.NewPath("ws-evict")
+
+	first, _ := cache.Cluster(path)
+	cache.Evict(path)
+
+	// After evict, Cluster() must build a fresh client (the old one is gone)
+	// and must NOT re-cache: subsequent calls must keep producing fresh
+	// clients, because the cluster has been signalled as deleted.
+	second, _ := cache.Cluster(path)
+	if first == second {
+		t.Fatalf("expected a fresh client after Evict, got the cached one")
+	}
+	third, _ := cache.Cluster(path)
+	if second == third {
+		t.Fatalf("expected Cluster() to keep building post-eviction (not cache), got identical clients")
+	}
+	if got := builds.Load(); got != 3 {
+		t.Fatalf("expected 3 builds (initial + 2 post-evict), got %d", got)
+	}
+}
+
+func TestEvictCluster_FansOutToAllRegisteredCaches(t *testing.T) {
+	var buildsA, buildsB atomic.Int64
+	cacheA := newFakeCache(t, &buildsA)
+	cacheB := newFakeCache(t, &buildsB)
+	path := logicalcluster.NewPath("ws-fanout")
+
+	if _, err := cacheA.Cluster(path); err != nil {
+		t.Fatalf("cacheA Cluster: %v", err)
+	}
+	if _, err := cacheB.Cluster(path); err != nil {
+		t.Fatalf("cacheB Cluster: %v", err)
+	}
+
+	EvictCluster(path)
+
+	// Both caches should now treat the path as evicted and refuse to
+	// re-cache.
+	a1, _ := cacheA.Cluster(path)
+	a2, _ := cacheA.Cluster(path)
+	if a1 == a2 {
+		t.Fatalf("cacheA: expected re-eviction marker, got cached client")
+	}
+	b1, _ := cacheB.Cluster(path)
+	b2, _ := cacheB.Cluster(path)
+	if b1 == b2 {
+		t.Fatalf("cacheB: expected re-eviction marker, got cached client")
+	}
+}
+
+// TestRegistry_PrunesGCdCaches verifies that caches dropped by their owners
+// don't pin themselves alive through the registry. We can't directly force a
+// weak pointer to nil, so we drop the strong references, force GC, trigger
+// EvictCluster to compact, and assert the registry no longer holds the
+// dropped caches.
+func TestRegistry_PrunesGCdCaches(t *testing.T) {
+	// Drop any caches retained by previous tests in this binary so we start
+	// from a known floor.
+	flushRegistry()
+	if got := registrySize(); got != 0 {
+		t.Fatalf("expected empty registry after flush, got %d entries", got)
+	}
+
+	var builds atomic.Int64
+	// Scope the caches to an inner function so all strong references go
+	// out of scope before we force GC.
+	func() {
+		for range 5 {
+			c := newFakeCache(t, &builds)
+			_, _ = c.Cluster(logicalcluster.NewPath("ws-gc"))
+			_ = c
+		}
+	}()
+
+	if got := registrySize(); got != 5 {
+		t.Fatalf("expected 5 registry entries pre-GC, got %d", got)
+	}
+
+	// Drop our reference to anything that might be holding the caches and
+	// give the GC a chance to reclaim. weak.Pointer reclamation needs the
+	// underlying object to be unreachable AND the GC to have actually swept.
+	const attempts = 50
+	for range attempts {
+		runtime.GC()
+		runtime.GC()
+		EvictCluster(logicalcluster.NewPath("trigger-prune"))
+		if registrySize() == 0 {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("registry did not prune dead entries: still has %d", registrySize())
+}
+
+func registrySize() int {
+	evictorsMu.Lock()
+	defer evictorsMu.Unlock()
+	return len(evictors)
+}
+
+// flushRegistry forces the registry to compact, dropping any entries whose
+// underlying cache has been collected. Test-only helper.
+func flushRegistry() {
+	for range 50 {
+		runtime.GC()
+		runtime.GC()
+		before := registrySize()
+		EvictCluster(logicalcluster.NewPath("flush"))
+		if registrySize() == before {
+			return
+		}
+	}
+}

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/client/clientset.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/client/clientset.go
@@ -35,6 +35,7 @@ import (
 
 type ClusterInterface interface {
 	Cluster(logicalcluster.Path) client.Interface
+	Evict(logicalcluster.Path)
 	Discovery() discovery.DiscoveryInterface
 	ApiextensionsV1() apiextensionsv1.ApiextensionsV1ClusterInterface
 	ApiextensionsV1beta1() apiextensionsv1beta1.ApiextensionsV1beta1ClusterInterface
@@ -72,6 +73,16 @@ func (c *ClusterClientset) Cluster(clusterPath logicalcluster.Path) client.Inter
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops cached clients for clusterPath across all per-group clients
+// and the top-level cluster cache, and prevents future caching for that
+// path.
+func (c *ClusterClientset) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
+	c.apiextensionsV1.Evict(clusterPath)
+	c.apiextensionsV1beta1.Evict(clusterPath)
+
 }
 
 // NewForConfig creates a new ClusterClientset for the given config.

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/client/fake/clientset.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/client/fake/clientset.go
@@ -110,6 +110,9 @@ func (c *ClusterClientset) Cluster(clusterPath logicalcluster.Path) clientset.In
 	}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *ClusterClientset) Evict(clusterPath logicalcluster.Path) {}
+
 // ApiextensionsV1 retrieves the ApiextensionsV1ClusterClient
 func (c *ClusterClientset) ApiextensionsV1() kcpapiextensionsv1.ApiextensionsV1ClusterInterface {
 	return &kcpfakeapiextensionsv1.ApiextensionsV1ClusterClient{Fake: &c.Fake}

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1/apiextensions_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1/apiextensions_client.go
@@ -37,6 +37,7 @@ type ApiextensionsV1ClusterInterface interface {
 
 type ApiextensionsV1ClusterScoper interface {
 	Cluster(logicalcluster.Path) apiextensionsv1.ApiextensionsV1Interface
+	Evict(logicalcluster.Path)
 }
 
 // ApiextensionsV1ClusterClient is used to interact with features provided by the apiextensions.k8s.io group.
@@ -49,6 +50,12 @@ func (c *ApiextensionsV1ClusterClient) Cluster(clusterPath logicalcluster.Path) 
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *ApiextensionsV1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *ApiextensionsV1ClusterClient) CustomResourceDefinitions() CustomResourceDefinitionClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1/fake/apiextensions_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1/fake/apiextensions_client.go
@@ -40,6 +40,9 @@ func (c *ApiextensionsV1ClusterClient) Cluster(clusterPath logicalcluster.Path) 
 	return &ApiextensionsV1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *ApiextensionsV1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *ApiextensionsV1ClusterClient) CustomResourceDefinitions() kcpapiextensionsv1.CustomResourceDefinitionClusterInterface {
 	return newFakeCustomResourceDefinitionClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1beta1/apiextensions_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1beta1/apiextensions_client.go
@@ -37,6 +37,7 @@ type ApiextensionsV1beta1ClusterInterface interface {
 
 type ApiextensionsV1beta1ClusterScoper interface {
 	Cluster(logicalcluster.Path) apiextensionsv1beta1.ApiextensionsV1beta1Interface
+	Evict(logicalcluster.Path)
 }
 
 // ApiextensionsV1beta1ClusterClient is used to interact with features provided by the apiextensions.k8s.io group.
@@ -49,6 +50,12 @@ func (c *ApiextensionsV1beta1ClusterClient) Cluster(clusterPath logicalcluster.P
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *ApiextensionsV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *ApiextensionsV1beta1ClusterClient) CustomResourceDefinitions() CustomResourceDefinitionClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1beta1/fake/apiextensions_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/apiextensions/client/typed/apiextensions/v1beta1/fake/apiextensions_client.go
@@ -40,6 +40,9 @@ func (c *ApiextensionsV1beta1ClusterClient) Cluster(clusterPath logicalcluster.P
 	return &ApiextensionsV1beta1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *ApiextensionsV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *ApiextensionsV1beta1ClusterClient) CustomResourceDefinitions() kcpapiextensionsv1beta1.CustomResourceDefinitionClusterInterface {
 	return newFakeCustomResourceDefinitionClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/discovery/clientset.go
+++ b/staging/src/github.com/kcp-dev/client-go/discovery/clientset.go
@@ -40,6 +40,12 @@ func (c *ClusterClientset) Cluster(clusterPath logicalcluster.Path) discovery.Di
 	return c.clientCache.ClusterOrDie(clusterPath)
 }
 
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *ClusterClientset) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
+}
+
 // NewForConfig creates a new ClusterClientset for the given config.
 // If config's RateLimiter is not set and QPS and Burst are acceptable,
 // NewForConfig will generate a rate-limiter in configShallowCopy.

--- a/staging/src/github.com/kcp-dev/client-go/discovery/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/discovery/interface.go
@@ -24,5 +24,6 @@ import (
 
 type DiscoveryClusterInterface interface {
 	Cluster(logicalcluster.Path) discovery.DiscoveryInterface
+	Evict(logicalcluster.Path)
 	discovery.DiscoveryInterface
 }

--- a/staging/src/github.com/kcp-dev/client-go/dynamic/clientset.go
+++ b/staging/src/github.com/kcp-dev/client-go/dynamic/clientset.go
@@ -45,6 +45,12 @@ func (c *ClusterClientset) Cluster(clusterPath logicalcluster.Path) dynamic.Inte
 	return c.clientCache.ClusterOrDie(clusterPath)
 }
 
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *ClusterClientset) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
+}
+
 func (c *ClusterClientset) Resource(resource schema.GroupVersionResource) ResourceClusterInterface {
 	return &ClusterResourceClient{clientCache: c.clientCache, resource: resource}
 }

--- a/staging/src/github.com/kcp-dev/client-go/dynamic/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/dynamic/interface.go
@@ -30,6 +30,7 @@ import (
 
 type ClusterInterface interface {
 	Cluster(logicalcluster.Path) dynamic.Interface
+	Evict(logicalcluster.Path)
 	Resource(resource schema.GroupVersionResource) ResourceClusterInterface
 }
 

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/clientset.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/clientset.go
@@ -86,6 +86,7 @@ import (
 
 type ClusterInterface interface {
 	Cluster(logicalcluster.Path) client.Interface
+	Evict(logicalcluster.Path)
 	Discovery() discovery.DiscoveryInterface
 	AdmissionregistrationV1() admissionregistrationv1.AdmissionregistrationV1ClusterInterface
 	AdmissionregistrationV1alpha1() admissionregistrationv1alpha1.AdmissionregistrationV1alpha1ClusterInterface
@@ -480,6 +481,67 @@ func (c *ClusterClientset) Cluster(clusterPath logicalcluster.Path) client.Inter
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops cached clients for clusterPath across all per-group clients
+// and the top-level cluster cache, and prevents future caching for that
+// path.
+func (c *ClusterClientset) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
+	c.admissionregistrationV1.Evict(clusterPath)
+	c.admissionregistrationV1alpha1.Evict(clusterPath)
+	c.admissionregistrationV1beta1.Evict(clusterPath)
+	c.internalV1alpha1.Evict(clusterPath)
+	c.appsV1.Evict(clusterPath)
+	c.appsV1beta1.Evict(clusterPath)
+	c.appsV1beta2.Evict(clusterPath)
+	c.authenticationV1.Evict(clusterPath)
+	c.authenticationV1alpha1.Evict(clusterPath)
+	c.authenticationV1beta1.Evict(clusterPath)
+	c.authorizationV1.Evict(clusterPath)
+	c.authorizationV1beta1.Evict(clusterPath)
+	c.autoscalingV1.Evict(clusterPath)
+	c.autoscalingV2.Evict(clusterPath)
+	c.batchV1.Evict(clusterPath)
+	c.batchV1beta1.Evict(clusterPath)
+	c.certificatesV1.Evict(clusterPath)
+	c.certificatesV1alpha1.Evict(clusterPath)
+	c.certificatesV1beta1.Evict(clusterPath)
+	c.coordinationV1.Evict(clusterPath)
+	c.coordinationV1alpha2.Evict(clusterPath)
+	c.coordinationV1beta1.Evict(clusterPath)
+	c.coreV1.Evict(clusterPath)
+	c.discoveryV1.Evict(clusterPath)
+	c.discoveryV1beta1.Evict(clusterPath)
+	c.eventsV1.Evict(clusterPath)
+	c.eventsV1beta1.Evict(clusterPath)
+	c.extensionsV1beta1.Evict(clusterPath)
+	c.flowcontrolV1.Evict(clusterPath)
+	c.flowcontrolV1beta1.Evict(clusterPath)
+	c.flowcontrolV1beta2.Evict(clusterPath)
+	c.flowcontrolV1beta3.Evict(clusterPath)
+	c.networkingV1.Evict(clusterPath)
+	c.networkingV1beta1.Evict(clusterPath)
+	c.nodeV1.Evict(clusterPath)
+	c.nodeV1alpha1.Evict(clusterPath)
+	c.nodeV1beta1.Evict(clusterPath)
+	c.policyV1.Evict(clusterPath)
+	c.policyV1beta1.Evict(clusterPath)
+	c.rbacV1.Evict(clusterPath)
+	c.rbacV1alpha1.Evict(clusterPath)
+	c.rbacV1beta1.Evict(clusterPath)
+	c.resourceV1.Evict(clusterPath)
+	c.resourceV1alpha3.Evict(clusterPath)
+	c.resourceV1beta1.Evict(clusterPath)
+	c.resourceV1beta2.Evict(clusterPath)
+	c.schedulingV1.Evict(clusterPath)
+	c.schedulingV1alpha2.Evict(clusterPath)
+	c.schedulingV1beta1.Evict(clusterPath)
+	c.storageV1.Evict(clusterPath)
+	c.storageV1alpha1.Evict(clusterPath)
+	c.storageV1beta1.Evict(clusterPath)
+	c.storagemigrationV1beta1.Evict(clusterPath)
+
 }
 
 // NewForConfig creates a new ClusterClientset for the given config.

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/fake/clientset.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/fake/clientset.go
@@ -263,6 +263,9 @@ func (c *ClusterClientset) Cluster(clusterPath logicalcluster.Path) clientset.In
 	}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *ClusterClientset) Evict(clusterPath logicalcluster.Path) {}
+
 // AdmissionregistrationV1 retrieves the AdmissionregistrationV1ClusterClient
 func (c *ClusterClientset) AdmissionregistrationV1() kcpadmissionregistrationv1.AdmissionregistrationV1ClusterInterface {
 	return &kcpfakeadmissionregistrationv1.AdmissionregistrationV1ClusterClient{Fake: &c.Fake}

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1/admissionregistration_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1/admissionregistration_client.go
@@ -42,6 +42,7 @@ type AdmissionregistrationV1ClusterInterface interface {
 
 type AdmissionregistrationV1ClusterScoper interface {
 	Cluster(logicalcluster.Path) admissionregistrationv1.AdmissionregistrationV1Interface
+	Evict(logicalcluster.Path)
 }
 
 // AdmissionregistrationV1ClusterClient is used to interact with features provided by the admissionregistration.k8s.io group.
@@ -54,6 +55,12 @@ func (c *AdmissionregistrationV1ClusterClient) Cluster(clusterPath logicalcluste
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *AdmissionregistrationV1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *AdmissionregistrationV1ClusterClient) MutatingAdmissionPolicies() MutatingAdmissionPolicyClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1/fake/admissionregistration_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1/fake/admissionregistration_client.go
@@ -40,6 +40,9 @@ func (c *AdmissionregistrationV1ClusterClient) Cluster(clusterPath logicalcluste
 	return &AdmissionregistrationV1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *AdmissionregistrationV1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *AdmissionregistrationV1ClusterClient) MutatingAdmissionPolicies() kcpadmissionregistrationv1.MutatingAdmissionPolicyClusterInterface {
 	return newFakeMutatingAdmissionPolicyClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1alpha1/admissionregistration_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1alpha1/admissionregistration_client.go
@@ -40,6 +40,7 @@ type AdmissionregistrationV1alpha1ClusterInterface interface {
 
 type AdmissionregistrationV1alpha1ClusterScoper interface {
 	Cluster(logicalcluster.Path) admissionregistrationv1alpha1.AdmissionregistrationV1alpha1Interface
+	Evict(logicalcluster.Path)
 }
 
 // AdmissionregistrationV1alpha1ClusterClient is used to interact with features provided by the admissionregistration.k8s.io group.
@@ -52,6 +53,12 @@ func (c *AdmissionregistrationV1alpha1ClusterClient) Cluster(clusterPath logical
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *AdmissionregistrationV1alpha1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *AdmissionregistrationV1alpha1ClusterClient) MutatingAdmissionPolicies() MutatingAdmissionPolicyClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1alpha1/fake/admissionregistration_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1alpha1/fake/admissionregistration_client.go
@@ -40,6 +40,9 @@ func (c *AdmissionregistrationV1alpha1ClusterClient) Cluster(clusterPath logical
 	return &AdmissionregistrationV1alpha1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *AdmissionregistrationV1alpha1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *AdmissionregistrationV1alpha1ClusterClient) MutatingAdmissionPolicies() kcpadmissionregistrationv1alpha1.MutatingAdmissionPolicyClusterInterface {
 	return newFakeMutatingAdmissionPolicyClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/admissionregistration_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/admissionregistration_client.go
@@ -42,6 +42,7 @@ type AdmissionregistrationV1beta1ClusterInterface interface {
 
 type AdmissionregistrationV1beta1ClusterScoper interface {
 	Cluster(logicalcluster.Path) admissionregistrationv1beta1.AdmissionregistrationV1beta1Interface
+	Evict(logicalcluster.Path)
 }
 
 // AdmissionregistrationV1beta1ClusterClient is used to interact with features provided by the admissionregistration.k8s.io group.
@@ -54,6 +55,12 @@ func (c *AdmissionregistrationV1beta1ClusterClient) Cluster(clusterPath logicalc
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *AdmissionregistrationV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *AdmissionregistrationV1beta1ClusterClient) MutatingAdmissionPolicies() MutatingAdmissionPolicyClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/fake/admissionregistration_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/admissionregistration/v1beta1/fake/admissionregistration_client.go
@@ -40,6 +40,9 @@ func (c *AdmissionregistrationV1beta1ClusterClient) Cluster(clusterPath logicalc
 	return &AdmissionregistrationV1beta1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *AdmissionregistrationV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *AdmissionregistrationV1beta1ClusterClient) MutatingAdmissionPolicies() kcpadmissionregistrationv1beta1.MutatingAdmissionPolicyClusterInterface {
 	return newFakeMutatingAdmissionPolicyClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apiserverinternal/v1alpha1/apiserverinternal_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apiserverinternal/v1alpha1/apiserverinternal_client.go
@@ -37,6 +37,7 @@ type InternalV1alpha1ClusterInterface interface {
 
 type InternalV1alpha1ClusterScoper interface {
 	Cluster(logicalcluster.Path) apiserverinternalv1alpha1.InternalV1alpha1Interface
+	Evict(logicalcluster.Path)
 }
 
 // InternalV1alpha1ClusterClient is used to interact with features provided by the internal.apiserver.k8s.io group.
@@ -49,6 +50,12 @@ func (c *InternalV1alpha1ClusterClient) Cluster(clusterPath logicalcluster.Path)
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *InternalV1alpha1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *InternalV1alpha1ClusterClient) StorageVersions() StorageVersionClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apiserverinternal/v1alpha1/fake/apiserverinternal_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apiserverinternal/v1alpha1/fake/apiserverinternal_client.go
@@ -40,6 +40,9 @@ func (c *InternalV1alpha1ClusterClient) Cluster(clusterPath logicalcluster.Path)
 	return &InternalV1alpha1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *InternalV1alpha1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *InternalV1alpha1ClusterClient) StorageVersions() kcpapiserverinternalv1alpha1.StorageVersionClusterInterface {
 	return newFakeStorageVersionClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1/apps_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1/apps_client.go
@@ -41,6 +41,7 @@ type AppsV1ClusterInterface interface {
 
 type AppsV1ClusterScoper interface {
 	Cluster(logicalcluster.Path) appsv1.AppsV1Interface
+	Evict(logicalcluster.Path)
 }
 
 // AppsV1ClusterClient is used to interact with features provided by the apps group.
@@ -53,6 +54,12 @@ func (c *AppsV1ClusterClient) Cluster(clusterPath logicalcluster.Path) appsv1.Ap
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *AppsV1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *AppsV1ClusterClient) ControllerRevisions() ControllerRevisionClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1/fake/apps_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1/fake/apps_client.go
@@ -40,6 +40,9 @@ func (c *AppsV1ClusterClient) Cluster(clusterPath logicalcluster.Path) appsv1.Ap
 	return &AppsV1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *AppsV1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *AppsV1ClusterClient) ControllerRevisions() kcpappsv1.ControllerRevisionClusterInterface {
 	return newFakeControllerRevisionClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta1/apps_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta1/apps_client.go
@@ -39,6 +39,7 @@ type AppsV1beta1ClusterInterface interface {
 
 type AppsV1beta1ClusterScoper interface {
 	Cluster(logicalcluster.Path) appsv1beta1.AppsV1beta1Interface
+	Evict(logicalcluster.Path)
 }
 
 // AppsV1beta1ClusterClient is used to interact with features provided by the apps group.
@@ -51,6 +52,12 @@ func (c *AppsV1beta1ClusterClient) Cluster(clusterPath logicalcluster.Path) apps
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *AppsV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *AppsV1beta1ClusterClient) ControllerRevisions() ControllerRevisionClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta1/fake/apps_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta1/fake/apps_client.go
@@ -40,6 +40,9 @@ func (c *AppsV1beta1ClusterClient) Cluster(clusterPath logicalcluster.Path) apps
 	return &AppsV1beta1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *AppsV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *AppsV1beta1ClusterClient) ControllerRevisions() kcpappsv1beta1.ControllerRevisionClusterInterface {
 	return newFakeControllerRevisionClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta2/apps_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta2/apps_client.go
@@ -41,6 +41,7 @@ type AppsV1beta2ClusterInterface interface {
 
 type AppsV1beta2ClusterScoper interface {
 	Cluster(logicalcluster.Path) appsv1beta2.AppsV1beta2Interface
+	Evict(logicalcluster.Path)
 }
 
 // AppsV1beta2ClusterClient is used to interact with features provided by the apps group.
@@ -53,6 +54,12 @@ func (c *AppsV1beta2ClusterClient) Cluster(clusterPath logicalcluster.Path) apps
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *AppsV1beta2ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *AppsV1beta2ClusterClient) ControllerRevisions() ControllerRevisionClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta2/fake/apps_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/apps/v1beta2/fake/apps_client.go
@@ -40,6 +40,9 @@ func (c *AppsV1beta2ClusterClient) Cluster(clusterPath logicalcluster.Path) apps
 	return &AppsV1beta2Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *AppsV1beta2ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *AppsV1beta2ClusterClient) ControllerRevisions() kcpappsv1beta2.ControllerRevisionClusterInterface {
 	return newFakeControllerRevisionClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1/authentication_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1/authentication_client.go
@@ -38,6 +38,7 @@ type AuthenticationV1ClusterInterface interface {
 
 type AuthenticationV1ClusterScoper interface {
 	Cluster(logicalcluster.Path) authenticationv1.AuthenticationV1Interface
+	Evict(logicalcluster.Path)
 }
 
 // AuthenticationV1ClusterClient is used to interact with features provided by the authentication.k8s.io group.
@@ -50,6 +51,12 @@ func (c *AuthenticationV1ClusterClient) Cluster(clusterPath logicalcluster.Path)
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *AuthenticationV1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *AuthenticationV1ClusterClient) SelfSubjectReviews() SelfSubjectReviewClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1/fake/authentication_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1/fake/authentication_client.go
@@ -40,6 +40,9 @@ func (c *AuthenticationV1ClusterClient) Cluster(clusterPath logicalcluster.Path)
 	return &AuthenticationV1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *AuthenticationV1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *AuthenticationV1ClusterClient) SelfSubjectReviews() kcpauthenticationv1.SelfSubjectReviewClusterInterface {
 	return newFakeSelfSubjectReviewClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1alpha1/authentication_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1alpha1/authentication_client.go
@@ -37,6 +37,7 @@ type AuthenticationV1alpha1ClusterInterface interface {
 
 type AuthenticationV1alpha1ClusterScoper interface {
 	Cluster(logicalcluster.Path) authenticationv1alpha1.AuthenticationV1alpha1Interface
+	Evict(logicalcluster.Path)
 }
 
 // AuthenticationV1alpha1ClusterClient is used to interact with features provided by the authentication.k8s.io group.
@@ -49,6 +50,12 @@ func (c *AuthenticationV1alpha1ClusterClient) Cluster(clusterPath logicalcluster
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *AuthenticationV1alpha1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *AuthenticationV1alpha1ClusterClient) SelfSubjectReviews() SelfSubjectReviewClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1alpha1/fake/authentication_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1alpha1/fake/authentication_client.go
@@ -40,6 +40,9 @@ func (c *AuthenticationV1alpha1ClusterClient) Cluster(clusterPath logicalcluster
 	return &AuthenticationV1alpha1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *AuthenticationV1alpha1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *AuthenticationV1alpha1ClusterClient) SelfSubjectReviews() kcpauthenticationv1alpha1.SelfSubjectReviewClusterInterface {
 	return newFakeSelfSubjectReviewClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1beta1/authentication_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1beta1/authentication_client.go
@@ -38,6 +38,7 @@ type AuthenticationV1beta1ClusterInterface interface {
 
 type AuthenticationV1beta1ClusterScoper interface {
 	Cluster(logicalcluster.Path) authenticationv1beta1.AuthenticationV1beta1Interface
+	Evict(logicalcluster.Path)
 }
 
 // AuthenticationV1beta1ClusterClient is used to interact with features provided by the authentication.k8s.io group.
@@ -50,6 +51,12 @@ func (c *AuthenticationV1beta1ClusterClient) Cluster(clusterPath logicalcluster.
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *AuthenticationV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *AuthenticationV1beta1ClusterClient) SelfSubjectReviews() SelfSubjectReviewClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1beta1/fake/authentication_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authentication/v1beta1/fake/authentication_client.go
@@ -40,6 +40,9 @@ func (c *AuthenticationV1beta1ClusterClient) Cluster(clusterPath logicalcluster.
 	return &AuthenticationV1beta1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *AuthenticationV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *AuthenticationV1beta1ClusterClient) SelfSubjectReviews() kcpauthenticationv1beta1.SelfSubjectReviewClusterInterface {
 	return newFakeSelfSubjectReviewClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1/authorization_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1/authorization_client.go
@@ -40,6 +40,7 @@ type AuthorizationV1ClusterInterface interface {
 
 type AuthorizationV1ClusterScoper interface {
 	Cluster(logicalcluster.Path) authorizationv1.AuthorizationV1Interface
+	Evict(logicalcluster.Path)
 }
 
 // AuthorizationV1ClusterClient is used to interact with features provided by the authorization.k8s.io group.
@@ -52,6 +53,12 @@ func (c *AuthorizationV1ClusterClient) Cluster(clusterPath logicalcluster.Path) 
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *AuthorizationV1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *AuthorizationV1ClusterClient) LocalSubjectAccessReviews() LocalSubjectAccessReviewClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1/fake/authorization_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1/fake/authorization_client.go
@@ -40,6 +40,9 @@ func (c *AuthorizationV1ClusterClient) Cluster(clusterPath logicalcluster.Path) 
 	return &AuthorizationV1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *AuthorizationV1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *AuthorizationV1ClusterClient) LocalSubjectAccessReviews() kcpauthorizationv1.LocalSubjectAccessReviewClusterInterface {
 	return newFakeLocalSubjectAccessReviewClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1beta1/authorization_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1beta1/authorization_client.go
@@ -40,6 +40,7 @@ type AuthorizationV1beta1ClusterInterface interface {
 
 type AuthorizationV1beta1ClusterScoper interface {
 	Cluster(logicalcluster.Path) authorizationv1beta1.AuthorizationV1beta1Interface
+	Evict(logicalcluster.Path)
 }
 
 // AuthorizationV1beta1ClusterClient is used to interact with features provided by the authorization.k8s.io group.
@@ -52,6 +53,12 @@ func (c *AuthorizationV1beta1ClusterClient) Cluster(clusterPath logicalcluster.P
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *AuthorizationV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *AuthorizationV1beta1ClusterClient) LocalSubjectAccessReviews() LocalSubjectAccessReviewClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1beta1/fake/authorization_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/authorization/v1beta1/fake/authorization_client.go
@@ -40,6 +40,9 @@ func (c *AuthorizationV1beta1ClusterClient) Cluster(clusterPath logicalcluster.P
 	return &AuthorizationV1beta1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *AuthorizationV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *AuthorizationV1beta1ClusterClient) LocalSubjectAccessReviews() kcpauthorizationv1beta1.LocalSubjectAccessReviewClusterInterface {
 	return newFakeLocalSubjectAccessReviewClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v1/autoscaling_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v1/autoscaling_client.go
@@ -37,6 +37,7 @@ type AutoscalingV1ClusterInterface interface {
 
 type AutoscalingV1ClusterScoper interface {
 	Cluster(logicalcluster.Path) autoscalingv1.AutoscalingV1Interface
+	Evict(logicalcluster.Path)
 }
 
 // AutoscalingV1ClusterClient is used to interact with features provided by the autoscaling group.
@@ -49,6 +50,12 @@ func (c *AutoscalingV1ClusterClient) Cluster(clusterPath logicalcluster.Path) au
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *AutoscalingV1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *AutoscalingV1ClusterClient) HorizontalPodAutoscalers() HorizontalPodAutoscalerClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v1/fake/autoscaling_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v1/fake/autoscaling_client.go
@@ -40,6 +40,9 @@ func (c *AutoscalingV1ClusterClient) Cluster(clusterPath logicalcluster.Path) au
 	return &AutoscalingV1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *AutoscalingV1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *AutoscalingV1ClusterClient) HorizontalPodAutoscalers() kcpautoscalingv1.HorizontalPodAutoscalerClusterInterface {
 	return newFakeHorizontalPodAutoscalerClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2/autoscaling_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2/autoscaling_client.go
@@ -37,6 +37,7 @@ type AutoscalingV2ClusterInterface interface {
 
 type AutoscalingV2ClusterScoper interface {
 	Cluster(logicalcluster.Path) autoscalingv2.AutoscalingV2Interface
+	Evict(logicalcluster.Path)
 }
 
 // AutoscalingV2ClusterClient is used to interact with features provided by the autoscaling group.
@@ -49,6 +50,12 @@ func (c *AutoscalingV2ClusterClient) Cluster(clusterPath logicalcluster.Path) au
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *AutoscalingV2ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *AutoscalingV2ClusterClient) HorizontalPodAutoscalers() HorizontalPodAutoscalerClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2/fake/autoscaling_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/autoscaling/v2/fake/autoscaling_client.go
@@ -40,6 +40,9 @@ func (c *AutoscalingV2ClusterClient) Cluster(clusterPath logicalcluster.Path) au
 	return &AutoscalingV2Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *AutoscalingV2ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *AutoscalingV2ClusterClient) HorizontalPodAutoscalers() kcpautoscalingv2.HorizontalPodAutoscalerClusterInterface {
 	return newFakeHorizontalPodAutoscalerClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1/batch_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1/batch_client.go
@@ -38,6 +38,7 @@ type BatchV1ClusterInterface interface {
 
 type BatchV1ClusterScoper interface {
 	Cluster(logicalcluster.Path) batchv1.BatchV1Interface
+	Evict(logicalcluster.Path)
 }
 
 // BatchV1ClusterClient is used to interact with features provided by the batch group.
@@ -50,6 +51,12 @@ func (c *BatchV1ClusterClient) Cluster(clusterPath logicalcluster.Path) batchv1.
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *BatchV1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *BatchV1ClusterClient) CronJobs() CronJobClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1/fake/batch_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1/fake/batch_client.go
@@ -40,6 +40,9 @@ func (c *BatchV1ClusterClient) Cluster(clusterPath logicalcluster.Path) batchv1.
 	return &BatchV1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *BatchV1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *BatchV1ClusterClient) CronJobs() kcpbatchv1.CronJobClusterInterface {
 	return newFakeCronJobClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1beta1/batch_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1beta1/batch_client.go
@@ -37,6 +37,7 @@ type BatchV1beta1ClusterInterface interface {
 
 type BatchV1beta1ClusterScoper interface {
 	Cluster(logicalcluster.Path) batchv1beta1.BatchV1beta1Interface
+	Evict(logicalcluster.Path)
 }
 
 // BatchV1beta1ClusterClient is used to interact with features provided by the batch group.
@@ -49,6 +50,12 @@ func (c *BatchV1beta1ClusterClient) Cluster(clusterPath logicalcluster.Path) bat
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *BatchV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *BatchV1beta1ClusterClient) CronJobs() CronJobClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1beta1/fake/batch_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/batch/v1beta1/fake/batch_client.go
@@ -40,6 +40,9 @@ func (c *BatchV1beta1ClusterClient) Cluster(clusterPath logicalcluster.Path) bat
 	return &BatchV1beta1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *BatchV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *BatchV1beta1ClusterClient) CronJobs() kcpbatchv1beta1.CronJobClusterInterface {
 	return newFakeCronJobClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1/certificates_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1/certificates_client.go
@@ -37,6 +37,7 @@ type CertificatesV1ClusterInterface interface {
 
 type CertificatesV1ClusterScoper interface {
 	Cluster(logicalcluster.Path) certificatesv1.CertificatesV1Interface
+	Evict(logicalcluster.Path)
 }
 
 // CertificatesV1ClusterClient is used to interact with features provided by the certificates.k8s.io group.
@@ -49,6 +50,12 @@ func (c *CertificatesV1ClusterClient) Cluster(clusterPath logicalcluster.Path) c
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *CertificatesV1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *CertificatesV1ClusterClient) CertificateSigningRequests() CertificateSigningRequestClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1/fake/certificates_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1/fake/certificates_client.go
@@ -40,6 +40,9 @@ func (c *CertificatesV1ClusterClient) Cluster(clusterPath logicalcluster.Path) c
 	return &CertificatesV1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *CertificatesV1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *CertificatesV1ClusterClient) CertificateSigningRequests() kcpcertificatesv1.CertificateSigningRequestClusterInterface {
 	return newFakeCertificateSigningRequestClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1alpha1/certificates_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1alpha1/certificates_client.go
@@ -37,6 +37,7 @@ type CertificatesV1alpha1ClusterInterface interface {
 
 type CertificatesV1alpha1ClusterScoper interface {
 	Cluster(logicalcluster.Path) certificatesv1alpha1.CertificatesV1alpha1Interface
+	Evict(logicalcluster.Path)
 }
 
 // CertificatesV1alpha1ClusterClient is used to interact with features provided by the certificates.k8s.io group.
@@ -49,6 +50,12 @@ func (c *CertificatesV1alpha1ClusterClient) Cluster(clusterPath logicalcluster.P
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *CertificatesV1alpha1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *CertificatesV1alpha1ClusterClient) ClusterTrustBundles() ClusterTrustBundleClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1alpha1/fake/certificates_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1alpha1/fake/certificates_client.go
@@ -40,6 +40,9 @@ func (c *CertificatesV1alpha1ClusterClient) Cluster(clusterPath logicalcluster.P
 	return &CertificatesV1alpha1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *CertificatesV1alpha1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *CertificatesV1alpha1ClusterClient) ClusterTrustBundles() kcpcertificatesv1alpha1.ClusterTrustBundleClusterInterface {
 	return newFakeClusterTrustBundleClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1beta1/certificates_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1beta1/certificates_client.go
@@ -39,6 +39,7 @@ type CertificatesV1beta1ClusterInterface interface {
 
 type CertificatesV1beta1ClusterScoper interface {
 	Cluster(logicalcluster.Path) certificatesv1beta1.CertificatesV1beta1Interface
+	Evict(logicalcluster.Path)
 }
 
 // CertificatesV1beta1ClusterClient is used to interact with features provided by the certificates.k8s.io group.
@@ -51,6 +52,12 @@ func (c *CertificatesV1beta1ClusterClient) Cluster(clusterPath logicalcluster.Pa
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *CertificatesV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *CertificatesV1beta1ClusterClient) CertificateSigningRequests() CertificateSigningRequestClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1beta1/fake/certificates_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/certificates/v1beta1/fake/certificates_client.go
@@ -40,6 +40,9 @@ func (c *CertificatesV1beta1ClusterClient) Cluster(clusterPath logicalcluster.Pa
 	return &CertificatesV1beta1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *CertificatesV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *CertificatesV1beta1ClusterClient) CertificateSigningRequests() kcpcertificatesv1beta1.CertificateSigningRequestClusterInterface {
 	return newFakeCertificateSigningRequestClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1/coordination_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1/coordination_client.go
@@ -37,6 +37,7 @@ type CoordinationV1ClusterInterface interface {
 
 type CoordinationV1ClusterScoper interface {
 	Cluster(logicalcluster.Path) coordinationv1.CoordinationV1Interface
+	Evict(logicalcluster.Path)
 }
 
 // CoordinationV1ClusterClient is used to interact with features provided by the coordination.k8s.io group.
@@ -49,6 +50,12 @@ func (c *CoordinationV1ClusterClient) Cluster(clusterPath logicalcluster.Path) c
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *CoordinationV1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *CoordinationV1ClusterClient) Leases() LeaseClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1/fake/coordination_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1/fake/coordination_client.go
@@ -40,6 +40,9 @@ func (c *CoordinationV1ClusterClient) Cluster(clusterPath logicalcluster.Path) c
 	return &CoordinationV1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *CoordinationV1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *CoordinationV1ClusterClient) Leases() kcpcoordinationv1.LeaseClusterInterface {
 	return newFakeLeaseClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1alpha2/coordination_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1alpha2/coordination_client.go
@@ -37,6 +37,7 @@ type CoordinationV1alpha2ClusterInterface interface {
 
 type CoordinationV1alpha2ClusterScoper interface {
 	Cluster(logicalcluster.Path) coordinationv1alpha2.CoordinationV1alpha2Interface
+	Evict(logicalcluster.Path)
 }
 
 // CoordinationV1alpha2ClusterClient is used to interact with features provided by the coordination.k8s.io group.
@@ -49,6 +50,12 @@ func (c *CoordinationV1alpha2ClusterClient) Cluster(clusterPath logicalcluster.P
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *CoordinationV1alpha2ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *CoordinationV1alpha2ClusterClient) LeaseCandidates() LeaseCandidateClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1alpha2/fake/coordination_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1alpha2/fake/coordination_client.go
@@ -40,6 +40,9 @@ func (c *CoordinationV1alpha2ClusterClient) Cluster(clusterPath logicalcluster.P
 	return &CoordinationV1alpha2Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *CoordinationV1alpha2ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *CoordinationV1alpha2ClusterClient) LeaseCandidates() kcpcoordinationv1alpha2.LeaseCandidateClusterInterface {
 	return newFakeLeaseCandidateClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1beta1/coordination_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1beta1/coordination_client.go
@@ -38,6 +38,7 @@ type CoordinationV1beta1ClusterInterface interface {
 
 type CoordinationV1beta1ClusterScoper interface {
 	Cluster(logicalcluster.Path) coordinationv1beta1.CoordinationV1beta1Interface
+	Evict(logicalcluster.Path)
 }
 
 // CoordinationV1beta1ClusterClient is used to interact with features provided by the coordination.k8s.io group.
@@ -50,6 +51,12 @@ func (c *CoordinationV1beta1ClusterClient) Cluster(clusterPath logicalcluster.Pa
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *CoordinationV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *CoordinationV1beta1ClusterClient) Leases() LeaseClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1beta1/fake/coordination_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/coordination/v1beta1/fake/coordination_client.go
@@ -40,6 +40,9 @@ func (c *CoordinationV1beta1ClusterClient) Cluster(clusterPath logicalcluster.Pa
 	return &CoordinationV1beta1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *CoordinationV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *CoordinationV1beta1ClusterClient) Leases() kcpcoordinationv1beta1.LeaseClusterInterface {
 	return newFakeLeaseClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/core_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/core_client.go
@@ -52,6 +52,7 @@ type CoreV1ClusterInterface interface {
 
 type CoreV1ClusterScoper interface {
 	Cluster(logicalcluster.Path) corev1.CoreV1Interface
+	Evict(logicalcluster.Path)
 }
 
 // CoreV1ClusterClient is used to interact with features provided by the  group.
@@ -64,6 +65,12 @@ func (c *CoreV1ClusterClient) Cluster(clusterPath logicalcluster.Path) corev1.Co
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *CoreV1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *CoreV1ClusterClient) ComponentStatuses() ComponentStatusClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/core_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/core/v1/fake/core_client.go
@@ -40,6 +40,9 @@ func (c *CoreV1ClusterClient) Cluster(clusterPath logicalcluster.Path) corev1.Co
 	return &CoreV1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *CoreV1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *CoreV1ClusterClient) ComponentStatuses() kcpcorev1.ComponentStatusClusterInterface {
 	return newFakeComponentStatusClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1/discovery_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1/discovery_client.go
@@ -37,6 +37,7 @@ type DiscoveryV1ClusterInterface interface {
 
 type DiscoveryV1ClusterScoper interface {
 	Cluster(logicalcluster.Path) discoveryv1.DiscoveryV1Interface
+	Evict(logicalcluster.Path)
 }
 
 // DiscoveryV1ClusterClient is used to interact with features provided by the discovery.k8s.io group.
@@ -49,6 +50,12 @@ func (c *DiscoveryV1ClusterClient) Cluster(clusterPath logicalcluster.Path) disc
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *DiscoveryV1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *DiscoveryV1ClusterClient) EndpointSlices() EndpointSliceClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1/fake/discovery_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1/fake/discovery_client.go
@@ -40,6 +40,9 @@ func (c *DiscoveryV1ClusterClient) Cluster(clusterPath logicalcluster.Path) disc
 	return &DiscoveryV1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *DiscoveryV1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *DiscoveryV1ClusterClient) EndpointSlices() kcpdiscoveryv1.EndpointSliceClusterInterface {
 	return newFakeEndpointSliceClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1beta1/discovery_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1beta1/discovery_client.go
@@ -37,6 +37,7 @@ type DiscoveryV1beta1ClusterInterface interface {
 
 type DiscoveryV1beta1ClusterScoper interface {
 	Cluster(logicalcluster.Path) discoveryv1beta1.DiscoveryV1beta1Interface
+	Evict(logicalcluster.Path)
 }
 
 // DiscoveryV1beta1ClusterClient is used to interact with features provided by the discovery.k8s.io group.
@@ -49,6 +50,12 @@ func (c *DiscoveryV1beta1ClusterClient) Cluster(clusterPath logicalcluster.Path)
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *DiscoveryV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *DiscoveryV1beta1ClusterClient) EndpointSlices() EndpointSliceClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1beta1/fake/discovery_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/discovery/v1beta1/fake/discovery_client.go
@@ -40,6 +40,9 @@ func (c *DiscoveryV1beta1ClusterClient) Cluster(clusterPath logicalcluster.Path)
 	return &DiscoveryV1beta1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *DiscoveryV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *DiscoveryV1beta1ClusterClient) EndpointSlices() kcpdiscoveryv1beta1.EndpointSliceClusterInterface {
 	return newFakeEndpointSliceClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1/events_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1/events_client.go
@@ -37,6 +37,7 @@ type EventsV1ClusterInterface interface {
 
 type EventsV1ClusterScoper interface {
 	Cluster(logicalcluster.Path) eventsv1.EventsV1Interface
+	Evict(logicalcluster.Path)
 }
 
 // EventsV1ClusterClient is used to interact with features provided by the events.k8s.io group.
@@ -49,6 +50,12 @@ func (c *EventsV1ClusterClient) Cluster(clusterPath logicalcluster.Path) eventsv
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *EventsV1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *EventsV1ClusterClient) Events() EventClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1/fake/events_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1/fake/events_client.go
@@ -40,6 +40,9 @@ func (c *EventsV1ClusterClient) Cluster(clusterPath logicalcluster.Path) eventsv
 	return &EventsV1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *EventsV1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *EventsV1ClusterClient) Events() kcpeventsv1.EventClusterInterface {
 	return newFakeEventClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1beta1/events_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1beta1/events_client.go
@@ -37,6 +37,7 @@ type EventsV1beta1ClusterInterface interface {
 
 type EventsV1beta1ClusterScoper interface {
 	Cluster(logicalcluster.Path) eventsv1beta1.EventsV1beta1Interface
+	Evict(logicalcluster.Path)
 }
 
 // EventsV1beta1ClusterClient is used to interact with features provided by the events.k8s.io group.
@@ -49,6 +50,12 @@ func (c *EventsV1beta1ClusterClient) Cluster(clusterPath logicalcluster.Path) ev
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *EventsV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *EventsV1beta1ClusterClient) Events() EventClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1beta1/fake/events_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/events/v1beta1/fake/events_client.go
@@ -40,6 +40,9 @@ func (c *EventsV1beta1ClusterClient) Cluster(clusterPath logicalcluster.Path) ev
 	return &EventsV1beta1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *EventsV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *EventsV1beta1ClusterClient) Events() kcpeventsv1beta1.EventClusterInterface {
 	return newFakeEventClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/extensions/v1beta1/extensions_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/extensions/v1beta1/extensions_client.go
@@ -41,6 +41,7 @@ type ExtensionsV1beta1ClusterInterface interface {
 
 type ExtensionsV1beta1ClusterScoper interface {
 	Cluster(logicalcluster.Path) extensionsv1beta1.ExtensionsV1beta1Interface
+	Evict(logicalcluster.Path)
 }
 
 // ExtensionsV1beta1ClusterClient is used to interact with features provided by the extensions group.
@@ -53,6 +54,12 @@ func (c *ExtensionsV1beta1ClusterClient) Cluster(clusterPath logicalcluster.Path
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *ExtensionsV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *ExtensionsV1beta1ClusterClient) DaemonSets() DaemonSetClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/extensions/v1beta1/fake/extensions_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/extensions/v1beta1/fake/extensions_client.go
@@ -40,6 +40,9 @@ func (c *ExtensionsV1beta1ClusterClient) Cluster(clusterPath logicalcluster.Path
 	return &ExtensionsV1beta1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *ExtensionsV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *ExtensionsV1beta1ClusterClient) DaemonSets() kcpextensionsv1beta1.DaemonSetClusterInterface {
 	return newFakeDaemonSetClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1/fake/flowcontrol_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1/fake/flowcontrol_client.go
@@ -40,6 +40,9 @@ func (c *FlowcontrolV1ClusterClient) Cluster(clusterPath logicalcluster.Path) fl
 	return &FlowcontrolV1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *FlowcontrolV1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *FlowcontrolV1ClusterClient) FlowSchemas() kcpflowcontrolv1.FlowSchemaClusterInterface {
 	return newFakeFlowSchemaClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1/flowcontrol_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1/flowcontrol_client.go
@@ -38,6 +38,7 @@ type FlowcontrolV1ClusterInterface interface {
 
 type FlowcontrolV1ClusterScoper interface {
 	Cluster(logicalcluster.Path) flowcontrolv1.FlowcontrolV1Interface
+	Evict(logicalcluster.Path)
 }
 
 // FlowcontrolV1ClusterClient is used to interact with features provided by the flowcontrol.apiserver.k8s.io group.
@@ -50,6 +51,12 @@ func (c *FlowcontrolV1ClusterClient) Cluster(clusterPath logicalcluster.Path) fl
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *FlowcontrolV1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *FlowcontrolV1ClusterClient) FlowSchemas() FlowSchemaClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta1/fake/flowcontrol_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta1/fake/flowcontrol_client.go
@@ -40,6 +40,9 @@ func (c *FlowcontrolV1beta1ClusterClient) Cluster(clusterPath logicalcluster.Pat
 	return &FlowcontrolV1beta1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *FlowcontrolV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *FlowcontrolV1beta1ClusterClient) FlowSchemas() kcpflowcontrolv1beta1.FlowSchemaClusterInterface {
 	return newFakeFlowSchemaClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta1/flowcontrol_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta1/flowcontrol_client.go
@@ -38,6 +38,7 @@ type FlowcontrolV1beta1ClusterInterface interface {
 
 type FlowcontrolV1beta1ClusterScoper interface {
 	Cluster(logicalcluster.Path) flowcontrolv1beta1.FlowcontrolV1beta1Interface
+	Evict(logicalcluster.Path)
 }
 
 // FlowcontrolV1beta1ClusterClient is used to interact with features provided by the flowcontrol.apiserver.k8s.io group.
@@ -50,6 +51,12 @@ func (c *FlowcontrolV1beta1ClusterClient) Cluster(clusterPath logicalcluster.Pat
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *FlowcontrolV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *FlowcontrolV1beta1ClusterClient) FlowSchemas() FlowSchemaClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta2/fake/flowcontrol_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta2/fake/flowcontrol_client.go
@@ -40,6 +40,9 @@ func (c *FlowcontrolV1beta2ClusterClient) Cluster(clusterPath logicalcluster.Pat
 	return &FlowcontrolV1beta2Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *FlowcontrolV1beta2ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *FlowcontrolV1beta2ClusterClient) FlowSchemas() kcpflowcontrolv1beta2.FlowSchemaClusterInterface {
 	return newFakeFlowSchemaClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta2/flowcontrol_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta2/flowcontrol_client.go
@@ -38,6 +38,7 @@ type FlowcontrolV1beta2ClusterInterface interface {
 
 type FlowcontrolV1beta2ClusterScoper interface {
 	Cluster(logicalcluster.Path) flowcontrolv1beta2.FlowcontrolV1beta2Interface
+	Evict(logicalcluster.Path)
 }
 
 // FlowcontrolV1beta2ClusterClient is used to interact with features provided by the flowcontrol.apiserver.k8s.io group.
@@ -50,6 +51,12 @@ func (c *FlowcontrolV1beta2ClusterClient) Cluster(clusterPath logicalcluster.Pat
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *FlowcontrolV1beta2ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *FlowcontrolV1beta2ClusterClient) FlowSchemas() FlowSchemaClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta3/fake/flowcontrol_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta3/fake/flowcontrol_client.go
@@ -40,6 +40,9 @@ func (c *FlowcontrolV1beta3ClusterClient) Cluster(clusterPath logicalcluster.Pat
 	return &FlowcontrolV1beta3Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *FlowcontrolV1beta3ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *FlowcontrolV1beta3ClusterClient) FlowSchemas() kcpflowcontrolv1beta3.FlowSchemaClusterInterface {
 	return newFakeFlowSchemaClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta3/flowcontrol_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/flowcontrol/v1beta3/flowcontrol_client.go
@@ -38,6 +38,7 @@ type FlowcontrolV1beta3ClusterInterface interface {
 
 type FlowcontrolV1beta3ClusterScoper interface {
 	Cluster(logicalcluster.Path) flowcontrolv1beta3.FlowcontrolV1beta3Interface
+	Evict(logicalcluster.Path)
 }
 
 // FlowcontrolV1beta3ClusterClient is used to interact with features provided by the flowcontrol.apiserver.k8s.io group.
@@ -50,6 +51,12 @@ func (c *FlowcontrolV1beta3ClusterClient) Cluster(clusterPath logicalcluster.Pat
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *FlowcontrolV1beta3ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *FlowcontrolV1beta3ClusterClient) FlowSchemas() FlowSchemaClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1/fake/networking_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1/fake/networking_client.go
@@ -40,6 +40,9 @@ func (c *NetworkingV1ClusterClient) Cluster(clusterPath logicalcluster.Path) net
 	return &NetworkingV1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *NetworkingV1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *NetworkingV1ClusterClient) IPAddresses() kcpnetworkingv1.IPAddressClusterInterface {
 	return newFakeIPAddressClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1/networking_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1/networking_client.go
@@ -41,6 +41,7 @@ type NetworkingV1ClusterInterface interface {
 
 type NetworkingV1ClusterScoper interface {
 	Cluster(logicalcluster.Path) networkingv1.NetworkingV1Interface
+	Evict(logicalcluster.Path)
 }
 
 // NetworkingV1ClusterClient is used to interact with features provided by the networking.k8s.io group.
@@ -53,6 +54,12 @@ func (c *NetworkingV1ClusterClient) Cluster(clusterPath logicalcluster.Path) net
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *NetworkingV1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *NetworkingV1ClusterClient) IPAddresses() IPAddressClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1beta1/fake/networking_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1beta1/fake/networking_client.go
@@ -40,6 +40,9 @@ func (c *NetworkingV1beta1ClusterClient) Cluster(clusterPath logicalcluster.Path
 	return &NetworkingV1beta1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *NetworkingV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *NetworkingV1beta1ClusterClient) IPAddresses() kcpnetworkingv1beta1.IPAddressClusterInterface {
 	return newFakeIPAddressClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1beta1/networking_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/networking/v1beta1/networking_client.go
@@ -40,6 +40,7 @@ type NetworkingV1beta1ClusterInterface interface {
 
 type NetworkingV1beta1ClusterScoper interface {
 	Cluster(logicalcluster.Path) networkingv1beta1.NetworkingV1beta1Interface
+	Evict(logicalcluster.Path)
 }
 
 // NetworkingV1beta1ClusterClient is used to interact with features provided by the networking.k8s.io group.
@@ -52,6 +53,12 @@ func (c *NetworkingV1beta1ClusterClient) Cluster(clusterPath logicalcluster.Path
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *NetworkingV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *NetworkingV1beta1ClusterClient) IPAddresses() IPAddressClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1/fake/node_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1/fake/node_client.go
@@ -40,6 +40,9 @@ func (c *NodeV1ClusterClient) Cluster(clusterPath logicalcluster.Path) nodev1.No
 	return &NodeV1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *NodeV1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *NodeV1ClusterClient) RuntimeClasses() kcpnodev1.RuntimeClassClusterInterface {
 	return newFakeRuntimeClassClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1/node_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1/node_client.go
@@ -37,6 +37,7 @@ type NodeV1ClusterInterface interface {
 
 type NodeV1ClusterScoper interface {
 	Cluster(logicalcluster.Path) nodev1.NodeV1Interface
+	Evict(logicalcluster.Path)
 }
 
 // NodeV1ClusterClient is used to interact with features provided by the node.k8s.io group.
@@ -49,6 +50,12 @@ func (c *NodeV1ClusterClient) Cluster(clusterPath logicalcluster.Path) nodev1.No
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *NodeV1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *NodeV1ClusterClient) RuntimeClasses() RuntimeClassClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1alpha1/fake/node_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1alpha1/fake/node_client.go
@@ -40,6 +40,9 @@ func (c *NodeV1alpha1ClusterClient) Cluster(clusterPath logicalcluster.Path) nod
 	return &NodeV1alpha1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *NodeV1alpha1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *NodeV1alpha1ClusterClient) RuntimeClasses() kcpnodev1alpha1.RuntimeClassClusterInterface {
 	return newFakeRuntimeClassClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1alpha1/node_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1alpha1/node_client.go
@@ -37,6 +37,7 @@ type NodeV1alpha1ClusterInterface interface {
 
 type NodeV1alpha1ClusterScoper interface {
 	Cluster(logicalcluster.Path) nodev1alpha1.NodeV1alpha1Interface
+	Evict(logicalcluster.Path)
 }
 
 // NodeV1alpha1ClusterClient is used to interact with features provided by the node.k8s.io group.
@@ -49,6 +50,12 @@ func (c *NodeV1alpha1ClusterClient) Cluster(clusterPath logicalcluster.Path) nod
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *NodeV1alpha1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *NodeV1alpha1ClusterClient) RuntimeClasses() RuntimeClassClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1beta1/fake/node_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1beta1/fake/node_client.go
@@ -40,6 +40,9 @@ func (c *NodeV1beta1ClusterClient) Cluster(clusterPath logicalcluster.Path) node
 	return &NodeV1beta1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *NodeV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *NodeV1beta1ClusterClient) RuntimeClasses() kcpnodev1beta1.RuntimeClassClusterInterface {
 	return newFakeRuntimeClassClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1beta1/node_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/node/v1beta1/node_client.go
@@ -37,6 +37,7 @@ type NodeV1beta1ClusterInterface interface {
 
 type NodeV1beta1ClusterScoper interface {
 	Cluster(logicalcluster.Path) nodev1beta1.NodeV1beta1Interface
+	Evict(logicalcluster.Path)
 }
 
 // NodeV1beta1ClusterClient is used to interact with features provided by the node.k8s.io group.
@@ -49,6 +50,12 @@ func (c *NodeV1beta1ClusterClient) Cluster(clusterPath logicalcluster.Path) node
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *NodeV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *NodeV1beta1ClusterClient) RuntimeClasses() RuntimeClassClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1/fake/policy_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1/fake/policy_client.go
@@ -40,6 +40,9 @@ func (c *PolicyV1ClusterClient) Cluster(clusterPath logicalcluster.Path) policyv
 	return &PolicyV1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *PolicyV1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *PolicyV1ClusterClient) Evictions() kcppolicyv1.EvictionClusterInterface {
 	return newFakeEvictionClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1/policy_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1/policy_client.go
@@ -38,6 +38,7 @@ type PolicyV1ClusterInterface interface {
 
 type PolicyV1ClusterScoper interface {
 	Cluster(logicalcluster.Path) policyv1.PolicyV1Interface
+	Evict(logicalcluster.Path)
 }
 
 // PolicyV1ClusterClient is used to interact with features provided by the policy group.
@@ -50,6 +51,12 @@ func (c *PolicyV1ClusterClient) Cluster(clusterPath logicalcluster.Path) policyv
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *PolicyV1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *PolicyV1ClusterClient) Evictions() EvictionClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1beta1/fake/policy_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1beta1/fake/policy_client.go
@@ -40,6 +40,9 @@ func (c *PolicyV1beta1ClusterClient) Cluster(clusterPath logicalcluster.Path) po
 	return &PolicyV1beta1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *PolicyV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *PolicyV1beta1ClusterClient) Evictions() kcppolicyv1beta1.EvictionClusterInterface {
 	return newFakeEvictionClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1beta1/policy_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/policy/v1beta1/policy_client.go
@@ -38,6 +38,7 @@ type PolicyV1beta1ClusterInterface interface {
 
 type PolicyV1beta1ClusterScoper interface {
 	Cluster(logicalcluster.Path) policyv1beta1.PolicyV1beta1Interface
+	Evict(logicalcluster.Path)
 }
 
 // PolicyV1beta1ClusterClient is used to interact with features provided by the policy group.
@@ -50,6 +51,12 @@ func (c *PolicyV1beta1ClusterClient) Cluster(clusterPath logicalcluster.Path) po
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *PolicyV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *PolicyV1beta1ClusterClient) Evictions() EvictionClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1/fake/rbac_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1/fake/rbac_client.go
@@ -40,6 +40,9 @@ func (c *RbacV1ClusterClient) Cluster(clusterPath logicalcluster.Path) rbacv1.Rb
 	return &RbacV1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *RbacV1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *RbacV1ClusterClient) ClusterRoles() kcprbacv1.ClusterRoleClusterInterface {
 	return newFakeClusterRoleClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1/rbac_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1/rbac_client.go
@@ -40,6 +40,7 @@ type RbacV1ClusterInterface interface {
 
 type RbacV1ClusterScoper interface {
 	Cluster(logicalcluster.Path) rbacv1.RbacV1Interface
+	Evict(logicalcluster.Path)
 }
 
 // RbacV1ClusterClient is used to interact with features provided by the rbac.authorization.k8s.io group.
@@ -52,6 +53,12 @@ func (c *RbacV1ClusterClient) Cluster(clusterPath logicalcluster.Path) rbacv1.Rb
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *RbacV1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *RbacV1ClusterClient) ClusterRoles() ClusterRoleClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1alpha1/fake/rbac_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1alpha1/fake/rbac_client.go
@@ -40,6 +40,9 @@ func (c *RbacV1alpha1ClusterClient) Cluster(clusterPath logicalcluster.Path) rba
 	return &RbacV1alpha1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *RbacV1alpha1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *RbacV1alpha1ClusterClient) ClusterRoles() kcprbacv1alpha1.ClusterRoleClusterInterface {
 	return newFakeClusterRoleClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1alpha1/rbac_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1alpha1/rbac_client.go
@@ -40,6 +40,7 @@ type RbacV1alpha1ClusterInterface interface {
 
 type RbacV1alpha1ClusterScoper interface {
 	Cluster(logicalcluster.Path) rbacv1alpha1.RbacV1alpha1Interface
+	Evict(logicalcluster.Path)
 }
 
 // RbacV1alpha1ClusterClient is used to interact with features provided by the rbac.authorization.k8s.io group.
@@ -52,6 +53,12 @@ func (c *RbacV1alpha1ClusterClient) Cluster(clusterPath logicalcluster.Path) rba
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *RbacV1alpha1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *RbacV1alpha1ClusterClient) ClusterRoles() ClusterRoleClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1beta1/fake/rbac_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1beta1/fake/rbac_client.go
@@ -40,6 +40,9 @@ func (c *RbacV1beta1ClusterClient) Cluster(clusterPath logicalcluster.Path) rbac
 	return &RbacV1beta1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *RbacV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *RbacV1beta1ClusterClient) ClusterRoles() kcprbacv1beta1.ClusterRoleClusterInterface {
 	return newFakeClusterRoleClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1beta1/rbac_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/rbac/v1beta1/rbac_client.go
@@ -40,6 +40,7 @@ type RbacV1beta1ClusterInterface interface {
 
 type RbacV1beta1ClusterScoper interface {
 	Cluster(logicalcluster.Path) rbacv1beta1.RbacV1beta1Interface
+	Evict(logicalcluster.Path)
 }
 
 // RbacV1beta1ClusterClient is used to interact with features provided by the rbac.authorization.k8s.io group.
@@ -52,6 +53,12 @@ func (c *RbacV1beta1ClusterClient) Cluster(clusterPath logicalcluster.Path) rbac
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *RbacV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *RbacV1beta1ClusterClient) ClusterRoles() ClusterRoleClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1/fake/resource_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1/fake/resource_client.go
@@ -40,6 +40,9 @@ func (c *ResourceV1ClusterClient) Cluster(clusterPath logicalcluster.Path) resou
 	return &ResourceV1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *ResourceV1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *ResourceV1ClusterClient) DeviceClasses() kcpresourcev1.DeviceClassClusterInterface {
 	return newFakeDeviceClassClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1/resource_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1/resource_client.go
@@ -40,6 +40,7 @@ type ResourceV1ClusterInterface interface {
 
 type ResourceV1ClusterScoper interface {
 	Cluster(logicalcluster.Path) resourcev1.ResourceV1Interface
+	Evict(logicalcluster.Path)
 }
 
 // ResourceV1ClusterClient is used to interact with features provided by the resource.k8s.io group.
@@ -52,6 +53,12 @@ func (c *ResourceV1ClusterClient) Cluster(clusterPath logicalcluster.Path) resou
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *ResourceV1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *ResourceV1ClusterClient) DeviceClasses() DeviceClassClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1alpha3/fake/resource_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1alpha3/fake/resource_client.go
@@ -40,6 +40,9 @@ func (c *ResourceV1alpha3ClusterClient) Cluster(clusterPath logicalcluster.Path)
 	return &ResourceV1alpha3Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *ResourceV1alpha3ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *ResourceV1alpha3ClusterClient) DeviceTaintRules() kcpresourcev1alpha3.DeviceTaintRuleClusterInterface {
 	return newFakeDeviceTaintRuleClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1alpha3/resource_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1alpha3/resource_client.go
@@ -38,6 +38,7 @@ type ResourceV1alpha3ClusterInterface interface {
 
 type ResourceV1alpha3ClusterScoper interface {
 	Cluster(logicalcluster.Path) resourcev1alpha3.ResourceV1alpha3Interface
+	Evict(logicalcluster.Path)
 }
 
 // ResourceV1alpha3ClusterClient is used to interact with features provided by the resource.k8s.io group.
@@ -50,6 +51,12 @@ func (c *ResourceV1alpha3ClusterClient) Cluster(clusterPath logicalcluster.Path)
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *ResourceV1alpha3ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *ResourceV1alpha3ClusterClient) DeviceTaintRules() DeviceTaintRuleClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta1/fake/resource_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta1/fake/resource_client.go
@@ -40,6 +40,9 @@ func (c *ResourceV1beta1ClusterClient) Cluster(clusterPath logicalcluster.Path) 
 	return &ResourceV1beta1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *ResourceV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *ResourceV1beta1ClusterClient) DeviceClasses() kcpresourcev1beta1.DeviceClassClusterInterface {
 	return newFakeDeviceClassClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta1/resource_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta1/resource_client.go
@@ -40,6 +40,7 @@ type ResourceV1beta1ClusterInterface interface {
 
 type ResourceV1beta1ClusterScoper interface {
 	Cluster(logicalcluster.Path) resourcev1beta1.ResourceV1beta1Interface
+	Evict(logicalcluster.Path)
 }
 
 // ResourceV1beta1ClusterClient is used to interact with features provided by the resource.k8s.io group.
@@ -52,6 +53,12 @@ func (c *ResourceV1beta1ClusterClient) Cluster(clusterPath logicalcluster.Path) 
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *ResourceV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *ResourceV1beta1ClusterClient) DeviceClasses() DeviceClassClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta2/fake/resource_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta2/fake/resource_client.go
@@ -40,6 +40,9 @@ func (c *ResourceV1beta2ClusterClient) Cluster(clusterPath logicalcluster.Path) 
 	return &ResourceV1beta2Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *ResourceV1beta2ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *ResourceV1beta2ClusterClient) DeviceClasses() kcpresourcev1beta2.DeviceClassClusterInterface {
 	return newFakeDeviceClassClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta2/resource_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/resource/v1beta2/resource_client.go
@@ -41,6 +41,7 @@ type ResourceV1beta2ClusterInterface interface {
 
 type ResourceV1beta2ClusterScoper interface {
 	Cluster(logicalcluster.Path) resourcev1beta2.ResourceV1beta2Interface
+	Evict(logicalcluster.Path)
 }
 
 // ResourceV1beta2ClusterClient is used to interact with features provided by the resource.k8s.io group.
@@ -53,6 +54,12 @@ func (c *ResourceV1beta2ClusterClient) Cluster(clusterPath logicalcluster.Path) 
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *ResourceV1beta2ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *ResourceV1beta2ClusterClient) DeviceClasses() DeviceClassClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1/fake/scheduling_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1/fake/scheduling_client.go
@@ -40,6 +40,9 @@ func (c *SchedulingV1ClusterClient) Cluster(clusterPath logicalcluster.Path) sch
 	return &SchedulingV1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *SchedulingV1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *SchedulingV1ClusterClient) PriorityClasses() kcpschedulingv1.PriorityClassClusterInterface {
 	return newFakePriorityClassClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1/scheduling_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1/scheduling_client.go
@@ -37,6 +37,7 @@ type SchedulingV1ClusterInterface interface {
 
 type SchedulingV1ClusterScoper interface {
 	Cluster(logicalcluster.Path) schedulingv1.SchedulingV1Interface
+	Evict(logicalcluster.Path)
 }
 
 // SchedulingV1ClusterClient is used to interact with features provided by the scheduling.k8s.io group.
@@ -49,6 +50,12 @@ func (c *SchedulingV1ClusterClient) Cluster(clusterPath logicalcluster.Path) sch
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *SchedulingV1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *SchedulingV1ClusterClient) PriorityClasses() PriorityClassClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1alpha2/fake/scheduling_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1alpha2/fake/scheduling_client.go
@@ -40,6 +40,9 @@ func (c *SchedulingV1alpha2ClusterClient) Cluster(clusterPath logicalcluster.Pat
 	return &SchedulingV1alpha2Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *SchedulingV1alpha2ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *SchedulingV1alpha2ClusterClient) PodGroups() kcpschedulingv1alpha2.PodGroupClusterInterface {
 	return newFakePodGroupClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1alpha2/scheduling_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1alpha2/scheduling_client.go
@@ -38,6 +38,7 @@ type SchedulingV1alpha2ClusterInterface interface {
 
 type SchedulingV1alpha2ClusterScoper interface {
 	Cluster(logicalcluster.Path) schedulingv1alpha2.SchedulingV1alpha2Interface
+	Evict(logicalcluster.Path)
 }
 
 // SchedulingV1alpha2ClusterClient is used to interact with features provided by the scheduling.k8s.io group.
@@ -50,6 +51,12 @@ func (c *SchedulingV1alpha2ClusterClient) Cluster(clusterPath logicalcluster.Pat
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *SchedulingV1alpha2ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *SchedulingV1alpha2ClusterClient) PodGroups() PodGroupClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1beta1/fake/scheduling_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1beta1/fake/scheduling_client.go
@@ -40,6 +40,9 @@ func (c *SchedulingV1beta1ClusterClient) Cluster(clusterPath logicalcluster.Path
 	return &SchedulingV1beta1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *SchedulingV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *SchedulingV1beta1ClusterClient) PriorityClasses() kcpschedulingv1beta1.PriorityClassClusterInterface {
 	return newFakePriorityClassClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1beta1/scheduling_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/scheduling/v1beta1/scheduling_client.go
@@ -37,6 +37,7 @@ type SchedulingV1beta1ClusterInterface interface {
 
 type SchedulingV1beta1ClusterScoper interface {
 	Cluster(logicalcluster.Path) schedulingv1beta1.SchedulingV1beta1Interface
+	Evict(logicalcluster.Path)
 }
 
 // SchedulingV1beta1ClusterClient is used to interact with features provided by the scheduling.k8s.io group.
@@ -49,6 +50,12 @@ func (c *SchedulingV1beta1ClusterClient) Cluster(clusterPath logicalcluster.Path
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *SchedulingV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *SchedulingV1beta1ClusterClient) PriorityClasses() PriorityClassClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/fake/storage_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/fake/storage_client.go
@@ -40,6 +40,9 @@ func (c *StorageV1ClusterClient) Cluster(clusterPath logicalcluster.Path) storag
 	return &StorageV1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *StorageV1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *StorageV1ClusterClient) CSIDrivers() kcpstoragev1.CSIDriverClusterInterface {
 	return newFakeCSIDriverClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/storage_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1/storage_client.go
@@ -42,6 +42,7 @@ type StorageV1ClusterInterface interface {
 
 type StorageV1ClusterScoper interface {
 	Cluster(logicalcluster.Path) storagev1.StorageV1Interface
+	Evict(logicalcluster.Path)
 }
 
 // StorageV1ClusterClient is used to interact with features provided by the storage.k8s.io group.
@@ -54,6 +55,12 @@ func (c *StorageV1ClusterClient) Cluster(clusterPath logicalcluster.Path) storag
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *StorageV1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *StorageV1ClusterClient) CSIDrivers() CSIDriverClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1alpha1/fake/storage_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1alpha1/fake/storage_client.go
@@ -40,6 +40,9 @@ func (c *StorageV1alpha1ClusterClient) Cluster(clusterPath logicalcluster.Path) 
 	return &StorageV1alpha1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *StorageV1alpha1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *StorageV1alpha1ClusterClient) CSIStorageCapacities() kcpstoragev1alpha1.CSIStorageCapacityClusterInterface {
 	return newFakeCSIStorageCapacityClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1alpha1/storage_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1alpha1/storage_client.go
@@ -39,6 +39,7 @@ type StorageV1alpha1ClusterInterface interface {
 
 type StorageV1alpha1ClusterScoper interface {
 	Cluster(logicalcluster.Path) storagev1alpha1.StorageV1alpha1Interface
+	Evict(logicalcluster.Path)
 }
 
 // StorageV1alpha1ClusterClient is used to interact with features provided by the storage.k8s.io group.
@@ -51,6 +52,12 @@ func (c *StorageV1alpha1ClusterClient) Cluster(clusterPath logicalcluster.Path) 
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *StorageV1alpha1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *StorageV1alpha1ClusterClient) CSIStorageCapacities() CSIStorageCapacityClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/fake/storage_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/fake/storage_client.go
@@ -40,6 +40,9 @@ func (c *StorageV1beta1ClusterClient) Cluster(clusterPath logicalcluster.Path) s
 	return &StorageV1beta1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *StorageV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *StorageV1beta1ClusterClient) CSIDrivers() kcpstoragev1beta1.CSIDriverClusterInterface {
 	return newFakeCSIDriverClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/storage_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storage/v1beta1/storage_client.go
@@ -42,6 +42,7 @@ type StorageV1beta1ClusterInterface interface {
 
 type StorageV1beta1ClusterScoper interface {
 	Cluster(logicalcluster.Path) storagev1beta1.StorageV1beta1Interface
+	Evict(logicalcluster.Path)
 }
 
 // StorageV1beta1ClusterClient is used to interact with features provided by the storage.k8s.io group.
@@ -54,6 +55,12 @@ func (c *StorageV1beta1ClusterClient) Cluster(clusterPath logicalcluster.Path) s
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *StorageV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *StorageV1beta1ClusterClient) CSIDrivers() CSIDriverClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storagemigration/v1beta1/fake/storagemigration_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storagemigration/v1beta1/fake/storagemigration_client.go
@@ -40,6 +40,9 @@ func (c *StoragemigrationV1beta1ClusterClient) Cluster(clusterPath logicalcluste
 	return &StoragemigrationV1beta1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *StoragemigrationV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *StoragemigrationV1beta1ClusterClient) StorageVersionMigrations() kcpstoragemigrationv1beta1.StorageVersionMigrationClusterInterface {
 	return newFakeStorageVersionMigrationClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storagemigration/v1beta1/storagemigration_client.go
+++ b/staging/src/github.com/kcp-dev/client-go/kubernetes/typed/storagemigration/v1beta1/storagemigration_client.go
@@ -37,6 +37,7 @@ type StoragemigrationV1beta1ClusterInterface interface {
 
 type StoragemigrationV1beta1ClusterScoper interface {
 	Cluster(logicalcluster.Path) storagemigrationv1beta1.StoragemigrationV1beta1Interface
+	Evict(logicalcluster.Path)
 }
 
 // StoragemigrationV1beta1ClusterClient is used to interact with features provided by the storagemigration.k8s.io group.
@@ -49,6 +50,12 @@ func (c *StoragemigrationV1beta1ClusterClient) Cluster(clusterPath logicalcluste
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *StoragemigrationV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *StoragemigrationV1beta1ClusterClient) StorageVersionMigrations() StorageVersionMigrationClusterInterface {

--- a/staging/src/github.com/kcp-dev/client-go/metadata/clientset.go
+++ b/staging/src/github.com/kcp-dev/client-go/metadata/clientset.go
@@ -43,6 +43,12 @@ func (c *ClusterClientset) Cluster(clusterPath logicalcluster.Path) metadata.Int
 	return c.clientCache.ClusterOrDie(clusterPath)
 }
 
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *ClusterClientset) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
+}
+
 func (c *ClusterClientset) Resource(resource schema.GroupVersionResource) ResourceClusterInterface {
 	return &ClusterResourceClient{clientCache: c.clientCache, resource: resource}
 }

--- a/staging/src/github.com/kcp-dev/client-go/metadata/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/metadata/interface.go
@@ -29,6 +29,7 @@ import (
 
 type ClusterInterface interface {
 	Cluster(logicalcluster.Path) metadata.Interface
+	Evict(logicalcluster.Path)
 	Resource(resource schema.GroupVersionResource) ResourceClusterInterface
 }
 

--- a/staging/src/github.com/kcp-dev/client-go/scale/clientset.go
+++ b/staging/src/github.com/kcp-dev/client-go/scale/clientset.go
@@ -47,6 +47,12 @@ func (c ClusterClientset) Cluster(clusterPath logicalcluster.Path) scale.ScalesG
 	return c.clientCache.ClusterOrDie(clusterPath)
 }
 
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c ClusterClientset) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
+}
+
 var _ ClusterInterface = (*ClusterClientset)(nil)
 
 // NewForConfig creates a new ClusterClientset for the given config.

--- a/staging/src/github.com/kcp-dev/client-go/scale/interface.go
+++ b/staging/src/github.com/kcp-dev/client-go/scale/interface.go
@@ -24,4 +24,5 @@ import (
 
 type ClusterInterface interface {
 	Cluster(logicalcluster.Path) scale.ScalesGetter
+	Evict(logicalcluster.Path)
 }

--- a/staging/src/github.com/kcp-dev/client-go/third_party/k8s.io/client-go/dynamic/fake/simple.go
+++ b/staging/src/github.com/kcp-dev/client-go/third_party/k8s.io/client-go/dynamic/fake/simple.go
@@ -157,6 +157,9 @@ func (c *FakeDynamicClusterClientset) Cluster(clusterPath logicalcluster.Path) d
 	}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *FakeDynamicClusterClientset) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *FakeDynamicClusterClientset) Resource(resource schema.GroupVersionResource) kcpdynamic.ResourceClusterInterface {
 	return &FakeDynamicClusterClient{
 		Fake:          c.Fake,

--- a/staging/src/github.com/kcp-dev/client-go/third_party/k8s.io/client-go/metadata/fake/simple.go
+++ b/staging/src/github.com/kcp-dev/client-go/third_party/k8s.io/client-go/metadata/fake/simple.go
@@ -103,6 +103,9 @@ func (c *FakeMetadataClusterClientset) Cluster(clusterPath logicalcluster.Path) 
 	return c.cluster(clusterPath)
 }
 
+// Evict is a no-op on the fake clientset; it has no cluster-keyed cache to drop.
+func (c *FakeMetadataClusterClientset) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *FakeMetadataClusterClientset) cluster(clusterPath logicalcluster.Path) metadata.Interface {
 	return &FakeMetadataClient{
 		Fake:        c.Fake,

--- a/staging/src/github.com/kcp-dev/code-generator/cmd/cluster-client-gen/generators/fake/generator_fake_for_clientset.go
+++ b/staging/src/github.com/kcp-dev/code-generator/cmd/cluster-client-gen/generators/fake/generator_fake_for_clientset.go
@@ -233,6 +233,9 @@ func (c *ClusterClientset) Cluster(clusterPath logicalcluster.Path) clientset.In
 		clusterPath: clusterPath,
 	}
 }
+
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *ClusterClientset) Evict(clusterPath logicalcluster.Path) {}
 `
 
 var clusterClientsetInterfaceImplTemplate = `

--- a/staging/src/github.com/kcp-dev/code-generator/cmd/cluster-client-gen/generators/fake/generator_fake_for_group.go
+++ b/staging/src/github.com/kcp-dev/code-generator/cmd/cluster-client-gen/generators/fake/generator_fake_for_group.go
@@ -145,6 +145,9 @@ func (c *$.GroupGoName$$.Version$ClusterClient) Cluster(clusterPath logicalclust
 	}
 	return &$.GroupGoName$$.Version$Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
+
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *$.GroupGoName$$.Version$ClusterClient) Evict(clusterPath logicalcluster.Path) {}
 `
 
 var clusterGetterImpl = `

--- a/staging/src/github.com/kcp-dev/code-generator/cmd/cluster-client-gen/generators/generator_for_clientset.go
+++ b/staging/src/github.com/kcp-dev/code-generator/cmd/cluster-client-gen/generators/generator_for_clientset.go
@@ -101,6 +101,7 @@ func (g *genClientset) GenerateType(c *generator.Context, _ *types.Type, w io.Wr
 		sw.Do(clientsetInterfaceImplTemplate, g)
 	}
 	sw.Do(getClusterTemplate, m)
+	sw.Do(evictTemplate, m)
 	sw.Do(newClientsetForConfigTemplate, m)
 	sw.Do(newClientsetForConfigAndClientTemplate, m)
 	sw.Do(newClientsetForConfigOrDieTemplate, m)
@@ -112,6 +113,7 @@ func (g *genClientset) GenerateType(c *generator.Context, _ *types.Type, w io.Wr
 var clientsetInterface = `
 type ClusterInterface interface {
 	Cluster(logicalcluster.Path) client.Interface
+	Evict(logicalcluster.Path)
 	Discovery() $.DiscoveryInterface|raw$
     $range .allGroups$$.GroupGoName$$.Version$() $.PackageAlias$.$.GroupGoName$$.Version$ClusterInterface
 	$end$
@@ -152,6 +154,17 @@ func (c *ClusterClientset) Cluster(clusterPath logicalcluster.Path) client.Inter
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+`
+
+var evictTemplate = `
+// Evict drops cached clients for clusterPath across all per-group clients
+// and the top-level cluster cache, and prevents future caching for that
+// path.
+func (c *ClusterClientset) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
+$range .allGroups$    c.$.LowerCaseGroupGoName$$.Version$.Evict(clusterPath)
+$end$
 }
 `
 

--- a/staging/src/github.com/kcp-dev/code-generator/cmd/cluster-client-gen/generators/generator_for_group.go
+++ b/staging/src/github.com/kcp-dev/code-generator/cmd/cluster-client-gen/generators/generator_for_group.go
@@ -149,6 +149,7 @@ type $.GroupGoName$$.Version$ClusterInterface interface {
 var clusterScoperTemplate = `
 type $.GroupGoName$$.Version$ClusterScoper interface {
 	Cluster(logicalcluster.Path) $.typedInterfaceReference|raw$
+	Evict(logicalcluster.Path)
 }
 `
 
@@ -163,6 +164,12 @@ func (c *$.GroupGoName$$.Version$ClusterClient) Cluster(clusterPath logicalclust
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *$.GroupGoName$$.Version$ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 `
 

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/clientset.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/clientset.go
@@ -42,6 +42,7 @@ import (
 
 type ClusterInterface interface {
 	Cluster(logicalcluster.Path) client.Interface
+	Evict(logicalcluster.Path)
 	Discovery() discovery.DiscoveryInterface
 	ExampleV1() examplev1.ExampleV1ClusterInterface
 	ExampleV1alpha1() examplev1alpha1.ExampleV1alpha1ClusterInterface
@@ -121,6 +122,22 @@ func (c *ClusterClientset) Cluster(clusterPath logicalcluster.Path) client.Inter
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops cached clients for clusterPath across all per-group clients
+// and the top-level cluster cache, and prevents future caching for that
+// path.
+func (c *ClusterClientset) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
+	c.exampleV1.Evict(clusterPath)
+	c.exampleV1alpha1.Evict(clusterPath)
+	c.exampleV1beta1.Evict(clusterPath)
+	c.exampleV2.Evict(clusterPath)
+	c.example3V1.Evict(clusterPath)
+	c.exampleDashedV1.Evict(clusterPath)
+	c.existinginterfacesV1.Evict(clusterPath)
+	c.secondexampleV1.Evict(clusterPath)
+
 }
 
 // NewForConfig creates a new ClusterClientset for the given config.

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/fake/clientset.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/fake/clientset.go
@@ -129,6 +129,9 @@ func (c *ClusterClientset) Cluster(clusterPath logicalcluster.Path) clientset.In
 	}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *ClusterClientset) Evict(clusterPath logicalcluster.Path) {}
+
 // ExampleV1 retrieves the ExampleV1ClusterClient
 func (c *ClusterClientset) ExampleV1() kcpexamplev1.ExampleV1ClusterInterface {
 	return &kcpfakeexamplev1.ExampleV1ClusterClient{Fake: &c.Fake}

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1/example_client.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1/example_client.go
@@ -40,6 +40,7 @@ type ExampleV1ClusterInterface interface {
 
 type ExampleV1ClusterScoper interface {
 	Cluster(logicalcluster.Path) examplev1.ExampleV1Interface
+	Evict(logicalcluster.Path)
 }
 
 // ExampleV1ClusterClient is used to interact with features provided by the example.dev group.
@@ -52,6 +53,12 @@ func (c *ExampleV1ClusterClient) Cluster(clusterPath logicalcluster.Path) exampl
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *ExampleV1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *ExampleV1ClusterClient) ClusterTestTypes() ClusterTestTypeClusterInterface {

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1/fake/example_client.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1/fake/example_client.go
@@ -41,6 +41,9 @@ func (c *ExampleV1ClusterClient) Cluster(clusterPath logicalcluster.Path) exampl
 	return &ExampleV1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *ExampleV1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *ExampleV1ClusterClient) ClusterTestTypes() kcpexamplev1.ClusterTestTypeClusterInterface {
 	return newFakeClusterTestTypeClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1alpha1/example_client.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1alpha1/example_client.go
@@ -39,6 +39,7 @@ type ExampleV1alpha1ClusterInterface interface {
 
 type ExampleV1alpha1ClusterScoper interface {
 	Cluster(logicalcluster.Path) examplev1alpha1.ExampleV1alpha1Interface
+	Evict(logicalcluster.Path)
 }
 
 // ExampleV1alpha1ClusterClient is used to interact with features provided by the example.dev group.
@@ -51,6 +52,12 @@ func (c *ExampleV1alpha1ClusterClient) Cluster(clusterPath logicalcluster.Path) 
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *ExampleV1alpha1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *ExampleV1alpha1ClusterClient) ClusterTestTypes() ClusterTestTypeClusterInterface {

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1alpha1/fake/example_client.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1alpha1/fake/example_client.go
@@ -41,6 +41,9 @@ func (c *ExampleV1alpha1ClusterClient) Cluster(clusterPath logicalcluster.Path) 
 	return &ExampleV1alpha1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *ExampleV1alpha1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *ExampleV1alpha1ClusterClient) ClusterTestTypes() kcpexamplev1alpha1.ClusterTestTypeClusterInterface {
 	return newFakeClusterTestTypeClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1beta1/example_client.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1beta1/example_client.go
@@ -39,6 +39,7 @@ type ExampleV1beta1ClusterInterface interface {
 
 type ExampleV1beta1ClusterScoper interface {
 	Cluster(logicalcluster.Path) examplev1beta1.ExampleV1beta1Interface
+	Evict(logicalcluster.Path)
 }
 
 // ExampleV1beta1ClusterClient is used to interact with features provided by the example.dev group.
@@ -51,6 +52,12 @@ func (c *ExampleV1beta1ClusterClient) Cluster(clusterPath logicalcluster.Path) e
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *ExampleV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *ExampleV1beta1ClusterClient) ClusterTestTypes() ClusterTestTypeClusterInterface {

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1beta1/fake/example_client.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/typed/example/v1beta1/fake/example_client.go
@@ -41,6 +41,9 @@ func (c *ExampleV1beta1ClusterClient) Cluster(clusterPath logicalcluster.Path) e
 	return &ExampleV1beta1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *ExampleV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *ExampleV1beta1ClusterClient) ClusterTestTypes() kcpexamplev1beta1.ClusterTestTypeClusterInterface {
 	return newFakeClusterTestTypeClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/typed/example/v2/example_client.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/typed/example/v2/example_client.go
@@ -39,6 +39,7 @@ type ExampleV2ClusterInterface interface {
 
 type ExampleV2ClusterScoper interface {
 	Cluster(logicalcluster.Path) examplev2.ExampleV2Interface
+	Evict(logicalcluster.Path)
 }
 
 // ExampleV2ClusterClient is used to interact with features provided by the example.dev group.
@@ -51,6 +52,12 @@ func (c *ExampleV2ClusterClient) Cluster(clusterPath logicalcluster.Path) exampl
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *ExampleV2ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *ExampleV2ClusterClient) ClusterTestTypes() ClusterTestTypeClusterInterface {

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/typed/example/v2/fake/example_client.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/typed/example/v2/fake/example_client.go
@@ -41,6 +41,9 @@ func (c *ExampleV2ClusterClient) Cluster(clusterPath logicalcluster.Path) exampl
 	return &ExampleV2Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *ExampleV2ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *ExampleV2ClusterClient) ClusterTestTypes() kcpexamplev2.ClusterTestTypeClusterInterface {
 	return newFakeClusterTestTypeClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/typed/example3/v1/example3_client.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/typed/example3/v1/example3_client.go
@@ -39,6 +39,7 @@ type Example3V1ClusterInterface interface {
 
 type Example3V1ClusterScoper interface {
 	Cluster(logicalcluster.Path) example3v1.Example3V1Interface
+	Evict(logicalcluster.Path)
 }
 
 // Example3V1ClusterClient is used to interact with features provided by the example3.some.corp group.
@@ -51,6 +52,12 @@ func (c *Example3V1ClusterClient) Cluster(clusterPath logicalcluster.Path) examp
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *Example3V1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *Example3V1ClusterClient) ClusterTestTypes() ClusterTestTypeClusterInterface {

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/typed/example3/v1/fake/example3_client.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/typed/example3/v1/fake/example3_client.go
@@ -41,6 +41,9 @@ func (c *Example3V1ClusterClient) Cluster(clusterPath logicalcluster.Path) examp
 	return &Example3V1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *Example3V1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *Example3V1ClusterClient) ClusterTestTypes() kcpexample3v1.ClusterTestTypeClusterInterface {
 	return newFakeClusterTestTypeClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/typed/exampledashed/v1/exampledashed_client.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/typed/exampledashed/v1/exampledashed_client.go
@@ -39,6 +39,7 @@ type ExampleDashedV1ClusterInterface interface {
 
 type ExampleDashedV1ClusterScoper interface {
 	Cluster(logicalcluster.Path) exampledashedv1.ExampleDashedV1Interface
+	Evict(logicalcluster.Path)
 }
 
 // ExampleDashedV1ClusterClient is used to interact with features provided by the example-dashed.some.corp group.
@@ -51,6 +52,12 @@ func (c *ExampleDashedV1ClusterClient) Cluster(clusterPath logicalcluster.Path) 
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *ExampleDashedV1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *ExampleDashedV1ClusterClient) ClusterTestTypes() ClusterTestTypeClusterInterface {

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/typed/exampledashed/v1/fake/exampledashed_client.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/typed/exampledashed/v1/fake/exampledashed_client.go
@@ -41,6 +41,9 @@ func (c *ExampleDashedV1ClusterClient) Cluster(clusterPath logicalcluster.Path) 
 	return &ExampleDashedV1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *ExampleDashedV1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *ExampleDashedV1ClusterClient) ClusterTestTypes() kcpexampledashedv1.ClusterTestTypeClusterInterface {
 	return newFakeClusterTestTypeClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/typed/existinginterfaces/v1/existinginterfaces_client.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/typed/existinginterfaces/v1/existinginterfaces_client.go
@@ -39,6 +39,7 @@ type ExistinginterfacesV1ClusterInterface interface {
 
 type ExistinginterfacesV1ClusterScoper interface {
 	Cluster(logicalcluster.Path) existinginterfacesv1.ExistinginterfacesV1Interface
+	Evict(logicalcluster.Path)
 }
 
 // ExistinginterfacesV1ClusterClient is used to interact with features provided by the existinginterfaces.acme.corp group.
@@ -51,6 +52,12 @@ func (c *ExistinginterfacesV1ClusterClient) Cluster(clusterPath logicalcluster.P
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *ExistinginterfacesV1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *ExistinginterfacesV1ClusterClient) ClusterTestTypes() ClusterTestTypeClusterInterface {

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/typed/existinginterfaces/v1/fake/existinginterfaces_client.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/typed/existinginterfaces/v1/fake/existinginterfaces_client.go
@@ -41,6 +41,9 @@ func (c *ExistinginterfacesV1ClusterClient) Cluster(clusterPath logicalcluster.P
 	return &ExistinginterfacesV1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *ExistinginterfacesV1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *ExistinginterfacesV1ClusterClient) ClusterTestTypes() kcpexistinginterfacesv1.ClusterTestTypeClusterInterface {
 	return newFakeClusterTestTypeClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/typed/secondexample/v1/fake/secondexample_client.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/typed/secondexample/v1/fake/secondexample_client.go
@@ -41,6 +41,9 @@ func (c *SecondexampleV1ClusterClient) Cluster(clusterPath logicalcluster.Path) 
 	return &SecondexampleV1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *SecondexampleV1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *SecondexampleV1ClusterClient) ClusterTestTypes() kcpsecondexamplev1.ClusterTestTypeClusterInterface {
 	return newFakeClusterTestTypeClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/typed/secondexample/v1/secondexample_client.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcp/clients/clientset/versioned/typed/secondexample/v1/secondexample_client.go
@@ -39,6 +39,7 @@ type SecondexampleV1ClusterInterface interface {
 
 type SecondexampleV1ClusterScoper interface {
 	Cluster(logicalcluster.Path) secondexamplev1.SecondexampleV1Interface
+	Evict(logicalcluster.Path)
 }
 
 // SecondexampleV1ClusterClient is used to interact with features provided by the secondexample.dev group.
@@ -51,6 +52,12 @@ func (c *SecondexampleV1ClusterClient) Cluster(clusterPath logicalcluster.Path) 
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *SecondexampleV1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *SecondexampleV1ClusterClient) ClusterTestTypes() ClusterTestTypeClusterInterface {

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/clientset.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/clientset.go
@@ -42,6 +42,7 @@ import (
 
 type ClusterInterface interface {
 	Cluster(logicalcluster.Path) client.Interface
+	Evict(logicalcluster.Path)
 	Discovery() discovery.DiscoveryInterface
 	ExampleV1() examplev1.ExampleV1ClusterInterface
 	ExampleV1alpha1() examplev1alpha1.ExampleV1alpha1ClusterInterface
@@ -121,6 +122,22 @@ func (c *ClusterClientset) Cluster(clusterPath logicalcluster.Path) client.Inter
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops cached clients for clusterPath across all per-group clients
+// and the top-level cluster cache, and prevents future caching for that
+// path.
+func (c *ClusterClientset) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
+	c.exampleV1.Evict(clusterPath)
+	c.exampleV1alpha1.Evict(clusterPath)
+	c.exampleV1beta1.Evict(clusterPath)
+	c.exampleV2.Evict(clusterPath)
+	c.example3V1.Evict(clusterPath)
+	c.exampleDashedV1.Evict(clusterPath)
+	c.existinginterfacesV1.Evict(clusterPath)
+	c.secondexampleV1.Evict(clusterPath)
+
 }
 
 // NewForConfig creates a new ClusterClientset for the given config.

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/fake/clientset.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/fake/clientset.go
@@ -129,6 +129,9 @@ func (c *ClusterClientset) Cluster(clusterPath logicalcluster.Path) clientset.In
 	}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *ClusterClientset) Evict(clusterPath logicalcluster.Path) {}
+
 // ExampleV1 retrieves the ExampleV1ClusterClient
 func (c *ClusterClientset) ExampleV1() kcpexamplev1.ExampleV1ClusterInterface {
 	return &kcpfakeexamplev1.ExampleV1ClusterClient{Fake: &c.Fake}

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1/example_client.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1/example_client.go
@@ -40,6 +40,7 @@ type ExampleV1ClusterInterface interface {
 
 type ExampleV1ClusterScoper interface {
 	Cluster(logicalcluster.Path) examplev1.ExampleV1Interface
+	Evict(logicalcluster.Path)
 }
 
 // ExampleV1ClusterClient is used to interact with features provided by the example.dev group.
@@ -52,6 +53,12 @@ func (c *ExampleV1ClusterClient) Cluster(clusterPath logicalcluster.Path) exampl
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *ExampleV1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *ExampleV1ClusterClient) ClusterTestTypes() ClusterTestTypeClusterInterface {

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1/fake/example_client.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1/fake/example_client.go
@@ -41,6 +41,9 @@ func (c *ExampleV1ClusterClient) Cluster(clusterPath logicalcluster.Path) exampl
 	return &ExampleV1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *ExampleV1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *ExampleV1ClusterClient) ClusterTestTypes() kcpexamplev1.ClusterTestTypeClusterInterface {
 	return newFakeClusterTestTypeClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1alpha1/example_client.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1alpha1/example_client.go
@@ -39,6 +39,7 @@ type ExampleV1alpha1ClusterInterface interface {
 
 type ExampleV1alpha1ClusterScoper interface {
 	Cluster(logicalcluster.Path) examplev1alpha1.ExampleV1alpha1Interface
+	Evict(logicalcluster.Path)
 }
 
 // ExampleV1alpha1ClusterClient is used to interact with features provided by the example.dev group.
@@ -51,6 +52,12 @@ func (c *ExampleV1alpha1ClusterClient) Cluster(clusterPath logicalcluster.Path) 
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *ExampleV1alpha1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *ExampleV1alpha1ClusterClient) ClusterTestTypes() ClusterTestTypeClusterInterface {

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1alpha1/fake/example_client.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1alpha1/fake/example_client.go
@@ -41,6 +41,9 @@ func (c *ExampleV1alpha1ClusterClient) Cluster(clusterPath logicalcluster.Path) 
 	return &ExampleV1alpha1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *ExampleV1alpha1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *ExampleV1alpha1ClusterClient) ClusterTestTypes() kcpexamplev1alpha1.ClusterTestTypeClusterInterface {
 	return newFakeClusterTestTypeClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1beta1/example_client.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1beta1/example_client.go
@@ -39,6 +39,7 @@ type ExampleV1beta1ClusterInterface interface {
 
 type ExampleV1beta1ClusterScoper interface {
 	Cluster(logicalcluster.Path) examplev1beta1.ExampleV1beta1Interface
+	Evict(logicalcluster.Path)
 }
 
 // ExampleV1beta1ClusterClient is used to interact with features provided by the example.dev group.
@@ -51,6 +52,12 @@ func (c *ExampleV1beta1ClusterClient) Cluster(clusterPath logicalcluster.Path) e
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *ExampleV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *ExampleV1beta1ClusterClient) ClusterTestTypes() ClusterTestTypeClusterInterface {

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1beta1/fake/example_client.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v1beta1/fake/example_client.go
@@ -41,6 +41,9 @@ func (c *ExampleV1beta1ClusterClient) Cluster(clusterPath logicalcluster.Path) e
 	return &ExampleV1beta1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *ExampleV1beta1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *ExampleV1beta1ClusterClient) ClusterTestTypes() kcpexamplev1beta1.ClusterTestTypeClusterInterface {
 	return newFakeClusterTestTypeClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v2/example_client.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v2/example_client.go
@@ -39,6 +39,7 @@ type ExampleV2ClusterInterface interface {
 
 type ExampleV2ClusterScoper interface {
 	Cluster(logicalcluster.Path) examplev2.ExampleV2Interface
+	Evict(logicalcluster.Path)
 }
 
 // ExampleV2ClusterClient is used to interact with features provided by the example.dev group.
@@ -51,6 +52,12 @@ func (c *ExampleV2ClusterClient) Cluster(clusterPath logicalcluster.Path) exampl
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *ExampleV2ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *ExampleV2ClusterClient) ClusterTestTypes() ClusterTestTypeClusterInterface {

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v2/fake/example_client.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example/v2/fake/example_client.go
@@ -41,6 +41,9 @@ func (c *ExampleV2ClusterClient) Cluster(clusterPath logicalcluster.Path) exampl
 	return &ExampleV2Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *ExampleV2ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *ExampleV2ClusterClient) ClusterTestTypes() kcpexamplev2.ClusterTestTypeClusterInterface {
 	return newFakeClusterTestTypeClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example3/v1/example3_client.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example3/v1/example3_client.go
@@ -39,6 +39,7 @@ type Example3V1ClusterInterface interface {
 
 type Example3V1ClusterScoper interface {
 	Cluster(logicalcluster.Path) example3v1.Example3V1Interface
+	Evict(logicalcluster.Path)
 }
 
 // Example3V1ClusterClient is used to interact with features provided by the example3.some.corp group.
@@ -51,6 +52,12 @@ func (c *Example3V1ClusterClient) Cluster(clusterPath logicalcluster.Path) examp
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *Example3V1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *Example3V1ClusterClient) ClusterTestTypes() ClusterTestTypeClusterInterface {

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example3/v1/fake/example3_client.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/typed/example3/v1/fake/example3_client.go
@@ -41,6 +41,9 @@ func (c *Example3V1ClusterClient) Cluster(clusterPath logicalcluster.Path) examp
 	return &Example3V1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *Example3V1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *Example3V1ClusterClient) ClusterTestTypes() kcpexample3v1.ClusterTestTypeClusterInterface {
 	return newFakeClusterTestTypeClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/typed/exampledashed/v1/exampledashed_client.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/typed/exampledashed/v1/exampledashed_client.go
@@ -39,6 +39,7 @@ type ExampleDashedV1ClusterInterface interface {
 
 type ExampleDashedV1ClusterScoper interface {
 	Cluster(logicalcluster.Path) exampledashedv1.ExampleDashedV1Interface
+	Evict(logicalcluster.Path)
 }
 
 // ExampleDashedV1ClusterClient is used to interact with features provided by the example-dashed.some.corp group.
@@ -51,6 +52,12 @@ func (c *ExampleDashedV1ClusterClient) Cluster(clusterPath logicalcluster.Path) 
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *ExampleDashedV1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *ExampleDashedV1ClusterClient) ClusterTestTypes() ClusterTestTypeClusterInterface {

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/typed/exampledashed/v1/fake/exampledashed_client.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/typed/exampledashed/v1/fake/exampledashed_client.go
@@ -41,6 +41,9 @@ func (c *ExampleDashedV1ClusterClient) Cluster(clusterPath logicalcluster.Path) 
 	return &ExampleDashedV1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *ExampleDashedV1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *ExampleDashedV1ClusterClient) ClusterTestTypes() kcpexampledashedv1.ClusterTestTypeClusterInterface {
 	return newFakeClusterTestTypeClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/typed/existinginterfaces/v1/existinginterfaces_client.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/typed/existinginterfaces/v1/existinginterfaces_client.go
@@ -39,6 +39,7 @@ type ExistinginterfacesV1ClusterInterface interface {
 
 type ExistinginterfacesV1ClusterScoper interface {
 	Cluster(logicalcluster.Path) existinginterfacesv1.ExistinginterfacesV1Interface
+	Evict(logicalcluster.Path)
 }
 
 // ExistinginterfacesV1ClusterClient is used to interact with features provided by the existinginterfaces.acme.corp group.
@@ -51,6 +52,12 @@ func (c *ExistinginterfacesV1ClusterClient) Cluster(clusterPath logicalcluster.P
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *ExistinginterfacesV1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *ExistinginterfacesV1ClusterClient) ClusterTestTypes() ClusterTestTypeClusterInterface {

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/typed/existinginterfaces/v1/fake/existinginterfaces_client.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/typed/existinginterfaces/v1/fake/existinginterfaces_client.go
@@ -41,6 +41,9 @@ func (c *ExistinginterfacesV1ClusterClient) Cluster(clusterPath logicalcluster.P
 	return &ExistinginterfacesV1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *ExistinginterfacesV1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *ExistinginterfacesV1ClusterClient) ClusterTestTypes() kcpexistinginterfacesv1.ClusterTestTypeClusterInterface {
 	return newFakeClusterTestTypeClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/typed/secondexample/v1/fake/secondexample_client.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/typed/secondexample/v1/fake/secondexample_client.go
@@ -41,6 +41,9 @@ func (c *SecondexampleV1ClusterClient) Cluster(clusterPath logicalcluster.Path) 
 	return &SecondexampleV1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *SecondexampleV1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *SecondexampleV1ClusterClient) ClusterTestTypes() kcpsecondexamplev1.ClusterTestTypeClusterInterface {
 	return newFakeClusterTestTypeClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/typed/secondexample/v1/secondexample_client.go
+++ b/staging/src/github.com/kcp-dev/code-generator/examples/pkg/kcpexisting/clients/clientset/versioned/typed/secondexample/v1/secondexample_client.go
@@ -39,6 +39,7 @@ type SecondexampleV1ClusterInterface interface {
 
 type SecondexampleV1ClusterScoper interface {
 	Cluster(logicalcluster.Path) secondexamplev1.SecondexampleV1Interface
+	Evict(logicalcluster.Path)
 }
 
 // SecondexampleV1ClusterClient is used to interact with features provided by the secondexample.dev group.
@@ -51,6 +52,12 @@ func (c *SecondexampleV1ClusterClient) Cluster(clusterPath logicalcluster.Path) 
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *SecondexampleV1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *SecondexampleV1ClusterClient) ClusterTestTypes() ClusterTestTypeClusterInterface {

--- a/staging/src/github.com/kcp-dev/sdk/client/clientset/versioned/cluster/clientset.go
+++ b/staging/src/github.com/kcp-dev/sdk/client/clientset/versioned/cluster/clientset.go
@@ -39,6 +39,7 @@ import (
 
 type ClusterInterface interface {
 	Cluster(logicalcluster.Path) client.Interface
+	Evict(logicalcluster.Path)
 	Discovery() discovery.DiscoveryInterface
 	ApisV1alpha1() apisv1alpha1.ApisV1alpha1ClusterInterface
 	ApisV1alpha2() apisv1alpha2.ApisV1alpha2ClusterInterface
@@ -104,6 +105,20 @@ func (c *ClusterClientset) Cluster(clusterPath logicalcluster.Path) client.Inter
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops cached clients for clusterPath across all per-group clients
+// and the top-level cluster cache, and prevents future caching for that
+// path.
+func (c *ClusterClientset) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
+	c.apisV1alpha1.Evict(clusterPath)
+	c.apisV1alpha2.Evict(clusterPath)
+	c.cacheV1alpha1.Evict(clusterPath)
+	c.coreV1alpha1.Evict(clusterPath)
+	c.tenancyV1alpha1.Evict(clusterPath)
+	c.topologyV1alpha1.Evict(clusterPath)
+
 }
 
 // NewForConfig creates a new ClusterClientset for the given config.

--- a/staging/src/github.com/kcp-dev/sdk/client/clientset/versioned/cluster/fake/clientset.go
+++ b/staging/src/github.com/kcp-dev/sdk/client/clientset/versioned/cluster/fake/clientset.go
@@ -122,6 +122,9 @@ func (c *ClusterClientset) Cluster(clusterPath logicalcluster.Path) clientset.In
 	}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *ClusterClientset) Evict(clusterPath logicalcluster.Path) {}
+
 // ApisV1alpha1 retrieves the ApisV1alpha1ClusterClient
 func (c *ClusterClientset) ApisV1alpha1() kcpapisv1alpha1.ApisV1alpha1ClusterInterface {
 	return &kcpfakeapisv1alpha1.ApisV1alpha1ClusterClient{Fake: &c.Fake}

--- a/staging/src/github.com/kcp-dev/sdk/client/clientset/versioned/cluster/typed/apis/v1alpha1/apis_client.go
+++ b/staging/src/github.com/kcp-dev/sdk/client/clientset/versioned/cluster/typed/apis/v1alpha1/apis_client.go
@@ -41,6 +41,7 @@ type ApisV1alpha1ClusterInterface interface {
 
 type ApisV1alpha1ClusterScoper interface {
 	Cluster(logicalcluster.Path) kcpv1alpha1.ApisV1alpha1Interface
+	Evict(logicalcluster.Path)
 }
 
 // ApisV1alpha1ClusterClient is used to interact with features provided by the apis.kcp.io group.
@@ -53,6 +54,12 @@ func (c *ApisV1alpha1ClusterClient) Cluster(clusterPath logicalcluster.Path) kcp
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *ApisV1alpha1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *ApisV1alpha1ClusterClient) APIBindings() APIBindingClusterInterface {

--- a/staging/src/github.com/kcp-dev/sdk/client/clientset/versioned/cluster/typed/apis/v1alpha1/fake/apis_client.go
+++ b/staging/src/github.com/kcp-dev/sdk/client/clientset/versioned/cluster/typed/apis/v1alpha1/fake/apis_client.go
@@ -40,6 +40,9 @@ func (c *ApisV1alpha1ClusterClient) Cluster(clusterPath logicalcluster.Path) api
 	return &ApisV1alpha1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *ApisV1alpha1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *ApisV1alpha1ClusterClient) APIBindings() kcpapisv1alpha1.APIBindingClusterInterface {
 	return newFakeAPIBindingClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/sdk/client/clientset/versioned/cluster/typed/apis/v1alpha2/apis_client.go
+++ b/staging/src/github.com/kcp-dev/sdk/client/clientset/versioned/cluster/typed/apis/v1alpha2/apis_client.go
@@ -38,6 +38,7 @@ type ApisV1alpha2ClusterInterface interface {
 
 type ApisV1alpha2ClusterScoper interface {
 	Cluster(logicalcluster.Path) kcpv1alpha2.ApisV1alpha2Interface
+	Evict(logicalcluster.Path)
 }
 
 // ApisV1alpha2ClusterClient is used to interact with features provided by the apis.kcp.io group.
@@ -50,6 +51,12 @@ func (c *ApisV1alpha2ClusterClient) Cluster(clusterPath logicalcluster.Path) kcp
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *ApisV1alpha2ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *ApisV1alpha2ClusterClient) APIBindings() APIBindingClusterInterface {

--- a/staging/src/github.com/kcp-dev/sdk/client/clientset/versioned/cluster/typed/apis/v1alpha2/fake/apis_client.go
+++ b/staging/src/github.com/kcp-dev/sdk/client/clientset/versioned/cluster/typed/apis/v1alpha2/fake/apis_client.go
@@ -40,6 +40,9 @@ func (c *ApisV1alpha2ClusterClient) Cluster(clusterPath logicalcluster.Path) api
 	return &ApisV1alpha2Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *ApisV1alpha2ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *ApisV1alpha2ClusterClient) APIBindings() kcpapisv1alpha2.APIBindingClusterInterface {
 	return newFakeAPIBindingClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/sdk/client/clientset/versioned/cluster/typed/cache/v1alpha1/cache_client.go
+++ b/staging/src/github.com/kcp-dev/sdk/client/clientset/versioned/cluster/typed/cache/v1alpha1/cache_client.go
@@ -38,6 +38,7 @@ type CacheV1alpha1ClusterInterface interface {
 
 type CacheV1alpha1ClusterScoper interface {
 	Cluster(logicalcluster.Path) kcpv1alpha1.CacheV1alpha1Interface
+	Evict(logicalcluster.Path)
 }
 
 // CacheV1alpha1ClusterClient is used to interact with features provided by the cache.kcp.io group.
@@ -50,6 +51,12 @@ func (c *CacheV1alpha1ClusterClient) Cluster(clusterPath logicalcluster.Path) kc
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *CacheV1alpha1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *CacheV1alpha1ClusterClient) CachedResources() CachedResourceClusterInterface {

--- a/staging/src/github.com/kcp-dev/sdk/client/clientset/versioned/cluster/typed/cache/v1alpha1/fake/cache_client.go
+++ b/staging/src/github.com/kcp-dev/sdk/client/clientset/versioned/cluster/typed/cache/v1alpha1/fake/cache_client.go
@@ -40,6 +40,9 @@ func (c *CacheV1alpha1ClusterClient) Cluster(clusterPath logicalcluster.Path) ca
 	return &CacheV1alpha1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *CacheV1alpha1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *CacheV1alpha1ClusterClient) CachedResources() kcpcachev1alpha1.CachedResourceClusterInterface {
 	return newFakeCachedResourceClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/sdk/client/clientset/versioned/cluster/typed/core/v1alpha1/core_client.go
+++ b/staging/src/github.com/kcp-dev/sdk/client/clientset/versioned/cluster/typed/core/v1alpha1/core_client.go
@@ -38,6 +38,7 @@ type CoreV1alpha1ClusterInterface interface {
 
 type CoreV1alpha1ClusterScoper interface {
 	Cluster(logicalcluster.Path) kcpv1alpha1.CoreV1alpha1Interface
+	Evict(logicalcluster.Path)
 }
 
 // CoreV1alpha1ClusterClient is used to interact with features provided by the core.kcp.io group.
@@ -50,6 +51,12 @@ func (c *CoreV1alpha1ClusterClient) Cluster(clusterPath logicalcluster.Path) kcp
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *CoreV1alpha1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *CoreV1alpha1ClusterClient) LogicalClusters() LogicalClusterClusterInterface {

--- a/staging/src/github.com/kcp-dev/sdk/client/clientset/versioned/cluster/typed/core/v1alpha1/fake/core_client.go
+++ b/staging/src/github.com/kcp-dev/sdk/client/clientset/versioned/cluster/typed/core/v1alpha1/fake/core_client.go
@@ -40,6 +40,9 @@ func (c *CoreV1alpha1ClusterClient) Cluster(clusterPath logicalcluster.Path) cor
 	return &CoreV1alpha1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *CoreV1alpha1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *CoreV1alpha1ClusterClient) LogicalClusters() kcpcorev1alpha1.LogicalClusterClusterInterface {
 	return newFakeLogicalClusterClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/sdk/client/clientset/versioned/cluster/typed/tenancy/v1alpha1/fake/tenancy_client.go
+++ b/staging/src/github.com/kcp-dev/sdk/client/clientset/versioned/cluster/typed/tenancy/v1alpha1/fake/tenancy_client.go
@@ -40,6 +40,9 @@ func (c *TenancyV1alpha1ClusterClient) Cluster(clusterPath logicalcluster.Path) 
 	return &TenancyV1alpha1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *TenancyV1alpha1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *TenancyV1alpha1ClusterClient) Workspaces() kcptenancyv1alpha1.WorkspaceClusterInterface {
 	return newFakeWorkspaceClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/sdk/client/clientset/versioned/cluster/typed/tenancy/v1alpha1/tenancy_client.go
+++ b/staging/src/github.com/kcp-dev/sdk/client/clientset/versioned/cluster/typed/tenancy/v1alpha1/tenancy_client.go
@@ -39,6 +39,7 @@ type TenancyV1alpha1ClusterInterface interface {
 
 type TenancyV1alpha1ClusterScoper interface {
 	Cluster(logicalcluster.Path) kcpv1alpha1.TenancyV1alpha1Interface
+	Evict(logicalcluster.Path)
 }
 
 // TenancyV1alpha1ClusterClient is used to interact with features provided by the tenancy.kcp.io group.
@@ -51,6 +52,12 @@ func (c *TenancyV1alpha1ClusterClient) Cluster(clusterPath logicalcluster.Path) 
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *TenancyV1alpha1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *TenancyV1alpha1ClusterClient) Workspaces() WorkspaceClusterInterface {

--- a/staging/src/github.com/kcp-dev/sdk/client/clientset/versioned/cluster/typed/topology/v1alpha1/fake/topology_client.go
+++ b/staging/src/github.com/kcp-dev/sdk/client/clientset/versioned/cluster/typed/topology/v1alpha1/fake/topology_client.go
@@ -40,6 +40,9 @@ func (c *TopologyV1alpha1ClusterClient) Cluster(clusterPath logicalcluster.Path)
 	return &TopologyV1alpha1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *TopologyV1alpha1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *TopologyV1alpha1ClusterClient) Partitions() kcptopologyv1alpha1.PartitionClusterInterface {
 	return newFakePartitionClusterClient(c)
 }

--- a/staging/src/github.com/kcp-dev/sdk/client/clientset/versioned/cluster/typed/topology/v1alpha1/topology_client.go
+++ b/staging/src/github.com/kcp-dev/sdk/client/clientset/versioned/cluster/typed/topology/v1alpha1/topology_client.go
@@ -38,6 +38,7 @@ type TopologyV1alpha1ClusterInterface interface {
 
 type TopologyV1alpha1ClusterScoper interface {
 	Cluster(logicalcluster.Path) kcpv1alpha1.TopologyV1alpha1Interface
+	Evict(logicalcluster.Path)
 }
 
 // TopologyV1alpha1ClusterClient is used to interact with features provided by the topology.kcp.io group.
@@ -50,6 +51,12 @@ func (c *TopologyV1alpha1ClusterClient) Cluster(clusterPath logicalcluster.Path)
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *TopologyV1alpha1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *TopologyV1alpha1ClusterClient) Partitions() PartitionClusterInterface {

--- a/test/e2e/fixtures/wildwest/client/clientset/versioned/cluster/clientset.go
+++ b/test/e2e/fixtures/wildwest/client/clientset/versioned/cluster/clientset.go
@@ -35,6 +35,7 @@ import (
 
 type ClusterInterface interface {
 	Cluster(logicalcluster.Path) client.Interface
+	Evict(logicalcluster.Path)
 	Discovery() discovery.DiscoveryInterface
 	WildwestV1alpha1() wildwestv1alpha1.WildwestV1alpha1ClusterInterface
 }
@@ -65,6 +66,15 @@ func (c *ClusterClientset) Cluster(clusterPath logicalcluster.Path) client.Inter
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops cached clients for clusterPath across all per-group clients
+// and the top-level cluster cache, and prevents future caching for that
+// path.
+func (c *ClusterClientset) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
+	c.wildwestV1alpha1.Evict(clusterPath)
+
 }
 
 // NewForConfig creates a new ClusterClientset for the given config.

--- a/test/e2e/fixtures/wildwest/client/clientset/versioned/cluster/fake/clientset.go
+++ b/test/e2e/fixtures/wildwest/client/clientset/versioned/cluster/fake/clientset.go
@@ -108,6 +108,9 @@ func (c *ClusterClientset) Cluster(clusterPath logicalcluster.Path) clientset.In
 	}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *ClusterClientset) Evict(clusterPath logicalcluster.Path) {}
+
 // WildwestV1alpha1 retrieves the WildwestV1alpha1ClusterClient
 func (c *ClusterClientset) WildwestV1alpha1() kcpwildwestv1alpha1.WildwestV1alpha1ClusterInterface {
 	return &kcpfakewildwestv1alpha1.WildwestV1alpha1ClusterClient{Fake: &c.Fake}

--- a/test/e2e/fixtures/wildwest/client/clientset/versioned/cluster/typed/wildwest/v1alpha1/fake/wildwest_client.go
+++ b/test/e2e/fixtures/wildwest/client/clientset/versioned/cluster/typed/wildwest/v1alpha1/fake/wildwest_client.go
@@ -41,6 +41,9 @@ func (c *WildwestV1alpha1ClusterClient) Cluster(clusterPath logicalcluster.Path)
 	return &WildwestV1alpha1Client{Fake: c.Fake, ClusterPath: clusterPath}
 }
 
+// Evict is a no-op on the fake client; it has no cluster-keyed cache to drop.
+func (c *WildwestV1alpha1ClusterClient) Evict(clusterPath logicalcluster.Path) {}
+
 func (c *WildwestV1alpha1ClusterClient) Cowboys() kcpwildwestv1alpha1.CowboyClusterInterface {
 	return newFakeCowboyClusterClient(c)
 }

--- a/test/e2e/fixtures/wildwest/client/clientset/versioned/cluster/typed/wildwest/v1alpha1/wildwest_client.go
+++ b/test/e2e/fixtures/wildwest/client/clientset/versioned/cluster/typed/wildwest/v1alpha1/wildwest_client.go
@@ -39,6 +39,7 @@ type WildwestV1alpha1ClusterInterface interface {
 
 type WildwestV1alpha1ClusterScoper interface {
 	Cluster(logicalcluster.Path) kcpv1alpha1.WildwestV1alpha1Interface
+	Evict(logicalcluster.Path)
 }
 
 // WildwestV1alpha1ClusterClient is used to interact with features provided by the wildwest.dev group.
@@ -51,6 +52,12 @@ func (c *WildwestV1alpha1ClusterClient) Cluster(clusterPath logicalcluster.Path)
 		panic("A specific cluster must be provided when scoping, not the wildcard.")
 	}
 	return c.clientCache.ClusterOrDie(clusterPath)
+}
+
+// Evict drops the cached client for clusterPath and prevents re-caching
+// for it.
+func (c *WildwestV1alpha1ClusterClient) Evict(clusterPath logicalcluster.Path) {
+	c.clientCache.Evict(clusterPath)
 }
 
 func (c *WildwestV1alpha1ClusterClient) Cowboys() CowboyClusterInterface {


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Different solution to https://github.com/kcp-dev/kcp/pull/4138 with wiring instead of a global package state variable.
Based on that PR branch but removed the pprof and docs changes.

I think this makes more sense - `.Cluster` is the start of the lifecycle of a cluster for the client and `.Evict` is the end.
User don't have to use the `.Evict` - but anyone who looks at the API surface will immediately know that clients are not "free" and that they'll have to keep in mind that they may need to lifecycle the clusters at some point.
Additionally when a user runs into OOM issues they'll be spared the investigation _and_ they have the solution in hand.
If we hide this away in package-level state machine users will not know about this _and_ won't be able to find it if they go looking for solutions.

Diff only: https://github.com/kcp-dev/kcp/pull/4163

## What Type of PR Is This?

/kind bug

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
