### PR TITLE
implement additional metrics for backend traffic

### DIFF
--- a/pkg/proxy/lookup/lookup.go
+++ b/pkg/proxy/lookup/lookup.go
@@ -195,6 +195,7 @@ func resolveClusterName(w http.ResponseWriter, req *http.Request, index proxyind
 
 	ctx = WithClusterName(ctx, result.Cluster)
 	ctx = WithWorkspaceType(ctx, result.Type)
+	ctx = WithShardName(ctx, result.Shard)
 
 	return req.WithContext(ctx), &result
 }
@@ -203,6 +204,8 @@ type lookupKey int
 
 const (
 	shardContextKey lookupKey = iota
+	shardNameContextKey
+	shardNameHolderContextKey
 	clusterContextKey
 	workspaceTypeContextKey
 )
@@ -217,6 +220,38 @@ func ShardURLFrom(ctx context.Context) *url.URL {
 		return nil
 	}
 	return shardURL
+}
+
+func WithShardName(parent context.Context, shardName string) context.Context {
+	// Also update the holder if one exists, so outer middleware can access the shard name
+	// even though they only have access to the original request's context.
+	if holder, ok := parent.Value(shardNameHolderContextKey).(*ShardNameHolder); ok {
+		holder.Name = shardName
+	}
+	return context.WithValue(parent, shardNameContextKey, shardName)
+}
+
+func ShardNameFrom(ctx context.Context) string {
+	shardName, ok := ctx.Value(shardNameContextKey).(string)
+	if !ok {
+		return ""
+	}
+	return shardName
+}
+
+// ShardNameHolder is a mutable container for the shard name that can be stored
+// in context before the shard is known, then updated later. This allows outer
+// middleware to access the shard name even when inner handlers create new
+// request objects with WithContext().
+type ShardNameHolder struct {
+	Name string
+}
+
+// WithShardNameHolder stores a ShardNameHolder in the context. The holder can
+// be updated later when WithShardName is called.
+func WithShardNameHolder(parent context.Context) (context.Context, *ShardNameHolder) {
+	holder := &ShardNameHolder{}
+	return context.WithValue(parent, shardNameHolderContextKey, holder), holder
 }
 
 func WithClusterName(parent context.Context, cluster logicalcluster.Name) context.Context {

--- a/pkg/proxy/mapping.go
+++ b/pkg/proxy/mapping.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/klog/v2"
 
+	"github.com/kcp-dev/kcp/pkg/proxy/metrics"
 	"github.com/kcp-dev/kcp/pkg/server/proxy"
 	"github.com/kcp-dev/kcp/pkg/server/proxy/types"
 )
@@ -80,11 +81,13 @@ func NewHandler(ctx context.Context, mappings []types.PathMapping) (http.Handler
 		if isShardMapping(m) {
 			clusterProxy := newShardReverseProxy()
 			clusterProxy.Transport = transport
+			clusterProxy.ErrorHandler = metrics.NewProxyErrorHandler()
 			handler = clusterProxy
 		} else {
 			// TODO: handle virtual workspace apiservers per shard
 			proxy := httputil.NewSingleHostReverseProxy(u)
 			proxy.Transport = transport
+			proxy.ErrorHandler = metrics.NewProxyErrorHandler()
 			handler = proxy
 		}
 

--- a/pkg/proxy/metrics/metrics.go
+++ b/pkg/proxy/metrics/metrics.go
@@ -17,13 +17,30 @@ limitations under the License.
 package metrics
 
 import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"io"
 	"net/http"
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
+	"k8s.io/apiserver/pkg/endpoints/responsewriter"
 	compbasemetrics "k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/klog/v2"
+
+	"github.com/kcp-dev/kcp/pkg/proxy/lookup"
+)
+
+// TLS error type constants for categorization.
+const (
+	TLSErrorTypeUnknownCA        = "unknown_ca"
+	TLSErrorTypeExpiredCert      = "expired_cert"
+	TLSErrorTypeCipherMismatch   = "cipher_mismatch"
+	TLSErrorTypeHostnameMismatch = "hostname_mismatch"
+	TLSErrorTypeOther            = "other"
 )
 
 // WithLatencyTracking tracks the number of seconds it took the wrapped handler
