### PR TITLE
Fix CachedResource virtual-storage discovery on multi-replica/embedded-VW shards

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -741,15 +741,40 @@ func NewConfig(ctx context.Context, opts kcpserveroptions.CompletedOptions) (*Co
 	c.ApiExtensions.ExtraConfig.TableConverterProvider = NewTableConverterProvider()
 
 	if kcpfeatures.DefaultFeatureGate.Enabled(kcpfeatures.CacheAPIs) {
-		// vwClientConfig is used by the proxy handler to proxy the client requests to the virtual workspace.
+		// vwClientConfig is used by the aggregating CRD-version discovery server and the virtual
+		// resources server to forward requests to the virtual workspace endpoint URLs advertised
+		// in CachedResourceEndpointSlices.
 		vwClientConfig := rest.CopyConfig(c.GenericConfig.LoopbackClientConfig)
-		if !opts.Virtual.Enabled {
+		if opts.Extra.ShardClientCertFile != "" && opts.Extra.ShardClientKeyFile != "" {
+			// On a real, multi-component deployment the advertised endpoint URL is the serving
+			// shard's own external virtual-workspace URL (Shard.Spec.VirtualWorkspaceURL, e.g.
+			// https://shard.example:8443/services/replication/...), which is reached through the
+			// cluster ingress that routes by TLS SNI directly to that shard — not the in-cluster
+			// Service address and not loopback, even when the virtual workspace runs embedded in
+			// this shard.
+			//
+			// The loopback config therefore cannot be used: its bearer token is only valid on the
+			// loopback listener (the forwarded request would authenticate as anonymous and be
+			// denied) and its ServerName is the loopback name (so the ingress cannot SNI-route the
+			// connection and resets it). Authenticate with the shard client certificate against a
+			// CA that trusts the shard serving certificate, drop the loopback bearer token, and
+			// leave ServerName empty so the SNI is derived from the target host.
+			virtualWorkspaceCAFile := opts.Extra.ShardVirtualWorkspaceCAFile
+			if virtualWorkspaceCAFile == "" {
+				// With embedded virtual workspaces --shard-virtual-workspace-ca-file is typically
+				// not set; fall back to the root CA, which signs the shard serving certificate.
+				virtualWorkspaceCAFile = opts.Controllers.SAController.RootCAFile
+			}
+			vwClientConfig.BearerToken = ""
+			vwClientConfig.BearerTokenFile = ""
 			vwClientConfig.TLSClientConfig = rest.TLSClientConfig{
-				CAFile:   opts.Extra.ShardVirtualWorkspaceCAFile,
+				CAFile:   virtualWorkspaceCAFile,
 				CertFile: opts.Extra.ShardClientCertFile,
 				KeyFile:  opts.Extra.ShardClientKeyFile,
 			}
 		}
+		// Otherwise (no shard client certificate, e.g. an in-process test server) the endpoint URL
+		// points back at this same server, so the loopback config is correct and is kept as-is.
 
 		// We need an aggregating version discovery for CRDs that is RESTstorage-aware.
 		// The apiextensions apiserver sources its data from the apiBindingAwareCRDClusterLister.

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	pluginvalidatingadmissionpolicy "k8s.io/apiserver/pkg/admission/plugin/policy/validating"
 	"k8s.io/apiserver/pkg/cel/openapi/resolver"
+	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/cached/memory"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
@@ -1685,27 +1686,24 @@ func (s *Server) installGarbageCollectorController(ctx context.Context, config *
 }
 
 func (s *Server) installDynamicRESTMapper(ctx context.Context) error {
+	// installControllers (and thus this function) can be called again when a replica
+	// (re-)acquires leadership. The DynamicRESTMapper controllers are not leader-elected and
+	// are wired through a post-start hook, which must only be registered once and only before
+	// the server starts serving, so guard the whole setup with a sync.Once. The first call
+	// happens at server bootstrap, before serving begins.
+	s.dynamicRESTMapperOnce.Do(func() {
+		s.dynamicRESTMapperErr = s.setupDynamicRESTMapperControllers(ctx)
+	})
+	return s.dynamicRESTMapperErr
+}
+
+func (s *Server) setupDynamicRESTMapperControllers(ctx context.Context) error {
 	builtinTypesController, err := dynamicrestmapper.NewBuiltinTypesController(ctx, s.completedConfig.DynamicRESTMapper,
 		s.ApiExtensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions(),
 	)
 	if err != nil {
 		return err
 	}
-	err = s.registerController(&controllerWrapper{
-		Name: dynamicrestmapper.BuiltinTypesControllerName,
-		Wait: func(ctx context.Context, s *Server) error {
-			return wait.PollUntilContextCancel(ctx, waitPollInterval, true, func(ctx context.Context) (bool, error) {
-				return s.ApiExtensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions().Informer().HasSynced(), nil
-			})
-		},
-		Runner: func(ctx context.Context) {
-			builtinTypesController.Start(ctx, 2)
-		},
-	})
-	if err != nil {
-		return err
-	}
-
 	dynamicTypesController, err := dynamicrestmapper.NewDynamicTypesController(ctx, s.completedConfig.DynamicRESTMapper,
 		s.ApiExtensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions(),
 		s.KcpSharedInformerFactory.Apis().V1alpha2().APIBindings(),
@@ -1719,22 +1717,52 @@ func (s *Server) installDynamicRESTMapper(ctx context.Context) error {
 		return err
 	}
 
-	return s.registerController(&controllerWrapper{
-		Name: dynamicrestmapper.DynamicTypesControllerName,
-		Wait: func(ctx context.Context, s *Server) error {
-			return wait.PollUntilContextCancel(ctx, waitPollInterval, true, func(ctx context.Context) (bool, error) {
-				return s.ApiExtensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions().Informer().HasSynced() &&
-					s.KcpSharedInformerFactory.Apis().V1alpha2().APIBindings().Informer().HasSynced() &&
-					s.KcpSharedInformerFactory.Apis().V1alpha2().APIExports().Informer().HasSynced() &&
-					s.KcpSharedInformerFactory.Apis().V1alpha1().APIResourceSchemas().Informer().HasSynced() &&
-					s.CacheKcpSharedInformerFactory.Apis().V1alpha2().APIExports().Informer().HasSynced() &&
-					s.CacheKcpSharedInformerFactory.Apis().V1alpha1().APIResourceSchemas().Informer().HasSynced() &&
-					s.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters().Informer().HasSynced(), nil
-			})
+	controllers := []*controllerWrapper{
+		{
+			Name: dynamicrestmapper.BuiltinTypesControllerName,
+			Wait: func(ctx context.Context, s *Server) error {
+				return wait.PollUntilContextCancel(ctx, waitPollInterval, true, func(ctx context.Context) (bool, error) {
+					return s.ApiExtensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions().Informer().HasSynced(), nil
+				})
+			},
+			Runner: func(ctx context.Context) {
+				builtinTypesController.Start(ctx, 2)
+			},
 		},
-		Runner: func(ctx context.Context) {
-			dynamicTypesController.Start(ctx, 2)
+		{
+			Name: dynamicrestmapper.DynamicTypesControllerName,
+			Wait: func(ctx context.Context, s *Server) error {
+				return wait.PollUntilContextCancel(ctx, waitPollInterval, true, func(ctx context.Context) (bool, error) {
+					return s.ApiExtensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions().Informer().HasSynced() &&
+						s.KcpSharedInformerFactory.Apis().V1alpha2().APIBindings().Informer().HasSynced() &&
+						s.KcpSharedInformerFactory.Apis().V1alpha2().APIExports().Informer().HasSynced() &&
+						s.KcpSharedInformerFactory.Apis().V1alpha1().APIResourceSchemas().Informer().HasSynced() &&
+						s.CacheKcpSharedInformerFactory.Apis().V1alpha2().APIExports().Informer().HasSynced() &&
+						s.CacheKcpSharedInformerFactory.Apis().V1alpha1().APIResourceSchemas().Informer().HasSynced() &&
+						s.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters().Informer().HasSynced(), nil
+				})
+			},
+			Runner: func(ctx context.Context) {
+				dynamicTypesController.Start(ctx, 2)
+			},
 		},
+	}
+
+	// The DynamicRESTMapper is per-process, in-memory state that THIS shard replica's own
+	// API server reads (the aggregating CRD-version discovery server and the virtual resources
+	// server) to resolve GroupKinds to resources. Both controllers only mutate that in-memory
+	// mapper and never write to storage, so — unlike the leader-elected controllers started by
+	// kcp-start-controllers — they MUST run on every replica. If they only ran on the leader, a
+	// non-leader replica would serve requests against an empty mapper, making built-in/system
+	// types such as cache.kcp.io/CachedResourceEndpointSlice unresolvable and breaking discovery
+	// and serving of virtual-storage (CachedResource-backed) resources on that replica. Start
+	// them from a post-start hook that is not gated by leader election.
+	return s.AddPostStartHook("kcp-start-dynamicrestmapper-controllers", func(hookContext genericapiserver.PostStartHookContext) error {
+		controllerCtx := klog.NewContext(hookContext, klog.FromContext(hookContext).WithValues("postStartHook", "kcp-start-dynamicrestmapper-controllers"))
+		for _, controller := range controllers {
+			go s.runController(controllerCtx, controller)
+		}
+		return nil
 	})
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"sync"
 	"time"
 
 	extensionsapiserver "k8s.io/apiextensions-apiserver/pkg/apiserver"
@@ -84,6 +85,13 @@ type Server struct {
 	rootPhase1FinishedCh chan struct{}
 
 	controllers map[string]*controllerWrapper
+
+	// dynamicRESTMapperOnce guards wiring of the DynamicRESTMapper controllers, which run
+	// per-replica (not under leader election) and must be started exactly once per process,
+	// even though installControllers can be invoked again on leadership re-acquisition.
+	// dynamicRESTMapperErr caches the setup result so every caller observes the same error.
+	dynamicRESTMapperOnce sync.Once
+	dynamicRESTMapperErr  error
 }
 
 func (s *Server) AddPostStartHook(name string, hook genericapiserver.PostStartHookFunc) error {


### PR DESCRIPTION
## Summary

CachedResource-backed (virtual-storage) resources were intermittently undiscoverable and unservable on a kcp shard running with multiple replicas and/or embedded virtual workspaces. `kubectl get <resource>` returned:

```
Warning: Some resources are temporarily unavailable: [<resource>.<group>].
error: the server doesn't have a resource type "<resource>"
```

and the list/get failed. Whether it failed flapped depending on which shard replica served the request. There are two independent root causes.

### 1. DynamicRESTMapper controllers only ran on the leader replica

The builtin and dynamic REST mapper controllers populate a per-process, in-memory `DynamicRESTMapper` that *every* shard replica's own API server reads — the aggregating CRD-version discovery server and the virtual resources server use it to resolve GroupKinds (e.g. `cache.kcp.io/CachedResourceEndpointSlice`) to resources. They were registered under the leader-elected `kcp-start-controllers` hook, so on a shard with more than one replica only the leader populated its mapper. Non-leader replicas served requests against an empty mapper, so `RESTMapping` for system types failed (`no matches for kind "CachedResourceEndpointSlice" in group "cache.kcp.io"`) and every virtual-storage resource was dropped from discovery there.

Both controllers only mutate the in-memory mapper and never write to storage, so they are safe to run on every replica. They are now started from a dedicated post-start hook that is **not** gated by leader election, guarded by a `sync.Once` so a leadership re-acquisition does not re-wire them.

### 2. Virtual workspace forward client used the loopback SNI/identity with embedded virtual workspaces

The aggregating discovery and virtual resources servers forward requests to the virtual workspace endpoint URLs advertised in `CachedResourceEndpointSlice`. Each such URL is the serving shard's own external, SNI-routed virtual-workspace URL (`Shard.Spec.VirtualWorkspaceURL`, e.g. `https://<shard>.example:8443/services/replication/...`) — reached through the ingress/front-proxy, not the in-cluster Service address and not loopback, even when the virtual workspace runs embedded in that shard.

`vwClientConfig` was only given a usable TLS config (shard client cert + VW CA) when virtual workspaces were **not** embedded. With embedded virtual workspaces (the default), it kept the loopback client config, whose `ServerName` is the loopback name and whose bearer token is only valid on the loopback listener. The forwarded request's TLS SNI was therefore the loopback name, the ingress could not SNI-route the connection, and it was reset:

```
failed to perform API discovery: ... read: connection reset by peer
```

The forward client now always authenticates with the shard client certificate, drops the loopback bearer token, and leaves `ServerName` empty so the SNI is derived from the target host. When `--shard-virtual-workspace-ca-file` is unset (typical with embedded virtual workspaces) it falls back to the root CA, which signs the shard serving certificate.

## What Type of PR Is This?
/kind bug

## Related Issue(s)

Fixes #

## Release Notes

```release-note
Fix CachedResource-backed (virtual-storage) resources being intermittently undiscoverable or unservable on kcp shards running with multiple replicas or embedded virtual workspaces.
```
