### PR TITLE
Add kcptesting.WithDefaultTokenAuthFile

### DIFF
--- a/cmd/sharded-test-server/main.go
+++ b/cmd/sharded-test-server/main.go
@@ -34,6 +34,7 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
 
 	"github.com/kcp-dev/sdk/apis/core"
 	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
@@ -44,6 +45,7 @@ import (
 )
 
 func main() {
+	klog.InitFlags(flag.CommandLine)
 	logDirPath := flag.String("log-dir-path", "", "Path to the log files. If empty, log files are stored in the dot directories.")
 	workDirPath := flag.String("work-dir-path", "", "Path to the working directory where the .kcp* dot directories are created. If empty, the working directory is the current directory.")
 	numberOfShards := flag.Int("number-of-shards", 1, "The number of shards to create. The first created is assumed root.")

--- a/cmd/test-server/kcp/shard.go
+++ b/cmd/test-server/kcp/shard.go
@@ -37,10 +37,10 @@ import (
 	"k8s.io/klog/v2"
 
 	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
+	kcptesting "github.com/kcp-dev/sdk/testing"
 	kcptestingserver "github.com/kcp-dev/sdk/testing/server"
 
 	"github.com/kcp-dev/kcp/cmd/test-server/helpers"
-	"github.com/kcp-dev/kcp/test/e2e/framework"
 )
 
 //go:embed *.yaml
@@ -94,13 +94,18 @@ func (s *Shard) Start(ctx context.Context, quiet bool) error {
 		return err
 	}
 
+	tokenAuthFile, err := kcptesting.WriteDefaultTokenAuthFile(s.runtimeDir)
+	if err != nil {
+		return err
+	}
+
 	// setup command
 	workdir, commandLine := kcptestingserver.StartKcpCommand(s.name)
 	commandLine = append(commandLine, s.args...)
 	commandLine = append(commandLine,
 		"--root-directory", s.runtimeDir,
 		"--bind-address=127.0.0.1",
-		"--token-auth-file", framework.DefaultTokenAuthFile,
+		"--token-auth-file", tokenAuthFile,
 		"--audit-log-maxsize", "1024",
 		"--audit-log-mode=batch",
 		"--audit-log-batch-max-wait=1s",

--- a/staging/src/github.com/kcp-dev/sdk/testing/auth-tokens.csv
+++ b/staging/src/github.com/kcp-dev/sdk/testing/auth-tokens.csv
@@ -1,0 +1,6 @@
+user-1-token,user-1,1111-1111-1111-1111,"team-1"
+user-2-token,user-2,2222-2222-2222-2222,"team-2"
+user-3-token,user-3,3333-3333-3333-3333,"team-3"
+user-4-token,user-4,4444-4444-4444-4444,"team-4"
+user-5-token,user-5,5555-5555-5555-5555,"team-5"
+admin-token,admin,5555-5555-5555-5555,"system:masters"

--- a/staging/src/github.com/kcp-dev/sdk/testing/kcp.go
+++ b/staging/src/github.com/kcp-dev/sdk/testing/kcp.go
@@ -18,6 +18,7 @@ package testing
 
 import (
 	"embed"
+	"os"
 	"path/filepath"
 
 	"github.com/stretchr/testify/require"
@@ -28,8 +29,33 @@ import (
 	"github.com/kcp-dev/sdk/testing/third_party/library-go/crypto"
 )
 
-//go:embed *.yaml
+//go:embed *.yaml *.csv
 var fs embed.FS
+
+// WriteDefaultTokenAuthFile writes a default auth token CSV into dir and returns the absolute path.
+func WriteDefaultTokenAuthFile(dir string) (string, error) {
+	data, err := fs.ReadFile("auth-tokens.csv")
+	if err != nil {
+		return "", err
+	}
+	p := filepath.Join(dir, "auth-tokens.csv")
+	p, err = filepath.Abs(p)
+	if err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(p, data, 0o600); err != nil {
+		return "", err
+	}
+	return p, nil
+}
+
+// WithDefaultTokenAuthFile writes a default auth token file into a temporary dir
+// and adds --token-auth-file to the arguments.
+func WithDefaultTokenAuthFile(t TestingT) kcptestingserver.Option {
+	return func(cfg *kcptestingserver.Config) {
+		cfg.Args = append(cfg.Args, "--token-auth-file", copyEmbeddedToTempDir(t, fs, "auth-tokens.csv"))
+	}
+}
 
 // PrivateKcpServer returns a new kcp server fixture managing a new
 // server process that is not intended to be shared between tests.

--- a/staging/src/github.com/kcp-dev/sdk/testing/server/config.go
+++ b/staging/src/github.com/kcp-dev/sdk/testing/server/config.go
@@ -105,7 +105,7 @@ func WithScratchDirectories(artifactDir, dataDir string) Option {
 // WithCustomArguments applies provided arguments to a given kcp configuration.
 func WithCustomArguments(args ...string) Option {
 	return func(cfg *Config) {
-		cfg.Args = args
+		cfg.Args = append(cfg.Args, args...)
 	}
 }
 

--- a/test/e2e/framework/auth-tokens.csv
+++ b/test/e2e/framework/auth-tokens.csv
@@ -1,6 +1,0 @@
-user-1-token,user-1,1111-1111-1111-1111,"team-1"
-user-2-token,user-2,2222-2222-2222-2222,"team-2"
-user-3-token,user-3,3333-3333-3333-3333,"team-3"
-user-4-token,user-4,4444-4444-4444-4444,"team-4"
-user-5-token,user-5,5555-5555-5555-5555,"team-5"
-admin-token,admin,5555-5555-5555-5555,"system:masters"

--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -33,7 +33,7 @@ func init() {
 		panic(err)
 	}
 
-	DefaultTokenAuthFile = filepath.Join(repo, "test", "e2e", "framework", "auth-tokens.csv")
+	DefaultTokenAuthFile = filepath.Join(repo, "staging", "src", "github.com", "kcp-dev", "sdk", "testing", "auth-tokens.csv")
 
 	kcptesting.InitSharedKcpServer(kcptestingserver.WithCustomArguments(
 		"--token-auth-file", DefaultTokenAuthFile,

--- a/test/e2e/homeworkspaces/home_workspaces_test.go
+++ b/test/e2e/homeworkspaces/home_workspaces_test.go
@@ -44,10 +44,12 @@ func TestUserHomeWorkspaces(t *testing.T) {
 	t.Parallel()
 	framework.Suite(t, "control-plane")
 
-	server := kcptesting.PrivateKcpServer(t, kcptestingserver.WithCustomArguments(
-		"--token-auth-file", framework.DefaultTokenAuthFile,
-		"--home-workspaces-home-creator-groups=team-1",
-	))
+	server := kcptesting.PrivateKcpServer(t,
+		kcptesting.WithDefaultTokenAuthFile(t),
+		kcptestingserver.WithCustomArguments(
+			"--home-workspaces-home-creator-groups=team-1",
+		),
+	)
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	t.Cleanup(cancelFunc)

--- a/test/e2e/reconciler/cache/replication_test.go
+++ b/test/e2e/reconciler/cache/replication_test.go
@@ -475,7 +475,7 @@ func TestReplicationDisruptive(t *testing.T) {
 			t.Parallel()
 
 			server := kcptesting.PrivateKcpServer(t,
-				kcptestingserver.WithCustomArguments("--token-auth-file", framework.DefaultTokenAuthFile),
+				kcptesting.WithDefaultTokenAuthFile(t),
 			)
 
 			kcpRootShardConfig := server.RootShardSystemMasterBaseConfig(t)


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Why?

`cmd/test-server/kcp` is importing `test/e2e/framework` for the default token auth file.
This causes e.g. `sharded-test-server` to panic if run outside of the kcp repository.

Instead the default token auth file is an option that can be passed to the server upon init.
Funny enough that pattern already existed for the audit policy file.

I also wanted to try and scrap the `init` alltogether but that would technically be an API change and I want to backport this.

## What Type of PR Is This?

/kind bug

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