@@ -44,6 +61,33 @@ var (
 		},
 		[]string{"method", "code"},
 	)
+
+	tlsConnectionErrors = compbasemetrics.NewCounterVec(
+		&compbasemetrics.CounterOpts{
+			Name:           "kcp_listener_tls_connection_error",
+			Help:           "Total TLS connection failures to backend shards by error type.",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"shard", "error_type"},
+	)
+
+	backendRequestBodyBytes = compbasemetrics.NewCounterVec(
+		&compbasemetrics.CounterOpts{
+			Name:           "kcp_backend_rq_body_bytes",
+			Help:           "Total bytes forwarded in request bodies from clients to backend.",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"shard"},
+	)
+
+	backendResponseBodyBytes = compbasemetrics.NewCounterVec(
+		&compbasemetrics.CounterOpts{
+			Name:           "kcp_backend_rs_body_bytes",
+			Help:           "Total bytes returned in response bodies from backend to clients.",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"shard"},
+	)
 )
 
 var registerMetrics sync.Once
@@ -52,9 +96,142 @@ var registerMetrics sync.Once
 func Register() {
 	registerMetrics.Do(func() {
 		legacyregistry.MustRegister(requestLatencies)
+		legacyregistry.MustRegister(tlsConnectionErrors)
+		legacyregistry.MustRegister(backendRequestBodyBytes)
+		legacyregistry.MustRegister(backendResponseBodyBytes)
 	})
 }
 
 func init() {
 	Register()
+}
+
+// categorizeTLSError examines an error and returns the appropriate TLS error type label.
+// Returns an empty string if the error is not TLS-related.
+func categorizeTLSError(err error) string {
+	// Check for unknown certificate authority
+	var unknownAuthorityErr x509.UnknownAuthorityError
+	if errors.As(err, &unknownAuthorityErr) {
+		return TLSErrorTypeUnknownCA
+	}
+
+	// Check for certificate validation errors (includes expired certs)
+	var certInvalidErr x509.CertificateInvalidError
+	if errors.As(err, &certInvalidErr) {
+		if certInvalidErr.Reason == x509.Expired {
+			return TLSErrorTypeExpiredCert
+		}
+		// Other certificate validation errors are still TLS errors
+		return TLSErrorTypeOther
+	}
+
+	// Check for hostname/SAN mismatch errors
+	var hostnameErr x509.HostnameError
+	if errors.As(err, &hostnameErr) {
+		return TLSErrorTypeHostnameMismatch
+	}
+
+	// Check for TLS record header errors (often indicates protocol/cipher issues)
+	var recordHeaderErr tls.RecordHeaderError
+	if errors.As(err, &recordHeaderErr) {
+		return TLSErrorTypeCipherMismatch
+	}
+
+	// Not a recognized TLS error
+	return ""
+}
+
+// isTLSError checks if the error is related to TLS.
+func isTLSError(err error) bool {
+	return categorizeTLSError(err) != ""
+}
+
+// NewProxyErrorHandler returns an error handler for httputil.ReverseProxy that
+// tracks TLS connection errors and then delegates to the default behavior.
+func NewProxyErrorHandler() func(http.ResponseWriter, *http.Request, error) {
+	return func(w http.ResponseWriter, r *http.Request, err error) {
+		logger := klog.FromContext(r.Context())
+
+		if isTLSError(err) {
+			shardName := lookup.ShardNameFrom(r.Context())
+			if shardName == "" {
+				shardName = "unknown"
+			}
+			errorType := categorizeTLSError(err)
+			tlsConnectionErrors.WithLabelValues(shardName, errorType).Inc()
+			logger.V(4).Info("TLS connection error to backend", "shard", shardName, "type", errorType, "error", err)
+		}
+
+		// Default behavior: log the error and return 502 Bad Gateway
+		logger.Error(err, "proxy error")
+		w.WriteHeader(http.StatusBadGateway)
+	}
+}
+
+// countingReader wraps an io.ReadCloser to count bytes read.
+type countingReader struct {
+	io.ReadCloser
+	bytesRead int64
+}
+
+func (r *countingReader) Read(p []byte) (int, error) {
+	n, err := r.ReadCloser.Read(p)
+	r.bytesRead += int64(n)
+	return n, err
+}
+
+// responseWriterDelegator wraps an http.ResponseWriter to count bytes written.
+type responseWriterDelegator struct {
+	http.ResponseWriter
+	bytesWritten int64
+}
+
+func (r *responseWriterDelegator) Write(b []byte) (int, error) {
+	n, err := r.ResponseWriter.Write(b)
+	r.bytesWritten += int64(n)
+	return n, err
+}
+
+// Unwrap returns the underlying ResponseWriter, required for proper HTTP/2 support.
+func (r *responseWriterDelegator) Unwrap() http.ResponseWriter {
+	return r.ResponseWriter
+}
+
+// WithBodyTracking wraps the handler to track request and response body bytes.
+// Only requests that are routed to a backend shard (i.e., have a shard name in context)
+// are counted.
+func WithBodyTracking(delegate http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Wrap request body to count incoming bytes
+		reqCounter := &countingReader{ReadCloser: r.Body}
+		r.Body = reqCounter
+
+		// Wrap response writer to count outgoing bytes
+		respDelegator := &responseWriterDelegator{ResponseWriter: w}
+		wrappedWriter := responsewriter.WrapForHTTP1Or2(respDelegator)
+
+		// Store a holder in context that inner handlers can update with the shard name.
+		// This is necessary because inner handlers may create new request objects
+		// with WithContext(), and we need to access the shard name after they return.
+		ctx, holder := lookup.WithShardNameHolder(r.Context())
+		r = r.WithContext(ctx)
+
+		delegate.ServeHTTP(wrappedWriter, r)
+
+		// Only record metrics for requests that were routed to a backend shard.
+		// Requests handled locally by the front-proxy (e.g., /metrics, /readyz)
+		// won't have a shard name set.
+		shardName := holder.Name
+		if shardName == "" {
+			return
+		}
+
+		// Record metrics after request completes
+		if reqCounter.bytesRead > 0 {
+			backendRequestBodyBytes.WithLabelValues(shardName).Add(float64(reqCounter.bytesRead))
+		}
+		if respDelegator.bytesWritten > 0 {
+			backendResponseBodyBytes.WithLabelValues(shardName).Add(float64(respDelegator.bytesWritten))
+		}
+	})
 }

