### PR TITLE
Fix MAP & add MAP e2e tests

### DIFF
--- a/pkg/admission/mutatingadmissionpolicy/mutating_admission_policy.go
+++ b/pkg/admission/mutatingadmissionpolicy/mutating_admission_policy.go
@@ -245,7 +245,7 @@ func (k *KubeMutatingAdmissionPolicy) getOrCreateDelegate(policyClusterName, tar
 	}
 
 	plugin.SetNamespaceInformer(k.localKubeSharedInformerFactory.Core().V1().Namespaces().Cluster(targetClusterName))
-	plugin.SetExternalKubeClientSet(k.kubeClusterClient.Cluster(policyClusterName.Path()))
+	plugin.SetExternalKubeClientSet(k.kubeClusterClient.Cluster(targetClusterName.Path()))
 
 	discoveryClient := memory.NewMemCacheClient(k.kubeClusterClient.Cluster(policyClusterName.Path()).Discovery())
 	restMapper := restmapper.NewDeferredDiscoveryRESTMapper(discoveryClient)

--- a/pkg/admission/mutatingadmissionpolicy/mutating_admission_policy.go
+++ b/pkg/admission/mutatingadmissionpolicy/mutating_admission_policy.go
@@ -18,6 +18,7 @@ package mutatingadmissionpolicy
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"sync"
 
