### PR TITLE
fix(plugin): suppress expected APIBindings discovery error

### DIFF
--- a/staging/src/github.com/kcp-dev/cli/pkg/workspace/plugin/use.go
+++ b/staging/src/github.com/kcp-dev/cli/pkg/workspace/plugin/use.go
@@ -29,11 +29,13 @@ import (
 	"github.com/spf13/cobra"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/klog/v2"
 
 	"github.com/kcp-dev/cli/pkg/base"
 	pluginhelpers "github.com/kcp-dev/cli/pkg/helpers"
@@ -422,6 +424,11 @@ func getAPIBindings(ctx context.Context, kcpClusterClient kcpclientset.ClusterIn
 		return nil, nil
 	}
 	if err != nil {
+		// If the server doesn't have the API, it's expected. Log to debug, don't return an error.
+		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+			klog.V(4).Infof("error checking APIBindings: %v", err)
+			return nil, nil
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
**Description:**
This PR addresses the issue where `kubectl-ws` prints `error checking APIBindings: the server could not find the requested resource` when interacting with an older `kcp` server.

As per the expected behavior, missing API versions are now handled gracefully by suppressing `IsNotFound` and `IsNoMatchError` errors from the user's standard error output and moving them to `klog.V(4)` debug logs instead.

**Testing Done:**
- Compiled the updated `kubectl-ws` plugin locally
- Started a standalone local KCP server.
- Executed `./kubectl-ws use :` against the generated `admin.kubeconfig`.
- **Result:** Verified that the `error checking APIBindings` text is successfully suppressed from `stderr`, and the plugin correctly outputs standard workspace information.

Fixes #4106
Ref #4070

/kind bug

```release-note
NONE
```