### PR TITLE
Add static tilt setup

### DIFF
--- a/contrib/tilt/README.md
+++ b/contrib/tilt/README.md
@@ -46,6 +46,38 @@ v0.33.6, built 2023-09-29
 Once the tilt starts, press `space` and track the progress. The first boot might take
 a while as it needs to build all the images, run Prometheus, Grafana, loki, etc.
 
+## Static install (upstream images, no hot reload)
+
+The default `Tiltfile` builds the `kcp` and `kcp-front-proxy` images from your local
+sources and hot-reloads on code changes — use it when developing kcp itself.
+
+If you instead just want a working kcp to develop *against*, use `Tiltfile.static`.
+It installs the upstream kcp-operator and lets it deploy the upstream,
+version-matched kcp images. Nothing is built locally and code changes are not
+reloaded.
+
+```bash
+./contrib/tilt/kind-static.sh
+```
+or
+```bash
+make tilt-kind-up-static
+```
+
+Both variants share the same cluster name and URLs, so run only one at a time. The
+admin kubeconfigs are written to the repository root as `tilt-frontproxy.kubeconfig`,
+`tilt-root.kubeconfig` and `tilt-theseus.kubeconfig`.
+
+### Host resolution
+
+The kcp hostnames must resolve to `127.0.0.1` so the Tilt port-forward (on
+`:8443`) can be reached. The `.localhost` TLD is **not** auto-resolved on macOS,
+so add this line to `/etc/hosts`:
+
+```
+127.0.0.1 kcp.localhost root.kcp.localhost theseus.kcp.localhost
+```
+
 
 # Login using IDP:
 

--- a/contrib/tilt/Tiltfile.static
+++ b/contrib/tilt/Tiltfile.static
@@ -53,17 +53,42 @@ k8s_yaml(kustomize('./kcp-operator'))
 # registrations here. The static manifests below omit the .spec.image fields so
 # the kcp-operator deploys its own version-matched upstream kcp images.
 
+# Optional image-tag pin. When KCP_IMAGE_TAG is set (e.g. by a parent Tiltfile
+# that includes this one), pin every kcp component to that tag while keeping the
+# operator's default repositories — we set only .spec.image.tag (and the
+# RootShard proxy's), leaving .repository unset so the operator fills its
+# default. Unset → the operator's version-matched defaults (original behavior).
+kcp_image_tag = os.getenv('KCP_IMAGE_TAG', '')
+
+def _kcp_static_yaml(path):
+    if not kcp_image_tag:
+        return path  # unchanged: operator defaults
+    docs = read_yaml_stream(path)
+    for d in docs:
+        kind = d.get('kind', '')
+        if kind in ('RootShard', 'Shard', 'FrontProxy'):
+            img = d['spec'].get('image', {})
+            img['tag'] = kcp_image_tag
+            d['spec']['image'] = img
+        if kind == 'RootShard':
+            proxy = d['spec'].get('proxy', {})
+            pimg = proxy.get('image', {})
+            pimg['tag'] = kcp_image_tag
+            proxy['image'] = pimg
+            d['spec']['proxy'] = proxy
+    return encode_yaml_stream(docs)
+
 # Unlike the default Tiltfile, we do not register the RootShard/Shard/FrontProxy
 # kinds as workloads (no image injection), so Tilt groups each CR with its
 # same-named TLSRoute and Kubeconfig into a single resource named after the CR
 # (e.g. "root") rather than disambiguating with a "root:rootshard" suffix.
-k8s_yaml('./shard-root.static.yaml')
+k8s_yaml(_kcp_static_yaml('./shard-root.static.yaml'))
 k8s_resource('root', labels='kcp')
 
-k8s_yaml('./shard-theseus.static.yaml')
+k8s_yaml(_kcp_static_yaml('./shard-theseus.static.yaml'))
 k8s_resource('theseus', labels='kcp')
 
-k8s_yaml('./front-proxy.static.yaml')
+k8s_yaml(_kcp_static_yaml('./front-proxy.static.yaml'))
 k8s_resource('frontproxy', labels='kcp')
 
 k8s_kind('Kubeconfig')

