### PR TITLE
Prevent flaky test failures in nested_workspace_cleanup_when_an_org_w…

### DIFF
--- a/test/e2e/reconciler/workspacedeletion/controller_test.go
+++ b/test/e2e/reconciler/workspacedeletion/controller_test.go
@@ -280,7 +280,10 @@ func TestWorkspaceDeletion(t *testing.T) {
 					if apierrors.IsNotFound(err) {
 						return true, err.Error()
 					}
-					require.NoError(t, err, "failed to list namespaces in sub-workspace")
+					// Any other error (e.g. 504 under CI load) is transient: keep polling.
+					if err != nil {
+						return false, fmt.Sprintf("failed to list namespaces in sub-workspace: %v", err)
+					}
 
 					return len(nslist.Items) == 0, toYAML(t, nslist)
 				}, wait.ForeverTestTimeout, 100*time.Millisecond)
@@ -292,7 +295,10 @@ func TestWorkspaceDeletion(t *testing.T) {
 					if apierrors.IsNotFound(err) {
 						return true, err.Error()
 					}
-					require.NoError(t, err, "failed to list namespaces in org workspace")
+					// Any other error (e.g. 504 under CI load) is transient: keep polling.
+					if err != nil {
+						return false, fmt.Sprintf("failed to list namespaces in org workspace: %v", err)
+					}
 
 					return len(nslist.Items) == 0, toYAML(t, nslist)
 				}, wait.ForeverTestTimeout, 100*time.Millisecond)
@@ -304,7 +310,10 @@ func TestWorkspaceDeletion(t *testing.T) {
 					if apierrors.IsNotFound(err) {
 						return true, err.Error()
 					}
-					require.NoError(t, err, "failed to list workspaces in org workspace")
+					// Any other error (e.g. 504 under CI load) is transient: keep polling.
+					if err != nil {
+						return false, fmt.Sprintf("failed to list workspaces in org workspace: %v", err)
+					}
 
 					return len(wslist.Items) == 0, toYAML(t, wslist)
 				}, wait.ForeverTestTimeout, 100*time.Millisecond)


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

See e.g. https://public-prow.kcp.k8c.io/view/s3/prow-public-data/pr-logs/pull/kcp-dev_kcp/4164/pull-kcp-test-e2e-shared/2059893150104686592 

The test flakes in CI because of the high load because sometimes the response is fast enough.
The `require.NoError` will always fail the test even if it then proceeds to pass.

## What Type of PR Is This?

/kind flake

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
