### PR TITLE
Add cross-workspace admission validation example

### DIFF
--- a/config/examples/admission-webhook/README.md
+++ b/config/examples/admission-webhook/README.md
@@ -1,0 +1,110 @@
+# Validating objects across an APIExport/APIBinding
+
+This example shows how an **API provider** enforces validation on a custom
+resource (`Cowboy`) for **every consumer workspace** that binds the API — by
+registering the validation **once**, in the workspace that owns the `APIExport`.
+
+See also: [docs/content/concepts/apis/admission-webhooks.md](../../../docs/content/concepts/apis/admission-webhooks.md).
+
+## The key idea
+
+kcp makes admission **cluster-aware**. When a `Cowboy` is created in a consumer
+workspace, kcp's admission plugin notices the resource schema comes from an
+`APIBinding`, resolves the owning `APIExport`, and dispatches admission to the
+`ValidatingWebhookConfiguration` / `ValidatingAdmissionPolicy` that live **in the
+provider workspace** — not the consumer's. The reviewed object is annotated with
+`kcp.io/cluster: <consumer>` so the webhook knows which workspace it lives in.
+
+So you do **not** install a webhook in each consumer. You install it once where
+the `APIExport` lives, and it covers all bindings.
+
+```
+root:provider                                root:consumer
+┌──────────────────────────────┐            ┌─────────────────────────┐
+│ APIResourceSchema (cowboys)  │            │ APIBinding ─────────────┼─┐
+│ APIExport (today-cowboys) ◄──┼────────────┼─────────────────────────┘ │
+│ ValidatingWebhookConfig      │            │ Cowboy (intent: bad) ─────┼─┐
+│  (or ValidatingAdmissionPol.)│            └───────────────────────────┘ │
+└──────────────────────────────┘                                          │
+            ▲  admission of the consumer's Cowboy is dispatched here ─────┘
+```
+
+## Files
+
+| File | Workspace | What |
+|------|-----------|------|
+| `apiresourceschema.yaml` | `root:provider` | Schema of the `Cowboy` API |
+| `apiexport.yaml`         | `root:provider` | Exports the API |
+| `apibinding.yaml`        | `root:consumer` | Binds the export |
+| `validatingwebhookconfiguration.yaml` | `root:provider` | Webhook (external server); `url`/`caBundle` templated by `run.sh` |
+| `validatingadmissionpolicy.yaml`      | `root:provider` | Server-less CEL alternative |
+| `webhook/main.go`                     | host | Stdlib-only server: rejects `spec.intent == "bad"` |
+| `cowboy-good.yaml` / `cowboy-bad.yaml`| `root:consumer` | Admitted / rejected |
+| `run.sh` | — | One-shot driver for both modes |
+
+## Quick start
+
+Requires a running kcp reachable via `$KUBECONFIG` (defaults to the repo root
+`admin.kubeconfig`) and the `kubectl ws` plugin (`make install` or `bin/kubectl-ws`).
+
+```bash
+# webhook mode (external server). kcp must be able to reach this host; the script
+# uses host.docker.internal, which works for the Tilt/kind setup on Docker Desktop.
+./config/examples/admission-webhook/run.sh
+
+# server-less alternative (ValidatingAdmissionPolicy, no certs, no server):
+./config/examples/admission-webhook/run.sh policy
+
+# tear down the demo workspaces:
+./config/examples/admission-webhook/run.sh clean
+```
+
+Expected tail of a successful run:
+
+```
+== TEST 1: create a GOOD cowboy (expect ADMITTED)
+✓ good cowboy admitted
+== TEST 2: create a BAD cowboy (expect REJECTED)
+✓ bad cowboy rejected as expected:
+    Error from server: admission webhook "validate.cowboys.wildwest.dev" denied
+    the request: cowboy "bad-bart" rejected: spec.intent must not be "bad"
+    (workspace <consumer-cluster>)
+```
+
+The provider webhook server's log shows the reviewed object's
+`kcp.io/cluster` annotation = the consumer workspace, proving the
+cross-workspace dispatch.
+
+## Manual walkthrough (webhook mode)
+
+```bash
+export KUBECONFIG=$PWD/admin.kubeconfig   # from repo root
+
+# 1. Provider: schema + export
+kubectl ws :root
+kubectl ws create provider --ignore-existing --enter
+kubectl apply -f config/examples/admission-webhook/apiresourceschema.yaml
+kubectl apply -f config/examples/admission-webhook/apiexport.yaml
+
+# 2. Provider: run the webhook server + register it (see run.sh for cert/caBundle wiring)
+#    url: https://host.docker.internal:9443/validate
+
+# 3. Consumer: bind the export
+kubectl ws :root
+kubectl ws create consumer --ignore-existing --enter
+kubectl apply -f config/examples/admission-webhook/apibinding.yaml
+
+# 4. Test from the consumer workspace
+kubectl apply -f config/examples/admission-webhook/cowboy-good.yaml   # admitted
+kubectl apply -f config/examples/admission-webhook/cowboy-bad.yaml    # denied
+```
+
+## Notes
+
+- The webhook server (`webhook/main.go`) uses only the standard library, so it
+  has no dependencies to download. Run it with `go run .` from that directory.
+- `failurePolicy: Fail` means a Cowboy create is rejected if the webhook server is
+  unreachable — start the server before creating objects (run.sh does this).
+- For the external-webhook path kcp must be able to dial the server. In the
+  Tilt/kind setup, `host.docker.internal` resolves from inside the kind node to
+  the host. For other topologies, set a routable `url` and matching cert SAN.

