### PR TITLE
Set shard name annotation on LC and propagate to Workspace

### DIFF
--- a/pkg/authorization/bootstrap/policy.go
+++ b/pkg/authorization/bootstrap/policy.go
@@ -106,7 +106,7 @@ func clusterRoles() []rbacv1.ClusterRole {
 			ObjectMeta: metav1.ObjectMeta{Name: SystemExternalLogicalClusterAdmin},
 			Rules: []rbacv1.PolicyRule{
 				rbacv1helpers.NewRule("delete", "update", "get").Groups(core.GroupName).Resources("logicalclusters", "logicalclusters/status").RuleOrDie(),
-				rbacv1helpers.NewRule("delete", "update", "get").Groups(tenancy.GroupName).Resources("workspaces").RuleOrDie(),
+				rbacv1helpers.NewRule("delete", "update", "patch", "get").Groups(tenancy.GroupName).Resources("workspaces").RuleOrDie(),
 				rbacv1helpers.NewRule("get").Groups("").Resources("serviceaccounts", "secrets").RuleOrDie(),
 				rbacv1helpers.NewRule("access").URLs("/").RuleOrDie(),
 				// Allow the in-process initializing/terminating virtual workspaces to delegate

--- a/pkg/reconciler/core/logicalcluster/logicalcluster_controller.go
+++ b/pkg/reconciler/core/logicalcluster/logicalcluster_controller.go
@@ -25,11 +25,13 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
 	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
+	kcpdynamic "github.com/kcp-dev/client-go/dynamic"
 	"github.com/kcp-dev/logicalcluster/v3"
 	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
@@ -47,8 +49,10 @@ const (
 )
 
 func NewController(
+	shardName string,
 	shardExternalURL func() string,
 	kcpClusterClient kcpclientset.ClusterInterface,
+	externalLogicalClusterAdminConfig *rest.Config,
 	logicalClusterInformer corev1alpha1informers.LogicalClusterClusterInformer,
 	clusterContextManager *contextmanager.Manager[logicalcluster.Path],
 ) (*Controller, error) {
@@ -59,12 +63,14 @@ func NewController(
 				Name: ControllerName,
 			},
 		),
-		shardExternalURL:      shardExternalURL,
-		kcpClusterClient:      kcpClusterClient,
-		logicalClusterIndexer: logicalClusterInformer.Informer().GetIndexer(),
-		logicalClusterLister:  logicalClusterInformer.Lister(),
-		clusterContextManager: clusterContextManager,
-		commit:                committer.NewCommitter[*corev1alpha1.LogicalCluster, corev1alpha1client.LogicalClusterInterface, *corev1alpha1.LogicalClusterSpec, *corev1alpha1.LogicalClusterStatus](kcpClusterClient.CoreV1alpha1().LogicalClusters()),
+		shardName:                         shardName,
+		shardExternalURL:                  shardExternalURL,
+		kcpClusterClient:                  kcpClusterClient,
+		externalLogicalClusterAdminConfig: externalLogicalClusterAdminConfig,
+		logicalClusterIndexer:             logicalClusterInformer.Informer().GetIndexer(),
+		logicalClusterLister:              logicalClusterInformer.Lister(),
+		clusterContextManager:             clusterContextManager,
+		commit:                            committer.NewCommitter[*corev1alpha1.LogicalCluster, corev1alpha1client.LogicalClusterInterface, *corev1alpha1.LogicalClusterSpec, *corev1alpha1.LogicalClusterStatus](kcpClusterClient.CoreV1alpha1().LogicalClusters()),
 	}
 	_, _ = logicalClusterInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    func(obj interface{}) { c.enqueue(obj) },
@@ -82,9 +88,13 @@ type logicalClusterResource = committer.Resource[*corev1alpha1.LogicalClusterSpe
 type Controller struct {
 	queue workqueue.TypedRateLimitingInterface[string]
 
+	shardName        string
 	shardExternalURL func() string
 
 	kcpClusterClient kcpclientset.ClusterInterface
+
+	externalLogicalClusterAdminConfig *rest.Config // for front-proxy connections used to update parent Workspaces
+	dynamicExternalClient             kcpdynamic.ClusterInterface
 
 	logicalClusterIndexer cache.Indexer
 	logicalClusterLister  corev1alpha1listers.LogicalClusterClusterLister
@@ -109,6 +119,16 @@ func (c *Controller) enqueue(obj interface{}) {
 func (c *Controller) Start(ctx context.Context, numThreads int) {
 	defer utilruntime.HandleCrash()
 	defer c.queue.ShutDown()
+
+	// create external client that goes through the front-proxy. Used to update
+	// parent Workspaces whose shard might be different from this LC's shard.
+	externalConfig := rest.CopyConfig(c.externalLogicalClusterAdminConfig)
+	dynamicExternalClient, err := kcpdynamic.NewForConfig(externalConfig)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+	c.dynamicExternalClient = dynamicExternalClient
 
 	logger := logging.WithReconciler(klog.FromContext(ctx), ControllerName)
 	ctx = klog.NewContext(ctx, logger)

--- a/pkg/reconciler/core/logicalcluster/logicalcluster_reconcile.go
+++ b/pkg/reconciler/core/logicalcluster/logicalcluster_reconcile.go
@@ -18,9 +18,15 @@ package logicalcluster
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 
+	"github.com/kcp-dev/logicalcluster/v3"
 	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 )
 
@@ -36,10 +42,33 @@ type reconciler interface {
 }
 
 func (c *Controller) reconcile(ctx context.Context, logicalCluster *corev1alpha1.LogicalCluster) (bool, error) {
+	getOwner := func(ctx context.Context, owner corev1alpha1.LogicalClusterOwner) (metav1.Object, error) {
+		gvr, err := ownerGVR(owner)
+		if err != nil {
+			return nil, err
+		}
+		cluster := logicalcluster.NewPath(owner.Cluster)
+		return c.dynamicExternalClient.Cluster(cluster).Resource(gvr).Namespace(owner.Namespace).Get(ctx, owner.Name, metav1.GetOptions{})
+	}
+	patchOwner := func(ctx context.Context, owner corev1alpha1.LogicalClusterOwner, patch []byte) error {
+		gvr, err := ownerGVR(owner)
+		if err != nil {
+			return err
+		}
+		cluster := logicalcluster.NewPath(owner.Cluster)
+		_, err = c.dynamicExternalClient.Cluster(cluster).Resource(gvr).Namespace(owner.Namespace).Patch(ctx, owner.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+		return err
+	}
+
 	// reconcilers which modify Status should be last
 	// reconcilers which modify ObjectMeta, need to return reconcileStatusStopAndRequeue on change
 	reconcilers := []reconciler{
 		&metaDataReconciler{},
+		&shardAnnotationReconciler{
+			shardName:  c.shardName,
+			getOwner:   getOwner,
+			patchOwner: patchOwner,
+		},
 		&terminatorReconciler{},
 		&phaseReconciler{clusterContextManager: c.clusterContextManager},
 		&urlReconciler{shardExternalURL: c.shardExternalURL},
@@ -62,4 +91,21 @@ func (c *Controller) reconcile(ctx context.Context, logicalCluster *corev1alpha1
 	}
 
 	return requeue, utilerrors.NewAggregate(errs)
+}
+
+func ownerGVR(owner corev1alpha1.LogicalClusterOwner) (schema.GroupVersionResource, error) {
+	if owner.APIVersion == "" || owner.Resource == "" {
+		return schema.GroupVersionResource{}, fmt.Errorf("LogicalCluster owner missing apiVersion or resource")
+	}
+	var group, version string
+	if i := strings.Index(owner.APIVersion, "/"); i >= 0 {
+		group = owner.APIVersion[:i]
+		version = owner.APIVersion[i+1:]
+	} else {
+		version = owner.APIVersion
+	}
+	if version == "" {
+		return schema.GroupVersionResource{}, fmt.Errorf("LogicalCluster owner has invalid apiVersion %q", owner.APIVersion)
+	}
+	return schema.GroupVersionResource{Group: group, Version: version, Resource: owner.Resource}, nil
 }

--- a/pkg/reconciler/core/logicalcluster/logicalcluster_reconcile_metadata.go
+++ b/pkg/reconciler/core/logicalcluster/logicalcluster_reconcile_metadata.go
@@ -31,8 +31,7 @@ import (
 	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
 )
 
-type metaDataReconciler struct {
-}
+type metaDataReconciler struct{}
 
 func (r *metaDataReconciler) reconcile(ctx context.Context, logicalCluster *corev1alpha1.LogicalCluster) (reconcileStatus, error) {
 	logger := klog.FromContext(ctx)

--- a/pkg/reconciler/core/logicalcluster/logicalcluster_reconcile_shard.go
+++ b/pkg/reconciler/core/logicalcluster/logicalcluster_reconcile_shard.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logicalcluster
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"maps"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+
+	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
+)
+
+// shardAnnotationReconciler stamps the shard name as an annotation on the LogicalCluster.
+// This is separate from the metadataReconciler since this will also
+// requires updating the same annotation on the owning object, which may
+// live on another shard.
+type shardAnnotationReconciler struct {
+	shardName  string
+	getOwner   func(ctx context.Context, owner corev1alpha1.LogicalClusterOwner) (metav1.Object, error)
+	patchOwner func(ctx context.Context, owner corev1alpha1.LogicalClusterOwner, patch []byte) error
+}
+
+func (r *shardAnnotationReconciler) reconcile(ctx context.Context, lc *corev1alpha1.LogicalCluster) (reconcileStatus, error) {
+	// matches, nothing to do; if the local annotation is correct it is
+	// assumed that the annotation on the owner is also correct,
+	// otherwise each reconcile would incur additional front-proxy
+	// traffic just to check the annotation on the owner.
+	if lc.Annotations[corev1alpha1.LogicalClusterShardAnnotationKey] == r.shardName {
+		return reconcileStatusContinue, nil
+	}
+
+	prev := maps.Clone(lc.Annotations)
+	if lc.Annotations == nil {
+		lc.Annotations = map[string]string{}
+	}
+	lc.Annotations[corev1alpha1.LogicalClusterShardAnnotationKey] = r.shardName
+
+	if err := r.setAnnotationOnOwner(ctx, lc); err != nil {
+		// revert annotation on LC so annotation doesn't get committed
+		// and skips updating owner on next reconcile
+		lc.Annotations = prev
+		return reconcileStatusStopAndRequeue, err
+	}
+	return reconcileStatusStopAndRequeue, nil
+}
+
+func (r *shardAnnotationReconciler) setAnnotationOnOwner(ctx context.Context, lc *corev1alpha1.LogicalCluster) error {
+	if lc.Spec.Owner == nil {
+		return nil
+	}
+	owner := *lc.Spec.Owner
+
+	obj, err := r.getOwner(ctx, owner)
+	if err != nil {
+		return err
+	}
+	if obj.GetAnnotations()[corev1alpha1.LogicalClusterShardAnnotationKey] == r.shardName {
+		return nil
+	}
+
+	patch, err := json.Marshal(map[string]any{
+		"metadata": map[string]any{
+			"annotations": map[string]string{
+				corev1alpha1.LogicalClusterShardAnnotationKey: r.shardName,
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal shard annotation patch: %w", err)
+	}
+
+	klog.FromContext(ctx).V(3).Info("patching owner shard annotation",
+		"apiVersion", owner.APIVersion,
+		"resource", owner.Resource,
+		"cluster", owner.Cluster,
+		"namespace", owner.Namespace,
+		"name", owner.Name,
+		"shard", r.shardName,
+	)
+	return r.patchOwner(ctx, owner, patch)
+}

--- a/pkg/reconciler/core/logicalcluster/logicalcluster_reconcile_shard_test.go
+++ b/pkg/reconciler/core/logicalcluster/logicalcluster_reconcile_shard_test.go
@@ -1,0 +1,257 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logicalcluster
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
+	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
+)
+
+func TestShardAnnotationReconciler(t *testing.T) {
+	const shardName = "shard-A"
+	workspacesResource := schema.GroupResource{Group: tenancyv1alpha1.SchemeGroupVersion.Group, Resource: "workspaces"}
+
+	workspaceOwner := corev1alpha1.LogicalClusterOwner{
+		APIVersion: tenancyv1alpha1.SchemeGroupVersion.String(),
+		Resource:   "workspaces",
+		Cluster:    "root:org",
+		Name:       "ws",
+		UID:        "uid-1",
+	}
+	mountOwner := corev1alpha1.LogicalClusterOwner{
+		APIVersion: "tenancy.kcp.io/v1alpha1",
+		Resource:   "mounts",
+		Cluster:    "root:org",
+		Namespace:  "default",
+		Name:       "m1",
+		UID:        "uid-2",
+	}
+
+	type getCall struct {
+		owner corev1alpha1.LogicalClusterOwner
+	}
+	type patchCall struct {
+		owner corev1alpha1.LogicalClusterOwner
+		patch string
+	}
+
+	patchBody := `{"metadata":{"annotations":{"core.kcp.io/shard":"shard-A"}}}`
+
+	for _, tc := range []struct {
+		name string
+
+		input    *corev1alpha1.LogicalCluster
+		ownerObj metav1.Object
+		getErr   error
+		patchErr error
+
+		expected       metav1.ObjectMeta
+		wantStatus     reconcileStatus
+		wantErr        bool
+		wantGetCalls   []getCall
+		wantPatchCalls []patchCall
+	}{
+		{
+			name: "LC annotation already matches: no-op, continue",
+			input: &corev1alpha1.LogicalCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						corev1alpha1.LogicalClusterShardAnnotationKey: shardName,
+					},
+				},
+				Spec: corev1alpha1.LogicalClusterSpec{Owner: &workspaceOwner},
+			},
+			expected: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					corev1alpha1.LogicalClusterShardAnnotationKey: shardName,
+				},
+			},
+			wantStatus: reconcileStatusContinue,
+		},
+		{
+			name: "LC annotation absent, owner already correct: stamp LC, GET only",
+			input: &corev1alpha1.LogicalCluster{
+				Spec: corev1alpha1.LogicalClusterSpec{Owner: &workspaceOwner},
+			},
+			ownerObj: &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						corev1alpha1.LogicalClusterShardAnnotationKey: shardName,
+					},
+				},
+			},
+			expected: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					corev1alpha1.LogicalClusterShardAnnotationKey: shardName,
+				},
+			},
+			wantStatus:   reconcileStatusStopAndRequeue,
+			wantGetCalls: []getCall{{owner: workspaceOwner}},
+		},
+		{
+			name: "LC annotation stale, owner stale: stamp LC, GET + PATCH",
+			input: &corev1alpha1.LogicalCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						corev1alpha1.LogicalClusterShardAnnotationKey: "shard-other",
+					},
+				},
+				Spec: corev1alpha1.LogicalClusterSpec{Owner: &workspaceOwner},
+			},
+			ownerObj: &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						corev1alpha1.LogicalClusterShardAnnotationKey: "shard-other",
+					},
+				},
+			},
+			expected: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					corev1alpha1.LogicalClusterShardAnnotationKey: shardName,
+				},
+			},
+			wantStatus:     reconcileStatusStopAndRequeue,
+			wantGetCalls:   []getCall{{owner: workspaceOwner}},
+			wantPatchCalls: []patchCall{{owner: workspaceOwner, patch: patchBody}},
+		},
+		{
+			name: "Non-Workspace owner (mount): same flow, GET + PATCH",
+			input: &corev1alpha1.LogicalCluster{
+				Spec: corev1alpha1.LogicalClusterSpec{Owner: &mountOwner},
+			},
+			ownerObj: &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+			expected: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					corev1alpha1.LogicalClusterShardAnnotationKey: shardName,
+				},
+			},
+			wantStatus:     reconcileStatusStopAndRequeue,
+			wantGetCalls:   []getCall{{owner: mountOwner}},
+			wantPatchCalls: []patchCall{{owner: mountOwner, patch: patchBody}},
+		},
+		{
+			name: "Nil Owner (root LC): stamp LC, no remote calls",
+			input: &corev1alpha1.LogicalCluster{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+			expected: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					corev1alpha1.LogicalClusterShardAnnotationKey: shardName,
+				},
+			},
+			wantStatus: reconcileStatusStopAndRequeue,
+		},
+		{
+			name: "GET NotFound: LC stamp reverted, error returned",
+			input: &corev1alpha1.LogicalCluster{
+				Spec: corev1alpha1.LogicalClusterSpec{Owner: &workspaceOwner},
+			},
+			getErr:       apierrors.NewNotFound(workspacesResource, "ws"),
+			expected:     metav1.ObjectMeta{},
+			wantStatus:   reconcileStatusStopAndRequeue,
+			wantErr:      true,
+			wantGetCalls: []getCall{{owner: workspaceOwner}},
+		},
+		{
+			name: "GET error: LC stamp reverted, error returned",
+			input: &corev1alpha1.LogicalCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						corev1alpha1.LogicalClusterShardAnnotationKey: "shard-other",
+					},
+				},
+				Spec: corev1alpha1.LogicalClusterSpec{Owner: &workspaceOwner},
+			},
+			getErr: errors.New("boom"),
+			expected: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					corev1alpha1.LogicalClusterShardAnnotationKey: "shard-other",
+				},
+			},
+			wantStatus:   reconcileStatusStopAndRequeue,
+			wantErr:      true,
+			wantGetCalls: []getCall{{owner: workspaceOwner}},
+		},
+		{
+			name: "PATCH error: LC stamp reverted, error returned",
+			input: &corev1alpha1.LogicalCluster{
+				Spec: corev1alpha1.LogicalClusterSpec{Owner: &workspaceOwner},
+			},
+			ownerObj: &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						corev1alpha1.LogicalClusterShardAnnotationKey: "shard-other",
+					},
+				},
+			},
+			patchErr:       apierrors.NewNotFound(workspacesResource, "ws"),
+			expected:       metav1.ObjectMeta{},
+			wantStatus:     reconcileStatusStopAndRequeue,
+			wantErr:        true,
+			wantGetCalls:   []getCall{{owner: workspaceOwner}},
+			wantPatchCalls: []patchCall{{owner: workspaceOwner, patch: patchBody}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotGets []getCall
+			var gotPatches []patchCall
+
+			r := &shardAnnotationReconciler{
+				shardName: shardName,
+				getOwner: func(_ context.Context, owner corev1alpha1.LogicalClusterOwner) (metav1.Object, error) {
+					gotGets = append(gotGets, getCall{owner: owner})
+					if tc.getErr != nil {
+						return nil, tc.getErr
+					}
+					return tc.ownerObj, nil
+				},
+				patchOwner: func(_ context.Context, owner corev1alpha1.LogicalClusterOwner, patch []byte) error {
+					gotPatches = append(gotPatches, patchCall{owner: owner, patch: string(patch)})
+					return tc.patchErr
+				},
+			}
+
+			status, err := r.reconcile(context.Background(), tc.input)
+
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.wantStatus, status)
+
+			if diff := cmp.Diff(tc.input.ObjectMeta, tc.expected); diff != "" {
+				t.Errorf("ObjectMeta diff (-got +want):\n%s", diff)
+			}
+			require.Equal(t, tc.wantGetCalls, gotGets)
+			require.Equal(t, tc.wantPatchCalls, gotPatches)
+		})
+	}
+}