--- a/contrib/tilt/Tiltfile.static
+++ b/contrib/tilt/Tiltfile.static
@@ -1,0 +1,76 @@
+# Tiltfile.static
+#
+# Static kcp install: unlike the default Tiltfile, this does NOT build the kcp
+# and kcp-front-proxy images from local sources and does NOT hot-reload code
+# changes. Instead it installs the upstream kcp-operator and lets it deploy the
+# upstream, version-matched kcp images. Use this when you want a stable kcp to
+# develop *against* rather than to develop kcp itself.
+#
+# Run with:
+#   tilt up -f ./contrib/tilt/Tiltfile.static
+# or:
+#   make tilt-kind-up-static
+
+load('ext://helm_remote', 'helm_remote')
+load('ext://namespace', 'namespace_create')
+load("ext://cert_manager", "deploy_cert_manager")
+
+k8s_yaml('kernel-limits-job.yaml')
+
+current_context = k8s_context()
+
+deploy_cert_manager(version='v1.19.2')
+k8s_yaml('./issuer.yaml')
+
+namespace_create('envoy-gateway-system')
+helm_remote(
+  'gateway-helm',
+  repo_url='oci://registry-1.docker.io/envoyproxy',
+  repo_name='gateway-helm',
+  release_name='envoy',
+  namespace='envoy-gateway-system',
+  version='v1.7.0',
+  values=[],
+  set=[],
+)
+
+# install the gateway and configure tilt to start a port-forward to the
+# resulting service that will route the traffic.
+# the name of the gateway is random, hence the selector
+k8s_yaml('gateway.yaml')
+local_resource('ingress', serve_cmd="./port-forward.bash", allow_parallel=True)
+
+include('./observability/Tiltfile')
+
+# etcd
+# builtin kustomize does not support remote urls, see https://github.com/tilt-dev/tilt/issues/2383
+k8s_yaml(kustomize('etcd'))
+
+# kcp-operator (upstream)
+k8s_yaml(kustomize('./kcp-operator'))
+
+# NOTE: no kcp_build() / docker_build() and no k8s_kind() image_object
+# registrations here. The static manifests below omit the .spec.image fields so
+# the kcp-operator deploys its own version-matched upstream kcp images.
+
+# Unlike the default Tiltfile, we do not register the RootShard/Shard/FrontProxy
+# kinds as workloads (no image injection), so Tilt groups each CR with its
+# same-named TLSRoute and Kubeconfig into a single resource named after the CR
+# (e.g. "root") rather than disambiguating with a "root:rootshard" suffix.
+k8s_yaml('./shard-root.static.yaml')
+k8s_resource('root', labels='kcp')
+
+k8s_yaml('./shard-theseus.static.yaml')
+k8s_resource('theseus', labels='kcp')
+
+k8s_yaml('./front-proxy.static.yaml')
+k8s_resource('frontproxy', labels='kcp')
+
+k8s_kind('Kubeconfig')
+k8s_yaml('./kubeconfig-kcp-admin.yaml')
+local_resource('kcp-admin extract',
+    cmd="./extract-kubeconfig.bash",
+    deps=['frontproxy', 'root', 'theseus'],
+    labels='kcp',
+    allow_parallel=True,
+)

--- a/contrib/tilt/Tiltfile.static
+++ b/contrib/tilt/Tiltfile.static
@@ -53,28 +53,34 @@ k8s_yaml(kustomize('./kcp-operator'))
 # registrations here. The static manifests below omit the .spec.image fields so
 # the kcp-operator deploys its own version-matched upstream kcp images.
 
-# Optional image-tag pin. When KCP_IMAGE_TAG is set (e.g. by a parent Tiltfile
-# that includes this one), pin every kcp component to that tag while keeping the
-# operator's default repositories — we set only .spec.image.tag (and the
-# RootShard proxy's), leaving .repository unset so the operator fills its
-# default. Unset → the operator's version-matched defaults (original behavior).
+# Optional image pin. When KCP_IMAGE_TAG and/or KCP_IMAGE_REPO are set (e.g. by a
+# parent Tiltfile that includes this one), pin every kcp component to that
+# repository/tag. We set .spec.image.repository and/or .spec.image.tag (and the
+# RootShard proxy's). Leaving a field unset lets the operator fill its default
+# (version-matched repository / tag). Both unset → original behavior.
+# A repository override is needed when images live outside the operator's default
+# repo, e.g. PR builds in ghcr.io/kcp-dev/kcp-prs.
 kcp_image_tag = os.getenv('KCP_IMAGE_TAG', '')