--- a/config/examples/admission-webhook/apibinding.yaml
+++ b/config/examples/admission-webhook/apibinding.yaml
@@ -1,0 +1,11 @@
+# Applied in the CONSUMER workspace.
+# Binds the provider's APIExport so `cowboys` becomes available here.
+apiVersion: apis.kcp.io/v1alpha2
+kind: APIBinding
+metadata:
+  name: cowboys
+spec:
+  reference:
+    export:
+      path: root:provider   # workspace that holds the APIExport
+      name: today-cowboys

--- a/config/examples/admission-webhook/apiexport.yaml
+++ b/config/examples/admission-webhook/apiexport.yaml
@@ -1,0 +1,12 @@
+# Applied in the PROVIDER workspace.
+apiVersion: apis.kcp.io/v1alpha2
+kind: APIExport
+metadata:
+  name: today-cowboys
+spec:
+  resources:
+  - name: cowboys
+    group: wildwest.dev
+    schema: today.cowboys.wildwest.dev
+    storage:
+      crd: {}

--- a/config/examples/admission-webhook/apiresourceschema.yaml
+++ b/config/examples/admission-webhook/apiresourceschema.yaml
@@ -1,0 +1,40 @@
+# Applied in the PROVIDER workspace.
+# Schema of the API we export. APIResourceSchemas are immutable; the name MUST be
+# "<any-prefix>.<plural>.<group>".
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIResourceSchema
+metadata:
+  name: today.cowboys.wildwest.dev
+spec:
+  group: wildwest.dev
+  names:
+    kind: Cowboy
+    listKind: CowboyList
+    plural: cowboys
+    singular: cowboy
+    shortNames:
+    - cb
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      description: Cowboy is part of the wild west
+      type: object
+      properties:
+        spec:
+          description: CowboySpec holds the desired state of the Cowboy.
+          type: object
+          properties:
+            intent:
+              description: The intent of the cowboy (e.g. good, bad, ugly)
+              type: string
+        status:
+          description: CowboyStatus communicates the observed state of the Cowboy.
+          type: object
+          properties:
+            result:
+              type: string

--- a/config/examples/admission-webhook/cowboy-bad.yaml
+++ b/config/examples/admission-webhook/cowboy-bad.yaml
@@ -1,0 +1,9 @@
+# Applied in the CONSUMER workspace. Should be REJECTED by the webhook/policy that
+# lives in the PROVIDER workspace.
+apiVersion: wildwest.dev/v1alpha1
+kind: Cowboy
+metadata:
+  name: bad-bart
+  namespace: default
+spec:
+  intent: bad

