### PR TITLE
Enable SA auth in tilt & customizations

### DIFF
--- a/contrib/tilt/Tiltfile.static
+++ b/contrib/tilt/Tiltfile.static
@@ -63,6 +63,16 @@ k8s_yaml(kustomize('./kcp-operator'))
 kcp_image_tag = os.getenv('KCP_IMAGE_TAG', '')
 kcp_image_repo = os.getenv('KCP_IMAGE_REPO', '')
 
+# Optional static-token auth. When KCP_TOKEN_AUTH_SECRET is set (e.g. by a parent
+# Tiltfile that includes this one), wire spec.auth.tokenAuthFile into the root
+# shard, every shard and the front-proxy so the operator mounts the token CSV and
+# adds --token-auth-file. The Secret itself is the parent's responsibility — its
+# CSV contents / identity mapping are application-specific — we only inject the
+# reference. KCP_TOKEN_AUTH_KEY overrides the in-secret key (operator default:
+# token.csv). Unset → no token auth, operator defaults unchanged.
+kcp_token_auth_secret = os.getenv('KCP_TOKEN_AUTH_SECRET', '')
+kcp_token_auth_key = os.getenv('KCP_TOKEN_AUTH_KEY', '')
+
 def _apply_image_override(img):
     if kcp_image_repo:
         img['repository'] = kcp_image_repo
@@ -70,15 +80,28 @@ def _apply_image_override(img):
         img['tag'] = kcp_image_tag
     return img
 
+def _apply_token_auth(spec):
+    if not kcp_token_auth_secret:
+        return
+    taf = {'secretName': kcp_token_auth_secret}
+    if kcp_token_auth_key:
+        taf['key'] = kcp_token_auth_key
+    auth = spec.get('auth', {})
+    auth['tokenAuthFile'] = taf
+    spec['auth'] = auth
+
 def _kcp_static_yaml(path):
-    if not kcp_image_tag and not kcp_image_repo:
+    if not kcp_image_tag and not kcp_image_repo and not kcp_token_auth_secret:
         return path  # unchanged: operator defaults
+    image_override = bool(kcp_image_tag or kcp_image_repo)
     docs = read_yaml_stream(path)
     for d in docs:
         kind = d.get('kind', '')
         if kind in ('RootShard', 'Shard', 'FrontProxy'):
-            d['spec']['image'] = _apply_image_override(d['spec'].get('image', {}))
-        if kind == 'RootShard':
+            if image_override:
+                d['spec']['image'] = _apply_image_override(d['spec'].get('image', {}))
+            _apply_token_auth(d['spec'])
+        if kind == 'RootShard' and image_override:
             proxy = d['spec'].get('proxy', {})
             proxy['image'] = _apply_image_override(proxy.get('image', {}))
             d['spec']['proxy'] = proxy

--- a/contrib/tilt/front-proxy.static.yaml
+++ b/contrib/tilt/front-proxy.static.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   # no image override: the kcp-operator defaults to its version-matched
   # upstream kcp image (static install, no locally built images).
+  auth:
+    serviceAccount:
+      enabled: true
   rootShard:
     ref:
       name: root

--- a/contrib/tilt/shard-root.static.yaml
+++ b/contrib/tilt/shard-root.static.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   # no image override: the kcp-operator defaults to its version-matched
   # upstream kcp image (static install, no locally built images).
+  auth:
+    serviceAccount:
+      enabled: true
   extraArgs:
     # Enable alpha feature gates required by downstream consumers (kedge,
     # kro-multicluster). Operator appends these to the shard's container

--- a/contrib/tilt/shard-theseus.static.yaml
+++ b/contrib/tilt/shard-theseus.static.yaml
@@ -6,6 +6,9 @@ spec:
   rootShard:
     ref:
       name: root
+  auth:
+    serviceAccount:
+      enabled: true
   # no image override: the kcp-operator defaults to its version-matched
   # upstream kcp image (static install, no locally built images).
   extraArgs:


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Enable SA auth by default.
Allow includers to of tilt to override auth and image

## What Type of PR Is This?
/kind cleanup
<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
