### PR TITLE
implement loadtest-level-3

### DIFF
--- a/test/load/config.example.json
+++ b/test/load/config.example.json
@@ -7,6 +7,9 @@
     "createWorkspaceQPS": 2.0,
     "crudConfigMapQPS": 150,
     "providerWorkspacesCount": 10,
-    "consumerWorkspacesCount": 90
+    "consumerWorkspacesCount": 90,
+    "createAPIExportQPS": 2.0,
+    "createAPIBindingQPS": 2.0,
+    "crudSharedAPIQPS": 150
   }
 }

--- a/test/load/go.mod
+++ b/test/load/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/montanaflynn/stats v0.7.1
 	github.com/stretchr/testify v1.11.1
 	k8s.io/api v0.36.0
+	k8s.io/apiextensions-apiserver v0.36.0
 	k8s.io/apimachinery v0.36.0
 	k8s.io/client-go v0.36.0
 )
@@ -63,7 +64,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiextensions-apiserver v0.36.0 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260414162039-ec9c827d403f // indirect
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 // indirect

--- a/test/load/pkg/framework/execute.go
+++ b/test/load/pkg/framework/execute.go
@@ -17,6 +17,7 @@ limitations under the License.
 package framework
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -29,14 +30,14 @@ import (
 // Execute runs the given action for every sequence number yielded by the
 // TuningSet. Execute blocks until all actions complete and returns all
 // collected errors.
-func Execute(ts tuningset.TuningSet, action tuningset.Action, sink measurement.Sink) []error {
+func Execute(ctx context.Context, ts tuningset.TuningSet, action tuningset.Action, sink measurement.Sink) []error {
 	var mu sync.Mutex
 	var errs []error
 
 	var wg wait.Group
 	for seq := range ts {
 		wg.Start(func() {
-			if err := action(seq, sink); err != nil {
+			if err := action(ctx, seq, sink); err != nil {
 				mu.Lock()
 				errs = append(errs, fmt.Errorf("seq %d: %w", seq, err))
 				mu.Unlock()

--- a/test/load/pkg/framework/execute_test.go
+++ b/test/load/pkg/framework/execute_test.go
@@ -46,7 +46,7 @@ func TestExecuteWait(t *testing.T) {
 		return nil
 	}
 
-	errs := Execute(context.Background(), ts, action, nil)
+	errs := Execute(t.Context(), ts, action, nil)
 
 	require.Len(t, errs, 3) // 0, 2, 4
 	require.Equal(t, int64(5), atomic.LoadInt64(&completed), "Execute must wait for all actions to complete before returning")

--- a/test/load/pkg/framework/execute_test.go
+++ b/test/load/pkg/framework/execute_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package framework
 
 import (
+	"context"
 	"errors"
 	"sync/atomic"
 	"testing"
@@ -35,7 +36,7 @@ func TestExecuteWait(t *testing.T) {
 	ts := tuningset.NewUniformQPS(100, 5, 0)
 
 	var completed int64
-	action := func(seq int, sink measurement.Sink) error {
+	action := func(_ context.Context, seq int, sink measurement.Sink) error {
 		time.Sleep(500 * time.Millisecond)
 		atomic.AddInt64(&completed, 1)
 		// ensure that errors are not messing with waiting behavior
@@ -45,7 +46,7 @@ func TestExecuteWait(t *testing.T) {
 		return nil
 	}
 
-	errs := Execute(ts, action, nil)
+	errs := Execute(context.Background(), ts, action, nil)
 
 	require.Len(t, errs, 3) // 0, 2, 4
 	require.Equal(t, int64(5), atomic.LoadInt64(&completed), "Execute must wait for all actions to complete before returning")

--- a/test/load/pkg/tuningset/tuningset.go
+++ b/test/load/pkg/tuningset/tuningset.go
@@ -17,15 +17,17 @@ limitations under the License.
 package tuningset
 
 import (
+	"context"
 	"iter"
 
 	"github.com/kcp-dev/kcp/test/load/pkg/measurement"
 )
 
 // Action is a function that performs a single load test operation.
+// ctx is the context for cancellation and deadlines.
 // seq is the sequence number of the action.
 // sink is the measurement sink for recording metrics.
-type Action func(seq int, sink measurement.Sink) error
+type Action func(ctx context.Context, seq int, sink measurement.Sink) error
 
 // TuningSet is an iterator that yields sequence numbers according to a
 // timing pattern. It controls when each action is started by blocking

--- a/test/load/setup/manifests/kcp.yaml
+++ b/test/load/setup/manifests/kcp.yaml
@@ -32,7 +32,7 @@ spec:
       memory: 3Gi
     limits:
       cpu: "12"
-      memory: 34Gi
+      memory: 48Gi
   etcd:
     endpoints:
       - http://kcp-etcd-shard-1-client.etcd-system.svc.cluster.local:2379
@@ -127,7 +127,7 @@ spec:
       memory: 3Gi
     limits:
       cpu: "12"
-      memory: 34Gi
+      memory: 48Gi
   deploymentTemplate:
     spec:
       template:
@@ -180,7 +180,7 @@ spec:
       memory: 3Gi
     limits:
       cpu: "12"
-      memory: 34Gi
+      memory: 48Gi
   deploymentTemplate:
     spec:
       template:

--- a/test/load/testing/config.go
+++ b/test/load/testing/config.go
@@ -49,6 +49,9 @@ func defaultParams() Params {
 		CRUDConfigMapQPS:        150,
 		ProviderWorkspacesCount: 1000,
 		ConsumerWorkspacesCount: 9000,
+		CreateAPIExportQPS:      4.0,
+		CreateAPIBindingQPS:     4.0,
+		CRUDSharedAPIQPS:        150,
 	}
 }
 
@@ -76,10 +79,18 @@ type Params struct {
 
 	// ConsumerWorkspacesCount is the number of consumer workspaces for API sharing tests.
 	ConsumerWorkspacesCount int `json:"consumerWorkspacesCount"`
+
+	// CreateAPIExportQPS is the rate at which APIExport creation requests are sent.
+	CreateAPIExportQPS float64 `json:"createAPIExportQPS"`
+
+	// CreateAPIBindingQPS is the rate at which APIBinding creation requests are sent.
+	CreateAPIBindingQPS float64 `json:"createAPIBindingQPS"`
+
+	// CRUDSharedAPIQPS is the rate at which custom resource CRUD operations are sent.
+	CRUDSharedAPIQPS float64 `json:"crudSharedAPIQPS"`
 }
 
 // WorkspaceTree returns a workspace tree built from the configured parameters.
-// It panics if WorkspaceTreeType is not "symmetric" or "flat".
 func (p Params) WorkspaceTree() tree.WorkspaceTree {
 	switch p.WorkspaceTreeType {
 	case "symmetric":

--- a/test/load/testing/example_test.go
+++ b/test/load/testing/example_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package testing
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -61,7 +62,7 @@ func TestExample(t *testing.T) {
 	ts := tuningset.NewUniformQPS(15, 30, 0)
 	// this helper can be used as a control variable for section timing
 	section.Start()
-	section.Errors = framework.Execute(ts, func(seq int, s measurement.Sink) error {
+	section.Errors = framework.Execute(context.Background(), ts, func(_ context.Context, seq int, s measurement.Sink) error {
 		// automatically measure how long each action took
 		defer measurement.RecordElapsedDurationMS(time.Now(), s)
 

--- a/test/load/testing/example_test.go
+++ b/test/load/testing/example_test.go
@@ -62,7 +62,7 @@ func TestExample(t *testing.T) {
 	ts := tuningset.NewUniformQPS(15, 30, 0)
 	// this helper can be used as a control variable for section timing
 	section.Start()
-	section.Errors = framework.Execute(context.Background(), ts, func(_ context.Context, seq int, s measurement.Sink) error {
+	section.Errors = framework.Execute(t.Context(), ts, func(_ context.Context, seq int, s measurement.Sink) error {
 		// automatically measure how long each action took
 		defer measurement.RecordElapsedDurationMS(time.Now(), s)
 

--- a/test/load/testing/report.go
+++ b/test/load/testing/report.go
@@ -31,7 +31,7 @@ import (
 )
 
 // NewKCPReport creates a new Report and adds metadata about kcp its running against.
-func NewKCPReport(t *testing.T, title string, cfg *rest.Config) *measurement.Report {
+func NewKCPReport(ctx context.Context, t *testing.T, title string, cfg *rest.Config) *measurement.Report {
 	t.Helper()
 
 	report := measurement.NewReport(title)
@@ -49,7 +49,7 @@ func NewKCPReport(t *testing.T, title string, cfg *rest.Config) *measurement.Rep
 
 	report.Metadata = append(report.Metadata, measurement.Parameter{Key: "kcp Version", Value: sv.GitVersion})
 
-	shards, err := rootclient.CoreV1alpha1().Shards().List(context.Background(), metav1.ListOptions{})
+	shards, err := rootclient.CoreV1alpha1().Shards().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		t.Fatalf("Could not list kcp shards: %v", err)
 	}

--- a/test/load/testing/workspace.go
+++ b/test/load/testing/workspace.go
@@ -30,10 +30,10 @@ import (
 // workspacesExist checks whether count workspaces already exist by
 // verifying that the last workspace name is present. This is a cheap heuristic
 // that avoids listing all workspaces.
-func workspacesExist(wt tree.WorkspaceTree, client kcpclientset.ClusterInterface, count int) (bool, error) {
+func workspacesExist(ctx context.Context, wt tree.WorkspaceTree, client kcpclientset.ClusterInterface, count int) (bool, error) {
 	lastName := wt.WorkspaceName(count)
 	parentPath := wt.PathForSequenceNumber(wt.ParentSequenceNumber(count))
-	_, err := client.Cluster(parentPath).TenancyV1alpha1().Workspaces().Get(context.Background(), lastName, metav1.GetOptions{})
+	_, err := client.Cluster(parentPath).TenancyV1alpha1().Workspaces().Get(ctx, lastName, metav1.GetOptions{})
 	if err != nil {
 		// we also need IsForbidden here in case we are requesting a child ws whose
 		// parent does not exist either.

--- a/test/load/testing/workspace_apisharing_test.go
+++ b/test/load/testing/workspace_apisharing_test.go
@@ -1,0 +1,381 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	kcpdynamic "github.com/kcp-dev/client-go/dynamic"
+	apisv1alpha1 "github.com/kcp-dev/sdk/apis/apis/v1alpha1"
+	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
+	"github.com/kcp-dev/sdk/apis/third_party/conditions/util/conditions"
+	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
+
+	"github.com/kcp-dev/kcp/test/load/pkg/framework"
+	"github.com/kcp-dev/kcp/test/load/pkg/measurement"
+	"github.com/kcp-dev/kcp/test/load/pkg/stats"
+	"github.com/kcp-dev/kcp/test/load/pkg/tree"
+	"github.com/kcp-dev/kcp/test/load/pkg/tuningset"
+)
+
+//nolint:paralleltest // load test against shared kcp cluster, parallel execution would conflict on workspace names and skew timing measurements
+func TestAPISharing(t *testing.T) {
+	cfg := framework.Require(t, framework.KCPFrontProxyKubeconfig)
+	params := testConfig.Params
+
+	client, err := kcpclientset.NewForConfig(cfg.FrontProxyKubeconfig)
+	require.NoError(t, err)
+
+	dynamicClusterClient, err := kcpdynamic.NewForConfig(cfg.FrontProxyKubeconfig)
+	require.NoError(t, err)
+
+	var sections []measurement.Section
+
+	wt := params.WorkspaceTree()
+
+	// Ensure workspaces exist, creating them if necessary.
+	exist, err := workspacesExist(wt, client, params.WorkspaceCount)
+	require.NoError(t, err)
+	if exist {
+		t.Logf("workspaces already exist, skipping creation")
+	} else {
+		t.Logf("Creating required workspaces")
+		createSection := createWorkspaces(t, client, wt, params.CreateWorkspaceQPS, params.WorkspaceCount)
+		sections = append(sections, createSection)
+	}
+
+	t.Logf("Creating APIExports in provider workspaces")
+	exportSection := createAPIExports(t, client, wt, params.CreateAPIExportQPS, params.ProviderWorkspacesCount)
+	sections = append(sections, exportSection)
+
+	t.Logf("Creating APIBindings in consumer workspaces")
+	bindingSection := createAPIBindings(t, client, wt, params.CreateAPIBindingQPS, params.ProviderWorkspacesCount, params.ConsumerWorkspacesCount)
+	sections = append(sections, bindingSection)
+
+	t.Logf("Running custom resource CRUD operations")
+	crudSection := crudCustomResources(t, dynamicClusterClient, wt, params.CRUDSharedAPIQPS, params.ProviderWorkspacesCount, params.ConsumerWorkspacesCount)
+	sections = append(sections, crudSection)
+
+	report := NewKCPReport(t, "API Sharing", cfg.FrontProxyKubeconfig)
+	report.Sections = sections
+	report.PrettyPrint(os.Stdout)
+
+	for _, sec := range sections {
+		require.Empty(t, sec.Errors, "section %q encountered errors", sec.Title)
+	}
+}
+
+// createAPIExports creates an APIResourceSchema and APIExport in each of the
+// first providerCount workspaces in the tree.
+func createAPIExports(t *testing.T, client kcpclientset.ClusterInterface, wt tree.WorkspaceTree, qps float64, providerCount int) measurement.Section {
+	t.Helper()
+
+	section := measurement.Section{
+		Title: "APIExport Creation",
+		Parameters: []measurement.Parameter{
+			{Key: "ProviderWorkspaces", Value: fmt.Sprintf("%d", providerCount)},
+			{Key: "QPS", Value: fmt.Sprintf("%f", qps)},
+		},
+		Sink: &measurement.Memory{
+			Stats: []stats.NamedStat{stats.P99(), stats.Avg()},
+		},
+	}
+
+	ts := tuningset.NewUniformQPS(qps, providerCount, 1)
+	section.Start()
+	action := func(seq int, s measurement.Sink) error {
+		defer measurement.RecordElapsedDurationMS(time.Now(), s)
+
+		ctx := context.Background()
+		wsPath := wt.PathForSequenceNumber(seq)
+
+		schemaName := fmt.Sprintf("v1alpha1.loadtestresources%d.loadtest.kcp.io", seq)
+		resourceName := fmt.Sprintf("loadtestresources%d", seq)
+		exportName := fmt.Sprintf("loadtest-export-%d", seq)
+
+		// Create the APIResourceSchema.
+		schema := &apisv1alpha1.APIResourceSchema{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: schemaName,
+			},
+			Spec: apisv1alpha1.APIResourceSchemaSpec{
+				Group: "loadtest.kcp.io",
+				Names: apiextensionsv1.CustomResourceDefinitionNames{
+					Kind:     fmt.Sprintf("LoadTestResource%d", seq),
+					ListKind: fmt.Sprintf("LoadTestResource%dList", seq),
+					Plural:   resourceName,
+					Singular: fmt.Sprintf("loadtestresource%d", seq),
+				},
+				Scope: "Namespaced",
+				Versions: []apisv1alpha1.APIResourceVersion{
+					{
+						Name:    "v1alpha1",
+						Served:  true,
+						Storage: true,
+						Schema: runtime.RawExtension{
+							Raw: []byte(`{"type":"object","properties":{"apiVersion":{"type":"string"},"kind":{"type":"string"},"metadata":{"type":"object"},"spec":{"type":"object","properties":{"data":{"type":"string"}}}}}`),
+						},
+					},
+				},
+			},
+		}
+
+		opStart := time.Now()
+		_, err := client.Cluster(wsPath).ApisV1alpha1().APIResourceSchemas().Create(ctx, schema, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to create APIResourceSchema in %s: %w", wsPath, err)
+		}
+		s.Drop(measurement.Measurement{Name: "schema_create_duration_ms", Value: time.Since(opStart).Seconds() * 1000})
+
+		// Create the APIExport referencing the schema.
+		export := &apisv1alpha2.APIExport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: exportName,
+			},
+			Spec: apisv1alpha2.APIExportSpec{
+				Resources: []apisv1alpha2.ResourceSchema{
+					{
+						Name:   resourceName,
+						Group:  "loadtest.kcp.io",
+						Schema: schemaName,
+						Storage: apisv1alpha2.ResourceSchemaStorage{
+							CRD: &apisv1alpha2.ResourceSchemaStorageCRD{},
+						},
+					},
+				},
+			},
+		}
+
+		opStart = time.Now()
+		_, err = client.Cluster(wsPath).ApisV1alpha2().APIExports().Create(ctx, export, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to create APIExport in %s: %w", wsPath, err)
+		}
+		s.Drop(measurement.Measurement{Name: "export_create_duration_ms", Value: time.Since(opStart).Seconds() * 1000})
+
+		// Wait for the APIExport identity to become valid.
+		opStart = time.Now()
+		err = wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+			got, err := client.Cluster(wsPath).ApisV1alpha2().APIExports().Get(ctx, exportName, metav1.GetOptions{})
+			if err != nil {
+				return false, nil //nolint:nilerr
+			}
+			return conditions.IsTrue(got, apisv1alpha2.APIExportIdentityValid), nil
+		})
+		if err != nil {
+			return fmt.Errorf("APIExport in %s did not become ready: %w", wsPath, err)
+		}
+		s.Drop(measurement.Measurement{Name: "export_ready_duration_ms", Value: time.Since(opStart).Seconds() * 1000})
+
+		return nil
+	}
+
+	section.Errors = framework.Execute(ts, action, section.Sink)
+	section.End()
+
+	return section
+}
+
+// createAPIBindings creates an APIBinding in each consumer workspace (sequence
+// numbers providerCount+1 through providerCount+consumerCount) that binds to
+// the provider workspaces in a round-robin fashion.
+func createAPIBindings(t *testing.T, client kcpclientset.ClusterInterface, wt tree.WorkspaceTree, qps float64, providerCount, consumerCount int) measurement.Section {
+	t.Helper()
+
+	section := measurement.Section{
+		Title: "APIBinding Creation",
+		Parameters: []measurement.Parameter{
+			{Key: "ConsumerWorkspaces", Value: fmt.Sprintf("%d", consumerCount)},
+			{Key: "ProviderWorkspaces", Value: fmt.Sprintf("%d", providerCount)},
+			{Key: "CRUD-QPS", Value: fmt.Sprintf("%f", qps)},
+		},
+		Sink: &measurement.Memory{
+			Stats: []stats.NamedStat{stats.P99(), stats.Avg()},
+		},
+	}
+
+	// Consumer workspaces start after the provider workspaces.
+	consumerStart := providerCount + 1
+	ts := tuningset.NewUniformQPS(qps, consumerCount, consumerStart)
+	section.Start()
+	action := func(seq int, s measurement.Sink) error {
+		defer measurement.RecordElapsedDurationMS(time.Now(), s)
+
+		ctx := context.Background()
+		consumerPath := wt.PathForSequenceNumber(seq)
+
+		// Round-robin: map consumer index to provider sequence number (1-based).
+		consumerIndex := seq - consumerStart
+		providerSeq := (consumerIndex % providerCount) + 1
+		providerPath := wt.PathForSequenceNumber(providerSeq)
+		exportName := fmt.Sprintf("loadtest-export-%d", providerSeq)
+		bindingName := fmt.Sprintf("loadtest-binding-%d", providerSeq)
+
+		binding := &apisv1alpha2.APIBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: bindingName,
+			},
+			Spec: apisv1alpha2.APIBindingSpec{
+				Reference: apisv1alpha2.BindingReference{
+					Export: &apisv1alpha2.ExportBindingReference{
+						Path: providerPath.String(),
+						Name: exportName,
+					},
+				},
+			},
+		}
+
+		opStart := time.Now()
+		_, err := client.Cluster(consumerPath).ApisV1alpha2().APIBindings().Create(ctx, binding, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to create APIBinding in %s: %w", consumerPath, err)
+		}
+		s.Drop(measurement.Measurement{Name: "binding_create_duration_ms", Value: time.Since(opStart).Seconds() * 1000})
+
+		// Wait for the binding to become bound.
+		opStart = time.Now()
+		err = wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+			got, err := client.Cluster(consumerPath).ApisV1alpha2().APIBindings().Get(ctx, bindingName, metav1.GetOptions{})
+			if err != nil {
+				return false, nil //nolint:nilerr
+			}
+			return got.Status.Phase == apisv1alpha2.APIBindingPhaseBound, nil
+		})
+		if err != nil {
+			return fmt.Errorf("APIBinding in %s did not become bound: %w", consumerPath, err)
+		}
+		s.Drop(measurement.Measurement{Name: "binding_ready_duration_ms", Value: time.Since(opStart).Seconds() * 1000})
+
+		return nil
+	}
+
+	section.Errors = framework.Execute(ts, action, section.Sink)
+	section.End()
+
+	return section
+}
+
+// crudCustomResources performs a Create/Get/Update/Delete cycle for a custom
+// resource in each consumer workspace. The resource type is determined by the
+// round-robin provider assignment.
+func crudCustomResources(t *testing.T, dynamicClient kcpdynamic.ClusterInterface, wt tree.WorkspaceTree, qps float64, providerCount, consumerCount int) measurement.Section {
+	t.Helper()
+
+	section := measurement.Section{
+		Title: "Custom Resource CRUD",
+		Parameters: []measurement.Parameter{
+			{Key: "ConsumerWorkspaces", Value: fmt.Sprintf("%d", consumerCount)},
+			{Key: "QPS", Value: fmt.Sprintf("%f", qps*4)},
+		},
+		Sink: &measurement.Memory{
+			Stats: []stats.NamedStat{stats.P99(), stats.Avg()},
+		},
+	}
+
+	consumerStart := providerCount + 1
+	ts := tuningset.NewUniformQPS(qps, consumerCount, consumerStart)
+	section.Start()
+	action := func(seq int, s measurement.Sink) error {
+		defer measurement.RecordElapsedDurationMS(time.Now(), s)
+
+		ctx := context.Background()
+		consumerPath := wt.PathForSequenceNumber(seq)
+
+		// Determine which provider resource this consumer is bound to.
+		consumerIndex := seq - consumerStart
+		providerSeq := (consumerIndex % providerCount) + 1
+		resourceName := fmt.Sprintf("loadtestresources%d", providerSeq)
+
+		gvr := schema.GroupVersionResource{
+			Group:    "loadtest.kcp.io",
+			Version:  "v1alpha1",
+			Resource: resourceName,
+		}
+
+		resClient := dynamicClient.Cluster(consumerPath).Resource(gvr).Namespace("default")
+		objName := fmt.Sprintf("loadtest-cr-%d", seq)
+
+		// Create
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "loadtest.kcp.io/v1alpha1",
+				"kind":       fmt.Sprintf("LoadTestResource%d", providerSeq),
+				"metadata": map[string]interface{}{
+					"name":      objName,
+					"namespace": "default",
+				},
+				"spec": map[string]interface{}{
+					"data": "initial-value",
+				},
+			},
+		}
+
+		opStart := time.Now()
+		created, err := resClient.Create(ctx, obj, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to create custom resource in %s: %w", consumerPath, err)
+		}
+		s.Drop(measurement.Measurement{Name: "create_duration_ms", Value: time.Since(opStart).Seconds() * 1000})
+
+		// Get
+		opStart = time.Now()
+		_, err = resClient.Get(ctx, objName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to get custom resource in %s: %w", consumerPath, err)
+		}
+		s.Drop(measurement.Measurement{Name: "get_duration_ms", Value: time.Since(opStart).Seconds() * 1000})
+
+		// Update
+		if err := unstructured.SetNestedField(created.Object, "updated-value", "spec", "data"); err != nil {
+			return fmt.Errorf("failed to set spec.data: %w", err)
+		}
+		opStart = time.Now()
+		_, err = resClient.Update(ctx, created, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to update custom resource in %s: %w", consumerPath, err)
+		}
+		s.Drop(measurement.Measurement{Name: "update_duration_ms", Value: time.Since(opStart).Seconds() * 1000})
+
+		// Delete
+		opStart = time.Now()
+		err = resClient.Delete(ctx, objName, metav1.DeleteOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to delete custom resource in %s: %w", consumerPath, err)
+		}
+		s.Drop(measurement.Measurement{Name: "delete_duration_ms", Value: time.Since(opStart).Seconds() * 1000})
+
+		return nil
+	}
+
+	section.Errors = framework.Execute(ts, action, section.Sink)
+	section.End()
+
+	return section
+}

--- a/test/load/testing/workspace_apisharing_test.go
+++ b/test/load/testing/workspace_apisharing_test.go
@@ -61,7 +61,7 @@ func TestAPISharing(t *testing.T) {
 	wt := params.WorkspaceTree()
 
 	// Ensure workspaces exist, creating them if necessary.
-	exist, err := workspacesExist(wt, client, params.WorkspaceCount)
+	exist, err := workspacesExist(t.Context(), wt, client, params.WorkspaceCount)
 	require.NoError(t, err)
 	if exist {
 		t.Logf("workspaces already exist, skipping creation")
@@ -83,7 +83,7 @@ func TestAPISharing(t *testing.T) {
 	crudSection := crudCustomResources(t, dynamicClusterClient, wt, params.CRUDSharedAPIQPS, params.ProviderWorkspacesCount, params.ConsumerWorkspacesCount)
 	sections = append(sections, crudSection)
 
-	report := NewKCPReport(t, "API Sharing", cfg.FrontProxyKubeconfig)
+	report := NewKCPReport(t.Context(), t, "API Sharing", cfg.FrontProxyKubeconfig)
 	report.Sections = sections
 	report.PrettyPrint(os.Stdout)
 
@@ -196,7 +196,7 @@ func createAPIExports(t *testing.T, client kcpclientset.ClusterInterface, wt tre
 		return nil
 	}
 
-	section.Errors = framework.Execute(context.Background(), ts, action, section.Sink)
+	section.Errors = framework.Execute(t.Context(), ts, action, section.Sink)
 	section.End()
 
 	return section
@@ -274,7 +274,7 @@ func createAPIBindings(t *testing.T, client kcpclientset.ClusterInterface, wt tr
 		return nil
 	}
 
-	section.Errors = framework.Execute(context.Background(), ts, action, section.Sink)
+	section.Errors = framework.Execute(t.Context(), ts, action, section.Sink)
 	section.End()
 
 	return section
@@ -371,7 +371,7 @@ func crudCustomResources(t *testing.T, dynamicClient kcpdynamic.ClusterInterface
 		return nil
 	}
 
-	section.Errors = framework.Execute(context.Background(), ts, action, section.Sink)
+	section.Errors = framework.Execute(t.Context(), ts, action, section.Sink)
 	section.End()
 
 	return section

--- a/test/load/testing/workspace_apisharing_test.go
+++ b/test/load/testing/workspace_apisharing_test.go
@@ -110,10 +110,9 @@ func createAPIExports(t *testing.T, client kcpclientset.ClusterInterface, wt tre
 
 	ts := tuningset.NewUniformQPS(qps, providerCount, 1)
 	section.Start()
-	action := func(seq int, s measurement.Sink) error {
+	action := func(ctx context.Context, seq int, s measurement.Sink) error {
 		defer measurement.RecordElapsedDurationMS(time.Now(), s)
 
-		ctx := context.Background()
 		wsPath := wt.PathForSequenceNumber(seq)
 
 		schemaName := fmt.Sprintf("v1alpha1.loadtestresources%d.loadtest.kcp.io", seq)
@@ -197,7 +196,7 @@ func createAPIExports(t *testing.T, client kcpclientset.ClusterInterface, wt tre
 		return nil
 	}
 
-	section.Errors = framework.Execute(ts, action, section.Sink)
+	section.Errors = framework.Execute(context.Background(), ts, action, section.Sink)
 	section.End()
 
 	return section
@@ -225,10 +224,9 @@ func createAPIBindings(t *testing.T, client kcpclientset.ClusterInterface, wt tr
 	consumerStart := providerCount + 1
 	ts := tuningset.NewUniformQPS(qps, consumerCount, consumerStart)
 	section.Start()
-	action := func(seq int, s measurement.Sink) error {
+	action := func(ctx context.Context, seq int, s measurement.Sink) error {
 		defer measurement.RecordElapsedDurationMS(time.Now(), s)
 
-		ctx := context.Background()
 		consumerPath := wt.PathForSequenceNumber(seq)
 
 		// Round-robin: map consumer index to provider sequence number (1-based).
@@ -276,7 +274,7 @@ func createAPIBindings(t *testing.T, client kcpclientset.ClusterInterface, wt tr
 		return nil
 	}
 
-	section.Errors = framework.Execute(ts, action, section.Sink)
+	section.Errors = framework.Execute(context.Background(), ts, action, section.Sink)
 	section.End()
 
 	return section
@@ -302,10 +300,9 @@ func crudCustomResources(t *testing.T, dynamicClient kcpdynamic.ClusterInterface
 	consumerStart := providerCount + 1
 	ts := tuningset.NewUniformQPS(qps, consumerCount, consumerStart)
 	section.Start()
-	action := func(seq int, s measurement.Sink) error {
+	action := func(ctx context.Context, seq int, s measurement.Sink) error {
 		defer measurement.RecordElapsedDurationMS(time.Now(), s)
 
-		ctx := context.Background()
 		consumerPath := wt.PathForSequenceNumber(seq)
 
 		// Determine which provider resource this consumer is bound to.
@@ -374,7 +371,7 @@ func crudCustomResources(t *testing.T, dynamicClient kcpdynamic.ClusterInterface
 		return nil
 	}
 
-	section.Errors = framework.Execute(ts, action, section.Sink)
+	section.Errors = framework.Execute(context.Background(), ts, action, section.Sink)
 	section.End()
 
 	return section

--- a/test/load/testing/workspace_creation_test.go
+++ b/test/load/testing/workspace_creation_test.go
@@ -52,7 +52,7 @@ func TestWorkspaceCreation(t *testing.T) {
 	createSection := createWorkspaces(t, client, params.WorkspaceTree(), params.CreateWorkspaceQPS, params.WorkspaceCount)
 	sections = append(sections, createSection)
 
-	report := NewKCPReport(t, "Workspace Creation", cfg.FrontProxyKubeconfig)
+	report := NewKCPReport(t.Context(), t, "Workspace Creation", cfg.FrontProxyKubeconfig)
 	report.Sections = sections
 	report.PrettyPrint(os.Stdout)
 
@@ -115,7 +115,7 @@ func createWorkspaces(t *testing.T, client kcpclientset.ClusterInterface, wt tre
 		return nil
 	}
 
-	section.Errors = framework.Execute(context.Background(), ts, action, section.Sink)
+	section.Errors = framework.Execute(t.Context(), ts, action, section.Sink)
 	section.End()
 
 	return section

--- a/test/load/testing/workspace_creation_test.go
+++ b/test/load/testing/workspace_creation_test.go
@@ -79,10 +79,9 @@ func createWorkspaces(t *testing.T, client kcpclientset.ClusterInterface, wt tre
 
 	ts := tuningset.NewUniformQPS(qps, count, 1)
 	section.Start()
-	action := func(seq int, s measurement.Sink) error {
+	action := func(ctx context.Context, seq int, s measurement.Sink) error {
 		defer measurement.RecordElapsedDurationMS(time.Now(), s)
 
-		ctx := context.Background()
 		wsName := wt.WorkspaceName(seq)
 
 		ws := &tenancyv1alpha1.Workspace{
@@ -116,7 +115,7 @@ func createWorkspaces(t *testing.T, client kcpclientset.ClusterInterface, wt tre
 		return nil
 	}
 
-	section.Errors = framework.Execute(ts, action, section.Sink)
+	section.Errors = framework.Execute(context.Background(), ts, action, section.Sink)
 	section.End()
 
 	return section

--- a/test/load/testing/workspace_simple_crud_test.go
+++ b/test/load/testing/workspace_simple_crud_test.go
@@ -95,12 +95,11 @@ func crudConfigMaps(t *testing.T, wt tree.WorkspaceTree, kubeClusterClient kcpku
 
 	ts := tuningset.NewUniformQPS(qps, count, 1)
 	section.Start()
-	action := func(seq int, s measurement.Sink) error {
+	action := func(ctx context.Context, seq int, s measurement.Sink) error {
 		cmClient := kubeClusterClient.Cluster(wt.PathForSequenceNumber(seq)).CoreV1().ConfigMaps("default")
 
 		defer measurement.RecordElapsedDurationMS(time.Now(), s)
 
-		ctx := context.Background()
 		cmName := fmt.Sprintf("loadtest-cm-%d", seq)
 
 		// Create
@@ -154,7 +153,7 @@ func crudConfigMaps(t *testing.T, wt tree.WorkspaceTree, kubeClusterClient kcpku
 		return nil
 	}
 
-	section.Errors = framework.Execute(ts, action, section.Sink)
+	section.Errors = framework.Execute(context.Background(), ts, action, section.Sink)
 	section.End()
 
 	return section

--- a/test/load/testing/workspace_simple_crud_test.go
+++ b/test/load/testing/workspace_simple_crud_test.go
@@ -54,7 +54,7 @@ func TestWorkspaceSimpleCRUD(t *testing.T) {
 	wt := params.WorkspaceTree()
 
 	// Ensure workspaces exist, creating them if necessary.
-	exist, err := workspacesExist(wt, client, params.WorkspaceCount)
+	exist, err := workspacesExist(t.Context(), wt, client, params.WorkspaceCount)
 	require.NoError(t, err)
 	if exist {
 		t.Logf("workspaces already exist, skipping creation")
@@ -68,7 +68,7 @@ func TestWorkspaceSimpleCRUD(t *testing.T) {
 	crudSection := crudConfigMaps(t, wt, kubeClusterClient, params.CRUDConfigMapQPS, params.WorkspaceCount)
 	sections = append(sections, crudSection)
 
-	report := NewKCPReport(t, "Workspace Simple Configmap CRUD", cfg.FrontProxyKubeconfig)
+	report := NewKCPReport(t.Context(), t, "Workspace Simple Configmap CRUD", cfg.FrontProxyKubeconfig)
 	report.Sections = sections
 	report.PrettyPrint(os.Stdout)
 
@@ -153,7 +153,7 @@ func crudConfigMaps(t *testing.T, wt tree.WorkspaceTree, kubeClusterClient kcpku
 		return nil
 	}
 
-	section.Errors = framework.Execute(context.Background(), ts, action, section.Sink)
+	section.Errors = framework.Execute(t.Context(), ts, action, section.Sink)
 	section.End()
 
 	return section


### PR DESCRIPTION
## Summary

This PR adds load-test level 3 according to our specification. Specifcally this means creation of ApiExports and Bindings and CRUD on the objects.

This is only to be merged after https://github.com/kcp-dev/kcp/pull/4160 has been merged. Hopefully we will get stacked PRs soon.

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->
/kind feature

## Related Issue(s)

Fixes https://github.com/platform-mesh/backlog/issues/164

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