--- a/pkg/proxy/metrics/metrics_test.go
+++ b/pkg/proxy/metrics/metrics_test.go
@@ -1,0 +1,347 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCategorizeTLSError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected string
+	}{
+		{
+			name:     "unknown authority error",
+			err:      x509.UnknownAuthorityError{},
+			expected: TLSErrorTypeUnknownCA,
+		},
+		{
+			name:     "wrapped unknown authority error",
+			err:      fmt.Errorf("connection failed: %w", x509.UnknownAuthorityError{}),
+			expected: TLSErrorTypeUnknownCA,
+		},
+		{
+			name:     "expired certificate error",
+			err:      x509.CertificateInvalidError{Reason: x509.Expired},
+			expected: TLSErrorTypeExpiredCert,
+		},
+		{
+			name:     "wrapped expired certificate error",
+			err:      fmt.Errorf("tls handshake: %w", x509.CertificateInvalidError{Reason: x509.Expired}),
+			expected: TLSErrorTypeExpiredCert,
+		},
+		{
+			name:     "other certificate invalid error",
+			err:      x509.CertificateInvalidError{Reason: x509.NotAuthorizedToSign},
+			expected: TLSErrorTypeOther,
+		},
+		{
+			name:     "hostname error",
+			err:      x509.HostnameError{},
+			expected: TLSErrorTypeHostnameMismatch,
+		},
+		{
+			name:     "tls record header error",
+			err:      tls.RecordHeaderError{},
+			expected: TLSErrorTypeCipherMismatch,
+		},
+		{
+			name:     "generic error",
+			err:      errors.New("some random error"),
+			expected: "",
+		},
+		{
+			name:     "connection refused",
+			err:      errors.New("connection refused"),
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := categorizeTLSError(tt.err)
+			if got != tt.expected {
+				t.Errorf("categorizeTLSError() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsTLSError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "unknown authority error",
+			err:      x509.UnknownAuthorityError{},
+			expected: true,
+		},
+		{
+			name:     "certificate invalid error",
+			err:      x509.CertificateInvalidError{},
+			expected: true,
+		},
+		{
+			name:     "hostname error",
+			err:      x509.HostnameError{},
+			expected: true,
+		},
+		{
+			name:     "tls record header error",
+			err:      tls.RecordHeaderError{},
+			expected: true,
+		},
+		{
+			name:     "wrapped tls error",
+			err:      fmt.Errorf("connection failed: %w", x509.UnknownAuthorityError{}),
+			expected: true,
+		},
+		{
+			name:     "generic error",
+			err:      errors.New("connection refused"),
+			expected: false,
+		},
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isTLSError(tt.err)
+			if got != tt.expected {
+				t.Errorf("isTLSError() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCountingReader(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		readChunkSize int
+		expectedBytes int64
+	}{
+		{
+			name:          "empty body",
+			input:         "",
+			readChunkSize: 10,
+			expectedBytes: 0,
+		},
+		{
+			name:          "small body",
+			input:         "hello",
+			readChunkSize: 10,
+			expectedBytes: 5,
+		},
+		{
+			name:          "body read in chunks",
+			input:         "hello world, this is a test",
+			readChunkSize: 5,
+			expectedBytes: 27,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := &countingReader{
+				ReadCloser: io.NopCloser(strings.NewReader(tt.input)),
+			}
+
+			buf := make([]byte, tt.readChunkSize)
+			for {
+				_, err := reader.Read(buf)
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+
+			if reader.bytesRead != tt.expectedBytes {
+				t.Errorf("bytesRead = %d, want %d", reader.bytesRead, tt.expectedBytes)
+			}
+		})
+	}
+}
+
+func TestResponseWriterDelegator(t *testing.T) {
+	tests := []struct {
+		name          string
+		writes        []string
+		expectedBytes int64
+	}{
+		{
+			name:          "no writes",
+			writes:        nil,
+			expectedBytes: 0,
+		},
+		{
+			name:          "single write",
+			writes:        []string{"hello"},
+			expectedBytes: 5,
+		},
+		{
+			name:          "multiple writes",
+			writes:        []string{"hello", " ", "world"},
+			expectedBytes: 11,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			delegator := &responseWriterDelegator{ResponseWriter: recorder}
+
+			for _, s := range tt.writes {
+				_, err := delegator.Write([]byte(s))
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+
+			if delegator.bytesWritten != tt.expectedBytes {
+				t.Errorf("bytesWritten = %d, want %d", delegator.bytesWritten, tt.expectedBytes)
+			}
+
+			// Verify the underlying writer received the data
+			if recorder.Body.String() != strings.Join(tt.writes, "") {
+				t.Errorf("body = %q, want %q", recorder.Body.String(), strings.Join(tt.writes, ""))
+			}
+		})
+	}
+}
+
+func TestResponseWriterDelegator_Unwrap(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	delegator := &responseWriterDelegator{ResponseWriter: recorder}
+
+	if delegator.Unwrap() != recorder {
+		t.Error("Unwrap() should return the underlying ResponseWriter")
+	}
+}
+
+func TestWithBodyTracking(t *testing.T) {
+	tests := []struct {
+		name         string
+		requestBody  string
+		responseBody string
+	}{
+		{
+			name:         "empty bodies",
+			requestBody:  "",
+			responseBody: "",
+		},
+		{
+			name:         "request body only",
+			requestBody:  "request data",
+			responseBody: "",
+		},
+		{
+			name:         "response body only",
+			requestBody:  "",
+			responseBody: "response data",
+		},
+		{
+			name:         "both bodies",
+			requestBody:  "request data",
+			responseBody: "response data",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a handler that reads the request body and writes a response
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Read the entire request body
+				_, _ = io.ReadAll(r.Body)
+				// Write the response
+				if tt.responseBody != "" {
+					_, _ = w.Write([]byte(tt.responseBody))
+				}
+			})
+
+			// Wrap with body tracking
+			wrapped := WithBodyTracking(handler)
+
+			// Create request
+			req := httptest.NewRequest(http.MethodPost, "/test", bytes.NewReader([]byte(tt.requestBody)))
+			recorder := httptest.NewRecorder()
+
+			// Execute
+			wrapped.ServeHTTP(recorder, req)
+
+			// Note: We can't directly verify the metrics were incremented without
+			// exposing the counters or using the prometheus testutil package.
+			// The structural tests above verify the counting logic works.
+			// Here we just verify the handler executed correctly.
+			if recorder.Body.String() != tt.responseBody {
+				t.Errorf("response body = %q, want %q", recorder.Body.String(), tt.responseBody)
+			}
+		})
+	}
+}
+
+func TestNewProxyErrorHandler(t *testing.T) {
+	tests := []struct {
+		name           string
+		err            error
+		expectedStatus int
+	}{
+		{
+			name:           "tls error",
+			err:            x509.UnknownAuthorityError{},
+			expectedStatus: http.StatusBadGateway,
+		},
+		{
+			name:           "non-tls error",
+			err:            errors.New("connection refused"),
+			expectedStatus: http.StatusBadGateway,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := NewProxyErrorHandler()
+			recorder := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
+
+			handler(recorder, req, tt.err)
+
+			if recorder.Code != tt.expectedStatus {
+				t.Errorf("status = %d, want %d", recorder.Code, tt.expectedStatus)
+			}
+		})
+	}
+}

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -140,6 +140,7 @@ func NewServer(ctx context.Context, c CompletedConfig) (*Server, error) {
 	handler = kcpfilters.WithInClusterServiceAccountRequestRewrite(handler)
 	handler = genericapifilters.WithRequestInfo(handler, requestInfoFactory)
 	handler = genericfilters.WithHTTPLogging(handler)
+	handler = metrics.WithBodyTracking(handler)
 	handler = metrics.WithLatencyTracking(handler)
 	handler = genericfilters.WithPanicRecovery(handler, requestInfoFactory)
 	handler = genericfilters.WithCORS(handler, c.Options.CorsAllowedOriginList, nil, nil, nil, "true")


### PR DESCRIPTION
## Summary
This PR adds 3 new metrics to the front-proxy:

* `kcp_backend_rq_body_bytes{shard=...}` – number of request body bytes sent from the front-proxy to the backend shards.
* `kcp_backend_rs_body_bytes{shard=...}` – number of request body bytes received from a backend.
* `kcp_listener_tls_connection_error{shard=...}` – count of TLS-related errors

## What Type of PR Is This?
/kind feature

## Related Issue(s)
Fixes #4042

## Release Notes
```release-note
Add `kcp_backend_rq_body_bytes`, `kcp_backend_rs_body_bytes`, `kcp_listener_tls_connection_error` metrics to front-proxy.
```
