### PR TITLE
Demote dynamicrestmapper "processing key" logs to V(4)

### DIFF
--- a/pkg/reconciler/dynamicrestmapper/dynamicrestmapper_builtin_controller.go
+++ b/pkg/reconciler/dynamicrestmapper/dynamicrestmapper_builtin_controller.go
@@ -163,7 +163,7 @@ func (c *BuiltinTypesController) processNextWorkItem(ctx context.Context) bool {
 
 	logger := logging.WithQueueKey(klog.FromContext(ctx), key)
 	ctx = klog.NewContext(ctx, logger)
-	logger.Info("processing key")
+	logger.V(4).Info("processing key")
 
 	// No matter what, tell the queue we're done with this key, to unblock
 	// other workers.

--- a/pkg/reconciler/dynamicrestmapper/dynamicrestmapper_dynamic_controller.go
+++ b/pkg/reconciler/dynamicrestmapper/dynamicrestmapper_dynamic_controller.go
@@ -384,7 +384,7 @@ func (c *DynamicTypesController) processNextWorkItem(ctx context.Context) bool {
 
 	logger := logging.WithQueueKey(klog.FromContext(ctx), key)
 	ctx = klog.NewContext(ctx, logger)
-	logger.Info("processing key")
+	logger.V(4).Info("processing key")
 
 	// No matter what, tell the queue we're done with this key, to unblock
 	// other workers.


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Both controllers logged "processing key" at default Info level, firing on every queue item at -v=0. Peer controllers in the codebase put the same message behind V(4)+; align with that.

## What Type of PR Is This?
/kind cleanup

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Reduce dynamicrestmapper logging to v(4)
```