--- a/config/examples/admission-webhook/cowboy-good.yaml
+++ b/config/examples/admission-webhook/cowboy-good.yaml
@@ -1,0 +1,8 @@
+# Applied in the CONSUMER workspace. Should be ADMITTED.
+apiVersion: wildwest.dev/v1alpha1
+kind: Cowboy
+metadata:
+  name: lucky-luke
+  namespace: default
+spec:
+  intent: good

--- a/config/examples/admission-webhook/run.sh
+++ b/config/examples/admission-webhook/run.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The kcp Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# End-to-end demo: validate objects across an APIExport/APIBinding using either a
+# cross-workspace admission webhook (default) or a ValidatingAdmissionPolicy.
+#
+# Prereqs:
+#   - a running kcp reachable via $KUBECONFIG (defaults to ./admin.kubeconfig in the repo root)
+#   - the `kubectl ws` plugin on PATH (bin/kubectl-ws or `make install`)
+#   - for webhook mode: kcp must be able to reach this host (this script uses
+#     host.docker.internal, which works for the Tilt/kind setup on Docker Desktop)
+#
+# Usage:
+#   ./run.sh            # webhook mode (external server)
+#   ./run.sh policy     # ValidatingAdmissionPolicy mode (no server, no certs)
+#   ./run.sh clean      # delete the provider/consumer workspaces created by the demo
+set -euo pipefail
+
+MODE="${1:-webhook}"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$DIR/../../.." && pwd)"
+export KUBECONFIG="${KUBECONFIG:-$REPO_ROOT/admin.kubeconfig}"
+
+# Resolve the ws plugin (prefer the repo's bin).
+WS="kubectl-ws"
+[ -x "$REPO_ROOT/bin/kubectl-ws" ] && WS="$REPO_ROOT/bin/kubectl-ws"
+
+WEBHOOK_PORT=9443
+WEBHOOK_HOST=host.docker.internal
+CERTDIR="$DIR/.certs"
+SERVER_PID=""
+
+log()  { printf '\n\033[1;34m== %s\033[0m\n' "$*"; }
+ok()   { printf '\033[1;32m✓ %s\033[0m\n' "$*"; }
+fail() { printf '\033[1;31m✗ %s\033[0m\n' "$*"; }
+
+cleanup() {
+  [ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+if [ "$MODE" = "clean" ]; then
+  log "Deleting demo workspaces"
+  "$WS" :root >/dev/null
+  kubectl delete workspace provider consumer --ignore-not-found
+  ok "cleaned up"
+  exit 0
+fi
+
+#############################################
+# PROVIDER workspace: schema + export
+#############################################
+log "Creating PROVIDER workspace root:provider"
+"$WS" :root >/dev/null
+"$WS" create provider --ignore-existing --enter >/dev/null
+kubectl apply -f "$DIR/apiresourceschema.yaml"
+kubectl apply -f "$DIR/apiexport.yaml"
+ok "APIResourceSchema + APIExport created in root:provider"
+
+if [ "$MODE" = "webhook" ]; then
+  #############################################
+  # PROVIDER: serving cert + webhook server
+  #############################################
+  log "Generating self-signed serving cert (SAN=$WEBHOOK_HOST)"
+  mkdir -p "$CERTDIR"
+  openssl req -x509 -newkey rsa:2048 -nodes \
+    -keyout "$CERTDIR/tls.key" -out "$CERTDIR/tls.crt" -days 365 \
+    -subj "/CN=$WEBHOOK_HOST" \
+    -addext "subjectAltName=DNS:$WEBHOOK_HOST,DNS:localhost,IP:127.0.0.1" >/dev/null 2>&1
+  ok "cert written to $CERTDIR"
+
+  log "Starting webhook server on :$WEBHOOK_PORT"
+  ( cd "$DIR/webhook" && exec go run . \
+      --tls-cert "$CERTDIR/tls.crt" --tls-key "$CERTDIR/tls.key" \
+      --addr ":$WEBHOOK_PORT" ) &
+  SERVER_PID=$!
+
+  # Wait for the server to come up.
+  for _ in $(seq 1 30); do
+    if curl -sk "https://127.0.0.1:$WEBHOOK_PORT/healthz" >/dev/null 2>&1; then break; fi
+    sleep 1
+  done
+  curl -sk "https://127.0.0.1:$WEBHOOK_PORT/healthz" >/dev/null && ok "webhook server is up"
+
+  log "Registering ValidatingWebhookConfiguration in root:provider"
+  CA_BUNDLE="$(base64 < "$CERTDIR/tls.crt" | tr -d '\n')"
+  WEBHOOK_URL="https://$WEBHOOK_HOST:$WEBHOOK_PORT/validate"
+  sed -e "s|CA_BUNDLE|$CA_BUNDLE|" -e "s|WEBHOOK_URL|$WEBHOOK_URL|" \
+    "$DIR/validatingwebhookconfiguration.yaml" | kubectl apply -f -
+  ok "webhook registered"
+else
+  #############################################
+  # PROVIDER: ValidatingAdmissionPolicy (no server)
+  #############################################
+  log "Applying ValidatingAdmissionPolicy in root:provider"
+  kubectl apply -f "$DIR/validatingadmissionpolicy.yaml"
+  ok "policy applied"
+fi
+
+#############################################
+# CONSUMER workspace: bind + test
+#############################################
+log "Creating CONSUMER workspace root:consumer and binding the export"
+"$WS" :root >/dev/null
+"$WS" create consumer --ignore-existing --enter >/dev/null
+kubectl apply -f "$DIR/apibinding.yaml"
+
+log "Waiting for the cowboys API to be served in root:consumer"
+for _ in $(seq 1 60); do
+  if kubectl get cowboys -A >/dev/null 2>&1; then break; fi
+  sleep 1
+done
+kubectl get cowboys -A >/dev/null 2>&1 && ok "cowboys API is served"
+
+log "TEST 1: create a GOOD cowboy (expect ADMITTED)"
+if kubectl apply -f "$DIR/cowboy-good.yaml"; then
+  ok "good cowboy admitted"
+else
+  fail "good cowboy was unexpectedly rejected"; exit 1
+fi
+
+log "TEST 2: create a BAD cowboy (expect REJECTED)"
+if kubectl apply -f "$DIR/cowboy-bad.yaml" 2>/tmp/cowboy-bad.err; then
+  fail "bad cowboy was admitted -- validation did NOT work"; exit 1
+else
+  ok "bad cowboy rejected as expected:"
+  sed 's/^/    /' /tmp/cowboy-bad.err
+fi
+
+log "DONE"
+echo "Provider webhook/policy validated objects created in the consumer workspace."
+echo "Inspect with:   KUBECONFIG=$KUBECONFIG $WS :root:consumer && kubectl get cowboys"
+echo "Tear down with: $DIR/run.sh clean"

--- a/config/examples/admission-webhook/validatingadmissionpolicy.yaml
+++ b/config/examples/admission-webhook/validatingadmissionpolicy.yaml
@@ -1,0 +1,30 @@
+# Applied in the PROVIDER workspace.
+#
+# Server-less alternative to the webhook: a ValidatingAdmissionPolicy runs CEL
+# inside kcp -- no external server, no certs. kcp makes VAPs cluster-aware the
+# same way as webhooks: define them in the provider workspace and they apply to
+# every consumer that binds the export.
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: cowboy-intent-policy
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["wildwest.dev"]
+      apiVersions: ["v1alpha1"]
+      operations: ["CREATE", "UPDATE"]
+      resources: ["cowboys"]
+  validations:
+  - expression: '!has(object.spec.intent) || object.spec.intent != "bad"'
+    message: 'spec.intent must not be "bad"'
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: cowboy-intent-policy-binding
+spec:
+  policyName: cowboy-intent-policy
+  validationActions: ["Deny"]

--- a/config/examples/admission-webhook/validatingwebhookconfiguration.yaml
+++ b/config/examples/admission-webhook/validatingwebhookconfiguration.yaml
@@ -1,0 +1,27 @@
+# Applied in the PROVIDER workspace -- the APIExport OWNER workspace.
+#
+# This is the key kcp behaviour: register the webhook ONCE, in the workspace that
+# owns the API (the APIExport). kcp's cluster-aware admission plugin dispatches
+# admission of `cowboys` from EVERY consumer workspace that binds the export to
+# this single configuration. The reviewed object carries a `kcp.io/cluster`
+# annotation telling the webhook which consumer workspace it lives in.
+#
+# run.sh substitutes WEBHOOK_URL and CA_BUNDLE before applying.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: cowboy-intent-validator
+webhooks:
+- name: validate.cowboys.wildwest.dev
+  admissionReviewVersions: ["v1"]
+  sideEffects: None
+  failurePolicy: Fail
+  rules:
+  - apiGroups: ["wildwest.dev"]
+    apiVersions: ["v1alpha1"]
+    operations: ["CREATE", "UPDATE"]
+    resources: ["cowboys"]
+    scope: "*"
+  clientConfig:
+    url: "WEBHOOK_URL"
+    caBundle: "CA_BUNDLE"

--- a/config/examples/admission-webhook/webhook/main.go
+++ b/config/examples/admission-webhook/webhook/main.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2025 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// A minimal validating admission webhook server for the cowboys API.
+//
+// Rule enforced: a Cowboy's spec.intent must NOT be "bad".
+//
+// Stdlib only -- it decodes the AdmissionReview as generic JSON so there are no
+// Kubernetes dependencies to download.
+//
+//	go run . --tls-cert=tls.crt --tls-key=tls.key --addr=:9443
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"io"
+	"log"
+	"net/http"
+	"time"
+)
+
+func main() {
+	var certFile, keyFile, addr string
+	flag.StringVar(&certFile, "tls-cert", "tls.crt", "path to TLS serving cert")
+	flag.StringVar(&keyFile, "tls-key", "tls.key", "path to TLS serving key")
+	flag.StringVar(&addr, "addr", ":9443", "listen address")
+	flag.Parse()
+
+	http.HandleFunc("/validate", validate)
+	http.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+
+	srv := &http.Server{
+		Addr:              addr,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+	}
+
+	log.Printf("cowboy validating webhook listening on %s", addr)
+	log.Fatal(srv.ListenAndServeTLS(certFile, keyFile))
+}
+
+func validate(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	var review map[string]any
+	if err := json.Unmarshal(body, &review); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	req, _ := review["request"].(map[string]any)
+	uid, _ := req["uid"].(string)
+	obj, _ := req["object"].(map[string]any)
+	meta, _ := obj["metadata"].(map[string]any)
+	spec, _ := obj["spec"].(map[string]any)
+
+	name, _ := meta["name"].(string)
+	intent, _ := spec["intent"].(string)
+
+	// kcp stamps the object with the consumer workspace it actually lives in.
+	cluster := ""
+	if ann, ok := meta["annotations"].(map[string]any); ok {
+		cluster, _ = ann["kcp.io/cluster"].(string)
+	}
+	log.Printf("reviewing cowboy %q from workspace cluster %q intent=%q", name, cluster, intent)
+
+	resp := map[string]any{"uid": uid, "allowed": true}
+	if intent == "bad" {
+		resp["allowed"] = false
+		resp["status"] = map[string]any{
+			"code":    403,
+			"message": "cowboy \"" + name + "\" rejected: spec.intent must not be \"bad\" (workspace " + cluster + ")",
+		}
+	}
+
+	out := map[string]any{
+		"apiVersion": "admission.k8s.io/v1",
+		"kind":       "AdmissionReview",
+		"response":   resp,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(out); err != nil {
+		log.Printf("error writing response: %v", err)
+	}
+}


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Demonstrate validating objects across an APIExport/APIBinding using a cluster-aware ValidatingWebhookConfiguration (external server) and a server-less ValidatingAdmissionPolicy alternative. Includes a stdlib-only webhook server and a one-shot run.sh driver.

## What Type of PR Is This?
/kind feature

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
