### PR TITLE
Add --external-etcd-servers to sharded-test-server

### DIFF
--- a/cmd/sharded-test-server/cache.go
+++ b/cmd/sharded-test-server/cache.go
@@ -42,7 +42,7 @@ import (
 	"github.com/kcp-dev/kcp/cmd/test-server/helpers"
 )
 
-func startCacheServer(ctx context.Context, logDirPath, workingDir, hostIP string, syntheticDelay time.Duration, clientCA *crypto.CA, clientCAPath string) (<-chan error, string, error) {
+func startCacheServer(ctx context.Context, logDirPath, workingDir, hostIP string, syntheticDelay time.Duration, clientCA *crypto.CA, clientCAPath, externalEtcdServers string) (<-chan error, string, error) {
 	cyan := color.New(color.BgHiCyan, color.FgHiWhite).SprintFunc()
 	inverse := color.New(color.BgHiWhite, color.FgHiCyan).SprintFunc()
 	out := lineprefix.New(
@@ -86,12 +86,21 @@ func startCacheServer(ctx context.Context, logDirPath, workingDir, hostIP string
 		commandLine,
 		fmt.Sprintf("--root-directory=%s", cacheWorkingDir),
 		"--bind-address="+hostIP,
-		"--embedded-etcd-client-port=8010",
-		"--embedded-etcd-peer-port=8011",
 		fmt.Sprintf("--secure-port=%d", cachePort),
 		fmt.Sprintf("--synthetic-delay=%s", syntheticDelay.String()),
 		fmt.Sprintf("--client-ca-file=%s", clientCAPath),
 	)
+	if externalEtcdServers != "" {
+		commandLine = append(commandLine,
+			fmt.Sprintf("--etcd-servers=%s", externalEtcdServers),
+			"--etcd-prefix=/cache",
+		)
+	} else {
+		commandLine = append(commandLine,
+			"--embedded-etcd-client-port=8010",
+			"--embedded-etcd-peer-port=8011",
+		)
+	}
 	fmt.Fprintf(out, "running: %v\n", strings.Join(commandLine, " "))
 	cmd := exec.CommandContext(ctx, commandLine[0], commandLine[1:]...) //nolint:gosec
 	cmd.Dir = workdir

--- a/cmd/sharded-test-server/main.go
+++ b/cmd/sharded-test-server/main.go
@@ -52,6 +52,7 @@ func main() {
 	cacheSyntheticDelay := flag.Duration("cache-synthetic-delay", 0, "The duration of time the cache server will inject a delay for to all inbound requests.")
 	quiet := flag.Bool("quiet", false, "Suppress output of the subprocesses")
 	cacheServerKubeconfig := flag.String("cache-kubeconfig", "", "Path to a kubeconfig of an external cache-server. If empty, a dedicated cache-server is started.")
+	externalEtcdServers := flag.String("external-etcd-servers", "", "Comma-separated list of etcd server URLs to use for shards and the cache-server instead of starting embedded etcds. Each component gets its own --etcd-prefix.")
 
 	// split flags into --proxy-*, --shard-* and everything else (generic). The former are
 	// passed to the respective components.
@@ -67,13 +68,13 @@ func main() {
 	}
 	flag.CommandLine.Parse(genericFlags) //nolint:errcheck
 
-	if err := start(proxyFlags, shardFlags, *logDirPath, *workDirPath, *numberOfShards, *quiet, *cacheSyntheticDelay, *cacheServerKubeconfig); err != nil {
+	if err := start(proxyFlags, shardFlags, *logDirPath, *workDirPath, *numberOfShards, *quiet, *cacheSyntheticDelay, *cacheServerKubeconfig, *externalEtcdServers); err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)
 	}
 }
 
-func start(proxyFlags, shardFlags []string, logDirPath, workDirPath string, numberOfShards int, quiet bool, cacheSyntheticDelay time.Duration, cacheServerConfigPath string) error {
+func start(proxyFlags, shardFlags []string, logDirPath, workDirPath string, numberOfShards int, quiet bool, cacheSyntheticDelay time.Duration, cacheServerConfigPath, externalEtcdServers string) error {
 	// We use a shutdown context to know that it's time to gather metrics, before stopping the shards, proxy, etc.
 	shutdownCtx, shutdownCancel := context.WithCancel(genericapiserver.SetupSignalContext())
 	defer shutdownCancel()
@@ -201,7 +202,7 @@ func start(proxyFlags, shardFlags []string, logDirPath, workDirPath string, numb
 
 	cacheServerErrCh := make(chan indexErrTuple)
 	if cacheServerConfigPath == "" {
-		cacheServerCh, configPath, err := startCacheServer(ctx, logDirPath, workDirPath, hostIP.String(), cacheSyntheticDelay, clientCA, filepath.Join(workDirPath, ".kcp", "client-ca.crt"))
+		cacheServerCh, configPath, err := startCacheServer(ctx, logDirPath, workDirPath, hostIP.String(), cacheSyntheticDelay, clientCA, filepath.Join(workDirPath, ".kcp", "client-ca.crt"), externalEtcdServers)
 		if err != nil {
 			return fmt.Errorf("error starting the cache server: %w", err)
 		}
@@ -223,7 +224,7 @@ func start(proxyFlags, shardFlags []string, logDirPath, workDirPath string, numb
 	// start shards
 	shards := make([]*testshard.Shard, numberOfShards)
 	for i := range numberOfShards {
-		shard, err := newShard(ctx, i, shardFlags, standaloneVW, servingCA, hostIP.String(), logDirPath, workDirPath, cacheServerConfigPath, clientCA)
+		shard, err := newShard(ctx, i, shardFlags, standaloneVW, servingCA, hostIP.String(), logDirPath, workDirPath, cacheServerConfigPath, clientCA, externalEtcdServers)
 		if err != nil {
 			return err
 		}

--- a/cmd/sharded-test-server/shard.go
+++ b/cmd/sharded-test-server/shard.go
@@ -33,7 +33,7 @@ import (
 	shard "github.com/kcp-dev/kcp/cmd/test-server/kcp"
 )
 
-func newShard(ctx context.Context, n int, args []string, standaloneVW bool, servingCA *crypto.CA, hostIP string, logDirPath, workDirPath, cacheServerConfigPath string, clientCA *crypto.CA) (*shard.Shard, error) {
+func newShard(ctx context.Context, n int, args []string, standaloneVW bool, servingCA *crypto.CA, hostIP string, logDirPath, workDirPath, cacheServerConfigPath string, clientCA *crypto.CA, externalEtcdServers string) (*shard.Shard, error) {
 	logger := klog.FromContext(ctx).WithValues("shard", n)
 	kcpDir := filepath.Join(workDirPath, ".kcp")
 	shardDir := filepath.Join(workDirPath, fmt.Sprintf(".kcp-%d", n))
@@ -74,14 +74,31 @@ func newShard(ctx context.Context, n int, args []string, standaloneVW bool, serv
 		auditFilePath = filepath.Join(logDirPath, fmt.Sprintf("audit-%d.log", n))
 	}
 
+	shardName := "root"
 	if n > 0 {
+		shardName = fmt.Sprintf("shard-%d", n)
+	}
+
+	args = append(args, "--shard-name="+shardName)
+
+	if externalEtcdServers == "" {
 		args = append(args,
-			fmt.Sprintf("--shard-name=shard-%d", n),
-			fmt.Sprintf("--root-shard-kubeconfig-file=%s", filepath.Join(workDirPath, ".kcp-0", "admin.kubeconfig")),
 			fmt.Sprintf("--embedded-etcd-client-port=%d", embeddedEtcdClientPort(n)),
 			fmt.Sprintf("--embedded-etcd-peer-port=%d", embeddedEtcdPeerPort(n)),
 		)
+	} else {
+		args = append(args,
+			fmt.Sprintf("--etcd-servers=%s", externalEtcdServers),
+			fmt.Sprintf("--etcd-prefix=/shard/%s", shardName),
+		)
 	}
+
+	if n > 0 {
+		args = append(args,
+			fmt.Sprintf("--root-shard-kubeconfig-file=%s", filepath.Join(workDirPath, ".kcp-0", "admin.kubeconfig")),
+		)
+	}
+
 	args = append(args,
 		/*fmt.Sprintf("--cluster-workspace-shard-name=kcp-%d", n),*/
 		fmt.Sprintf("--root-directory=%s", filepath.Join(workDirPath, fmt.Sprintf(".kcp-%d", n))),


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Allows to run the components started by sharded-test-server against a single etcd instance instead of the embedded etcd.

## What Type of PR Is This?

/kind feature

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
