### PR TITLE
Override prebuilt binary path for NO_GORUN from env

### DIFF
--- a/staging/src/github.com/kcp-dev/sdk/testing/server/fixture.go
+++ b/staging/src/github.com/kcp-dev/sdk/testing/server/fixture.go
@@ -204,6 +204,13 @@ func StartKcpCommand(identity string) (string, []string) {
 // run`).
 func Command(executableName, identity string) (string, []string) {
 	if env.NoGoRunEnvSet() {
+		// kcp -> KCP_ASSET_KCP
+		// kcp-front-proxy -> KCP_ASSET_KCP_FRONT_PROXY
+		// cache-server -> KCP_ASSET_CACHE_SERVER
+		envExeName := "KCP_ASSET_" + strings.ToUpper(strings.ReplaceAll(executableName, "-", "_"))
+		if val, ok := os.LookupEnv(envExeName); ok {
+			return "", []string{val}
+		}
 		return "", []string{executableName}
 	}
 

--- a/test/e2e/framework/kubectl.go
+++ b/test/e2e/framework/kubectl.go
@@ -29,18 +29,21 @@ import (
 	kcptesting "github.com/kcp-dev/sdk/testing"
 	"github.com/kcp-dev/sdk/testing/env"
 	kcptestinghelpers "github.com/kcp-dev/sdk/testing/helpers"
+	kcptestingserver "github.com/kcp-dev/sdk/testing/server"
 )
 
 // KcpCliPluginCommand returns the expected workdir and cli args to run
 // a plugin via go run.
 func KcpCliPluginCommand(plugin string) (string, []string, error) {
+	if env.NoGoRunEnvSet() {
+		// If NO_GORUN is set use kcptestingserver for the env lookup
+		workdir, cmd := kcptestingserver.Command("kubectl-"+plugin, plugin)
+		return workdir, cmd, nil
+	}
+
 	repo, err := kcptestinghelpers.RepositoryDir()
 	if err != nil {
 		return "", nil, err
-	}
-
-	if env.NoGoRunEnvSet() {
-		return repo, []string{filepath.Join("bin", "kubectl-"+plugin)}, nil
 	}
 
 	workdir := filepath.Join(repo, "staging", "src", "github.com", "kcp-dev", "cli")


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

This allows to rewrite any command to a prebuilt binary by the user.
Part feature part bugfix - needed e.g. for sharded-test-server to run externally with NO_GORUN and versioned binaries.

## What Type of PR Is This?

/kind feature
/kind bug

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
When `NO_GORUN` is set sdk/testing allows setting the paths to prebuilt binaries by setting `KCP_ASSET_$name` in the environment to the path of the prebuilt binary; `$name` is the capitalized executable name with dashes replacing underscores (e.g. `kcp-front-proxy` is looked up with `KCP_ASSET_KCP_FRONT_PROXY`)
```