+kcp_image_repo = os.getenv('KCP_IMAGE_REPO', '')
+
+def _apply_image_override(img):
+    if kcp_image_repo:
+        img['repository'] = kcp_image_repo
+    if kcp_image_tag:
+        img['tag'] = kcp_image_tag
+    return img
 
 def _kcp_static_yaml(path):
-    if not kcp_image_tag:
+    if not kcp_image_tag and not kcp_image_repo:
         return path  # unchanged: operator defaults
     docs = read_yaml_stream(path)
     for d in docs:
         kind = d.get('kind', '')
         if kind in ('RootShard', 'Shard', 'FrontProxy'):
-            img = d['spec'].get('image', {})
-            img['tag'] = kcp_image_tag
-            d['spec']['image'] = img
+            d['spec']['image'] = _apply_image_override(d['spec'].get('image', {}))
         if kind == 'RootShard':
             proxy = d['spec'].get('proxy', {})
-            pimg = proxy.get('image', {})
-            pimg['tag'] = kcp_image_tag
-            proxy['image'] = pimg
+            proxy['image'] = _apply_image_override(proxy.get('image', {}))
             d['spec']['proxy'] = proxy
     return encode_yaml_stream(docs)
 

--- a/contrib/tilt/extract-kubeconfig.bash
+++ b/contrib/tilt/extract-kubeconfig.bash
@@ -2,6 +2,13 @@
 
 set -xeo pipefail
 
+# Directory the extracted tilt-<name>.kubeconfig files are written to. Defaults
+# to the kcp repo root (../.. from contrib/tilt), preserving standalone
+# behavior. Consumers that include this Tiltfile from another repo can override
+# it (e.g. to land the kubeconfigs in their own project dir).
+KCP_KUBECONFIG_DIR="${KCP_KUBECONFIG_DIR:-../..}"
+mkdir -p "$KCP_KUBECONFIG_DIR"
+
 while [[ "$(kubectl api-resources --api-group operator.kcp.io | wc -l)" -lt 2 ]] ; do
     echo "Waiting for kcp-operator API to be available..."
     sleep 1
@@ -14,7 +21,7 @@ _extract() {
     kubectl wait "kubeconfig/$kubeconfig" --for=condition=Available --timeout=5m
     kubectl wait "secret/kcp-$kubeconfig-kubeconfig" --for=create --timeout=5m
     kubectl get "secret/kcp-$kubeconfig-kubeconfig" -o jsonpath='{.data.kubeconfig}' \
-        | base64 -d > "../../tilt-$kubeconfig.kubeconfig"
+        | base64 -d > "$KCP_KUBECONFIG_DIR/tilt-$kubeconfig.kubeconfig"
 }
 
 _extract frontproxy

--- a/contrib/tilt/front-proxy.static.yaml
+++ b/contrib/tilt/front-proxy.static.yaml
@@ -1,0 +1,45 @@
+apiVersion: operator.kcp.io/v1alpha1
+kind: FrontProxy
+metadata:
+  name: frontproxy
+spec:
+  # no image override: the kcp-operator defaults to its version-matched
+  # upstream kcp image (static install, no locally built images).
+  rootShard:
+    ref:
+      name: root
+  external:
+    hostname: kcp.localhost
+    port: 8443
+  deploymentTemplate:
+    spec:
+      template:
+        spec:
+          hostAliases:
+            - ip: 10.96.2.2
+              hostnames:
+                - kcp.localhost
+                - root.kcp.localhost
+                - theseus.kcp.localhost
+  certificateTemplates:
+    server:
+      spec:
+        dnsNames:
+        - kcp.localhost
+---
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: TLSRoute
+metadata:
+  name: front-proxy
+  namespace: default
+spec:
+  parentRefs:
+  - name: eg
+    namespace: envoy-gateway-system
+  hostnames:
+  - kcp.localhost
+  rules:
+  - backendRefs:
+    - name: frontproxy-front-proxy
+      port: 8443
+      namespace: default

