### PR TITLE
bump to Go 1.25.11

### DIFF
--- a/.github/workflows/docs-gen-and-push.yaml
+++ b/.github/workflows/docs-gen-and-push.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # tag=v6.4.0
         with:
-          go-version: v1.25.10
+          go-version: v1.25.11
           cache: true
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #tag=v6.2.0

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # tag=v6.4.0
         with:
-          go-version: v1.25.10
+          go-version: v1.25.11
 
       - name: Delete non-semver tags
         run: 'git tag -d $(git tag -l | grep -v "^v")'

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.25.10-1
+        - image: ghcr.io/kcp-dev/infra/build:1.25.11-1
           command:
             - make
             - verify-boilerplate
@@ -27,7 +27,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.25.10-1
+        - image: ghcr.io/kcp-dev/infra/build:1.25.11-1
           command:
             - make
             - verify-codegen
@@ -44,7 +44,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.25.10-1
+        - image: ghcr.io/kcp-dev/infra/build:1.25.11-1
           command:
             - make
             - lint
@@ -83,7 +83,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.25.10-1
+        - image: ghcr.io/kcp-dev/infra/build:1.25.11-1
           command:
             - make
             - test
@@ -104,7 +104,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.25.10-1
+        - image: ghcr.io/kcp-dev/infra/build:1.25.11-1
           command:
             - ./hack/run-with-prow.sh
             - ./hack/run-with-prometheus.sh
@@ -131,7 +131,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.25.10-1
+        - image: ghcr.io/kcp-dev/infra/build:1.25.11-1
           command:
             - ./hack/run-with-prow.sh
             - ./hack/run-with-prometheus.sh
@@ -158,7 +158,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.25.10-1
+        - image: ghcr.io/kcp-dev/infra/build:1.25.11-1
           command:
             - ./hack/run-with-prow.sh
             - ./hack/run-with-prometheus.sh
@@ -189,7 +189,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.25.10-1
+        - image: ghcr.io/kcp-dev/infra/build:1.25.11-1
           command:
             - ./hack/run-with-prow.sh
             - ./hack/run-with-prometheus.sh
@@ -216,7 +216,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.25.10-1
+        - image: ghcr.io/kcp-dev/infra/build:1.25.11-1
           command:
             - ./hack/run-with-prow.sh
             - ./hack/run-with-prometheus.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Build the binary
-FROM --platform=${BUILDPLATFORM} docker.io/golang:1.25.10 AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/golang:1.25.11 AS builder
 WORKDIR /workspace
 
 # Install dependencies.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ module github.com/kcp-dev/kcp
 // The script hack/verify-go-versions.sh checks that all version
 // references across the codebase are consistent with the versions
 // maintained here.
-// go-build-version 1.25.10
+// go-build-version 1.25.11
 go 1.25.0
 
 require (

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -185,6 +185,6 @@ rules:
     library: true
 recursive-delete-patterns:
   - '*/.gitattributes'
-default-go-version: 1.25.10
+default-go-version: 1.25.11
 skip-tags: false
 skip-non-semver-tags: true


### PR DESCRIPTION
## Summary
Time for the monthly Go update.

## What Type of PR Is This?
/kind chore

## Release Notes
```release-note
Update to Go 1.25.11
```
