### PR TITLE
remove misleading note about Go in getting started guide

### DIFF
--- a/docs/content/contributing/getting-started.md
+++ b/docs/content/contributing/getting-started.md
@@ -5,14 +5,7 @@
 1. Clone the [kcp-dev/kcp](https://github.com/kcp-dev/kcp) repository.
 2. [Install Go](https://golang.org/doc/install) (at least 1.26).
 3. Install [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl).
-
-Please note that the go language version numbers in these files must exactly agree: go/go.mod file, kcp/Dockerfile, and in all the kcp/.github/workflows yaml files that specify go-version. In kcp/Dockerfile it is indicated by the "golang" attribute. In go.mod it is indicated by the "go" directive." In the .github/workflows yaml files it is indicated by "go-version".
-
-If you wish to use a newer Go version (with the risk that your changes might not successfully pass CI when submitted as pull request), you can set an environment variable to ignore the Go version requirement.
-
-```sh
-export IGNORE_GO_VERSION=1
-```
+4. Install [jq](https://jqlang.org/).
 
 ## Developer Certificate of Origin (DCO)
 
@@ -52,7 +45,6 @@ export KUBECONFIG=.kcp/admin.kubeconfig
 ```sh
 kubectl api-resources
 ```
-
 
 ## Finding Areas to Contribute
 


### PR DESCRIPTION
## Summary
`IGNORE_GO_VERSION` has been removed in #3515, so no need to set it anymore. And when people set up their machines to work on kcp, we do not need to inform them about the exact rules on how to _update_ Go in kcp. These rules are also already covered by our verify-go-version script, so anyone accidentally doing the wrong thing would be caught anway.

## What Type of PR Is This?
/kind cleanup
/kind documentation

## Release Notes
```release-note
NONE
```