--- a/contrib/tilt/kind-static.sh
+++ b/contrib/tilt/kind-static.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The kcp Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Static variant of kind.sh: brings up a kind cluster and runs Tilt against
+# Tiltfile.static, which installs the upstream kcp-operator and deploys the
+# upstream kcp images instead of building them from local sources.
+
+set -e
+
+if ! command -v kind &> /dev/null; then
+  echo "kind not found, exiting"
+  exit 1
+fi
+
+if ! command -v helm &> /dev/null; then
+  echo "helm not found, exiting"
+  exit 1
+fi
+
+if ! command -v tilt &> /dev/null; then
+  echo "tilt not found, exiting"
+  echo "please follow the instructions at https://github.com/tilt-dev/tilt#install-tilt"
+  exit 1
+fi
+
+CLUSTER_NAME=kcp-tilt
+
+if ! kind get clusters | grep -w -q "$CLUSTER_NAME"; then
+    kind create cluster --name "$CLUSTER_NAME"
+fi
+
+kind export kubeconfig --name "$CLUSTER_NAME"
+
+echo "Once the setup is done and kcp is ready, the files 'tilt-frontproxy.kubeconfig',"
+echo "'tilt-root.kubeconfig' and 'tilt-theseus.kubeconfig' will be created in the"
+echo "repository root to access the kcp instance as an admin."
+echo
+
+# The kcp hostnames must resolve to 127.0.0.1 so the Tilt port-forward (:8443)
+# is reachable. The '.localhost' TLD is not auto-resolved on macOS, so check
+# that the entries exist in /etc/hosts and tell the user how to add them.
+KCP_HOSTS="kcp.localhost root.kcp.localhost theseus.kcp.localhost"
+missing_hosts=""
+for h in $KCP_HOSTS; do
+    if ! grep -Eq "(^|[[:space:]])${h//./\\.}([[:space:]]|\$)" /etc/hosts 2>/dev/null; then
+        missing_hosts="$missing_hosts $h"
+    fi
+done
+
+if [ -n "$missing_hosts" ]; then
+    echo "WARNING: the following kcp hostnames do not resolve via /etc/hosts:"
+    echo "  $missing_hosts"
+    echo "Add the following line to /etc/hosts (e.g. 'sudo vi /etc/hosts'), otherwise"
+    echo "kubectl will fail with 'no such host':"
+    echo
+    echo "  127.0.0.1 $KCP_HOSTS"
+    echo
+else
+    echo "/etc/hosts entries for kcp hostnames: OK"
+    echo
+fi
+
+echo "URLs:"
+echo "  front-proxy:    https://kcp.localhost:8443"
+echo "  root shard:     https://root.kcp.localhost:8443"
+echo "  theseus shard:  https://theseus.kcp.localhost:8443"
+echo "  grafana:        http://localhost:3333/"
+echo "  prometheus:     http://localhost:9091"
+
+echo "Starting tilt (static, upstream images)..."
+tilt up -f ./contrib/tilt/Tiltfile.static

--- a/contrib/tilt/shard-root.static.yaml
+++ b/contrib/tilt/shard-root.static.yaml
@@ -1,0 +1,65 @@
+apiVersion: operator.kcp.io/v1alpha1
+kind: RootShard
+metadata:
+  name: root
+spec:
+  # no image override: the kcp-operator defaults to its version-matched
+  # upstream kcp image (static install, no locally built images).
+  proxy:
+    deploymentTemplate:
+      spec:
+        template:
+          spec:
+            hostAliases:
+              - ip: 10.96.2.2
+                hostnames:
+                  - kcp.localhost
+                  - root.kcp.localhost
+                  - theseus.kcp.localhost
+  shardBaseURL: https://root.kcp.localhost:8443
+  external:
+    hostname: kcp.localhost
+    port: 8443
+  certificates:
+    issuerRef:
+      group: cert-manager.io
+      kind: Issuer
+      name: selfsigned
+  cache:
+    embedded:
+      enabled: true
+  etcd:
+    endpoints:
+      - http://etcd.kcp-root.svc.cluster.local:2379
+  deploymentTemplate:
+    spec:
+      template:
+        spec:
+          hostAliases:
+            - ip: 10.96.2.2
+              hostnames:
+                - kcp.localhost
+                - root.kcp.localhost
+                - theseus.kcp.localhost
+  certificateTemplates:
+    server:
+      spec:
+        dnsNames:
+        - root.kcp.localhost
+---
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: TLSRoute
+metadata:
+  name: root
+  namespace: default
+spec:
+  parentRefs:
+  - name: eg
+    namespace: envoy-gateway-system
+  hostnames:
+  - root.kcp.localhost
+  rules:
+  - backendRefs:
+    - name: root-kcp
+      port: 6443
+      namespace: default

