### PR TITLE
Add rbac to /metrics 

### DIFF
--- a/docs/content/setup/production/.pages
+++ b/docs/content/setup/production/.pages
@@ -7,3 +7,4 @@ nav:
   - kcp-vespucci.md
   - kcp-comer.md
   - audit-logging.md
+  - metrics.md

--- a/docs/content/setup/production/metrics.md
+++ b/docs/content/setup/production/metrics.md
@@ -28,9 +28,12 @@ https://<shard>:6443/clusters/<workspace>/metrics
 https://<cache-server>:6443/services/cache/shards/<shard>/clusters/<workspace>/metrics
 ```
 
-return `501 Not Implemented`. Metrics are a shard-wide signal and have no
-per-workspace or per-shard scope; the kcp HTTP filter rejects these requests
-before authorization runs.
+return `501 Not Implemented`. Today this is a placeholder: per-workspace and
+per-shard metrics are not yet implemented, and the data the underlying
+`/metrics` handler exposes is shard-wide with no per-workspace or per-shard
+meaning. The kcp HTTP filter rejects these requests before authorization runs
+so that a future implementation can fill in real workspace-scoped metrics
+without changing the URL contract.
 
 ## Authorizing a scraper on a shard
 

--- a/docs/content/setup/production/metrics.md
+++ b/docs/content/setup/production/metrics.md
@@ -1,6 +1,6 @@
 # Scraping kcp metrics
 
-kcp exposes Prometheus metrics on the `/metrics` endpoint of every shard and of
+kcp exposes Prometheus metrics on the `/metrics` endpoint of every shard and on
 the cache server. These are **shard-wide** resources: a single scrape returns
 process-level data for the entire shard, not for any particular workspace.
 
@@ -21,26 +21,49 @@ For the cache server:
 https://<cache-server>:6443/metrics
 ```
 
-Workspace- or shard-scoped variants such as
+## Workspace- and shard-scoped variants are rejected
+
+Requests such as
 
 ```
 https://<shard>:6443/clusters/<workspace>/metrics
 https://<cache-server>:6443/services/cache/shards/<shard>/clusters/<workspace>/metrics
+https://<cache-server>:6443/services/cache/shards/<shard>/metrics
 ```
 
-return `501 Not Implemented`. Today this is a placeholder: per-workspace and
-per-shard metrics are not yet implemented, and the data the underlying
-`/metrics` handler exposes is shard-wide with no per-workspace or per-shard
-meaning. The kcp HTTP filter rejects these requests before authorization runs
-so that a future implementation can fill in real workspace-scoped metrics
-without changing the URL contract.
+return `501 Not Implemented`. The kcp HTTP filter rejects these requests before
+authorization runs, so a workspace-local `ClusterRole` with
+`nonResourceURLs: ["/metrics"]` can no longer grant access to shard-wide data.
+
+!!! warning
+    Earlier kcp releases accidentally allowed a workspace administrator to grant
+    themselves access to shard metrics by creating a `ClusterRole` with
+    `nonResourceURLs: ["/metrics"]` and a binding inside their own workspace.
+    This was a privilege escalation: the data exposed is shard-wide, not
+    workspace content. The path is now rejected at any non-root scope and the
+    only authoritative binding is one created in `:root` (see below).
+
+### What the shard / cache server `/metrics` actually returns
+
+The bare top-level `/metrics` is the standard Prometheus exposition produced by
+the underlying apiserver process. It aggregates counters and histograms across
+every workspace served by the shard (or cached by the cache server) and there
+is no per-workspace breakdown.
+
+### Future per-workspace metrics
+
+Per-workspace and per-shard metrics are not implemented today. The 501 status
+is a deliberate placeholder so that a future implementation can fill in real
+workspace-scoped metrics under the same URL contract without forcing scrapers
+to migrate paths.
 
 ## Authorizing a scraper on a shard
 
 kcp ships a bootstrap `ClusterRole` named `system:kcp:metrics-reader` that grants
 `GET` on `/metrics`. To allow an identity to scrape every shard, create a
-`ClusterRoleBinding` in the `:root` workspace. The binding is replicated to all
-shards via the cache server, so a single binding is enough.
+`ClusterRoleBinding` in the `:root` workspace. The root workspace lives on the
+root shard, and the binding is replicated to all shards via the cache server,
+so a single binding in `:root` is sufficient to cover the entire deployment.
 
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -57,7 +80,7 @@ subjects:
     name: prometheus
 ```
 
-Apply it against the root workspace:
+Apply it to the root workspace:
 
 ```bash
 kubectl --kubeconfig=admin.kubeconfig --context root ws use :root
@@ -74,15 +97,6 @@ curl -k --cert prometheus.crt --key prometheus.key \
 
 Substitute `kind: Group` or `kind: ServiceAccount` in the binding to suit your
 identity provider.
-
-### Note: workspace-local `nonResourceURLs: /metrics` no longer works
-
-Earlier kcp releases accidentally allowed a workspace administrator to grant
-themselves access to shard metrics by creating a `ClusterRole` with
-`nonResourceURLs: ["/metrics"]` and a binding inside their own workspace. This
-was a privilege escalation: the data exposed is shard-wide, not workspace
-content. The path is now rejected at the workspace scope and the only
-authoritative binding is one created in `:root`.
 
 ## Authorizing a scraper on the cache server
 

