### PR TITLE
Stable VW URL ordering in WorkspaceType status

### DIFF
--- a/pkg/reconciler/tenancy/workspacetype/workspacetype_controller_reconcile.go
+++ b/pkg/reconciler/tenancy/workspacetype/workspacetype_controller_reconcile.go
@@ -17,13 +17,16 @@ limitations under the License.
 package workspacetype
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"net/url"
 	"path"
+	"slices"
 
 	"k8s.io/klog/v2"
 
+	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 	"github.com/kcp-dev/sdk/apis/tenancy/initialization"
 	"github.com/kcp-dev/sdk/apis/tenancy/termination"
 	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
@@ -62,7 +65,11 @@ func (c *controller) updateVirtualWorkspaceURLs(ctx context.Context, wt *tenancy
 		return fmt.Errorf("error listing Shards: %w", err)
 	}
 
-	desiredURLs := make(map[string]tenancyv1alpha1.VirtualWorkspaceType)
+	slices.SortFunc(shards, func(a, b *corev1alpha1.Shard) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
+
+	wt.Status.VirtualWorkspaces = make([]tenancyv1alpha1.VirtualWorkspace, 0, len(shards)*2)
 	for _, shard := range shards {
 		if shard.Spec.VirtualWorkspaceURL == "" {
 			continue
@@ -84,7 +91,10 @@ func (c *controller) updateVirtualWorkspaceURLs(ctx context.Context, wt *tenancy
 			string(initialization.InitializerForType(wt)),
 		)
 
-		desiredURLs[u.String()] = tenancyv1alpha1.VirtualWorkspaceTypeInitializing
+		wt.Status.VirtualWorkspaces = append(wt.Status.VirtualWorkspaces, tenancyv1alpha1.VirtualWorkspace{
+			URL:  u.String(),
+			Type: tenancyv1alpha1.VirtualWorkspaceTypeInitializing,
+		})
 
 		// add terminating workspace URLs
 		u.Path = path.Join(
@@ -94,15 +104,9 @@ func (c *controller) updateVirtualWorkspaceURLs(ctx context.Context, wt *tenancy
 			string(termination.TerminatorForType(wt)),
 		)
 
-		desiredURLs[u.String()] = tenancyv1alpha1.VirtualWorkspaceTypeTerminating
-	}
-
-	wt.Status.VirtualWorkspaces = nil
-
-	for url, vwType := range desiredURLs {
 		wt.Status.VirtualWorkspaces = append(wt.Status.VirtualWorkspaces, tenancyv1alpha1.VirtualWorkspace{
-			URL:  url,
-			Type: vwType,
+			URL:  u.String(),
+			Type: tenancyv1alpha1.VirtualWorkspaceTypeTerminating,
 		})
 	}
 

--- a/pkg/reconciler/tenancy/workspacetype/workspacetype_controller_reconcile_test.go
+++ b/pkg/reconciler/tenancy/workspacetype/workspacetype_controller_reconcile_test.go
@@ -61,6 +61,7 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 				Status: tenancyv1alpha1.WorkspaceTypeStatus{
+					VirtualWorkspaces: []tenancyv1alpha1.VirtualWorkspace{},
 					Conditions: conditionsv1alpha1.Conditions{
 						{
 							Type:   "Ready",


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

The WorkspaceType reconciler keep churning the status until the VW URLs are randomly in the right order to stop reconciling.
This makes the built URL list stable so one reconcile is enough.

## What Type of PR Is This?

/kind bug

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