@@ -262,7 +263,7 @@ func (k *KubeMutatingAdmissionPolicy) getOrCreateDelegate(policyClusterName, tar
 			mutating.NewMutatingAdmissionPolicyAccessor,
 			mutating.NewMutatingAdmissionPolicyBindingAccessor,
 			mutating.CompilePolicy,
-			nil,
+			&deferredInformerFactory{},
 			dynamicClient,
 			restMapper,
 			cn,
@@ -304,4 +305,13 @@ func (k *KubeMutatingAdmissionPolicy) logicalClusterDeleted(clusterName logicalc
 type stoppableMutatingAdmissionPolicy struct {
 	*mutating.Plugin
 	stop func()
+}
+
+// deferredInformerFactory is exactly the same as in the validating admission policy.
+type deferredInformerFactory struct {
+	informers.SharedInformerFactory
+}
+
+func (d *deferredInformerFactory) ForResource(resource schema.GroupVersionResource) (informers.GenericInformer, error) {
+	return nil, fmt.Errorf("deferring creation to dynamic informer. This is expected")
 }

--- a/pkg/admission/mutatingadmissionpolicy/mutating_admission_policy.go
+++ b/pkg/admission/mutatingadmissionpolicy/mutating_admission_policy.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/klog/v2"
 
 	kcpdynamic "github.com/kcp-dev/client-go/dynamic"
@@ -88,6 +89,8 @@ type KubeMutatingAdmissionPolicy struct {
 
 	getAPIBindings func(clusterName logicalcluster.Name) ([]*apisv1alpha2.APIBinding, error)
 
+	featureGates featuregate.FeatureGate
+
 	delegatesLock sync.RWMutex
 	delegates     map[delegateKey]*stoppableMutatingAdmissionPolicy
 
@@ -101,6 +104,7 @@ var _ = initializers.WantsKcpInformers(&KubeMutatingAdmissionPolicy{})
 var _ = initializers.WantsServerShutdownChannel(&KubeMutatingAdmissionPolicy{})
 var _ = initializers.WantsDynamicClusterClient(&KubeMutatingAdmissionPolicy{})
 var _ = initializer.WantsAuthorizer(&KubeMutatingAdmissionPolicy{})
+var _ = initializer.WantsFeatures(&KubeMutatingAdmissionPolicy{})
 var _ = admission.InitializationValidator(&KubeMutatingAdmissionPolicy{})
 
 func (k *KubeMutatingAdmissionPolicy) SetKubeClusterClient(kubeClusterClient kcpkubernetesclientset.ClusterInterface) {
@@ -153,6 +157,10 @@ func (k *KubeMutatingAdmissionPolicy) SetDynamicClusterClient(c kcpdynamic.Clust
 
 func (k *KubeMutatingAdmissionPolicy) SetAuthorizer(authz authorizer.Authorizer) {
 	k.authorizer = authz
+}
+
+func (k *KubeMutatingAdmissionPolicy) InspectFeatureGates(featureGates featuregate.FeatureGate) {
+	k.featureGates = featureGates
 }
 
 func (k *KubeMutatingAdmissionPolicy) ValidateInitialization() error {
@@ -238,6 +246,12 @@ func (k *KubeMutatingAdmissionPolicy) getOrCreateDelegate(policyClusterName, tar
 	plugin, err := mutating.NewPlugin(nil)
 	if err != nil {
 		return nil, err
+	}
+
+	// Default to enable MAP, but honour the feature gate if available.
+	plugin.SetEnabled(true)
+	if k.featureGates != nil {
+		plugin.InspectFeatureGates(k.featureGates)
 	}
 
 	delegate = &stoppableMutatingAdmissionPolicy{

--- a/test/e2e/conformance/mutatingadmissionpolicy_test.go
+++ b/test/e2e/conformance/mutatingadmissionpolicy_test.go
@@ -1,0 +1,786 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conformance
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	v1 "k8s.io/api/admission/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/ptr"
+
+	kcpapiextensionsclientset "github.com/kcp-dev/client-go/apiextensions/client"
+	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
+	"github.com/kcp-dev/logicalcluster/v3"
+	apisv1alpha1 "github.com/kcp-dev/sdk/apis/apis/v1alpha1"
+	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
+	"github.com/kcp-dev/sdk/apis/core"
+	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
+	kcptesting "github.com/kcp-dev/sdk/testing"
+	kcptestinghelpers "github.com/kcp-dev/sdk/testing/helpers"
+
+	"github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest"
+	wildwestv1alpha1 "github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/apis/wildwest/v1alpha1"
+	wildwestclientset "github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/client/clientset/versioned/cluster"
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+)
+
+func TestMutatingAdmissionPolicyInWorkspace(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "control-plane")
+
+	server := kcptesting.SharedKcpServer(t)
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	t.Cleanup(cancelFunc)
+
+	cfg := server.BaseConfig(t)
+
+	scheme := runtime.NewScheme()
+	err := admissionregistrationv1.AddToScheme(scheme)
+	require.NoError(t, err, "failed to add admission registration v1 scheme")
+	err = v1.AddToScheme(scheme)
+	require.NoError(t, err, "failed to add admission v1 scheme")
+	err = wildwestv1alpha1.AddToScheme(scheme)
+	require.NoError(t, err, "failed to add cowboy v1alpha1 to scheme")
+
+	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
+	ws1Path, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)
+	ws2Path, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)
+
+	kubeClusterClient, err := kcpkubernetesclientset.NewForConfig(cfg)
+	require.NoError(t, err, "failed to construct client for server")
+	cowbyClusterClient, err := wildwestclientset.NewForConfig(cfg)
+	require.NoError(t, err, "failed to construct cowboy client for server")
+	apiExtensionsClusterClient, err := kcpapiextensionsclientset.NewForConfig(cfg)
+	require.NoError(t, err, "failed to construct apiextensions client for server")
+
+	t.Logf("Install the Cowboy resources into logical clusters")
+	for _, wsPath := range []logicalcluster.Path{ws1Path, ws2Path} {
+		t.Logf("Bootstrapping Workspace CRDs in logical cluster %s", wsPath)
+		crdClient := apiExtensionsClusterClient.ApiextensionsV1().CustomResourceDefinitions()
+		wildwest.Create(t, wsPath, crdClient, metav1.GroupResource{Group: "wildwest.dev", Resource: "cowboys"})
+	}
+
+	kcpClusterClient, err := kcpclientset.NewForConfig(cfg)
+	require.NoError(t, err, "failed to construct kcp cluster client for server")
+	cowboysGVR := schema.GroupVersionResource{Group: "wildwest.dev", Resource: "cowboys", Version: "v1alpha1"}
+	for _, wsPath := range []logicalcluster.Path{ws1Path, ws2Path} {
+		kcptesting.WaitForAPIReady(t, kcpClusterClient.Cluster(wsPath).Discovery(), cowboysGVR.GroupVersion())
+	}
+
+	t.Logf("Installing mutating admission policy into the first workspace (JSONPatch + ApplyConfiguration)")
+	policy := &admissionregistrationv1.MutatingAdmissionPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "policy-",
+		},
+		Spec: admissionregistrationv1.MutatingAdmissionPolicySpec{
+			FailurePolicy:      ptr.To(admissionregistrationv1.Fail),
+			ReinvocationPolicy: admissionregistrationv1.NeverReinvocationPolicy,
+			MatchConstraints: &admissionregistrationv1.MatchResources{
+				ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+					{
+						RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+							Operations: []admissionregistrationv1.OperationType{
+								admissionregistrationv1.Create,
+								admissionregistrationv1.Update,
+							},
+							Rule: admissionregistrationv1.Rule{
+								APIGroups:   []string{wildwestv1alpha1.SchemeGroupVersion.Group},
+								APIVersions: []string{wildwestv1alpha1.SchemeGroupVersion.Version},
+								Resources:   []string{"cowboys"},
+							},
+						},
+					},
+				},
+			},
+			Mutations: []admissionregistrationv1.Mutation{
+				{
+					PatchType: admissionregistrationv1.PatchTypeJSONPatch,
+					JSONPatch: &admissionregistrationv1.JSONPatch{
+						Expression: `object.spec.intent == "bad" ? [JSONPatch{op: "replace", path: "/spec/intent", value: "good"}] : []`,
+					},
+				},
+				{
+					PatchType: admissionregistrationv1.PatchTypeApplyConfiguration,
+					ApplyConfiguration: &admissionregistrationv1.ApplyConfiguration{
+						Expression: `Object{metadata: Object.metadata{labels: {"mutated": "true"}}}`,
+					},
+				},
+			},
+		},
+	}
+	policy, err = kubeClusterClient.Cluster(ws1Path).AdmissionregistrationV1().MutatingAdmissionPolicies().Create(ctx, policy, metav1.CreateOptions{})
+	require.NoError(t, err, "failed to create MutatingAdmissionPolicy")
+
+	t.Logf("Installing mutating admission policy binding into the first workspace")
+	binding := &admissionregistrationv1.MutatingAdmissionPolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "binding-",
+		},
+		Spec: admissionregistrationv1.MutatingAdmissionPolicyBindingSpec{
+			PolicyName: policy.Name,
+		},
+	}
+	_, err = kubeClusterClient.Cluster(ws1Path).AdmissionregistrationV1().MutatingAdmissionPolicyBindings().Create(ctx, binding, metav1.CreateOptions{})
+	require.NoError(t, err, "failed to create MutatingAdmissionPolicyBinding")
+
+	newCowboy := func(intent string) *wildwestv1alpha1.Cowboy {
+		return &wildwestv1alpha1.Cowboy{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "cowboy-",
+			},
+			Spec: wildwestv1alpha1.CowboySpec{
+				Intent: intent,
+			},
+		}
+	}
+
+	t.Logf("Verifying that creating bad cowboy resource in first logical cluster is mutated to good and labelled")
+	var mutated *wildwestv1alpha1.Cowboy
+	require.Eventually(t, func() bool {
+		c, err := cowbyClusterClient.Cluster(ws1Path).WildwestV1alpha1().Cowboys("default").Create(ctx, newCowboy("bad"), metav1.CreateOptions{})
+		if err != nil {
+			t.Logf("Unexpected error when trying to create bad cowboy: %s", err)
+			return false
+		}
+		if c.Spec.Intent != "good" || c.Labels["mutated"] != "true" {
+			t.Logf("Cowboy not yet mutated (intent=%q, label=%q); the binding may not have propagated", c.Spec.Intent, c.Labels["mutated"])
+			return false
+		}
+		mutated = c
+		return true
+	}, wait.ForeverTestTimeout, 1*time.Second)
+	require.Equal(t, "good", mutated.Spec.Intent)
+	require.Equal(t, "true", mutated.Labels["mutated"])
+
+	t.Logf("Verifying that creating good cowboy resource in first logical cluster keeps its intent but is labelled")
+	good, err := cowbyClusterClient.Cluster(ws1Path).WildwestV1alpha1().Cowboys("default").Create(ctx, newCowboy("good"), metav1.CreateOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "good", good.Spec.Intent)
+	require.Equal(t, "true", good.Labels["mutated"])
+
+	t.Logf("Verifying that creating bad cowboy resource in second logical cluster is unaffected (policy should not apply here)")
+	untouched, err := cowbyClusterClient.Cluster(ws2Path).WildwestV1alpha1().Cowboys("default").Create(ctx, newCowboy("bad"), metav1.CreateOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "bad", untouched.Spec.Intent)
+	require.NotEqual(t, "true", untouched.Labels["mutated"])
+}
+
+func TestMutatingAdmissionPolicyCrossWorkspaceAPIBinding(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "control-plane")
+
+	server := kcptesting.SharedKcpServer(t)
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	t.Cleanup(cancelFunc)
+
+	cfg := server.BaseConfig(t)
+
+	scheme := runtime.NewScheme()
+	err := admissionregistrationv1.AddToScheme(scheme)
+	require.NoError(t, err, "failed to add admission registration v1 scheme")
+	err = v1.AddToScheme(scheme)
+	require.NoError(t, err, "failed to add admission v1 scheme")
+	err = wildwestv1alpha1.AddToScheme(scheme)
+	require.NoError(t, err, "failed to add cowboy v1alpha1 to scheme")
+
+	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
+	sourcePath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)
+	targetPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)
+
+	kcpClusterClient, err := kcpclientset.NewForConfig(cfg)
+	require.NoError(t, err, "failed to construct kcp cluster client for server")
+
+	kubeClusterClient, err := kcpkubernetesclientset.NewForConfig(cfg)
+	require.NoError(t, err, "failed to construct client for server")
+
+	cowbyClusterClient, err := wildwestclientset.NewForConfig(cfg)
+	require.NoError(t, err, "failed to construct cowboy client for server")
+
+	t.Logf("Install a cowboys APIResourceSchema into workspace %q", sourcePath)
+	apiResourceSchema := &apisv1alpha1.APIResourceSchema{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "today.cowboys.wildwest.dev",
+		},
+		Spec: apisv1alpha1.APIResourceSchemaSpec{
+			Group: "wildwest.dev",
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Kind:     "Cowboy",
+				ListKind: "CowboyList",
+				Plural:   "cowboys",
+				Singular: "cowboy",
+			},
+			Scope: "Namespaced",
+			Versions: []apisv1alpha1.APIResourceVersion{
+				{
+					Name:    "v1alpha1",
+					Served:  true,
+					Storage: true,
+					Schema: runtime.RawExtension{
+						Raw: []byte(`{
+							"description": "Cowboy is part of the wild west",
+							"properties": {
+								"apiVersion": {"type": "string"},
+								"kind": {"type": "string"},
+								"metadata": {"type": "object"},
+								"spec": {
+									"type": "object",
+									"properties": {
+										"intent": {"type": "string"}
+									}
+								},
+								"status": {
+									"type": "object",
+									"properties": {
+										"result": {"type": "string"}
+									}
+								}
+							},
+							"type": "object"
+						}`),
+					},
+					Subresources: apiextensionsv1.CustomResourceSubresources{
+						Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
+					},
+				},
+			},
+		},
+	}
+	_, err = kcpClusterClient.Cluster(sourcePath).ApisV1alpha1().APIResourceSchemas().Create(ctx, apiResourceSchema, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("Create an APIExport for it")
+	cowboysAPIExport := &apisv1alpha2.APIExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cowboybebop",
+		},
+		Spec: apisv1alpha2.APIExportSpec{
+			Resources: []apisv1alpha2.ResourceSchema{
+				{
+					Name:   "cowboys",
+					Group:  "wildwest.dev",
+					Schema: "today.cowboys.wildwest.dev",
+					Storage: apisv1alpha2.ResourceSchemaStorage{
+						CRD: &apisv1alpha2.ResourceSchemaStorageCRD{},
+					},
+				},
+			},
+		},
+	}
+	_, err = kcpClusterClient.Cluster(sourcePath).ApisV1alpha2().APIExports().Create(ctx, cowboysAPIExport, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("Create an APIBinding in workspace %q that points to the cowboybebop export", targetPath)
+	apiBinding := &apisv1alpha2.APIBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cowboys",
+		},
+		Spec: apisv1alpha2.APIBindingSpec{
+			Reference: apisv1alpha2.BindingReference{
+				Export: &apisv1alpha2.ExportBindingReference{
+					Path: sourcePath.String(),
+					Name: cowboysAPIExport.Name,
+				},
+			},
+		},
+	}
+
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		_, err := kcpClusterClient.Cluster(targetPath).ApisV1alpha2().APIBindings().Create(ctx, apiBinding, metav1.CreateOptions{})
+		return err == nil, fmt.Sprintf("Error creating APIBinding: %v", err)
+	}, wait.ForeverTestTimeout, time.Millisecond*100)
+
+	t.Logf("Ensure cowboys are served in target workspace")
+	require.Eventually(t, func() bool {
+		_, err := cowbyClusterClient.Cluster(targetPath).WildwestV1alpha1().Cowboys("default").List(ctx, metav1.ListOptions{})
+		return err == nil
+	}, wait.ForeverTestTimeout, 100*time.Millisecond)
+
+	t.Logf("Installing mutating admission policy into the source workspace")
+	policy := &admissionregistrationv1.MutatingAdmissionPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "policy-",
+		},
+		Spec: admissionregistrationv1.MutatingAdmissionPolicySpec{
+			FailurePolicy:      ptr.To(admissionregistrationv1.Fail),
+			ReinvocationPolicy: admissionregistrationv1.NeverReinvocationPolicy,
+			MatchConstraints: &admissionregistrationv1.MatchResources{
+				ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+					{
+						RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+							Operations: []admissionregistrationv1.OperationType{
+								admissionregistrationv1.Create,
+								admissionregistrationv1.Update,
+							},
+							Rule: admissionregistrationv1.Rule{
+								APIGroups:   []string{wildwestv1alpha1.SchemeGroupVersion.Group},
+								APIVersions: []string{wildwestv1alpha1.SchemeGroupVersion.Version},
+								Resources:   []string{"cowboys"},
+							},
+						},
+					},
+				},
+			},
+			Mutations: []admissionregistrationv1.Mutation{
+				{
+					PatchType: admissionregistrationv1.PatchTypeJSONPatch,
+					JSONPatch: &admissionregistrationv1.JSONPatch{
+						Expression: `object.spec.intent == "bad" ? [JSONPatch{op: "replace", path: "/spec/intent", value: "good"}] : []`,
+					},
+				},
+			},
+		},
+	}
+	policy, err = kubeClusterClient.Cluster(sourcePath).AdmissionregistrationV1().MutatingAdmissionPolicies().Create(ctx, policy, metav1.CreateOptions{})
+	require.NoError(t, err, "failed to create MutatingAdmissionPolicy")
+
+	newCowboy := func(intent string) *wildwestv1alpha1.Cowboy {
+		return &wildwestv1alpha1.Cowboy{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "cowboy-",
+			},
+			Spec: wildwestv1alpha1.CowboySpec{
+				Intent: intent,
+			},
+		}
+	}
+
+	t.Logf("Verifying that creating bad cowboy in target workspace is unmutated before binding (policy is inactive without binding)")
+	c, err := cowbyClusterClient.Cluster(targetPath).WildwestV1alpha1().Cowboys("default").Create(ctx, newCowboy("bad"), metav1.CreateOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "bad", c.Spec.Intent)
+
+	t.Logf("Installing mutating admission policy binding into the source workspace")
+	binding := &admissionregistrationv1.MutatingAdmissionPolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "binding-",
+		},
+		Spec: admissionregistrationv1.MutatingAdmissionPolicyBindingSpec{
+			PolicyName: policy.Name,
+		},
+	}
+	_, err = kubeClusterClient.Cluster(sourcePath).AdmissionregistrationV1().MutatingAdmissionPolicyBindings().Create(ctx, binding, metav1.CreateOptions{})
+	require.NoError(t, err, "failed to create MutatingAdmissionPolicyBinding")
+
+	t.Logf("Verifying that creating bad cowboy in target workspace is mutated by policy in source workspace")
+	require.Eventually(t, func() bool {
+		c, err := cowbyClusterClient.Cluster(targetPath).WildwestV1alpha1().Cowboys("default").Create(ctx, newCowboy("bad"), metav1.CreateOptions{})
+		if err != nil {
+			t.Logf("Unexpected error when trying to create bad cowboy: %s", err)
+			return false
+		}
+		if c.Spec.Intent != "good" {
+			t.Logf("Cowboy not yet mutated (intent=%q); the binding may not have propagated", c.Spec.Intent)
+			return false
+		}
+		return true
+	}, wait.ForeverTestTimeout, 1*time.Second)
+
+	t.Logf("Verifying that creating good cowboy in target workspace is left unchanged")
+	good, err := cowbyClusterClient.Cluster(targetPath).WildwestV1alpha1().Cowboys("default").Create(ctx, newCowboy("good"), metav1.CreateOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "good", good.Spec.Intent)
+}
+
+// TODO: Currently MutatingAdmissionPolicy with Params only works with single shard, in the same way ValidatingAdmissionPolicy with Params does.
+// see https://github.com/kcp-dev/kcp/issues/4110 for more infos. Once policies with Params
+// are supported in multi-shard setups, merge this test with the regular one above.
+func TestMutatingAdmissionPolicyInWorkspaceWithParams(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "control-plane")
+
+	server := kcptesting.SharedKcpServer(t)
+
+	if len(server.ShardNames()) > 1 {
+		t.Skip("MAP with Params is currently only supported with single shard setups, see code comments")
+	}
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	t.Cleanup(cancelFunc)
+
+	cfg := server.BaseConfig(t)
+
+	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
+	ws1Path, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)
+	ws2Path, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)
+
+	kubeClusterClient, err := kcpkubernetesclientset.NewForConfig(cfg)
+	require.NoError(t, err, "failed to construct client for server")
+	cowbyClusterClient, err := wildwestclientset.NewForConfig(cfg)
+	require.NoError(t, err, "failed to construct cowboy client for server")
+	apiExtensionsClusterClient, err := kcpapiextensionsclientset.NewForConfig(cfg)
+	require.NoError(t, err, "failed to construct apiextensions client for server")
+
+	t.Logf("Install the Cowboy resources into logical clusters")
+	for _, wsPath := range []logicalcluster.Path{ws1Path, ws2Path} {
+		t.Logf("Bootstrapping Workspace CRDs in logical cluster %s", wsPath)
+		crdClient := apiExtensionsClusterClient.ApiextensionsV1().CustomResourceDefinitions()
+		wildwest.Create(t, wsPath, crdClient, metav1.GroupResource{Group: "wildwest.dev", Resource: "cowboys"})
+	}
+
+	kcpClusterClient, err := kcpclientset.NewForConfig(cfg)
+	require.NoError(t, err, "failed to construct kcp cluster client for server")
+	cowboysGVR := schema.GroupVersionResource{Group: "wildwest.dev", Resource: "cowboys", Version: "v1alpha1"}
+	for _, wsPath := range []logicalcluster.Path{ws1Path, ws2Path} {
+		kcptesting.WaitForAPIReady(t, kcpClusterClient.Cluster(wsPath).Discovery(), cowboysGVR.GroupVersion())
+	}
+
+	t.Logf("Creating a ConfigMap to use as policy parameter in the first workspace")
+	paramConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "policy-params",
+			Namespace: "default",
+		},
+		Data: map[string]string{
+			"replacement": "good",
+		},
+	}
+	_, err = kubeClusterClient.Cluster(ws1Path).CoreV1().ConfigMaps("default").Create(ctx, paramConfigMap, metav1.CreateOptions{})
+	require.NoError(t, err, "failed to create param ConfigMap")
+
+	t.Logf("Installing mutating admission policy with paramKind into the first workspace")
+	policy := &admissionregistrationv1.MutatingAdmissionPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "policy-",
+		},
+		Spec: admissionregistrationv1.MutatingAdmissionPolicySpec{
+			FailurePolicy:      ptr.To(admissionregistrationv1.Fail),
+			ReinvocationPolicy: admissionregistrationv1.NeverReinvocationPolicy,
+			ParamKind: &admissionregistrationv1.ParamKind{
+				APIVersion: "v1",
+				Kind:       "ConfigMap",
+			},
+			MatchConstraints: &admissionregistrationv1.MatchResources{
+				ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+					{
+						RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+							Operations: []admissionregistrationv1.OperationType{
+								admissionregistrationv1.Create,
+								admissionregistrationv1.Update,
+							},
+							Rule: admissionregistrationv1.Rule{
+								APIGroups:   []string{wildwestv1alpha1.SchemeGroupVersion.Group},
+								APIVersions: []string{wildwestv1alpha1.SchemeGroupVersion.Version},
+								Resources:   []string{"cowboys"},
+							},
+						},
+					},
+				},
+			},
+			Mutations: []admissionregistrationv1.Mutation{
+				{
+					PatchType: admissionregistrationv1.PatchTypeJSONPatch,
+					JSONPatch: &admissionregistrationv1.JSONPatch{
+						Expression: `[JSONPatch{op: "replace", path: "/spec/intent", value: params.data["replacement"]}]`,
+					},
+				},
+			},
+		},
+	}
+	policy, err = kubeClusterClient.Cluster(ws1Path).AdmissionregistrationV1().MutatingAdmissionPolicies().Create(ctx, policy, metav1.CreateOptions{})
+	require.NoError(t, err, "failed to create MutatingAdmissionPolicy")
+
+	t.Logf("Installing mutating admission policy binding with paramRef into the first workspace")
+	binding := &admissionregistrationv1.MutatingAdmissionPolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "binding-",
+		},
+		Spec: admissionregistrationv1.MutatingAdmissionPolicyBindingSpec{
+			PolicyName: policy.Name,
+			ParamRef: &admissionregistrationv1.ParamRef{
+				Name:                    "policy-params",
+				Namespace:               "default",
+				ParameterNotFoundAction: ptr.To(admissionregistrationv1.DenyAction),
+			},
+		},
+	}
+	_, err = kubeClusterClient.Cluster(ws1Path).AdmissionregistrationV1().MutatingAdmissionPolicyBindings().Create(ctx, binding, metav1.CreateOptions{})
+	require.NoError(t, err, "failed to create MutatingAdmissionPolicyBinding")
+
+	newCowboy := func(intent string) *wildwestv1alpha1.Cowboy {
+		return &wildwestv1alpha1.Cowboy{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "cowboy-",
+			},
+			Spec: wildwestv1alpha1.CowboySpec{
+				Intent: intent,
+			},
+		}
+	}
+
+	t.Logf("Verifying that creating bad cowboy resource in first logical cluster is mutated to the param-driven value")
+	require.Eventually(t, func() bool {
+		c, err := cowbyClusterClient.Cluster(ws1Path).WildwestV1alpha1().Cowboys("default").Create(ctx, newCowboy("bad"), metav1.CreateOptions{})
+		if err != nil {
+			t.Logf("Unexpected error when trying to create bad cowboy: %s", err)
+			return false
+		}
+		if c.Spec.Intent != "good" {
+			t.Logf("Cowboy not yet mutated (intent=%q); the binding may not have propagated", c.Spec.Intent)
+			return false
+		}
+		return true
+	}, wait.ForeverTestTimeout, 1*time.Second)
+
+	t.Logf("Verifying that creating bad cowboy resource in second logical cluster is unaffected (policy should not apply here)")
+	untouched, err := cowbyClusterClient.Cluster(ws2Path).WildwestV1alpha1().Cowboys("default").Create(ctx, newCowboy("bad"), metav1.CreateOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "bad", untouched.Spec.Intent)
+}
+
+func TestMutatingAdmissionPolicyCrossWorkspaceAPIBindingWithParams(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "control-plane")
+
+	server := kcptesting.SharedKcpServer(t)
+
+	if len(server.ShardNames()) > 1 {
+		t.Skip("MAP with Params is currently only supported with single shard setups, see code comments")
+	}
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	t.Cleanup(cancelFunc)
+
+	cfg := server.BaseConfig(t)
+
+	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
+	sourcePath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)
+	targetPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)
+
+	kcpClusterClient, err := kcpclientset.NewForConfig(cfg)
+	require.NoError(t, err, "failed to construct kcp cluster client for server")
+
+	kubeClusterClient, err := kcpkubernetesclientset.NewForConfig(cfg)
+	require.NoError(t, err, "failed to construct client for server")
+
+	cowbyClusterClient, err := wildwestclientset.NewForConfig(cfg)
+	require.NoError(t, err, "failed to construct cowboy client for server")
+
+	t.Logf("Install a cowboys APIResourceSchema into workspace %q", sourcePath)
+	apiResourceSchema := &apisv1alpha1.APIResourceSchema{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "today.cowboys.wildwest.dev",
+		},
+		Spec: apisv1alpha1.APIResourceSchemaSpec{
+			Group: "wildwest.dev",
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Kind:     "Cowboy",
+				ListKind: "CowboyList",
+				Plural:   "cowboys",
+				Singular: "cowboy",
+			},
+			Scope: "Namespaced",
+			Versions: []apisv1alpha1.APIResourceVersion{
+				{
+					Name:    "v1alpha1",
+					Served:  true,
+					Storage: true,
+					Schema: runtime.RawExtension{
+						Raw: []byte(`{
+							"description": "Cowboy is part of the wild west",
+							"properties": {
+								"apiVersion": {"type": "string"},
+								"kind": {"type": "string"},
+								"metadata": {"type": "object"},
+								"spec": {
+									"type": "object",
+									"properties": {
+										"intent": {"type": "string"}
+									}
+								},
+								"status": {
+									"type": "object",
+									"properties": {
+										"result": {"type": "string"}
+									}
+								}
+							},
+							"type": "object"
+						}`),
+					},
+					Subresources: apiextensionsv1.CustomResourceSubresources{
+						Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
+					},
+				},
+			},
+		},
+	}
+	_, err = kcpClusterClient.Cluster(sourcePath).ApisV1alpha1().APIResourceSchemas().Create(ctx, apiResourceSchema, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("Create an APIExport for it")
+	cowboysAPIExport := &apisv1alpha2.APIExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cowboybebop",
+		},
+		Spec: apisv1alpha2.APIExportSpec{
+			Resources: []apisv1alpha2.ResourceSchema{
+				{
+					Name:   "cowboys",
+					Group:  "wildwest.dev",
+					Schema: "today.cowboys.wildwest.dev",
+					Storage: apisv1alpha2.ResourceSchemaStorage{
+						CRD: &apisv1alpha2.ResourceSchemaStorageCRD{},
+					},
+				},
+			},
+		},
+	}
+	_, err = kcpClusterClient.Cluster(sourcePath).ApisV1alpha2().APIExports().Create(ctx, cowboysAPIExport, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("Create an APIBinding in workspace %q that points to the cowboybebop export", targetPath)
+	apiBinding := &apisv1alpha2.APIBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cowboys",
+		},
+		Spec: apisv1alpha2.APIBindingSpec{
+			Reference: apisv1alpha2.BindingReference{
+				Export: &apisv1alpha2.ExportBindingReference{
+					Path: sourcePath.String(),
+					Name: cowboysAPIExport.Name,
+				},
+			},
+		},
+	}
+
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		_, err := kcpClusterClient.Cluster(targetPath).ApisV1alpha2().APIBindings().Create(ctx, apiBinding, metav1.CreateOptions{})
+		return err == nil, fmt.Sprintf("Error creating APIBinding: %v", err)
+	}, wait.ForeverTestTimeout, time.Millisecond*100)
+
+	t.Logf("Ensure cowboys are served in target workspace")
+	require.Eventually(t, func() bool {
+		_, err := cowbyClusterClient.Cluster(targetPath).WildwestV1alpha1().Cowboys("default").List(ctx, metav1.ListOptions{})
+		return err == nil
+	}, wait.ForeverTestTimeout, 100*time.Millisecond)
+
+	t.Logf("Creating a ConfigMap to use as policy parameter in the source workspace")
+	paramConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "policy-params",
+			Namespace: "default",
+		},
+		Data: map[string]string{
+			"replacement": "good",
+		},
+	}
+	_, err = kubeClusterClient.Cluster(sourcePath).CoreV1().ConfigMaps("default").Create(ctx, paramConfigMap, metav1.CreateOptions{})
+	require.NoError(t, err, "failed to create param ConfigMap")
+
+	t.Logf("Installing mutating admission policy with paramKind into the source workspace")
+	policy := &admissionregistrationv1.MutatingAdmissionPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "policy-",
+		},
+		Spec: admissionregistrationv1.MutatingAdmissionPolicySpec{
+			FailurePolicy:      ptr.To(admissionregistrationv1.Fail),
+			ReinvocationPolicy: admissionregistrationv1.NeverReinvocationPolicy,
+			ParamKind: &admissionregistrationv1.ParamKind{
+				APIVersion: "v1",
+				Kind:       "ConfigMap",
+			},
+			MatchConstraints: &admissionregistrationv1.MatchResources{
+				ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+					{
+						RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+							Operations: []admissionregistrationv1.OperationType{
+								admissionregistrationv1.Create,
+								admissionregistrationv1.Update,
+							},
+							Rule: admissionregistrationv1.Rule{
+								APIGroups:   []string{wildwestv1alpha1.SchemeGroupVersion.Group},
+								APIVersions: []string{wildwestv1alpha1.SchemeGroupVersion.Version},
+								Resources:   []string{"cowboys"},
+							},
+						},
+					},
+				},
+			},
+			Mutations: []admissionregistrationv1.Mutation{
+				{
+					PatchType: admissionregistrationv1.PatchTypeJSONPatch,
+					JSONPatch: &admissionregistrationv1.JSONPatch{
+						Expression: `[JSONPatch{op: "replace", path: "/spec/intent", value: params.data["replacement"]}]`,
+					},
+				},
+			},
+		},
+	}
+	policy, err = kubeClusterClient.Cluster(sourcePath).AdmissionregistrationV1().MutatingAdmissionPolicies().Create(ctx, policy, metav1.CreateOptions{})
+	require.NoError(t, err, "failed to create MutatingAdmissionPolicy")
+
+	newCowboy := func(intent string) *wildwestv1alpha1.Cowboy {
+		return &wildwestv1alpha1.Cowboy{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "cowboy-",
+			},
+			Spec: wildwestv1alpha1.CowboySpec{
+				Intent: intent,
+			},
+		}
+	}
+
+	t.Logf("Verifying that creating bad cowboy in target workspace is unmutated before binding (policy is inactive without binding)")
+	c, err := cowbyClusterClient.Cluster(targetPath).WildwestV1alpha1().Cowboys("default").Create(ctx, newCowboy("bad"), metav1.CreateOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "bad", c.Spec.Intent)
+
+	t.Logf("Installing mutating admission policy binding with paramRef into the source workspace")
+	binding := &admissionregistrationv1.MutatingAdmissionPolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "binding-",
+		},
+		Spec: admissionregistrationv1.MutatingAdmissionPolicyBindingSpec{
+			PolicyName: policy.Name,
+			ParamRef: &admissionregistrationv1.ParamRef{
+				Name:                    "policy-params",
+				Namespace:               "default",
+				ParameterNotFoundAction: ptr.To(admissionregistrationv1.DenyAction),
+			},
+		},
+	}
+	_, err = kubeClusterClient.Cluster(sourcePath).AdmissionregistrationV1().MutatingAdmissionPolicyBindings().Create(ctx, binding, metav1.CreateOptions{})
+	require.NoError(t, err, "failed to create MutatingAdmissionPolicyBinding")
+
+	t.Logf("Verifying that creating bad cowboy in target workspace is mutated by param-driven policy in source workspace")
+	require.Eventually(t, func() bool {
+		c, err := cowbyClusterClient.Cluster(targetPath).WildwestV1alpha1().Cowboys("default").Create(ctx, newCowboy("bad"), metav1.CreateOptions{})
+		if err != nil {
+			t.Logf("Unexpected error when trying to create bad cowboy: %s", err)
+			return false
+		}
+		if c.Spec.Intent != "good" {
+			t.Logf("Cowboy not yet mutated (intent=%q); the binding may not have propagated", c.Spec.Intent)
+			return false
+		}
+		return true
+	}, wait.ForeverTestTimeout, 1*time.Second)
+}


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

During the kube rebase I added MAPs since they were default-enabled now. I only did light smoke tests, not a full validation.
This PR adds e2e tests that are basically 1-to-1 the VAP tests copied.

I found three bugs during this:

1. The deferred informer factory from the VAP was missing
2. The MAP was targeting the wrong cluster, breaking MAPs for resources from APIBindings
3. The MAP feature-gate wasn't actually honoured

## What Type of PR Is This?

/kind bug
/kind chore

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes https://github.com/kcp-dev/kcp/issues/3291

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