--- a/docs/content/setup/production/metrics.md
+++ b/docs/content/setup/production/metrics.md
@@ -1,0 +1,124 @@
+# Scraping kcp metrics
+
+kcp exposes Prometheus metrics on the `/metrics` endpoint of every shard and of
+the cache server. These are **shard-wide** resources: a single scrape returns
+process-level data for the entire shard, not for any particular workspace.
+
+This page describes how to authorize a scraper (e.g. Prometheus) without using
+the `system:masters` group.
+
+## Where `/metrics` lives
+
+For each shard:
+
+```
+https://<shard>:6443/metrics
+```
+
+For the cache server:
+
+```
+https://<cache-server>:6443/metrics
+```
+
+Workspace- or shard-scoped variants such as
+
+```
+https://<shard>:6443/clusters/<workspace>/metrics
+https://<cache-server>:6443/services/cache/shards/<shard>/clusters/<workspace>/metrics
+```
+
+return `501 Not Implemented`. Metrics are a shard-wide signal and have no
+per-workspace or per-shard scope; the kcp HTTP filter rejects these requests
+before authorization runs.
+
+## Authorizing a scraper on a shard
+
+kcp ships a bootstrap `ClusterRole` named `system:kcp:metrics-reader` that grants
+`GET` on `/metrics`. To allow an identity to scrape every shard, create a
+`ClusterRoleBinding` in the `:root` workspace. The binding is replicated to all
+shards via the cache server, so a single binding is enough.
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-metrics-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:kcp:metrics-reader
+subjects:
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: prometheus
+```
+
+Apply it against the root workspace:
+
+```bash
+kubectl --kubeconfig=admin.kubeconfig --context root ws use :root
+kubectl apply -f prometheus-metrics-reader-binding.yaml
+```
+
+Any client authenticated as user `prometheus` (or whichever subject you bind)
+can now scrape `/metrics` on every shard:
+
+```bash
+curl -k --cert prometheus.crt --key prometheus.key \
+  https://<shard>:6443/metrics
+```
+
+Substitute `kind: Group` or `kind: ServiceAccount` in the binding to suit your
+identity provider.
+
+### Note: workspace-local `nonResourceURLs: /metrics` no longer works
+
+Earlier kcp releases accidentally allowed a workspace administrator to grant
+themselves access to shard metrics by creating a `ClusterRole` with
+`nonResourceURLs: ["/metrics"]` and a binding inside their own workspace. This
+was a privilege escalation: the data exposed is shard-wide, not workspace
+content. The path is now rejected at the workspace scope and the only
+authoritative binding is one created in `:root`.
+
+## Authorizing a scraper on the cache server
+
+The cache server has no workspace-aware RBAC. By default `/metrics` is reachable
+only by `system:masters`. To allow unauthenticated scraping (typical for an
+internal Prometheus running on the same private network), add `/metrics` to
+the cache server's `--authorization-always-allow-paths` flag:
+
+```
+--authorization-always-allow-paths=/healthz,/readyz,/livez,/metrics
+```
+
+The same flag already governs liveness/readiness scraping, so this is the
+established pattern. The cache server's request filter still rejects
+shard/workspace-scoped variants of `/metrics` with `501 Not Implemented` even
+when the path is added to the always-allow list.
+
+## Prometheus scrape config example
+
+```yaml
+scrape_configs:
+  - job_name: kcp-shards
+    metrics_path: /metrics
+    scheme: https
+    tls_config:
+      ca_file: /etc/prometheus/kcp-ca.crt
+      cert_file: /etc/prometheus/prometheus.crt
+      key_file: /etc/prometheus/prometheus.key
+    static_configs:
+      - targets:
+          - shard-1.kcp.svc:6443
+          - shard-2.kcp.svc:6443
+  - job_name: kcp-cache
+    metrics_path: /metrics
+    scheme: https
+    tls_config:
+      ca_file: /etc/prometheus/kcp-ca.crt
+      insecure_skip_verify: true
+    static_configs:
+      - targets:
+          - cache.kcp.svc:6443
+```

--- a/docs/content/setup/production/metrics.md
+++ b/docs/content/setup/production/metrics.md
@@ -33,15 +33,10 @@ https://<cache-server>:6443/services/cache/shards/<shard>/metrics
 
 return `501 Not Implemented`. The kcp HTTP filter rejects these requests before
 authorization runs, so a workspace-local `ClusterRole` with
-`nonResourceURLs: ["/metrics"]` can no longer grant access to shard-wide data.
-
-!!! warning
-    Earlier kcp releases accidentally allowed a workspace administrator to grant
-    themselves access to shard metrics by creating a `ClusterRole` with
-    `nonResourceURLs: ["/metrics"]` and a binding inside their own workspace.
-    This was a privilege escalation: the data exposed is shard-wide, not
-    workspace content. The path is now rejected at any non-root scope and the
-    only authoritative binding is one created in `:root` (see below).
+`nonResourceURLs: ["/metrics"]` can't access metrics. This is a deliberate design choice
+ to avoid the complexity of per-workspace for time being. This is placeholder for a future 
+ implementation that may add real workspace-scoped metrics under these paths without breaking 
+ existing scrapers.
 
 ### What the shard / cache server `/metrics` actually returns
 

--- a/pkg/authorization/bootstrap/policy.go
+++ b/pkg/authorization/bootstrap/policy.go
@@ -47,6 +47,12 @@ const (
 	SystemExternalLogicalClusterAdmin = "system:kcp:external-logical-cluster-admin"
 	// SystemKcpWorkspaceAccessGroup is a group that gives a user system:authenticated access to a workspace.
 	SystemKcpWorkspaceAccessGroup = "system:kcp:workspace:access"
+	// SystemKcpMetricsReader is a ClusterRole that grants read access to the
+	// shard-wide /metrics endpoint. A kcp-admin binds it inside :root to an
+	// identity (User, Group, or ServiceAccount) used by prometheus or similar
+	// scrapers. The binding is replicated to every shard via the cache server,
+	// so a single :root binding authorizes scraping on all shards.
+	SystemKcpMetricsReader = "system:kcp:metrics-reader"
 	// SystemKcpInitializerGroupPrefix is the group prefix used by the initializing virtual workspace's
 	// content proxy to mark a request as already authorized against the WorkspaceType's
 	// initializerPermissions. Concrete groups are formed as
@@ -119,6 +125,12 @@ func clusterRoles() []rbacv1.ClusterRole {
 			ObjectMeta: metav1.ObjectMeta{Name: SystemKcpWorkspaceAccessGroup},
 			Rules: []rbacv1.PolicyRule{
 				rbacv1helpers.NewRule("access").URLs("/").RuleOrDie(),
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: SystemKcpMetricsReader},
+			Rules: []rbacv1.PolicyRule{
+				rbacv1helpers.NewRule("get").URLs("/metrics").RuleOrDie(),
 			},
 		},
 		{

--- a/pkg/authorization/shardpaths/paths.go
+++ b/pkg/authorization/shardpaths/paths.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package shardpaths declares the set of HTTP paths that are served by a shard
+// (or the cache server) as shard-wide resources and must not be reachable via a
+// workspace-scoped URL such as /clusters/<ws>/<path> or
+// /services/cache/shards/<sh>/clusters/<ws>/<path>.
+package shardpaths
+
+import "k8s.io/apimachinery/pkg/util/sets"
+
+// Paths enumerates the URL paths that are shard-level only. The filters in
+// pkg/server/filters and pkg/cache/server reject any workspace-scoped request
+// targeting one of these paths, and scope a top-level request to the root
+// workspace for RBAC evaluation.
+var Paths = sets.New(
+	"/metrics",
+)

--- a/pkg/authorization/shardpaths/paths.go
+++ b/pkg/authorization/shardpaths/paths.go
@@ -27,14 +27,11 @@ import "k8s.io/apimachinery/pkg/util/sets"
 // targeting one of these paths, and scope a top-level request to the root
 // workspace for RBAC evaluation.
 //
-// The set includes /metrics and the standard kube health probes
-// (/livez, /readyz, /healthz). All of these expose process-level state for
-// the running shard or cache server with no per-workspace or per-shard
-// meaning, so the workspace-scoped forms (/clusters/<ws>/livez,
-// /services/cache/shards/<sh>/livez, ...) must not resolve.
+// Note: /livez, /readyz, /healthz are intentionally NOT in this set. They
+// must remain accessible via /clusters/<ws>/{healthz,...} so that authorized
+// in-workspace clients can probe shard liveness without bypassing workspace
+// scoping for everything else they do. Their workspace-scoped form returns
+// the same process-level result as the bare URL; nothing leaks.
 var Paths = sets.New(
 	"/metrics",
-	"/livez",
-	"/readyz",
-	"/healthz",
 )

--- a/pkg/authorization/shardpaths/paths.go
+++ b/pkg/authorization/shardpaths/paths.go
@@ -26,6 +26,15 @@ import "k8s.io/apimachinery/pkg/util/sets"
 // pkg/server/filters and pkg/cache/server reject any workspace-scoped request
 // targeting one of these paths, and scope a top-level request to the root
 // workspace for RBAC evaluation.
+//
+// The set includes /metrics and the standard kube health probes
+// (/livez, /readyz, /healthz). All of these expose process-level state for
+// the running shard or cache server with no per-workspace or per-shard
+// meaning, so the workspace-scoped forms (/clusters/<ws>/livez,
+// /services/cache/shards/<sh>/livez, ...) must not resolve.
 var Paths = sets.New(
 	"/metrics",
+	"/livez",
+	"/readyz",
+	"/healthz",
 )

--- a/pkg/authorization/workspace_content_authorizer.go
+++ b/pkg/authorization/workspace_content_authorizer.go
@@ -36,6 +36,7 @@ import (
 	rbacwrapper "github.com/kcp-dev/virtual-workspace-framework/pkg/wrappers/rbac"
 
 	"github.com/kcp-dev/kcp/pkg/authorization/bootstrap"
+	"github.com/kcp-dev/kcp/pkg/authorization/shardpaths"
 )
 
 const (
@@ -80,6 +81,15 @@ type workspaceContentAuthorizer struct {
 
 func (a *workspaceContentAuthorizer) Authorize(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
 	cluster := genericapirequest.ClusterFrom(ctx)
+
+	// Shard-level non-resource URLs (e.g. /metrics) carry no workspace semantics.
+	// WithShardLevelPaths has either rejected the request already or scoped it to
+	// :root. Skip the verb=access gate so a minimally-privileged identity bound
+	// only to a NonResourceURLs rule (e.g. system:kcp:metrics-reader) can scrape
+	// without also being granted broader workspace access.
+	if !attr.IsResourceRequest() && shardpaths.Paths.Has(attr.GetPath()) {
+		return DelegateAuthorization("shard-level path", a.delegate).Authorize(ctx, attr)
+	}
 
 	// empty or system workspaces have no meaning in the context of authorizing workspace content.
 	// To access system workspaces, the user must be privileged such that authorization is skipped completely.

--- a/pkg/authorization/workspace_content_authorizer_test.go
+++ b/pkg/authorization/workspace_content_authorizer_test.go
@@ -73,6 +73,8 @@ func TestWorkspaceContentAuthorizer(t *testing.T) {
 		wantReason, wantError string
 		wantDecision          authorizer.Decision
 		deepSARHeader         bool
+		path                  string
+		resourceRequest       bool
 	}{
 		{
 			testName: "unknown requested workspace",
@@ -226,6 +228,26 @@ func TestWorkspaceContentAuthorizer(t *testing.T) {
 			wantDecision:       authorizer.DecisionAllow,
 			wantReason:         "delegating due to deep SAR request",
 		},
+		{
+			testName: "shard-level /metrics path bypasses verb=access gate",
+
+			requestedWorkspace: "root:ready",
+			requestingUser:     &user.DefaultInfo{Name: "metrics-scraper"},
+			path:               "/metrics",
+			resourceRequest:    false,
+			wantDecision:       authorizer.DecisionAllow,
+			wantReason:         "delegating due to shard-level path",
+		},
+		{
+			testName: "resource request to /metrics does NOT bypass (defense in depth)",
+
+			requestedWorkspace: "root:ready",
+			requestingUser:     &user.DefaultInfo{Name: "user-unknown"},
+			path:               "/metrics",
+			resourceRequest:    true,
+			wantDecision:       authorizer.DecisionNoOpinion,
+			wantReason:         "no verb=access permission on /",
+		},
 	} {
 		t.Run(tt.testName, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
@@ -378,7 +400,9 @@ func TestWorkspaceContentAuthorizer(t *testing.T) {
 			}
 			ctx = request.WithCluster(ctx, requestedCluster)
 			attr := authorizer.AttributesRecord{
-				User: tt.requestingUser,
+				User:            tt.requestingUser,
+				Path:            tt.path,
+				ResourceRequest: tt.resourceRequest,
 			}
 			if tt.deepSARHeader {
 				ctx = context.WithValue(ctx, deepSARKey, true)

--- a/pkg/cache/server/config.go
+++ b/pkg/cache/server/config.go
@@ -153,6 +153,10 @@ func NewConfig(opts *cacheserveroptions.CompletedOptions, optionalLocalShardRest
 		// request context, reject any request whose cluster.Name is path-shaped
 		// so a bogus name cannot leak into etcd keys.
 		apiHandler = filters.WithClusterNameShapeInvariant(apiHandler)
+		// After WithClusterScope and WithShardScope have populated the request
+		// context, reject shard-level URLs that arrived through a workspace-
+		// or shard-scoped prefix (e.g. /services/cache/shards/X/clusters/Y/metrics).
+		apiHandler = WithCacheShardLevelPaths(apiHandler)
 		apiHandler = filters.WithClusterScope(apiHandler)
 		apiHandler = WithShardScope(apiHandler)
 		apiHandler = WithServiceScope(apiHandler)

--- a/pkg/cache/server/handler.go
+++ b/pkg/cache/server/handler.go
@@ -64,14 +64,14 @@ func init() {
 // /shards/amber/clusters/system:amber/apis/apis.kcp.io/v1alpha1/apiexports
 //
 // Note:
-// not all paths require to have a valid shard name. Any path declared
-// shard-level in pkg/authorization/shardpaths (e.g. /metrics and the standard
-// /livez, /readyz, /healthz probes) passes through so that prometheus-style
-// scrapers and liveness probes can hit the cache server directly without
+// not all paths require to have a valid shard name,
+// as of today the following paths pass through: "/livez", "/readyz", "/healthz",
+// and any path declared shard-level in pkg/authorization/shardpaths (e.g. /metrics)
+// so that prometheus-style scrapers can hit the cache server directly without
 // constructing a /shards/<sh>/ prefix.
 func WithShardScope(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if shardpaths.Paths.Has(req.URL.Path) {
+		if path := req.URL.Path; path == "/livez" || path == "/readyz" || path == "/healthz" || shardpaths.Paths.Has(path) {
 			handler.ServeHTTP(w, req)
 			return
 		}

--- a/pkg/cache/server/handler.go
+++ b/pkg/cache/server/handler.go
@@ -64,14 +64,14 @@ func init() {
 // /shards/amber/clusters/system:amber/apis/apis.kcp.io/v1alpha1/apiexports
 //
 // Note:
-// not all paths require to have a valid shard name,
-// as of today the following paths pass through: "/livez", "/readyz", "/healthz",
-// and any path declared shard-level in pkg/authorization/shardpaths (e.g. /metrics)
-// so that prometheus-style scrapers can hit the cache server directly without
+// not all paths require to have a valid shard name. Any path declared
+// shard-level in pkg/authorization/shardpaths (e.g. /metrics and the standard
+// /livez, /readyz, /healthz probes) passes through so that prometheus-style
+// scrapers and liveness probes can hit the cache server directly without
 // constructing a /shards/<sh>/ prefix.
 func WithShardScope(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if path := req.URL.Path; path == "/livez" || path == "/readyz" || path == "/healthz" || shardpaths.Paths.Has(path) {
+		if shardpaths.Paths.Has(req.URL.Path) {
 			handler.ServeHTTP(w, req)
 			return
 		}

--- a/pkg/cache/server/handler.go
+++ b/pkg/cache/server/handler.go
@@ -29,8 +29,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apiserver/pkg/audit"
 	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
 	"k8s.io/apiserver/pkg/endpoints/request"
+
+	"github.com/kcp-dev/kcp/pkg/authorization/shardpaths"
 )
 
 var (
@@ -62,10 +65,13 @@ func init() {
 //
 // Note:
 // not all paths require to have a valid shard name,
-// as of today the following paths pass through: "/livez", "/readyz", "/healthz".
+// as of today the following paths pass through: "/livez", "/readyz", "/healthz",
+// and any path declared shard-level in pkg/authorization/shardpaths (e.g. /metrics)
+// so that prometheus-style scrapers can hit the cache server directly without
+// constructing a /shards/<sh>/ prefix.
 func WithShardScope(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if path := req.URL.Path; path == "/livez" || path == "/readyz" || path == "/healthz" {
+		if path := req.URL.Path; path == "/livez" || path == "/readyz" || path == "/healthz" || shardpaths.Paths.Has(path) {
 			handler.ServeHTTP(w, req)
 			return
 		}
@@ -138,6 +144,31 @@ func WithServiceScope(handler http.Handler) http.Handler {
 				return
 			}
 			req.URL = newURL
+		}
+		handler.ServeHTTP(w, req)
+	})
+}
+
+// WithCacheShardLevelPaths enforces that shard-level URLs (see
+// pkg/authorization/shardpaths) are not reachable via a shard- or
+// workspace-scoped cache server URL such as
+// /services/cache/shards/<sh>/clusters/<ws>/metrics. The data exposed at these
+// paths is process-wide and has no per-shard or per-workspace meaning.
+//
+// Must run AFTER WithClusterScope and WithShardScope so the request context
+// reflects whether either prefix was present in the original URL.
+func WithCacheShardLevelPaths(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if !shardpaths.Paths.Has(req.URL.Path) {
+			handler.ServeHTTP(w, req)
+			return
+		}
+		shardScope := request.ShardFrom(req.Context())
+		cluster := request.ClusterFrom(req.Context())
+		if !shardScope.Empty() || (cluster != nil && !cluster.Name.Empty()) {
+			audit.AddAuditAnnotation(req.Context(), "shardpaths.kcp.io/rejected", req.URL.Path)
+			http.Error(w, "shard-level endpoint not available at shard or workspace scope", http.StatusNotImplemented)
+			return
 		}
 		handler.ServeHTTP(w, req)
 	})

--- a/pkg/cache/server/handler_test.go
+++ b/pkg/cache/server/handler_test.go
@@ -26,24 +26,28 @@ import (
 	"github.com/kcp-dev/logicalcluster/v3"
 )
 
-func TestWithShardScopePassesThroughMetrics(t *testing.T) {
-	nextCalled := false
-	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		nextCalled = true
-		w.WriteHeader(http.StatusOK)
-	})
+func TestWithShardScopePassesThroughShardLevelPaths(t *testing.T) {
+	for _, path := range []string{"/metrics", "/livez", "/readyz", "/healthz"} {
+		t.Run(path, func(t *testing.T) {
+			nextCalled := false
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				nextCalled = true
+				w.WriteHeader(http.StatusOK)
+			})
 
-	h := WithShardScope(next)
+			h := WithShardScope(next)
 
-	req := httptest.NewRequest(http.MethodGet, "https://cache.example/metrics", http.NoBody)
-	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, req)
+			req := httptest.NewRequest(http.MethodGet, "https://cache.example"+path, http.NoBody)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
 
-	if !nextCalled {
-		t.Fatalf("next handler should be called for top-level /metrics on cache server")
-	}
-	if rec.Code != http.StatusOK {
-		t.Errorf("status: got %d, want %d", rec.Code, http.StatusOK)
+			if !nextCalled {
+				t.Fatalf("next handler should be called for top-level %s on cache server", path)
+			}
+			if rec.Code != http.StatusOK {
+				t.Errorf("status: got %d, want %d", rec.Code, http.StatusOK)
+			}
+		})
 	}
 }
 
@@ -91,6 +95,19 @@ func TestWithCacheShardLevelPaths(t *testing.T) {
 			cluster:        &request.Cluster{Name: logicalcluster.Name("ws-1234")},
 			wantStatus:     http.StatusNotImplemented,
 			wantNextCalled: false,
+		},
+		{
+			name:           "livez with shard set is rejected with 501",
+			path:           "/livez",
+			shard:          request.Shard("amber"),
+			wantStatus:     http.StatusNotImplemented,
+			wantNextCalled: false,
+		},
+		{
+			name:           "readyz top-level passes through",
+			path:           "/readyz",
+			wantStatus:     http.StatusOK,
+			wantNextCalled: true,
 		},
 	}
 

--- a/pkg/cache/server/handler_test.go
+++ b/pkg/cache/server/handler_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+)
+
+func TestWithShardScopePassesThroughMetrics(t *testing.T) {
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	h := WithShardScope(next)
+
+	req := httptest.NewRequest(http.MethodGet, "https://cache.example/metrics", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if !nextCalled {
+		t.Fatalf("next handler should be called for top-level /metrics on cache server")
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("status: got %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
+func TestWithCacheShardLevelPaths(t *testing.T) {
+	tests := []struct {
+		name           string
+		path           string
+		shard          request.Shard
+		cluster        *request.Cluster
+		wantStatus     int
+		wantNextCalled bool
+	}{
+		{
+			name:           "non-shard path passes through",
+			path:           "/apis/apis.kcp.io/v1alpha1/apiexports",
+			shard:          request.Shard("amber"),
+			cluster:        &request.Cluster{Name: logicalcluster.Name("ws-1234")},
+			wantStatus:     http.StatusOK,
+			wantNextCalled: true,
+		},
+		{
+			name:           "metrics with no shard and no cluster passes through",
+			path:           "/metrics",
+			wantStatus:     http.StatusOK,
+			wantNextCalled: true,
+		},
+		{
+			name:           "metrics with shard set is rejected with 501",
+			path:           "/metrics",
+			shard:          request.Shard("amber"),
+			wantStatus:     http.StatusNotImplemented,
+			wantNextCalled: false,
+		},
+		{
+			name:           "metrics with cluster set is rejected with 501",
+			path:           "/metrics",
+			cluster:        &request.Cluster{Name: logicalcluster.Name("ws-1234")},
+			wantStatus:     http.StatusNotImplemented,
+			wantNextCalled: false,
+		},
+		{
+			name:           "metrics with both shard and cluster set is rejected",
+			path:           "/metrics",
+			shard:          request.Shard("amber"),
+			cluster:        &request.Cluster{Name: logicalcluster.Name("ws-1234")},
+			wantStatus:     http.StatusNotImplemented,
+			wantNextCalled: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			nextCalled := false
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				nextCalled = true
+				w.WriteHeader(http.StatusOK)
+			})
+
+			h := WithCacheShardLevelPaths(next)
+
+			req := httptest.NewRequest(http.MethodGet, "https://cache.example"+tc.path, nil)
+			ctx := req.Context()
+			if !tc.shard.Empty() {
+				ctx = request.WithShard(ctx, tc.shard)
+			}
+			if tc.cluster != nil {
+				ctx = request.WithCluster(ctx, *tc.cluster)
+			}
+			req = req.WithContext(ctx)
+			rec := httptest.NewRecorder()
+
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Errorf("status: got %d, want %d", rec.Code, tc.wantStatus)
+			}
+			if nextCalled != tc.wantNextCalled {
+				t.Errorf("nextCalled: got %v, want %v", nextCalled, tc.wantNextCalled)
+			}
+		})
+	}
+}

--- a/pkg/cache/server/handler_test.go
+++ b/pkg/cache/server/handler_test.go
@@ -35,7 +35,7 @@ func TestWithShardScopePassesThroughMetrics(t *testing.T) {
 
 	h := WithShardScope(next)
 
-	req := httptest.NewRequest(http.MethodGet, "https://cache.example/metrics", nil)
+	req := httptest.NewRequest(http.MethodGet, "https://cache.example/metrics", http.NoBody)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 
@@ -104,7 +104,7 @@ func TestWithCacheShardLevelPaths(t *testing.T) {
 
 			h := WithCacheShardLevelPaths(next)
 
-			req := httptest.NewRequest(http.MethodGet, "https://cache.example"+tc.path, nil)
+			req := httptest.NewRequest(http.MethodGet, "https://cache.example"+tc.path, http.NoBody)
 			ctx := req.Context()
 			if !tc.shard.Empty() {
 				ctx = request.WithShard(ctx, tc.shard)

--- a/pkg/cache/server/handler_test.go
+++ b/pkg/cache/server/handler_test.go
@@ -26,28 +26,24 @@ import (
 	"github.com/kcp-dev/logicalcluster/v3"
 )
 
-func TestWithShardScopePassesThroughShardLevelPaths(t *testing.T) {
-	for _, path := range []string{"/metrics", "/livez", "/readyz", "/healthz"} {
-		t.Run(path, func(t *testing.T) {
-			nextCalled := false
-			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				nextCalled = true
-				w.WriteHeader(http.StatusOK)
-			})
+func TestWithShardScopePassesThroughMetrics(t *testing.T) {
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
 
-			h := WithShardScope(next)
+	h := WithShardScope(next)
 
-			req := httptest.NewRequest(http.MethodGet, "https://cache.example"+path, http.NoBody)
-			rec := httptest.NewRecorder()
-			h.ServeHTTP(rec, req)
+	req := httptest.NewRequest(http.MethodGet, "https://cache.example/metrics", http.NoBody)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
 
-			if !nextCalled {
-				t.Fatalf("next handler should be called for top-level %s on cache server", path)
-			}
-			if rec.Code != http.StatusOK {
-				t.Errorf("status: got %d, want %d", rec.Code, http.StatusOK)
-			}
-		})
+	if !nextCalled {
+		t.Fatalf("next handler should be called for top-level /metrics on cache server")
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("status: got %d, want %d", rec.Code, http.StatusOK)
 	}
 }
 
@@ -95,19 +91,6 @@ func TestWithCacheShardLevelPaths(t *testing.T) {
 			cluster:        &request.Cluster{Name: logicalcluster.Name("ws-1234")},
 			wantStatus:     http.StatusNotImplemented,
 			wantNextCalled: false,
-		},
-		{
-			name:           "livez with shard set is rejected with 501",
-			path:           "/livez",
-			shard:          request.Shard("amber"),
-			wantStatus:     http.StatusNotImplemented,
-			wantNextCalled: false,
-		},
-		{
-			name:           "readyz top-level passes through",
-			path:           "/readyz",
-			wantStatus:     http.StatusOK,
-			wantNextCalled: true,
 		},
 	}
 

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -612,6 +612,10 @@ func NewConfig(ctx context.Context, opts kcpserveroptions.CompletedOptions) (*Co
 		// path-shaped. Prevents path strings from leaking into etcd keys if the
 		// localproxy logic ever regresses.
 		apiHandler = kcpfilters.WithClusterNameShapeInvariant(apiHandler)
+		// After WithLocalProxy has set (or left empty) the cluster context, decide
+		// whether shard-wide URLs like /metrics may be served. Workspace-scoped
+		// requests are 501'd; top-level requests are evaluated against root RBAC.
+		apiHandler = kcpfilters.WithShardLevelPaths(apiHandler)
 		apiHandler, err = WithLocalProxy(apiHandler, opts.Extra.ShardName, opts.Extra.AdditionalMappingsFile, clusterIndex)
 		if err != nil {
 			panic(err) // shouldn't happen due to flag validation

--- a/pkg/server/filters/shardlevelpaths.go
+++ b/pkg/server/filters/shardlevelpaths.go
@@ -34,9 +34,11 @@ import (
 // It must run AFTER WithLocalProxy so the cluster context reflects whether the
 // request was made through a /clusters/<ws>/ prefix.
 //
-//   - workspace-scoped requests (cluster context already set to a non-root
-//     logical cluster) are rejected with 501 Not Implemented: the data exposed
-//     at these paths is shard-wide and has no per-workspace meaning.
+//   - any workspace-scoped form, including /clusters/root/<path>, is rejected
+//     with 501 Not Implemented. The data exposed is shard-wide and has no
+//     per-workspace meaning; rejecting the /clusters/root/ form too keeps the
+//     contract simple ("only the bare URL is valid") and avoids two ways of
+//     spelling the same thing.
 //   - top-level requests (no cluster context) are rewritten to evaluate
 //     authorization against the root workspace. A kcp-admin can therefore grant
 //     scrape access via a ClusterRoleBinding in :root referring to the
@@ -50,7 +52,7 @@ func WithShardLevelPaths(handler http.Handler) http.HandlerFunc {
 		}
 
 		cluster := request.ClusterFrom(req.Context())
-		if cluster != nil && !cluster.Name.Empty() && cluster.Name != core.RootCluster {
+		if cluster != nil && !cluster.Name.Empty() {
 			audit.AddAuditAnnotation(req.Context(), "shardpaths.kcp.io/rejected", req.URL.Path)
 			http.Error(w, "shard-level endpoint not available at workspace scope", http.StatusNotImplemented)
 			return

--- a/pkg/server/filters/shardlevelpaths.go
+++ b/pkg/server/filters/shardlevelpaths.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filters
+
+import (
+	"net/http"
+
+	"k8s.io/apiserver/pkg/audit"
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	"github.com/kcp-dev/sdk/apis/core"
+
+	"github.com/kcp-dev/kcp/pkg/authorization/shardpaths"
+)
+
+// WithShardLevelPaths enforces that shard-level URLs (see
+// pkg/authorization/shardpaths) are only served at the top of the shard's HTTP
+// path tree.
+//
+// It must run AFTER WithLocalProxy so the cluster context reflects whether the
+// request was made through a /clusters/<ws>/ prefix.
+//
+//   - workspace-scoped requests (cluster context already set to a non-root
+//     logical cluster) are rejected with 501 Not Implemented: the data exposed
+//     at these paths is shard-wide and has no per-workspace meaning.
+//   - top-level requests (no cluster context) are rewritten to evaluate
+//     authorization against the root workspace. A kcp-admin can therefore grant
+//     scrape access via a ClusterRoleBinding in :root referring to the
+//     system:kcp:metrics-reader role (bootstrapped) without exposing any other
+//     root-workspace privileges.
+func WithShardLevelPaths(handler http.Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		if !shardpaths.Paths.Has(req.URL.Path) {
+			handler.ServeHTTP(w, req)
+			return
+		}
+
+		cluster := request.ClusterFrom(req.Context())
+		if cluster != nil && !cluster.Name.Empty() && cluster.Name != core.RootCluster {
+			audit.AddAuditAnnotation(req.Context(), "shardpaths.kcp.io/rejected", req.URL.Path)
+			http.Error(w, "shard-level endpoint not available at workspace scope", http.StatusNotImplemented)
+			return
+		}
+
+		ctx := request.WithCluster(req.Context(), request.Cluster{Name: core.RootCluster})
+		handler.ServeHTTP(w, req.WithContext(ctx))
+	}
+}

--- a/pkg/server/filters/shardlevelpaths_test.go
+++ b/pkg/server/filters/shardlevelpaths_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filters
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+	"github.com/kcp-dev/sdk/apis/core"
+)
+
+func TestWithShardLevelPaths(t *testing.T) {
+	tests := []struct {
+		name           string
+		path           string
+		cluster        *request.Cluster
+		wantStatus     int
+		wantNextCalled bool
+		wantClusterIn  logicalcluster.Name
+	}{
+		{
+			name:           "non-shard path passes through unchanged",
+			path:           "/apis/apis.kcp.io/v1alpha1/apiexports",
+			cluster:        &request.Cluster{Name: logicalcluster.Name("ws-1234")},
+			wantStatus:     http.StatusOK,
+			wantNextCalled: true,
+			wantClusterIn:  logicalcluster.Name("ws-1234"),
+		},
+		{
+			name:           "metrics with no cluster context scopes to root",
+			path:           "/metrics",
+			cluster:        nil,
+			wantStatus:     http.StatusOK,
+			wantNextCalled: true,
+			wantClusterIn:  core.RootCluster,
+		},
+		{
+			name:           "metrics with empty cluster name scopes to root",
+			path:           "/metrics",
+			cluster:        &request.Cluster{},
+			wantStatus:     http.StatusOK,
+			wantNextCalled: true,
+			wantClusterIn:  core.RootCluster,
+		},
+		{
+			name:           "metrics with explicit root cluster passes through",
+			path:           "/metrics",
+			cluster:        &request.Cluster{Name: core.RootCluster},
+			wantStatus:     http.StatusOK,
+			wantNextCalled: true,
+			wantClusterIn:  core.RootCluster,
+		},
+		{
+			name:           "metrics with workspace cluster is rejected with 501",
+			path:           "/metrics",
+			cluster:        &request.Cluster{Name: logicalcluster.Name("ws-1234")},
+			wantStatus:     http.StatusNotImplemented,
+			wantNextCalled: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			nextCalled := false
+			var seenCluster logicalcluster.Name
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				nextCalled = true
+				if c := request.ClusterFrom(r.Context()); c != nil {
+					seenCluster = c.Name
+				}
+				w.WriteHeader(http.StatusOK)
+			})
+
+			h := WithShardLevelPaths(next)
+
+			req := httptest.NewRequest(http.MethodGet, "https://shard.example"+tc.path, nil)
+			if tc.cluster != nil {
+				req = req.WithContext(request.WithCluster(req.Context(), *tc.cluster))
+			}
+			rec := httptest.NewRecorder()
+
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Errorf("status: got %d, want %d", rec.Code, tc.wantStatus)
+			}
+			if nextCalled != tc.wantNextCalled {
+				t.Errorf("nextCalled: got %v, want %v", nextCalled, tc.wantNextCalled)
+			}
+			if tc.wantNextCalled && seenCluster != tc.wantClusterIn {
+				t.Errorf("cluster passed to next handler: got %q, want %q", seenCluster, tc.wantClusterIn)
+			}
+		})
+	}
+}

--- a/pkg/server/filters/shardlevelpaths_test.go
+++ b/pkg/server/filters/shardlevelpaths_test.go
@@ -75,19 +75,14 @@ func TestWithShardLevelPaths(t *testing.T) {
 			wantNextCalled: false,
 		},
 		{
-			name:           "livez with workspace cluster is rejected with 501",
+			// Probes are intentionally NOT in shardpaths so workspace-scoped
+			// liveness probing keeps working.
+			name:           "livez with workspace cluster passes through unchanged",
 			path:           "/livez",
 			cluster:        &request.Cluster{Name: logicalcluster.Name("ws-1234")},
-			wantStatus:     http.StatusNotImplemented,
-			wantNextCalled: false,
-		},
-		{
-			name:           "readyz top-level scopes to root",
-			path:           "/readyz",
-			cluster:        nil,
 			wantStatus:     http.StatusOK,
 			wantNextCalled: true,
-			wantClusterIn:  core.RootCluster,
+			wantClusterIn:  logicalcluster.Name("ws-1234"),
 		},
 	}
 

--- a/pkg/server/filters/shardlevelpaths_test.go
+++ b/pkg/server/filters/shardlevelpaths_test.go
@@ -61,12 +61,11 @@ func TestWithShardLevelPaths(t *testing.T) {
 			wantClusterIn:  core.RootCluster,
 		},
 		{
-			name:           "metrics with explicit root cluster passes through",
+			name:           "metrics with explicit root cluster is rejected (use the bare URL)",
 			path:           "/metrics",
 			cluster:        &request.Cluster{Name: core.RootCluster},
-			wantStatus:     http.StatusOK,
-			wantNextCalled: true,
-			wantClusterIn:  core.RootCluster,
+			wantStatus:     http.StatusNotImplemented,
+			wantNextCalled: false,
 		},
 		{
 			name:           "metrics with workspace cluster is rejected with 501",
@@ -74,6 +73,21 @@ func TestWithShardLevelPaths(t *testing.T) {
 			cluster:        &request.Cluster{Name: logicalcluster.Name("ws-1234")},
 			wantStatus:     http.StatusNotImplemented,
 			wantNextCalled: false,
+		},
+		{
+			name:           "livez with workspace cluster is rejected with 501",
+			path:           "/livez",
+			cluster:        &request.Cluster{Name: logicalcluster.Name("ws-1234")},
+			wantStatus:     http.StatusNotImplemented,
+			wantNextCalled: false,
+		},
+		{
+			name:           "readyz top-level scopes to root",
+			path:           "/readyz",
+			cluster:        nil,
+			wantStatus:     http.StatusOK,
+			wantNextCalled: true,
+			wantClusterIn:  core.RootCluster,
 		},
 	}
 

--- a/pkg/server/filters/shardlevelpaths_test.go
+++ b/pkg/server/filters/shardlevelpaths_test.go
@@ -91,7 +91,7 @@ func TestWithShardLevelPaths(t *testing.T) {
 
 			h := WithShardLevelPaths(next)
 
-			req := httptest.NewRequest(http.MethodGet, "https://shard.example"+tc.path, nil)
+			req := httptest.NewRequest(http.MethodGet, "https://shard.example"+tc.path, http.NoBody)
 			if tc.cluster != nil {
 				req = req.WithContext(request.WithCluster(req.Context(), *tc.cluster))
 			}

--- a/test/e2e/authorizer/shardmetrics_test.go
+++ b/test/e2e/authorizer/shardmetrics_test.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authorizer
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
+	"github.com/kcp-dev/sdk/apis/core"
+	kcptesting "github.com/kcp-dev/sdk/testing"
+	kcptestinghelpers "github.com/kcp-dev/sdk/testing/helpers"
+
+	"github.com/kcp-dev/kcp/pkg/authorization/bootstrap"
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+)
+
+// TestShardMetricsEndpoint exercises kcp#4062: shard-wide /metrics must not
+// be reachable through a workspace-scoped URL, and top-level scraping must be
+// authorizable through a ClusterRoleBinding in :root referring to the
+// bootstrapped system:kcp:metrics-reader role.
+func TestShardMetricsEndpoint(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "control-plane")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	server := kcptesting.SharedKcpServer(t)
+	rootShardCfg := server.RootShardSystemMasterBaseConfig(t)
+
+	adminKubeClusterClient, err := kcpkubernetesclientset.NewForConfig(rootShardCfg)
+	require.NoError(t, err)
+
+	// A workspace on the root shard so we can hit it directly via rootShardCfg
+	// without having to traverse the front-proxy.
+	wsPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(),
+		kcptesting.WithNamePrefix("shard-metrics"), kcptesting.WithRootShard())
+
+	// user-1 is workspace admin so it can create RBAC inside the workspace.
+	framework.AdmitWorkspaceAccess(ctx, t, adminKubeClusterClient, wsPath, []string{"user-1"}, nil, true)
+
+	// Inside the workspace, user-1 grants itself NonResourceURL /metrics.
+	// Pre-fix, this leaked shard-wide metrics; post-fix it must be ignored
+	// because the request is rejected before authz runs.
+	user1ClusterClient, err := kcpkubernetesclientset.NewForConfig(framework.StaticTokenUserConfig("user-1", rootShardCfg))
+	require.NoError(t, err)
+	_, err = user1ClusterClient.Cluster(wsPath).RbacV1().ClusterRoles().Create(ctx, &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "workspace-metrics-viewer"},
+		Rules: []rbacv1.PolicyRule{{
+			Verbs:           []string{"get"},
+			NonResourceURLs: []string{"/metrics"},
+		}},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+	_, err = user1ClusterClient.Cluster(wsPath).RbacV1().ClusterRoleBindings().Create(ctx, &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "user-1-workspace-metrics-viewer"},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     "workspace-metrics-viewer",
+		},
+		Subjects: []rbacv1.Subject{{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "User",
+			Name:     "user-1",
+		}},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	workspaceMetricsPath := fmt.Sprintf("/clusters/%s/metrics", wsPath.String())
+
+	t.Run("workspace-scoped /metrics is rejected with 501 even with matching workspace RBAC", func(t *testing.T) {
+		// Authorization is permission-cache-driven; wait until user-1's binding
+		// is observable inside the workspace, otherwise the test could pass
+		// for the wrong reason (403 from RBAC, not 501 from the filter).
+		kcptestinghelpers.Eventually(t, func() (bool, string) {
+			var code int
+			_, err := user1ClusterClient.RESTClient().
+				Get().AbsPath(workspaceMetricsPath).Do(ctx).StatusCode(&code).Raw()
+			if code == http.StatusNotImplemented && err != nil {
+				return true, ""
+			}
+			return false, fmt.Sprintf("status=%d err=%v", code, err)
+		}, 30*time.Second, 200*time.Millisecond, "expected 501 for workspace-scoped /metrics")
+	})
+
+	t.Run("workspace-scoped /metrics is rejected for system:masters too", func(t *testing.T) {
+		var code int
+		_, err := adminKubeClusterClient.RESTClient().
+			Get().AbsPath(workspaceMetricsPath).Do(ctx).StatusCode(&code).Raw()
+		require.Equal(t, http.StatusNotImplemented, code, "system:masters must not bypass the filter")
+		require.Error(t, err)
+	})
+
+	t.Run("top-level /metrics for an unbound user is forbidden", func(t *testing.T) {
+		// user-2 has no binding anywhere.
+		user2Client, err := kcpkubernetesclientset.NewForConfig(framework.StaticTokenUserConfig("user-2", rootShardCfg))
+		require.NoError(t, err)
+		var code int
+		_, err = user2Client.RESTClient().Get().AbsPath("/metrics").Do(ctx).StatusCode(&code).Raw()
+		require.Error(t, err)
+		require.Equal(t, http.StatusForbidden, code, "user without root binding must be denied")
+	})
+
+	t.Run("top-level /metrics with system:kcp:metrics-reader binding in :root succeeds", func(t *testing.T) {
+		// Bind user-3 to the bootstrap metrics-reader role inside :root.
+		_, err := adminKubeClusterClient.Cluster(core.RootCluster.Path()).RbacV1().ClusterRoleBindings().Create(ctx, &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{GenerateName: "metrics-reader-user-3-"},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "ClusterRole",
+				Name:     bootstrap.SystemKcpMetricsReader,
+			},
+			Subjects: []rbacv1.Subject{{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "User",
+				Name:     "user-3",
+			}},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		user3Client, err := kcpkubernetesclientset.NewForConfig(framework.StaticTokenUserConfig("user-3", rootShardCfg))
+		require.NoError(t, err)
+
+		kcptestinghelpers.Eventually(t, func() (bool, string) {
+			var code int
+			body, err := user3Client.RESTClient().Get().AbsPath("/metrics").Do(ctx).StatusCode(&code).Raw()
+			if err != nil {
+				return false, fmt.Sprintf("err=%v code=%d", err, code)
+			}
+			if code != http.StatusOK {
+				return false, fmt.Sprintf("status=%d", code)
+			}
+			// Prometheus exposition starts with "# HELP" or "# TYPE" lines;
+			// either way the kcp/k8s apiserver always emits a few metric lines.
+			if !strings.Contains(string(body), "apiserver_") {
+				return false, "no apiserver_ metrics in body"
+			}
+			return true, ""
+		}, wait.ForeverTestTimeout, 200*time.Millisecond, "user-3 should be able to scrape /metrics after root binding propagates")
+	})
+
+	t.Run("top-level /metrics for system:masters succeeds", func(t *testing.T) {
+		var code int
+		body, err := adminKubeClusterClient.RESTClient().Get().AbsPath("/metrics").Do(ctx).StatusCode(&code).Raw()
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, code)
+		require.Contains(t, string(body), "apiserver_")
+	})
+}

--- a/test/e2e/cache/cache_server_authz_test.go
+++ b/test/e2e/cache/cache_server_authz_test.go
@@ -110,9 +110,7 @@ func testHealthEndpointsWithoutAuth(t *testing.T, adminCfg *rest.Config) {
 func testMetricsAtShardOrWorkspaceScopeRejected(t *testing.T, adminCfg *rest.Config) {
 	t.Helper()
 
-	cfg := rest.CopyConfig(adminCfg)
-	cfg.NegotiatedSerializer = kubernetesscheme.Codecs.WithoutConversion()
-	client, err := rest.UnversionedRESTClientFor(cfg)
+	httpClient, err := rest.HTTPClientFor(adminCfg)
 	require.NoError(t, err)
 
 	scoped := []string{
@@ -123,11 +121,13 @@ func testMetricsAtShardOrWorkspaceScopeRejected(t *testing.T, adminCfg *rest.Con
 	for _, endpoint := range scoped {
 		t.Run(endpoint, func(t *testing.T) {
 			t.Parallel()
-			var code int
-			_, err := rest.NewRequest(client).RequestURI(endpoint).Do(t.Context()).StatusCode(&code).Raw()
-			require.Equalf(t, http.StatusNotImplemented, code,
-				"expected 501 for shard/workspace-scoped %s on cache server, got %d (err=%v)",
-				endpoint, code, err)
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, adminCfg.Host+endpoint, http.NoBody)
+			require.NoError(t, err)
+			resp, err := httpClient.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			require.Equalf(t, http.StatusNotImplemented, resp.StatusCode,
+				"expected 501 for shard/workspace-scoped %s on cache server", endpoint)
 		})
 	}
 }

--- a/test/e2e/cache/cache_server_authz_test.go
+++ b/test/e2e/cache/cache_server_authz_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cache
 
 import (
+	"net/http"
 	"path"
 	"testing"
 
@@ -76,6 +77,10 @@ func TestCacheServerAuthz(t *testing.T) {
 		t.Parallel()
 		testPrivilegedCertAllowed(t, adminRestConfig)
 	})
+	t.Run("MetricsAtShardOrWorkspaceScopeIsRejected", func(t *testing.T) {
+		t.Parallel()
+		testMetricsAtShardOrWorkspaceScopeRejected(t, adminRestConfig)
+	})
 }
 
 // testHealthEndpointsWithoutAuth verifies that health endpoints are accessible without any client certificate.
@@ -93,6 +98,36 @@ func testHealthEndpointsWithoutAuth(t *testing.T, adminCfg *rest.Config) {
 			body, err := rest.NewRequest(client).RequestURI(endpoint).Do(t.Context()).Raw()
 			require.NoError(t, err, "expected %s to be accessible without auth, got error", endpoint)
 			t.Logf("%s returned: %s", endpoint, string(body))
+		})
+	}
+}
+
+// testMetricsAtShardOrWorkspaceScopeRejected verifies that the cache server's
+// shard-level /metrics endpoint is not reachable via a shard- or workspace-
+// scoped URL (kcp#4062). The bare /metrics is still served by the apiserver,
+// but anything that pretends /metrics has per-shard or per-workspace meaning
+// must come back with 501 Not Implemented.
+func testMetricsAtShardOrWorkspaceScopeRejected(t *testing.T, adminCfg *rest.Config) {
+	t.Helper()
+
+	cfg := rest.CopyConfig(adminCfg)
+	cfg.NegotiatedSerializer = kubernetesscheme.Codecs.WithoutConversion()
+	client, err := rest.UnversionedRESTClientFor(cfg)
+	require.NoError(t, err)
+
+	scoped := []string{
+		"/services/cache/shards/amber/metrics",
+		"/services/cache/shards/amber/clusters/root/metrics",
+		"/services/cache/shards/amber/clusters/some-ws/metrics",
+	}
+	for _, endpoint := range scoped {
+		t.Run(endpoint, func(t *testing.T) {
+			t.Parallel()
+			var code int
+			_, err := rest.NewRequest(client).RequestURI(endpoint).Do(t.Context()).StatusCode(&code).Raw()
+			require.Equalf(t, http.StatusNotImplemented, code,
+				"expected 501 for shard/workspace-scoped %s on cache server, got %d (err=%v)",
+				endpoint, code, err)
 		})
 	}
 }


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Reject workspace-scoped /clusters/<ws>/metrics and cache-server /services/cache/shards/<sh>/clusters/<ws>/metrics with 501 Not Implemented. Metrics are shard-wide and have no per-workspace meaning; allowing them via a workspace ClusterRole + binding was a privilege escalation.

We might want to implement this down the line. For now - no. 

Top-level <shard>:6443/metrics is now authorized via root-workspace RBAC: a new bootstrap ClusterRole `system:kcp:metrics-reader` grants GET on `/metrics`, and a kcp-admin binds it once in `:root` for an identity of their choice. The binding is replicated to every shard via the cache server, so a single root binding covers all shards.

Cache server top-level /metrics is now reachable as well (previously, WithShardScope returned 400 for any path without a /shards/ prefix).

Fixes kcp-dev/kcp#4062

## What Type of PR Is This?
/kind feature

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Implement rbac for /metrics
```