--- a/contrib/tilt/shard-root.static.yaml
+++ b/contrib/tilt/shard-root.static.yaml
@@ -5,6 +5,13 @@ metadata:
 spec:
   # no image override: the kcp-operator defaults to its version-matched
   # upstream kcp image (static install, no locally built images).
+  extraArgs:
+    # Enable alpha feature gates required by downstream consumers (kedge,
+    # kro-multicluster). Operator appends these to the shard's container
+    # args (see kcp-operator internal/resources/rootshard/deployment.go).
+    #   CacheAPIs       — exposes cache.kcp.io/v1alpha1 CachedResource etc.
+    #   WorkspaceMounts — exposes the mount/claim mechanism on Workspace.
+    - --feature-gates=CacheAPIs=true,WorkspaceMounts=true
   proxy:
     deploymentTemplate:
       spec:

--- a/contrib/tilt/shard-theseus.static.yaml
+++ b/contrib/tilt/shard-theseus.static.yaml
@@ -8,6 +8,9 @@ spec:
       name: root
   # no image override: the kcp-operator defaults to its version-matched
   # upstream kcp image (static install, no locally built images).
+  extraArgs:
+    # Match RootShard above — see shard-root.static.yaml for rationale.
+    - --feature-gates=CacheAPIs=true,WorkspaceMounts=true
   shardBaseURL: https://theseus.kcp.localhost:8443
   external:
     hostname: kcp.localhost

--- a/contrib/tilt/shard-theseus.static.yaml
+++ b/contrib/tilt/shard-theseus.static.yaml
@@ -1,0 +1,57 @@
+apiVersion: operator.kcp.io/v1alpha1
+kind: Shard
+metadata:
+  name: theseus
+spec:
+  rootShard:
+    ref:
+      name: root
+  # no image override: the kcp-operator defaults to its version-matched
+  # upstream kcp image (static install, no locally built images).
+  shardBaseURL: https://theseus.kcp.localhost:8443
+  external:
+    hostname: kcp.localhost
+    port: 8443
+  certificates:
+    issuerRef:
+      group: cert-manager.io
+      kind: Issuer
+      name: selfsigned
+  cache:
+    embedded:
+      enabled: true
+  etcd:
+    endpoints:
+      - http://etcd.kcp-theseus.svc.cluster.local:2379
+  deploymentTemplate:
+    spec:
+      template:
+        spec:
+          hostAliases:
+            - ip: 10.96.2.2
+              hostnames:
+                - kcp.localhost
+                - root.kcp.localhost
+                - theseus.kcp.localhost
+  certificateTemplates:
+    server:
+      spec:
+        dnsNames:
+        - theseus.kcp.localhost
+---
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: TLSRoute
+metadata:
+  name: theseus
+  namespace: default
+spec:
+  parentRefs:
+  - name: eg
+    namespace: envoy-gateway-system
+  hostnames:
+  - theseus.kcp.localhost
+  rules:
+  - backendRefs:
+    - name: theseus-shard-kcp
+      port: 6443
+      namespace: default


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

When developing ontop of kcp one might want to integrate kcp into their setup but dont need reloads. 
This adds static tilt setup option where once can use it same as they would use grafana or other tool. 

## What Type of PR Is This?
/kind feature
<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