--- a/pkg/reconciler/tenancy/initialization/apibinder_initializer_reconcile.go
+++ b/pkg/reconciler/tenancy/initialization/apibinder_initializer_reconcile.go
@@ -18,9 +18,7 @@ package initialization
 
 import (
 	"context"
-	"crypto/sha256"
 	"fmt"
-	"math/big"
 	"sort"
 	"strings"
 
@@ -30,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/klog/v2"
 
+	kcpcrypto "github.com/kcp-dev/apimachinery/v2/pkg/util/crypto"
 	"github.com/kcp-dev/logicalcluster/v3"
 	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
 	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
@@ -280,7 +279,7 @@ func generateAPIBindingName(clusterName logicalcluster.Name, exportPath, exportN
 
 	exportNamePrefix := exportName[:maxLen]
 
-	hash := toBase36Sha224(
+	hash := kcpcrypto.Base62Sha224.String(
 		clusterName.String() + "|" + exportPath + "|" + exportName,
 	)
 
@@ -289,16 +288,6 @@ func generateAPIBindingName(clusterName logicalcluster.Name, exportPath, exportN
 	hash = strings.ToLower(hash)
 
 	return fmt.Sprintf("%s-%s", exportNamePrefix, hash)
-}
-
-func toBase36(hash [28]byte) string {
-	var i big.Int
-	i.SetBytes(hash[:])
-	return i.Text(62)
-}
-
-func toBase36Sha224(s string) string {
-	return toBase36(sha256.Sum224([]byte(s)))
 }
 
 func hasAcceptedPermissionClaims(binding *apisv1alpha2.APIBinding) bool {

--- a/pkg/reconciler/tenancy/workspace/workspace_controller.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_controller.go
@@ -153,8 +153,7 @@ func NewController(
 		workspaceIndexer: workspaceInformer.Informer().GetIndexer(),
 		workspaceLister:  workspaceInformer.Lister(),
 
-		globalShardIndexer: globalShardInformer.Informer().GetIndexer(),
-		globalShardLister:  globalShardInformer.Lister(),
+		globalShardLister: globalShardInformer.Lister(),
 
 		globalWorkspaceTypeIndexer: globalWorkspaceTypeInformer.Informer().GetIndexer(),
 		globalWorkspaceTypeLister:  globalWorkspaceTypeInformer.Lister(),
@@ -229,8 +228,7 @@ type Controller struct {
 	workspaceIndexer cache.Indexer
 	workspaceLister  tenancyv1alpha1listers.WorkspaceClusterLister
 
-	globalShardIndexer cache.Indexer
-	globalShardLister  corev1alpha1listers.ShardClusterLister
+	globalShardLister corev1alpha1listers.ShardClusterLister
 
 	globalWorkspaceTypeIndexer cache.Indexer
 	globalWorkspaceTypeLister  tenancyv1alpha1listers.WorkspaceTypeClusterLister
@@ -428,9 +426,6 @@ func InstallIndexers(
 	indexers.AddIfNotPresentOrDie(workspaceInformer.Informer().GetIndexer(), cache.Indexers{
 		unschedulable:    indexUnschedulable,
 		byLogicalCluster: indexWorkspaceByLogicalCluster,
-	})
-	indexers.AddIfNotPresentOrDie(globalShardInformer.Informer().GetIndexer(), cache.Indexers{
-		byBase36Sha224Name: indexByBase36Sha224Name,
 	})
 	indexers.AddIfNotPresentOrDie(globalWorkspaceTypeInformer.Informer().GetIndexer(), cache.Indexers{
 		indexers.ByLogicalClusterPathAndName: indexers.IndexByLogicalClusterPathAndName,

--- a/pkg/reconciler/tenancy/workspace/workspace_indexes.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_indexes.go
@@ -17,16 +17,13 @@ limitations under the License.
 package workspace
 
 import (
-	kcpcrypto "github.com/kcp-dev/apimachinery/v2/pkg/util/crypto"
-	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
 	"github.com/kcp-dev/sdk/apis/third_party/conditions/util/conditions"
 )
 
 const (
-	byBase36Sha224Name = "byBase36Sha224Name"
-	unschedulable      = "unschedulable"
-	byLogicalCluster   = "byLogicalCluster"
+	unschedulable    = "unschedulable"
+	byLogicalCluster = "byLogicalCluster"
 )
 
 func indexUnschedulable(obj interface{}) ([]string, error) {
@@ -47,9 +44,4 @@ func indexWorkspaceByLogicalCluster(obj interface{}) ([]string, error) {
 		return []string{}, nil
 	}
 	return []string{workspace.Spec.Cluster}, nil
-}
-
-func indexByBase36Sha224Name(obj interface{}) ([]string, error) {
-	s := obj.(*corev1alpha1.Shard)
-	return []string{kcpcrypto.Base36Sha224.StringPad(s.Name)[:8]}, nil
 }

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile.go
@@ -70,7 +70,9 @@ func (c *Controller) reconcile(ctx context.Context, ws *tenancyv1alpha1.Workspac
 	}
 
 	reconcilers := []reconciler{
-		&metaDataReconciler{},
+		&metaDataReconciler{
+			listShards: c.globalShardLister.List,
+		},
 		&deletionReconciler{
 			getLogicalCluster: func(ctx context.Context, cluster logicalcluster.Path) (*corev1alpha1.LogicalCluster, error) {
 				return c.kcpExternalClient.Cluster(cluster).CoreV1alpha1().LogicalClusters().Get(ctx, corev1alpha1.LogicalClusterName, metav1.GetOptions{})

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"time"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilserrors "k8s.io/apimachinery/pkg/util/errors"
 
@@ -48,15 +47,8 @@ type reconciler interface {
 }
 
 func (c *Controller) reconcile(ctx context.Context, ws *tenancyv1alpha1.Workspace) (bool, error) {
-	getShardByName := func(hash string) (*corev1alpha1.Shard, error) {
-		shards, err := c.globalShardIndexer.ByIndex(byBase36Sha224Name, hash)
-		if err != nil {
-			return nil, err
-		}
-		if len(shards) == 0 {
-			return nil, apierrors.NewNotFound(corev1alpha1.Resource("shard"), hash)
-		}
-		return shards[0].(*corev1alpha1.Shard), nil
+	getShard := func(name string) (*corev1alpha1.Shard, error) {
+		return c.globalShardLister.Cluster(core.RootCluster).Get(name)
 	}
 
 	kcpDirectClientFor := func(shard *corev1alpha1.Shard) (kcpclientset.ClusterInterface, error) {
@@ -86,17 +78,14 @@ func (c *Controller) reconcile(ctx context.Context, ws *tenancyv1alpha1.Workspac
 			deleteLogicalCluster: func(ctx context.Context, cluster logicalcluster.Path) error {
 				return c.kcpExternalClient.Cluster(cluster).CoreV1alpha1().LogicalClusters().Delete(ctx, corev1alpha1.LogicalClusterName, metav1.DeleteOptions{})
 			},
-			getShardByHash:                  getShardByName,
+			getShard:                        getShard,
 			kcpLogicalClusterAdminClientFor: kcpDirectClientFor,
 		},
 		&schedulingReconciler{
 			generateClusterName: randomClusterName,
-			getShard: func(name string) (*corev1alpha1.Shard, error) {
-				return c.globalShardLister.Cluster(core.RootCluster).Get(name)
-			},
-			getShardByHash:   getShardByName,
-			listShards:       c.globalShardLister.List,
-			getWorkspaceType: getType,
+			getShard:            getShard,
+			listShards:          c.globalShardLister.List,
+			getWorkspaceType:    getType,
 			getLogicalCluster: func(clusterName logicalcluster.Name) (*corev1alpha1.LogicalCluster, error) {
 				return c.logicalClusterLister.Cluster(clusterName).Get(corev1alpha1.LogicalClusterName)
 			},
@@ -108,7 +97,7 @@ func (c *Controller) reconcile(ctx context.Context, ws *tenancyv1alpha1.Workspac
 			getLogicalCluster: func(ctx context.Context, cluster logicalcluster.Path) (*corev1alpha1.LogicalCluster, error) {
 				return c.kcpExternalClient.Cluster(cluster).CoreV1alpha1().LogicalClusters().Get(ctx, corev1alpha1.LogicalClusterName, metav1.GetOptions{})
 			},
-			getShardByHash: getShardByName,
+			getShard: getShard,
 			requeueAfter: func(workspace *tenancyv1alpha1.Workspace, after time.Duration) {
 				c.queue.AddAfter(kcpcache.ToClusterAwareKey(logicalcluster.From(workspace).String(), "", workspace.Name), after)
 			},

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_deletion.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_deletion.go
@@ -35,7 +35,7 @@ type deletionReconciler struct {
 	getLogicalCluster    func(ctx context.Context, cluster logicalcluster.Path) (*corev1alpha1.LogicalCluster, error)
 	deleteLogicalCluster func(ctx context.Context, cluster logicalcluster.Path) error
 
-	getShardByHash func(hash string) (*corev1alpha1.Shard, error)
+	getShard func(name string) (*corev1alpha1.Shard, error)
 
 	kcpLogicalClusterAdminClientFor func(shard *corev1alpha1.Shard) (kcpclientset.ClusterInterface, error)
 }
@@ -75,13 +75,13 @@ func (r *deletionReconciler) reconcile(ctx context.Context, workspace *tenancyv1
 		// try again with a direct connection. It might be that the front-proxy
 		// does not know about the logical cluster. We don't want to leak, so
 		// try extra hard.
-		shardNameHash, hasShard := workspace.Annotations[WorkspaceShardHashAnnotationKey]
+		shardName, hasShard := workspace.Annotations[corev1alpha1.LogicalClusterShardAnnotationKey]
 		if !hasShard {
 			// nothing we can do beyond retrying
 			return reconcileStatusStopAndRequeue, getErr
 		}
 
-		shard, err := r.getShardByHash(shardNameHash)
+		shard, err := r.getShard(shardName)
 		if err != nil {
 			return reconcileStatusStopAndRequeue, err
 		}

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_deletion_test.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_deletion_test.go
@@ -57,8 +57,8 @@ func (f *fakeDeletionReconciler) deleteLogicalCluster() func(ctx context.Context
 	}
 }
 
-func (f *fakeDeletionReconciler) getShardByHash() func(hash string) (*corev1alpha1.Shard, error) {
-	return func(hash string) (*corev1alpha1.Shard, error) {
+func (f *fakeDeletionReconciler) getShard() func(name string) (*corev1alpha1.Shard, error) {
+	return func(name string) (*corev1alpha1.Shard, error) {
 		// for now we can work with a fixed shard
 		s := &corev1alpha1.Shard{}
 		return s, nil
@@ -183,7 +183,7 @@ func TestReconcile(t *testing.T) {
 			}
 			fdr.deletionReconciler.getLogicalCluster = fdr.getLogicalCluster()
 			fdr.deletionReconciler.deleteLogicalCluster = fdr.deleteLogicalCluster()
-			fdr.deletionReconciler.getShardByHash = fdr.getShardByHash()
+			fdr.deletionReconciler.getShard = fdr.getShard()
 			fdr.deletionReconciler.kcpLogicalClusterAdminClientFor = fdr.kcpLogicalClusterAdminClientFor()
 
 			status, err := fdr.deletionReconciler.reconcile(ctx, tc.workspace)

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_metadata.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_metadata.go
@@ -19,8 +19,10 @@ package workspace
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"
 
 	kcpcrypto "github.com/kcp-dev/apimachinery/v2/pkg/util/crypto"
@@ -28,7 +30,9 @@ import (
 	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
 )
 
-type metaDataReconciler struct{}
+type metaDataReconciler struct {
+	listShards func(selector labels.Selector) ([]*corev1alpha1.Shard, error)
+}
 
 func (r *metaDataReconciler) reconcile(ctx context.Context, workspace *tenancyv1alpha1.Workspace) (reconcileStatus, error) {
 	logger := klog.FromContext(ctx).WithValues("reconciler", "metadata")
@@ -52,15 +56,37 @@ func (r *metaDataReconciler) reconcile(ctx context.Context, workspace *tenancyv1
 		changed = true
 	}
 
-	// update deprecated internal shard hash annotation
-	if shard := workspace.Annotations[corev1alpha1.LogicalClusterShardAnnotationKey]; shard != "" {
-		expectedHash := kcpcrypto.Base36Sha224.StringPad(shard)[:8]
+	shardName := workspace.Annotations[corev1alpha1.LogicalClusterShardAnnotationKey]
+	switch {
+	case shardName != "":
+		// shard is set on new annotation, ensure the deprecated annotation matches
+		expectedHash := kcpcrypto.Base36Sha224.StringPad(shardName)[:8]
 		if got := workspace.Annotations[WorkspaceShardHashAnnotationKey]; got != expectedHash {
 			if workspace.Annotations == nil {
 				workspace.Annotations = map[string]string{}
 			}
 			workspace.Annotations[WorkspaceShardHashAnnotationKey] = expectedHash
 			changed = true
+		}
+	default:
+		// new annotation is not set, set it based on the deprecated annotation
+		shardHash, hasShardHash := workspace.Annotations[WorkspaceShardHashAnnotationKey]
+		if hasShardHash {
+			shards, err := r.listShards(labels.Everything())
+			if err != nil {
+				return reconcileStatusStopAndRequeue, fmt.Errorf("could not list shards: %w", err)
+			}
+			// iterate over the shards, calculate each hash and compare
+			// to set the new annotation
+			for _, shard := range shards {
+				hashed := kcpcrypto.Base36Sha224.StringPad(shard.Name)[:8]
+				if hashed != shardHash {
+					continue
+				}
+				workspace.Annotations[corev1alpha1.LogicalClusterShardAnnotationKey] = shard.Name
+				changed = true
+				break
+			}
 		}
 	}
 

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_metadata.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_metadata.go
@@ -28,8 +28,7 @@ import (
 	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
 )
 
-type metaDataReconciler struct {
-}
+type metaDataReconciler struct{}
 
 func (r *metaDataReconciler) reconcile(ctx context.Context, workspace *tenancyv1alpha1.Workspace) (reconcileStatus, error) {
 	logger := klog.FromContext(ctx).WithValues("reconciler", "metadata")

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_metadata.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_metadata.go
@@ -23,6 +23,7 @@ import (
 	authenticationv1 "k8s.io/api/authentication/v1"
 	"k8s.io/klog/v2"
 
+	kcpcrypto "github.com/kcp-dev/apimachinery/v2/pkg/util/crypto"
 	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
 )
@@ -50,6 +51,18 @@ func (r *metaDataReconciler) reconcile(ctx context.Context, workspace *tenancyv1
 		}
 		workspace.Labels[tenancyv1alpha1.WorkspacePhaseLabel] = expected
 		changed = true
+	}
+
+	// update deprecated internal shard hash annotation
+	if shard := workspace.Annotations[corev1alpha1.LogicalClusterShardAnnotationKey]; shard != "" {
+		expectedHash := kcpcrypto.Base36Sha224.StringPad(shard)[:8]
+		if got := workspace.Annotations[WorkspaceShardHashAnnotationKey]; got != expectedHash {
+			if workspace.Annotations == nil {
+				workspace.Annotations = map[string]string{}
+			}
+			workspace.Annotations[WorkspaceShardHashAnnotationKey] = expectedHash
+			changed = true
+		}
 	}
 
 	if workspace.Status.Phase == corev1alpha1.LogicalClusterPhaseReady {

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_metadata_test.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_metadata_test.go
@@ -35,10 +35,12 @@ func TestReconcileMetadata(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, testCase := range []struct {
-		name       string
-		input      *tenancyv1alpha1.Workspace
-		expected   metav1.ObjectMeta
-		wantStatus reconcileStatus
+		name         string
+		input        *tenancyv1alpha1.Workspace
+		expected     metav1.ObjectMeta
+		expectedSpec tenancyv1alpha1.WorkspaceSpec
+		wantStatus   reconcileStatus
+		wantErr      bool
 	}{
 		{
 			name: "removes everything but owner username when ready",
@@ -129,16 +131,103 @@ func TestReconcileMetadata(t *testing.T) {
 			},
 			wantStatus: reconcileStatusStopAndRequeue,
 		},
+		{
+			name: "derives deprecated hash from canonical shard annotation when missing",
+			input: &tenancyv1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						corev1alpha1.LogicalClusterShardAnnotationKey: "shard-1",
+					},
+					Labels: map[string]string{
+						"tenancy.kcp.io/phase": "Ready",
+					},
+				},
+				Status: tenancyv1alpha1.WorkspaceStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseReady,
+				},
+			},
+			expected: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					corev1alpha1.LogicalClusterShardAnnotationKey: "shard-1",
+					WorkspaceShardHashAnnotationKey:               "2e1tfbst",
+				},
+				Labels: map[string]string{
+					"tenancy.kcp.io/phase": "Ready",
+				},
+			},
+			wantStatus: reconcileStatusStopAndRequeue,
+		},
+		{
+			name: "rewrites stale deprecated hash when canonical shard changes",
+			input: &tenancyv1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						corev1alpha1.LogicalClusterShardAnnotationKey: "shard-1",
+						WorkspaceShardHashAnnotationKey:               "stale123",
+					},
+					Labels: map[string]string{
+						"tenancy.kcp.io/phase": "Ready",
+					},
+				},
+				Status: tenancyv1alpha1.WorkspaceStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseReady,
+				},
+			},
+			expected: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					corev1alpha1.LogicalClusterShardAnnotationKey: "shard-1",
+					WorkspaceShardHashAnnotationKey:               "2e1tfbst",
+				},
+				Labels: map[string]string{
+					"tenancy.kcp.io/phase": "Ready",
+				},
+			},
+			wantStatus: reconcileStatusStopAndRequeue,
+		},
+		{
+			name: "no-op when canonical and hash already in sync",
+			input: &tenancyv1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						corev1alpha1.LogicalClusterShardAnnotationKey: "shard-1",
+						WorkspaceShardHashAnnotationKey:               "2e1tfbst",
+					},
+					Labels: map[string]string{
+						"tenancy.kcp.io/phase": "Ready",
+					},
+				},
+				Status: tenancyv1alpha1.WorkspaceStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseReady,
+				},
+			},
+			expected: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					corev1alpha1.LogicalClusterShardAnnotationKey: "shard-1",
+					WorkspaceShardHashAnnotationKey:               "2e1tfbst",
+				},
+				Labels: map[string]string{
+					"tenancy.kcp.io/phase": "Ready",
+				},
+			},
+			wantStatus: reconcileStatusContinue,
+		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			reconciler := metaDataReconciler{}
 			status, err := reconciler.reconcile(context.Background(), testCase.input)
 
-			require.NoError(t, err)
+			if testCase.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
 			require.Equal(t, testCase.wantStatus, status)
 
 			if diff := cmp.Diff(testCase.input.ObjectMeta, testCase.expected); diff != "" {
 				t.Errorf("invalid output after reconciling metadata: %v", diff)
+			}
+			if diff := cmp.Diff(testCase.input.Spec, testCase.expectedSpec); diff != "" {
+				t.Errorf("invalid spec after reconciling metadata: %v", diff)
 			}
 		})
 	}

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_phase.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_phase.go
@@ -34,7 +34,7 @@ import (
 
 type phaseReconciler struct {
 	getLogicalCluster func(ctx context.Context, cluster logicalcluster.Path) (*corev1alpha1.LogicalCluster, error)
-	getShardByHash    func(hash string) (*corev1alpha1.Shard, error)
+	getShard          func(name string) (*corev1alpha1.Shard, error)
 
 	requeueAfter func(workspace *tenancyv1alpha1.Workspace, after time.Duration)
 }
@@ -62,9 +62,9 @@ func (r *phaseReconciler) reconcile(ctx context.Context, workspace *tenancyv1alp
 			} else if apierrors.IsNotFound(err) {
 				// The LogicalCluster may not be visible through the front-proxy yet
 				// because the shard index hasn't caught up.
-				shardHash, hasShard := workspace.Annotations[WorkspaceShardHashAnnotationKey]
+				shardName, hasShard := workspace.Annotations[corev1alpha1.LogicalClusterShardAnnotationKey]
 				if hasShard {
-					shard, shardErr := r.getShardByHash(shardHash)
+					shard, shardErr := r.getShard(shardName)
 					if shardErr == nil && shard.DeletionTimestamp.IsZero() {
 						if workspace.CreationTimestamp.IsZero() || time.Since(workspace.CreationTimestamp.Time) < logicalClusterTimeout {
 							logger.V(3).Info("LogicalCluster not found but shard is alive, requeueing", "shard", shard.Name)
@@ -103,9 +103,9 @@ func (r *phaseReconciler) reconcile(ctx context.Context, workspace *tenancyv1alp
 
 		case corev1alpha1.LogicalClusterPhaseUnavailable:
 			if conditions.IsFalse(workspace, tenancyv1alpha1.WorkspaceInitialized) && conditions.GetReason(workspace, tenancyv1alpha1.WorkspaceInitialized) == tenancyv1alpha1.WorkspaceInitializedWorkspaceDisappeared {
-				shardHash, hasShard := workspace.Annotations[WorkspaceShardHashAnnotationKey]
+				shardName, hasShard := workspace.Annotations[corev1alpha1.LogicalClusterShardAnnotationKey]
 				if hasShard {
-					shard, shardErr := r.getShardByHash(shardHash)
+					shard, shardErr := r.getShard(shardName)
 					if shardErr == nil && shard.DeletionTimestamp.IsZero() {
 						_, err := r.getLogicalCluster(ctx, logicalcluster.NewPath(workspace.Spec.Cluster))
 						if apierrors.IsNotFound(err) {

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_phase_test.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_phase_test.go
@@ -38,7 +38,7 @@ func TestReconcilePhase(t *testing.T) {
 		name              string
 		input             *tenancyv1alpha1.Workspace
 		getLogicalCluster func(ctx context.Context, cluster logicalcluster.Path) (*corev1alpha1.LogicalCluster, error)
-		getShardByHash    func(hash string) (*corev1alpha1.Shard, error)
+		getShard          func(name string) (*corev1alpha1.Shard, error)
 
 		wantPhase     corev1alpha1.LogicalClusterPhaseType
 		wantStatus    reconcileStatus
@@ -78,7 +78,7 @@ func TestReconcilePhase(t *testing.T) {
 			input: &tenancyv1alpha1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						WorkspaceShardHashAnnotationKey: "shard-hash-1",
+						corev1alpha1.LogicalClusterShardAnnotationKey: "shard-1",
 					},
 				},
 				Spec: tenancyv1alpha1.WorkspaceSpec{
@@ -92,7 +92,7 @@ func TestReconcilePhase(t *testing.T) {
 			getLogicalCluster: func(ctx context.Context, cluster logicalcluster.Path) (*corev1alpha1.LogicalCluster, error) {
 				return nil, apierrors.NewNotFound(corev1alpha1.Resource("logicalcluster"), "cluster-1")
 			},
-			getShardByHash: func(hash string) (*corev1alpha1.Shard, error) {
+			getShard: func(name string) (*corev1alpha1.Shard, error) {
 				return &corev1alpha1.Shard{ObjectMeta: metav1.ObjectMeta{Name: "shard-1"}}, nil
 			},
 			wantPhase:   corev1alpha1.LogicalClusterPhaseInitializing,
@@ -104,7 +104,7 @@ func TestReconcilePhase(t *testing.T) {
 			input: &tenancyv1alpha1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						WorkspaceShardHashAnnotationKey: "shard-hash-1",
+						corev1alpha1.LogicalClusterShardAnnotationKey: "shard-1",
 					},
 				},
 				Spec: tenancyv1alpha1.WorkspaceSpec{
@@ -118,8 +118,8 @@ func TestReconcilePhase(t *testing.T) {
 			getLogicalCluster: func(ctx context.Context, cluster logicalcluster.Path) (*corev1alpha1.LogicalCluster, error) {
 				return nil, apierrors.NewNotFound(corev1alpha1.Resource("logicalcluster"), "cluster-1")
 			},
-			getShardByHash: func(hash string) (*corev1alpha1.Shard, error) {
-				return nil, apierrors.NewNotFound(corev1alpha1.Resource("shard"), "shard-hash-1")
+			getShard: func(name string) (*corev1alpha1.Shard, error) {
+				return nil, apierrors.NewNotFound(corev1alpha1.Resource("shard"), "shard-1")
 			},
 			wantPhase:  corev1alpha1.LogicalClusterPhaseInitializing,
 			wantStatus: reconcileStatusContinue,
@@ -307,7 +307,7 @@ func TestReconcilePhase(t *testing.T) {
 			input: &tenancyv1alpha1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						WorkspaceShardHashAnnotationKey: "shard-hash-1",
+						corev1alpha1.LogicalClusterShardAnnotationKey: "shard-1",
 					},
 				},
 				Spec: tenancyv1alpha1.WorkspaceSpec{
@@ -334,7 +334,7 @@ func TestReconcilePhase(t *testing.T) {
 					},
 				}, nil
 			},
-			getShardByHash: func(hash string) (*corev1alpha1.Shard, error) {
+			getShard: func(name string) (*corev1alpha1.Shard, error) {
 				return &corev1alpha1.Shard{ObjectMeta: metav1.ObjectMeta{Name: "shard-1"}}, nil
 			},
 			wantPhase:  corev1alpha1.LogicalClusterPhaseReady,
@@ -350,7 +350,7 @@ func TestReconcilePhase(t *testing.T) {
 			input: &tenancyv1alpha1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						WorkspaceShardHashAnnotationKey: "shard-hash-1",
+						corev1alpha1.LogicalClusterShardAnnotationKey: "shard-1",
 					},
 				},
 				Spec: tenancyv1alpha1.WorkspaceSpec{
@@ -373,7 +373,7 @@ func TestReconcilePhase(t *testing.T) {
 			getLogicalCluster: func(ctx context.Context, cluster logicalcluster.Path) (*corev1alpha1.LogicalCluster, error) {
 				return nil, apierrors.NewNotFound(corev1alpha1.Resource("logicalcluster"), "cluster-1")
 			},
-			getShardByHash: func(hash string) (*corev1alpha1.Shard, error) {
+			getShard: func(name string) (*corev1alpha1.Shard, error) {
 				return &corev1alpha1.Shard{ObjectMeta: metav1.ObjectMeta{Name: "shard-1"}}, nil
 			},
 			wantPhase:  corev1alpha1.LogicalClusterPhaseUnavailable,
@@ -384,7 +384,7 @@ func TestReconcilePhase(t *testing.T) {
 			input: &tenancyv1alpha1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						WorkspaceShardHashAnnotationKey: "shard-hash-1",
+						corev1alpha1.LogicalClusterShardAnnotationKey: "shard-1",
 					},
 				},
 				Spec: tenancyv1alpha1.WorkspaceSpec{
@@ -407,8 +407,8 @@ func TestReconcilePhase(t *testing.T) {
 			getLogicalCluster: func(ctx context.Context, cluster logicalcluster.Path) (*corev1alpha1.LogicalCluster, error) {
 				return nil, apierrors.NewNotFound(corev1alpha1.Resource("logicalcluster"), "cluster-1")
 			},
-			getShardByHash: func(hash string) (*corev1alpha1.Shard, error) {
-				return nil, apierrors.NewNotFound(corev1alpha1.Resource("shard"), "shard-hash-1")
+			getShard: func(name string) (*corev1alpha1.Shard, error) {
+				return nil, apierrors.NewNotFound(corev1alpha1.Resource("shard"), "shard-1")
 			},
 			wantPhase:  corev1alpha1.LogicalClusterPhaseUnavailable,
 			wantStatus: reconcileStatusContinue,
@@ -518,7 +518,7 @@ func TestReconcilePhase(t *testing.T) {
 			requeued := false
 			reconciler := phaseReconciler{
 				getLogicalCluster: testCase.getLogicalCluster,
-				getShardByHash:    testCase.getShardByHash,
+				getShard:          testCase.getShard,
 				requeueAfter: func(workspace *tenancyv1alpha1.Workspace, after time.Duration) {
 					requeued = true
 				},

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_scheduling.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_scheduling.go
@@ -305,7 +305,15 @@ func (r *schedulingReconciler) createLogicalCluster(ctx context.Context, shard *
 			Name: corev1alpha1.LogicalClusterName,
 			Annotations: map[string]string{
 				tenancyv1alpha1.LogicalClusterTypeAnnotationKey: logicalcluster.NewPath(workspace.Spec.Type.Path).Join(string(workspace.Spec.Type.Name)).String(),
-				core.LogicalClusterPathAnnotationKey:            canonicalPath.String(),
+				// The shard must be set in the annotation when
+				// scheduling the LC, otherwise the LC metadata
+				// reconciler will detect this is a drift and try to set
+				// the annotation on the LC and the workspace, which
+				// will trigger another reconcile here.
+				// Not a problem, but doing this prevents a few
+				// reconcile cycles.
+				corev1alpha1.LogicalClusterShardAnnotationKey: shard.Name,
+				core.LogicalClusterPathAnnotationKey:          canonicalPath.String(),
 			},
 		},
 		Spec: corev1alpha1.LogicalClusterSpec{

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_scheduling.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_scheduling.go
@@ -54,6 +54,9 @@ import (
 const (
 	// WorkspaceShardHashAnnotationKey keeps track on which shard LogicalCluster must be scheduled. The value
 	// is a base36(sha224) hash of the Shard name.
+	//
+	// Deprecated: use corev1alpha1.LogicalClusterShardAnnotationKey instead.
+	// This key is still updated for backwards compatibility but will be removed in a future release.
 	WorkspaceShardHashAnnotationKey = "internal.tenancy.kcp.io/shard"
 
 	// workspaceClusterAnnotationKey keeps track of the logical cluster on the shard.
@@ -64,12 +67,28 @@ const (
 	unschedulableAnnotationKey = "experimental.core.kcp.io/unschedulable"
 )
 
+// applyShardToWorkspaceMetadata updates a workspaces shard metadata.
+func applyShardToWorkspaceMetadata(ws *tenancyv1alpha1.Workspace, shard *corev1alpha1.Shard) {
+	if ws.Annotations == nil {
+		ws.Annotations = map[string]string{}
+	}
+	ws.Annotations[corev1alpha1.LogicalClusterShardAnnotationKey] = shard.Name
+	ws.Annotations[WorkspaceShardHashAnnotationKey] = kcpcrypto.Base36Sha224.StringPad(shard.Name)[:8]
+
+	if ws.Labels == nil {
+		ws.Labels = map[string]string{}
+	}
+	delete(ws.Labels, "region")
+	if region, found := shard.Labels["region"]; found {
+		ws.Labels["region"] = region
+	}
+}
+
 type schedulingReconciler struct {
 	generateClusterName func(path logicalcluster.Path) (logicalcluster.Name, error)
 
-	getShard       func(name string) (*corev1alpha1.Shard, error)
-	getShardByHash func(hash string) (*corev1alpha1.Shard, error)
-	listShards     func(selector labels.Selector) ([]*corev1alpha1.Shard, error)
+	getShard   func(name string) (*corev1alpha1.Shard, error)
+	listShards func(selector labels.Selector) ([]*corev1alpha1.Shard, error)
 
 	getWorkspaceType func(clusterName logicalcluster.Path, name string) (*tenancyv1alpha1.WorkspaceType, error)
 
@@ -95,14 +114,14 @@ func (r *schedulingReconciler) reconcile(ctx context.Context, workspace *tenancy
 		// This is bit of edge case, but nevertheless we need to check if logical cluster url still matches the workspace url.
 		clusterNameString, hasCluster := workspace.Annotations[workspaceClusterAnnotationKey]
 		clusterName := logicalcluster.Name(clusterNameString)
-		shardNameHash, hasShard := workspace.Annotations[WorkspaceShardHashAnnotationKey]
+		shardName, hasShard := workspace.Annotations[corev1alpha1.LogicalClusterShardAnnotationKey]
 		if !hasShard || !hasCluster {
 			return reconcileStatusContinue, nil
 		}
-		shard, err := r.getShardByHash(shardNameHash)
+		shard, err := r.getShard(shardName)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				conditions.MarkFalse(workspace, tenancyv1alpha1.WorkspaceScheduled, tenancyv1alpha1.WorkspaceReasonUnschedulable, conditionsv1alpha1.ConditionSeverityError, "chosen shard hash %q does not exist anymore: %v", shardNameHash, err)
+				conditions.MarkFalse(workspace, tenancyv1alpha1.WorkspaceScheduled, tenancyv1alpha1.WorkspaceReasonUnschedulable, conditionsv1alpha1.ConditionSeverityError, "chosen shard %q does not exist anymore: %v", shardName, err)
 				return reconcileStatusContinue, nil
 			}
 			return reconcileStatusStopAndRequeue, err
@@ -138,7 +157,7 @@ func (r *schedulingReconciler) reconcile(ctx context.Context, workspace *tenancy
 		conditions.MarkTrue(workspace, tenancyv1alpha1.WorkspaceScheduled)
 		return reconcileStatusContinue, nil
 	case workspace.Spec.URL == "" || workspace.Spec.Cluster == "":
-		shardNameHash, hasShard := workspace.Annotations[WorkspaceShardHashAnnotationKey]
+		shardName, hasShard := workspace.Annotations[corev1alpha1.LogicalClusterShardAnnotationKey]
 		clusterNameString, hasCluster := workspace.Annotations[workspaceClusterAnnotationKey]
 		clusterName := logicalcluster.Name(clusterNameString)
 		hasFinalizer := sets.New[string](workspace.Finalizers...).Has(corev1alpha1.LogicalClusterFinalizerName)
@@ -160,14 +179,8 @@ func (r *schedulingReconciler) reconcile(ctx context.Context, workspace *tenancy
 				return reconcileStatusContinue, nil // retry is automatic when new shards show up
 			}
 			logger.V(2).Info("Chose shard", "shard", shard.Name)
-			shardNameHash = kcpcrypto.Base36Sha224.StringPad(shard.Name)[:8]
-			if workspace.Annotations == nil {
-				workspace.Annotations = map[string]string{}
-			}
-			workspace.Annotations[WorkspaceShardHashAnnotationKey] = shardNameHash
-			if region, found := shard.Labels["region"]; found {
-				workspace.Labels["region"] = region
-			}
+			applyShardToWorkspaceMetadata(workspace, shard)
+			shardName = shard.Name
 		}
 		if !hasCluster {
 			cluster, err := r.generateClusterName(logicalcluster.From(workspace).Path().Join(workspace.Name))
@@ -188,16 +201,16 @@ func (r *schedulingReconciler) reconcile(ctx context.Context, workspace *tenancy
 			return reconcileStatusStopAndRequeue, nil
 		}
 
-		shard, err := r.getShardByHash(shardNameHash)
+		shard, err := r.getShard(shardName)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				conditions.MarkFalse(workspace, tenancyv1alpha1.WorkspaceScheduled, tenancyv1alpha1.WorkspaceReasonUnschedulable, conditionsv1alpha1.ConditionSeverityError, "chosen shard hash %q does not exist anymore: %v", shardNameHash, err)
+				conditions.MarkFalse(workspace, tenancyv1alpha1.WorkspaceScheduled, tenancyv1alpha1.WorkspaceReasonUnschedulable, conditionsv1alpha1.ConditionSeverityError, "chosen shard %q does not exist anymore: %v", shardName, err)
 				return reconcileStatusContinue, nil
 			}
 			return reconcileStatusStopAndRequeue, err
 		}
 		if valid, reason, message := isValidShard(shard); !valid {
-			conditions.MarkFalse(workspace, tenancyv1alpha1.WorkspaceScheduled, tenancyv1alpha1.WorkspaceReasonUnschedulable, conditionsv1alpha1.ConditionSeverityError, "chosen shard hash %q is no longer valid, reason %q, message %q", shardNameHash, message, reason)
+			conditions.MarkFalse(workspace, tenancyv1alpha1.WorkspaceScheduled, tenancyv1alpha1.WorkspaceReasonUnschedulable, conditionsv1alpha1.ConditionSeverityError, "chosen shard %q is no longer valid, reason %q, message %q", shardName, message, reason)
 			return reconcileStatusContinue, nil
 		}
 

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_scheduling_test.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_scheduling_test.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
-	kcpcrypto "github.com/kcp-dev/apimachinery/v2/pkg/util/crypto"
 	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
 	kcpfakekubeclient "github.com/kcp-dev/client-go/kubernetes/fake"
 	kcpclientgotesting "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/testing"
@@ -73,7 +72,7 @@ func TestReconcileScheduling(t *testing.T) {
 				t.Helper()
 
 				initialWS.Annotations["internal.tenancy.kcp.io/cluster"] = "root-foo"
-				initialWS.Annotations["internal.tenancy.kcp.io/shard"] = "1pfxsevk"
+				initialWS.Annotations[corev1alpha1.LogicalClusterShardAnnotationKey] = "root"
 				initialWS.Finalizers = append(initialWS.Finalizers, "core.kcp.io/logicalcluster")
 				if !equality.Semantic.DeepEqual(ws, initialWS) {
 					t.Fatalf("unexpected Workspace:\n%s", cmp.Diff(ws, initialWS))
@@ -86,7 +85,13 @@ func TestReconcileScheduling(t *testing.T) {
 			initialShards:         []*corev1alpha1.Shard{shard("root")},
 			initialWorkspaceTypes: wellKnownWorkspaceTypes(),
 			targetWorkspace:       wellKnownFooWSForPhaseTwo(),
-			targetLogicalCluster:  &corev1alpha1.LogicalCluster{},
+			targetLogicalCluster: &corev1alpha1.LogicalCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						corev1alpha1.LogicalClusterShardAnnotationKey: "root",
+					},
+				},
+			},
 			validateWorkspace: func(t *testing.T, initialWS, wsAfterReconciliation *tenancyv1alpha1.Workspace) {
 				t.Helper()
 
@@ -119,8 +124,14 @@ func TestReconcileScheduling(t *testing.T) {
 				thisWS.Annotations["kcp.io/cluster"] = "root-foo"
 				return thisWS
 			}()},
-			targetWorkspace:      wellKnownFooWSForPhaseTwo(),
-			targetLogicalCluster: &corev1alpha1.LogicalCluster{},
+			targetWorkspace: wellKnownFooWSForPhaseTwo(),
+			targetLogicalCluster: &corev1alpha1.LogicalCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						corev1alpha1.LogicalClusterShardAnnotationKey: "root",
+					},
+				},
+			},
 			validateWorkspace: func(t *testing.T, initialWS, wsAfterReconciliation *tenancyv1alpha1.Workspace) {
 				t.Helper()
 
@@ -182,8 +193,14 @@ func TestReconcileScheduling(t *testing.T) {
 				thisWS.Annotations["kcp.io/cluster"] = "root-foo"
 				return thisWS
 			}()},
-			targetWorkspace:      wellKnownFooWSForPhaseTwo(),
-			targetLogicalCluster: &corev1alpha1.LogicalCluster{},
+			targetWorkspace: wellKnownFooWSForPhaseTwo(),
+			targetLogicalCluster: &corev1alpha1.LogicalCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						corev1alpha1.LogicalClusterShardAnnotationKey: "root",
+					},
+				},
+			},
 			validateWorkspace: func(t *testing.T, initialWS, wsAfterReconciliation *tenancyv1alpha1.Workspace) {
 				t.Helper()
 
@@ -245,7 +262,7 @@ func TestReconcileScheduling(t *testing.T) {
 				t.Helper()
 
 				initialWS.Annotations["internal.tenancy.kcp.io/cluster"] = "root-foo"
-				initialWS.Annotations["internal.tenancy.kcp.io/shard"] = "29hdqnv7"
+				initialWS.Annotations[corev1alpha1.LogicalClusterShardAnnotationKey] = "amber"
 				initialWS.Finalizers = append(initialWS.Finalizers, "core.kcp.io/logicalcluster")
 				if !equality.Semantic.DeepEqual(wsAfterReconciliation, initialWS) {
 					t.Fatalf("unexpected Workspace:\n%s", cmp.Diff(wsAfterReconciliation, initialWS))
@@ -272,6 +289,37 @@ func TestReconcileScheduling(t *testing.T) {
 					Status:   corev1.ConditionFalse,
 					Reason:   tenancyv1alpha1.WorkspaceReasonUnschedulable,
 					Message:  "No available shards to schedule the workspace",
+				})
+				if !equality.Semantic.DeepEqual(wsAfterReconciliation, initialWS) {
+					t.Fatalf("unexpected Workspace:\n%s", cmp.Diff(wsAfterReconciliation, initialWS))
+				}
+			},
+			expectedStatus: reconcileStatusContinue,
+		},
+		{
+			name:                  "shard hash changed: workspace URL is rebuilt from the new shard",
+			initialShards:         []*corev1alpha1.Shard{shard("root"), shard("amber")},
+			initialWorkspaceTypes: wellKnownWorkspaceTypes(),
+			targetWorkspace: func() *tenancyv1alpha1.Workspace {
+				ws := wellKnownFooWSForPhaseTwo()
+				// metaDataReconciler has already restamped the shard hash to amber,
+				// but the URL still points at the old (root) shard.
+				ws.Annotations[corev1alpha1.LogicalClusterShardAnnotationKey] = "amber"
+				ws.Annotations["internal.tenancy.kcp.io/shard"] = "29hdqnv7"
+				ws.Spec.URL = "https://root/clusters/root:foo"
+				ws.Spec.Cluster = "root-foo"
+				return ws
+			}(),
+			targetLogicalCluster: &corev1alpha1.LogicalCluster{},
+			validateWorkspace: func(t *testing.T, initialWS, wsAfterReconciliation *tenancyv1alpha1.Workspace) {
+				t.Helper()
+
+				clearLastTransitionTimeOnWsConditions(wsAfterReconciliation)
+				initialWS.CreationTimestamp = wsAfterReconciliation.CreationTimestamp
+				initialWS.Spec.URL = "https://amber/clusters/root:foo"
+				initialWS.Status.Conditions = append(initialWS.Status.Conditions, conditionsapi.Condition{
+					Type:   tenancyv1alpha1.WorkspaceScheduled,
+					Status: corev1.ConditionTrue,
 				})
 				if !equality.Semantic.DeepEqual(wsAfterReconciliation, initialWS) {
 					t.Fatalf("unexpected Workspace:\n%s", cmp.Diff(wsAfterReconciliation, initialWS))
@@ -324,14 +372,6 @@ func TestReconcileScheduling(t *testing.T) {
 						}
 					}
 					return shards, nil
-				},
-				getShardByHash: func(hash string) (*corev1alpha1.Shard, error) {
-					for _, shard := range scenario.initialShards {
-						if shardNameToBase36Sha224(shard.Name) == hash {
-							return shard, nil
-						}
-					}
-					return nil, kerrors.NewNotFound(tenancyv1alpha1.SchemeGroupVersion.WithResource("Shard").GroupResource(), hash)
 				},
 				getWorkspaceType: getType,
 				getLogicalCluster: func(clusterName logicalcluster.Name) (*corev1alpha1.LogicalCluster, error) {
@@ -395,6 +435,7 @@ func wellKnownFooWSForPhaseTwo() *tenancyv1alpha1.Workspace {
 	ws := workspace("foo")
 	// since this is part two we can assume the following fields are assigned
 	ws.Annotations["internal.tenancy.kcp.io/cluster"] = "root-foo"
+	ws.Annotations[corev1alpha1.LogicalClusterShardAnnotationKey] = "root"
 	ws.Annotations["internal.tenancy.kcp.io/shard"] = "1pfxsevk"
 	ws.Annotations["experimental.tenancy.kcp.io/owner"] = `{"username":"kcp-admin"}`
 	ws.Finalizers = append(ws.Finalizers, "core.kcp.io/logicalcluster")
@@ -587,8 +628,4 @@ func actionStrings(actions []kcpclientgotesting.Action) []string {
 		res = append(res, actionString(a))
 	}
 	return res
-}
-
-func shardNameToBase36Sha224(name string) string {
-	return kcpcrypto.Base36Sha224.StringPad(name)[:8]
 }

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_scheduling_test.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_scheduling_test.go
@@ -72,6 +72,7 @@ func TestReconcileScheduling(t *testing.T) {
 				t.Helper()
 
 				initialWS.Annotations["internal.tenancy.kcp.io/cluster"] = "root-foo"
+				initialWS.Annotations["internal.tenancy.kcp.io/shard"] = "1pfxsevk"
 				initialWS.Annotations[corev1alpha1.LogicalClusterShardAnnotationKey] = "root"
 				initialWS.Finalizers = append(initialWS.Finalizers, "core.kcp.io/logicalcluster")
 				if !equality.Semantic.DeepEqual(ws, initialWS) {
@@ -262,6 +263,7 @@ func TestReconcileScheduling(t *testing.T) {
 				t.Helper()
 
 				initialWS.Annotations["internal.tenancy.kcp.io/cluster"] = "root-foo"
+				initialWS.Annotations["internal.tenancy.kcp.io/shard"] = "29hdqnv7"
 				initialWS.Annotations[corev1alpha1.LogicalClusterShardAnnotationKey] = "amber"
 				initialWS.Finalizers = append(initialWS.Finalizers, "core.kcp.io/logicalcluster")
 				if !equality.Semantic.DeepEqual(wsAfterReconciliation, initialWS) {

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_scheduling_test.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_scheduling_test.go
@@ -455,6 +455,7 @@ func wellKnownLogicalClusterForFooWS() *corev1alpha1.LogicalCluster {
 				tenancyv1alpha1.ExperimentalWorkspaceOwnerAnnotationKey: `{"username":"kcp-admin"}`,
 				tenancyv1alpha1.LogicalClusterTypeAnnotationKey:         "root:universal",
 				core.LogicalClusterPathAnnotationKey:                    "root:foo",
+				corev1alpha1.LogicalClusterShardAnnotationKey:           "root",
 			},
 		},
 		Spec: corev1alpha1.LogicalClusterSpec{

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -712,7 +712,7 @@ func (s *Server) installWorkspaceMountsScheduler(ctx context.Context, config *re
 	})
 }
 
-func (s *Server) installLogicalCluster(ctx context.Context, config *rest.Config) error {
+func (s *Server) installLogicalCluster(ctx context.Context, config *rest.Config, externalLogicalClusterAdminConfig *rest.Config) error {
 	logicalClusterConfig := rest.CopyConfig(config)
 	logicalClusterConfig = rest.AddUserAgent(logicalClusterConfig, logicalclusterctrl.ControllerName)
 	kcpClusterClient, err := kcpclientset.NewForConfig(logicalClusterConfig)
@@ -720,9 +720,14 @@ func (s *Server) installLogicalCluster(ctx context.Context, config *rest.Config)
 		return err
 	}
 
+	externalAdminConfig := rest.CopyConfig(externalLogicalClusterAdminConfig)
+	externalAdminConfig = rest.AddUserAgent(externalAdminConfig, logicalclusterctrl.ControllerName)
+
 	logicalClusterController, err := logicalclusterctrl.NewController(
+		s.Options.Extra.ShardName,
 		s.CompletedConfig.ShardExternalURL,
 		kcpClusterClient,
+		externalAdminConfig,
 		s.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters(),
 		s.CompletedConfig.ClusterContextManager,
 	)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -285,7 +285,7 @@ func (s *Server) installControllers(ctx context.Context, controllerConfig *rest.
 		if err := s.installLogicalClusterDeletionController(ctx, controllerConfig, s.LogicalClusterAdminConfig, s.ExternalLogicalClusterAdminConfig); err != nil {
 			return err
 		}
-		if err := s.installLogicalCluster(ctx, controllerConfig); err != nil {
+		if err := s.installLogicalCluster(ctx, controllerConfig, s.ExternalLogicalClusterAdminConfig); err != nil {
 			return err
 		}
 	}

--- a/staging/src/github.com/kcp-dev/sdk/apis/core/v1alpha1/logicalcluster_types.go
+++ b/staging/src/github.com/kcp-dev/sdk/apis/core/v1alpha1/logicalcluster_types.go
@@ -70,6 +70,10 @@ const (
 	//
 	// Deprecated: use LogicalClusterInactiveAnnotationKey.
 	LogicalClusterInactiveAnnotationKeyLegacy = "internal.kcp.io/inactive"
+
+	// LogicalClusterShardAnnotationKey is the shard name the LogicalCluster is scheduled on.
+	// This annotation is set on both the LogicalCluster and its owner, if the owner is set.
+	LogicalClusterShardAnnotationKey = "core.kcp.io/shard"
 )
 
 // LogicalClusterPhaseType is the type of the current phase of the logical cluster.

--- a/staging/src/github.com/kcp-dev/sdk/testing/workspaces.go
+++ b/staging/src/github.com/kcp-dev/sdk/testing/workspaces.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 
-	kcpcrypto "github.com/kcp-dev/apimachinery/v2/pkg/util/crypto"
 	"github.com/kcp-dev/logicalcluster/v3"
 	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
 	"github.com/kcp-dev/sdk/apis/core"
@@ -270,15 +269,14 @@ func WorkspaceShard(ctx context.Context, kcpClient kcpclientset.ClusterInterface
 		return nil, err
 	}
 
-	// best effort to get a shard name from the hash in the annotation
-	hash := ws.Annotations["internal.tenancy.kcp.io/shard"]
-	if hash == "" {
-		return nil, fmt.Errorf("workspace %s does not have a shard hash annotation", logicalcluster.From(ws).Path().Join(ws.Name))
+	shardName := ws.Annotations[corev1alpha1.LogicalClusterShardAnnotationKey]
+	if shardName == "" {
+		return nil, fmt.Errorf("workspace %s does not have a shard name annotation", logicalcluster.From(ws).Path().Join(ws.Name))
 	}
 
-	for i := range shards.Items {
-		if name := shards.Items[i].Name; kcpcrypto.Base36Sha224.StringPad(name)[:8] == hash {
-			return &shards.Items[i], nil
+	for _, shard := range shards.Items {
+		if shardName == shard.Name {
+			return &shard, nil
 		}
 	}
 


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

See #4161, same PR but with shard name

Video showcasing upgrading from an existing installation (setup + workspace/lc creation on main, switch branch, start) and showing resilience of deleting annotations:

https://kubernetes.slack.com/archives/C09C7UP1VLM/p1780317437690859?thread_ts=1779973084.138509&cid=C09C7UP1VLM

## What Type of PR Is This?

/kind feature

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
LogicalClusters and Workspaces get the `core.kcp.io/shard` annotation with the value being the name of the shard they are scheduled on
```


