### PR TITLE
loadtest: configure CR sizing and complexity

### DIFF
--- a/test/load/config.example.json
+++ b/test/load/config.example.json
@@ -8,6 +8,7 @@
     "crudConfigMapQPS": 150,
     "providerWorkspacesCount": 10,
     "consumerWorkspacesCount": 90,
+    "bindingsPerConsumer": 1,
     "createAPIExportQPS": 2.0,
     "createAPIBindingQPS": 2.0,
     "crudSharedAPIQPS": 150

--- a/test/load/config.example.json
+++ b/test/load/config.example.json
@@ -11,6 +11,9 @@
     "bindingsPerConsumer": 1,
     "createAPIExportQPS": 2.0,
     "createAPIBindingQPS": 2.0,
-    "crudSharedAPIQPS": 150
+    "crudSharedAPIQPS": 150,
+    "crLeafFields": 160,
+    "crListItems": 30,
+    "crTargetSizeBytes": 6000
   }
 }

--- a/test/load/pkg/crgen/crgen.go
+++ b/test/load/pkg/crgen/crgen.go
@@ -1,0 +1,306 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package crgen generates custom resources and API sharing objects
+// (APIResourceSchema, APIExport, APIBinding) for use in kcp load testing.
+// The generated resources have configurable size and complexity to approximate
+// real-world workloads.
+package crgen
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	apisv1alpha1 "github.com/kcp-dev/sdk/apis/apis/v1alpha1"
+	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
+)
+
+// Dummy describes the desired shape and size of generated custom resources.
+// It serves as the central configuration for all resource generation in this
+// package — OpenAPI schemas, CR instances, and the typed API sharing objects
+// (APIResourceSchema, APIExport, APIBinding) all derive from it.
+// In order to allow creating multiple APIs from the same shape, generation
+// functions take an additional id parameter. For loadtests this is simply
+// the sequence number, but outside it can be used with any parameter.
+type Dummy struct {
+	// leafFields is the number of scalar string fields in spec (>= 1).
+	// The first field is always "data" and is used for the CRUD update path.
+	leafFields int
+
+	// listItems is the number of items in a spec.items[] array.
+	// Each item has 3 string sub-fields (name, value, description).
+	// 0 means no list field is generated.
+	listItems int
+
+	// targetSizeBytes pads spec.data to reach this approximate total CR
+	// JSON size. 0 means no padding is applied.
+	targetSizeBytes int
+}
+
+// NewDummy creates a Dummy with the given parameters.
+func NewDummy(leafFields, listItems, targetSizeBytes int) Dummy {
+	return Dummy{
+		leafFields:      leafFields,
+		listItems:       listItems,
+		targetSizeBytes: targetSizeBytes,
+	}
+}
+
+// GVR returns the GroupVersionResource for the load test API identified by id.
+func GVR(id string) schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    Group,
+		Version:  Version,
+		Resource: pluralResource(id),
+	}
+}
+
+// GenerateAPIResourceSchema returns a fully-formed APIResourceSchema for the
+// load test API identified by id. The embedded OpenAPI validation schema
+// matches the CR shape described by the Dummy config.
+func (d Dummy) GenerateAPIResourceSchema(id string) *apisv1alpha1.APIResourceSchema {
+	return &apisv1alpha1.APIResourceSchema{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: schemaObjectName(id),
+		},
+		Spec: apisv1alpha1.APIResourceSchemaSpec{
+			Group: Group,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Kind:     kindName(id),
+				ListKind: listKindName(id),
+				Plural:   pluralResource(id),
+				Singular: singularResource(id),
+			},
+			Scope: apiextensionsv1.NamespaceScoped,
+			Versions: []apisv1alpha1.APIResourceVersion{
+				{
+					Name:    Version,
+					Served:  true,
+					Storage: true,
+					Schema: runtime.RawExtension{
+						Raw: d.GenerateOpenAPISchema(),
+					},
+				},
+			},
+		},
+	}
+}
+
+// GenerateAPIExport returns a fully-formed APIExport for the load test API
+// identified by id. The export references the APIResourceSchema produced by
+// GenerateAPIResourceSchema with the same id.
+func (d Dummy) GenerateAPIExport(id string) *apisv1alpha2.APIExport {
+	return &apisv1alpha2.APIExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: exportObjectName(id),
+		},
+		Spec: apisv1alpha2.APIExportSpec{
+			Resources: []apisv1alpha2.ResourceSchema{
+				{
+					Name:   pluralResource(id),
+					Group:  Group,
+					Schema: schemaObjectName(id),
+					Storage: apisv1alpha2.ResourceSchemaStorage{
+						CRD: &apisv1alpha2.ResourceSchemaStorageCRD{},
+					},
+				},
+			},
+		},
+	}
+}
+
+// GenerateAPIBinding returns a fully-formed APIBinding that binds to the export
+// in the given provider workspace. providerID identifies which export is being
+// bound; providerPath is the logical cluster path of the provider workspace.
+func (d Dummy) GenerateAPIBinding(providerID string, providerPath string) *apisv1alpha2.APIBinding {
+	return &apisv1alpha2.APIBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: bindingObjectName(providerID),
+		},
+		Spec: apisv1alpha2.APIBindingSpec{
+			Reference: apisv1alpha2.BindingReference{
+				Export: &apisv1alpha2.ExportBindingReference{
+					Path: providerPath,
+					Name: exportObjectName(providerID),
+				},
+			},
+		},
+	}
+}
+
+// GenerateOpenAPISchema returns a JSON-encoded OpenAPI v3 schema suitable for
+// APIResourceSchema.Spec.Versions[].Schema.Raw. The schema validates CRs of
+// the shape described by the Dummy config.
+func (d Dummy) GenerateOpenAPISchema() []byte {
+	specProps := map[string]any{
+		"data": map[string]any{"type": "string"},
+	}
+
+	for i := 2; i <= d.leafFields; i++ {
+		specProps[fmt.Sprintf("field%d", i)] = map[string]any{"type": "string"}
+	}
+
+	if d.listItems > 0 {
+		specProps["items"] = map[string]any{
+			"type": "array",
+			"items": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"name":        map[string]any{"type": "string"},
+					"value":       map[string]any{"type": "string"},
+					"description": map[string]any{"type": "string"},
+				},
+			},
+		}
+	}
+
+	openAPISchema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"apiVersion": map[string]any{"type": "string"},
+			"kind":       map[string]any{"type": "string"},
+			"metadata":   map[string]any{"type": "object"},
+			"spec": map[string]any{
+				"type":       "object",
+				"properties": specProps,
+			},
+		},
+	}
+
+	data, err := json.Marshal(openAPISchema)
+	if err != nil {
+		// Should not happen, as we build from static literals only
+		panic(fmt.Sprintf("failed to marshal OpenAPI schema: %v", err))
+	}
+
+	return data
+}
+
+// GenerateCR returns a fully-formed *unstructured.Unstructured custom resource
+// conforming to the schema produced by GenerateOpenAPISchema. The resourceID
+// determines the Kind (LoadTestResource{resourceID}) and must match the id used
+// in GenerateAPIResourceSchema. The instanceName is used for the object's
+// metadata.name (loadtest-cr-{instanceName}) and should be unique within the
+// namespace. If d.targetSizeBytes > 0, spec.data is padded to reach the target
+// total JSON size.
+func (d Dummy) GenerateCR(resourceID, instanceName string) *unstructured.Unstructured {
+	spec := map[string]any{
+		"data": "initial-value",
+	}
+
+	for i := 2; i <= d.leafFields; i++ {
+		spec[fmt.Sprintf("field%d", i)] = fmt.Sprintf("value-%d", i)
+	}
+
+	if d.listItems > 0 {
+		items := make([]any, d.listItems)
+		for i := range d.listItems {
+			items[i] = map[string]any{
+				"name":        fmt.Sprintf("item-%d", i),
+				"value":       fmt.Sprintf("value-%d", i),
+				"description": fmt.Sprintf("description for item %d", i),
+			}
+		}
+		spec["items"] = items
+	}
+
+	obj := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": Group + "/" + Version,
+			"kind":       kindName(resourceID),
+			"metadata": map[string]any{
+				"name":      fmt.Sprintf("loadtest-cr-%s", instanceName),
+				"namespace": "default",
+			},
+			"spec": spec,
+		},
+	}
+
+	d.padToTargetSize(obj)
+
+	return obj
+}
+
+// padToTargetSize adjusts spec.data so the total JSON serialization reaches
+// approximately targetSizeBytes. No-op if targetSizeBytes is 0 or the object
+// already exceeds it.
+func (d Dummy) padToTargetSize(obj *unstructured.Unstructured) {
+	if d.targetSizeBytes <= 0 {
+		return
+	}
+
+	data, err := json.Marshal(obj.Object)
+	if err != nil {
+		return
+	}
+
+	currentSize := len(data)
+	if currentSize >= d.targetSizeBytes {
+		return
+	}
+
+	deficit := d.targetSizeBytes - currentSize
+
+	currentData, _, _ := unstructured.NestedString(obj.Object, "spec", "data")
+	paddedData := currentData + strings.Repeat("x", deficit)
+	_ = unstructured.SetNestedField(obj.Object, paddedData, "spec", "data")
+}
+
+const (
+	// Group is the API group for all load test resources.
+	Group = "loadtest.kcp.io"
+	// Version is the API version for all load test resources.
+	Version = "v1alpha1"
+)
+
+// These derive deterministic resource names from a string id. All load test
+// resources follow the same naming convention so that providers and consumers
+// can reference each other by id alone.
+
+func pluralResource(id string) string {
+	return fmt.Sprintf("loadtest%sresources", id)
+}
+
+func singularResource(id string) string {
+	return fmt.Sprintf("loadtest%sresource", id)
+}
+
+func kindName(id string) string {
+	return fmt.Sprintf("LoadTest%sResource", id)
+}
+
+func listKindName(id string) string {
+	return fmt.Sprintf("LoadTest%sResourceList", id)
+}
+
+func schemaObjectName(id string) string {
+	return fmt.Sprintf("%s.%s.%s", Version, pluralResource(id), Group)
+}
+
+func exportObjectName(id string) string {
+	return fmt.Sprintf("loadtest-%s-export", id)
+}
+
+func bindingObjectName(id string) string {
+	return fmt.Sprintf("loadtest-%s-binding", id)
+}

--- a/test/load/pkg/crgen/crgen_test.go
+++ b/test/load/pkg/crgen/crgen_test.go
@@ -1,0 +1,286 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crgen
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const (
+	testResourceID   = "test"
+	testInstanceName = "instance"
+	testInitialValue = "initial-value"
+)
+
+func TestGenerateOpenAPISchema(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		leafFields        int
+		listItems         int
+		expectedSpecProps []string
+		expectItems       bool
+	}{
+		{
+			name:              "minimal single field",
+			leafFields:        1,
+			listItems:         0,
+			expectedSpecProps: []string{"data"},
+			expectItems:       false,
+		},
+		{
+			name:              "multiple fields",
+			leafFields:        5,
+			listItems:         0,
+			expectedSpecProps: []string{"data", "field2", "field3", "field4", "field5"},
+			expectItems:       false,
+		},
+		{
+			name:              "multiple fields and list items",
+			leafFields:        2,
+			listItems:         3,
+			expectedSpecProps: []string{"data", "field2", "items"},
+			expectItems:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			d := NewDummy(tt.leafFields, tt.listItems, 0)
+			raw := d.GenerateOpenAPISchema()
+
+			var parsed map[string]any
+			require.NoError(t, json.Unmarshal(raw, &parsed))
+
+			props, ok := parsed["properties"].(map[string]any)
+			require.True(t, ok)
+			require.Contains(t, props, "apiVersion")
+			require.Contains(t, props, "kind")
+			require.Contains(t, props, "metadata")
+			require.Contains(t, props, "spec")
+
+			specMap, ok := props["spec"].(map[string]any)
+			require.True(t, ok)
+			specProps, ok := specMap["properties"].(map[string]any)
+			require.True(t, ok)
+
+			require.Len(t, specProps, len(tt.expectedSpecProps))
+			for _, key := range tt.expectedSpecProps {
+				require.Contains(t, specProps, key)
+			}
+
+			if tt.expectItems {
+				itemsSchema, ok := specProps["items"].(map[string]any)
+				require.True(t, ok)
+				require.Equal(t, "array", itemsSchema["type"])
+				itemsInner, ok := itemsSchema["items"].(map[string]any)
+				require.True(t, ok)
+				itemProps, ok := itemsInner["properties"].(map[string]any)
+				require.True(t, ok)
+				require.Contains(t, itemProps, "name")
+				require.Contains(t, itemProps, "value")
+				require.Contains(t, itemProps, "description")
+			}
+		})
+	}
+}
+
+func TestGenerateCR(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		leafFields      int
+		listItems       int
+		targetSizeBytes int
+		verify          func(t *testing.T, obj *unstructured.Unstructured)
+	}{
+		{
+			name:       "minimal",
+			leafFields: 1,
+			verify: func(t *testing.T, obj *unstructured.Unstructured) {
+				t.Helper()
+				require.Equal(t, Group+"/"+Version, obj.GetAPIVersion())
+				require.Equal(t, kindName(testResourceID), obj.GetKind())
+				require.Equal(t, "loadtest-cr-"+testInstanceName, obj.GetName())
+				require.Equal(t, "default", obj.GetNamespace())
+
+				data, found, err := unstructured.NestedString(obj.Object, "spec", "data")
+				require.NoError(t, err)
+				require.True(t, found)
+				require.Equal(t, testInitialValue, data)
+			},
+		},
+		{
+			name:       "multiple fields and list",
+			leafFields: 3,
+			listItems:  2,
+			verify: func(t *testing.T, obj *unstructured.Unstructured) {
+				t.Helper()
+				spec, ok := obj.Object["spec"].(map[string]any)
+				require.True(t, ok)
+
+				require.Equal(t, testInitialValue, spec["data"])
+				require.Equal(t, "value-2", spec["field2"])
+				require.Equal(t, "value-3", spec["field3"])
+
+				items, ok := spec["items"].([]any)
+				require.True(t, ok)
+				require.Len(t, items, 2)
+
+				item0, ok := items[0].(map[string]any)
+				require.True(t, ok)
+				require.Equal(t, "item-0", item0["name"])
+				require.Equal(t, "value-0", item0["value"])
+				require.Contains(t, item0["description"], "item 0")
+			},
+		},
+		{
+			name:            "pads to target size",
+			leafFields:      1,
+			targetSizeBytes: 4096,
+			verify: func(t *testing.T, obj *unstructured.Unstructured) {
+				t.Helper()
+				data, err := json.Marshal(obj.Object)
+				require.NoError(t, err)
+				require.InDelta(t, 4096, len(data), 10)
+			},
+		},
+		{
+			name:            "no padding when zero",
+			leafFields:      1,
+			targetSizeBytes: 0,
+			verify: func(t *testing.T, obj *unstructured.Unstructured) {
+				t.Helper()
+				data, err := json.Marshal(obj.Object)
+				require.NoError(t, err)
+				require.Less(t, len(data), 200)
+			},
+		},
+		{
+			name:            "no padding when already larger",
+			leafFields:      50,
+			targetSizeBytes: 10,
+			verify: func(t *testing.T, obj *unstructured.Unstructured) {
+				t.Helper()
+				data, found, err := unstructured.NestedString(obj.Object, "spec", "data")
+				require.NoError(t, err)
+				require.True(t, found)
+				require.Equal(t, testInitialValue, data)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			d := NewDummy(tt.leafFields, tt.listItems, tt.targetSizeBytes)
+			obj := d.GenerateCR(testResourceID, testInstanceName)
+			tt.verify(t, obj)
+		})
+	}
+}
+
+func TestGenerateAPIResourceSchema(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		leafFields int
+	}{
+		{name: "single leaf", leafFields: 1},
+		{name: "multiple leafs", leafFields: 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			d := NewDummy(tt.leafFields, 0, 0)
+			ars := d.GenerateAPIResourceSchema(testResourceID)
+
+			require.Equal(t, schemaObjectName(testResourceID), ars.Name)
+			require.Equal(t, Group, ars.Spec.Group)
+			require.Equal(t, apiextensionsv1.NamespaceScoped, ars.Spec.Scope)
+			require.Equal(t, kindName(testResourceID), ars.Spec.Names.Kind)
+			require.Equal(t, listKindName(testResourceID), ars.Spec.Names.ListKind)
+			require.Equal(t, pluralResource(testResourceID), ars.Spec.Names.Plural)
+			require.Equal(t, singularResource(testResourceID), ars.Spec.Names.Singular)
+
+			require.Len(t, ars.Spec.Versions, 1)
+			v := ars.Spec.Versions[0]
+			require.Equal(t, Version, v.Name)
+			require.True(t, v.Served)
+			require.True(t, v.Storage)
+			require.NotEmpty(t, v.Schema.Raw)
+
+			var parsed map[string]any
+			require.NoError(t, json.Unmarshal(v.Schema.Raw, &parsed))
+			require.Equal(t, "object", parsed["type"])
+		})
+	}
+}
+
+func TestGenerateAPIExport(t *testing.T) {
+	t.Parallel()
+
+	d := NewDummy(1, 0, 0)
+	export := d.GenerateAPIExport(testResourceID)
+
+	require.Equal(t, exportObjectName(testResourceID), export.Name)
+	require.Len(t, export.Spec.Resources, 1)
+
+	res := export.Spec.Resources[0]
+	require.Equal(t, pluralResource(testResourceID), res.Name)
+	require.Equal(t, Group, res.Group)
+	require.Equal(t, schemaObjectName(testResourceID), res.Schema)
+	require.NotNil(t, res.Storage.CRD)
+}
+
+func TestGenerateAPIBinding(t *testing.T) {
+	t.Parallel()
+
+	d := NewDummy(1, 0, 0)
+	binding := d.GenerateAPIBinding(testResourceID, "root:org:provider-1")
+
+	require.Equal(t, bindingObjectName(testResourceID), binding.Name)
+	require.NotNil(t, binding.Spec.Reference.Export)
+	require.Equal(t, "root:org:provider-1", binding.Spec.Reference.Export.Path)
+	require.Equal(t, exportObjectName(testResourceID), binding.Spec.Reference.Export.Name)
+}
+
+func TestGVR(t *testing.T) {
+	t.Parallel()
+
+	gvr := GVR(testResourceID)
+	require.Equal(t, schema.GroupVersionResource{
+		Group:    Group,
+		Version:  Version,
+		Resource: pluralResource(testResourceID),
+	}, gvr)
+}

--- a/test/load/testing/config.go
+++ b/test/load/testing/config.go
@@ -49,6 +49,7 @@ func defaultParams() Params {
 		CRUDConfigMapQPS:        150,
 		ProviderWorkspacesCount: 1000,
 		ConsumerWorkspacesCount: 9000,
+		BindingsPerConsumer:     1,
 		CreateAPIExportQPS:      4.0,
 		CreateAPIBindingQPS:     4.0,
 		CRUDSharedAPIQPS:        150,
@@ -79,6 +80,11 @@ type Params struct {
 
 	// ConsumerWorkspacesCount is the number of consumer workspaces for API sharing tests.
 	ConsumerWorkspacesCount int `json:"consumerWorkspacesCount"`
+
+	// BindingsPerConsumer is the number of APIBindings each consumer workspace creates.
+	// Providers are assigned via round-robin across the total binding slots
+	// (consumerWorkspacesCount * bindingsPerConsumer)
+	BindingsPerConsumer int `json:"bindingsPerConsumer"`
 
 	// CreateAPIExportQPS is the rate at which APIExport creation requests are sent.
 	CreateAPIExportQPS float64 `json:"createAPIExportQPS"`
@@ -116,6 +122,11 @@ func parseConfig(configFile string) error {
 
 	if err := json.Unmarshal(data, &testConfig); err != nil {
 		return fmt.Errorf("failed to parse config file %q: %w", configFile, err)
+	}
+
+	if testConfig.Params.BindingsPerConsumer > testConfig.Params.ProviderWorkspacesCount {
+		return fmt.Errorf("bindingsPerConsumer (%d) must not exceed providerWorkspacesCount (%d) — a consumer cannot bind to the same provider twice",
+			testConfig.Params.BindingsPerConsumer, testConfig.Params.ProviderWorkspacesCount)
 	}
 
 	return nil

--- a/test/load/testing/config.go
+++ b/test/load/testing/config.go
@@ -53,6 +53,9 @@ func defaultParams() Params {
 		CreateAPIExportQPS:      4.0,
 		CreateAPIBindingQPS:     4.0,
 		CRUDSharedAPIQPS:        150,
+		CRLeafFields:            160,
+		CRListItems:             30,
+		CRTargetSizeBytes:       6000,
 	}
 }
 
@@ -94,6 +97,19 @@ type Params struct {
 
 	// CRUDSharedAPIQPS is the rate at which custom resource CRUD operations are sent.
 	CRUDSharedAPIQPS float64 `json:"crudSharedAPIQPS"`
+
+	// CRLeafFields is the number of scalar string properties under spec.
+	// The first field is always "data" and is used for the CRUD update path.
+	CRLeafFields int `json:"crLeafFields"`
+
+	// CRListItems is the number of items in a spec.items[] array.
+	// Each item has 3 string sub-fields (name, value, description).
+	// 0 means no list field is generated.
+	CRListItems int `json:"crListItems"`
+
+	// CRTargetSizeBytes pads spec.data to reach this approximate total CR JSON size.
+	// 0 means no padding is applied.
+	CRTargetSizeBytes int `json:"crTargetSizeBytes"`
 }
 
 // WorkspaceTree returns a workspace tree built from the configured parameters.
@@ -127,6 +143,16 @@ func parseConfig(configFile string) error {
 	if testConfig.Params.BindingsPerConsumer > testConfig.Params.ProviderWorkspacesCount {
 		return fmt.Errorf("bindingsPerConsumer (%d) must not exceed providerWorkspacesCount (%d) — a consumer cannot bind to the same provider twice",
 			testConfig.Params.BindingsPerConsumer, testConfig.Params.ProviderWorkspacesCount)
+	}
+
+	if testConfig.Params.CRLeafFields < 1 {
+		return fmt.Errorf("crLeafFields must be >= 1, got %d", testConfig.Params.CRLeafFields)
+	}
+	if testConfig.Params.CRListItems < 0 {
+		return fmt.Errorf("crListItems must be >= 0, got %d", testConfig.Params.CRListItems)
+	}
+	if testConfig.Params.CRTargetSizeBytes < 0 {
+		return fmt.Errorf("crTargetSizeBytes must be >= 0, got %d", testConfig.Params.CRTargetSizeBytes)
 	}
 
 	return nil

--- a/test/load/testing/workspace_apisharing_test.go
+++ b/test/load/testing/workspace_apisharing_test.go
@@ -76,11 +76,11 @@ func TestAPISharing(t *testing.T) {
 	sections = append(sections, exportSection)
 
 	t.Logf("Creating APIBindings in consumer workspaces")
-	bindingSection := createAPIBindings(t, client, wt, params.CreateAPIBindingQPS, params.ProviderWorkspacesCount, params.ConsumerWorkspacesCount)
+	bindingSection := createAPIBindings(t, client, wt, params.CreateAPIBindingQPS, params.ProviderWorkspacesCount, params.ConsumerWorkspacesCount, params.BindingsPerConsumer)
 	sections = append(sections, bindingSection)
 
 	t.Logf("Running custom resource CRUD operations")
-	crudSection := crudCustomResources(t, dynamicClusterClient, wt, params.CRUDSharedAPIQPS, params.ProviderWorkspacesCount, params.ConsumerWorkspacesCount)
+	crudSection := crudCustomResources(t, dynamicClusterClient, wt, params.CRUDSharedAPIQPS, params.ProviderWorkspacesCount, params.ConsumerWorkspacesCount, params.BindingsPerConsumer)
 	sections = append(sections, crudSection)
 
 	report := NewKCPReport(t.Context(), t, "API Sharing", cfg.FrontProxyKubeconfig)
@@ -202,36 +202,37 @@ func createAPIExports(t *testing.T, client kcpclientset.ClusterInterface, wt tre
 	return section
 }
 
-// createAPIBindings creates an APIBinding in each consumer workspace (sequence
-// numbers providerCount+1 through providerCount+consumerCount) that binds to
-// the provider workspaces in a round-robin fashion.
-func createAPIBindings(t *testing.T, client kcpclientset.ClusterInterface, wt tree.WorkspaceTree, qps float64, providerCount, consumerCount int) measurement.Section {
+// createAPIBindings creates APIBindings in each consumer workspace (sequence
+// numbers providerCount+1 through providerCount+consumerCount). Each consumer
+// gets bindingsPerConsumer bindings. Providers are assigned via a global
+// round-robin across all binding slots (consumerCount * bindingsPerConsumer).
+func createAPIBindings(t *testing.T, client kcpclientset.ClusterInterface, wt tree.WorkspaceTree, qps float64, providerCount, consumerCount, bindingsPerConsumer int) measurement.Section {
 	t.Helper()
+
+	totalBindings := consumerCount * bindingsPerConsumer
 
 	section := measurement.Section{
 		Title: "APIBinding Creation",
 		Parameters: []measurement.Parameter{
 			{Key: "ConsumerWorkspaces", Value: fmt.Sprintf("%d", consumerCount)},
 			{Key: "ProviderWorkspaces", Value: fmt.Sprintf("%d", providerCount)},
-			{Key: "CRUD-QPS", Value: fmt.Sprintf("%f", qps)},
+			{Key: "BindingsPerConsumer", Value: fmt.Sprintf("%d", bindingsPerConsumer)},
+			{Key: "TotalBindings", Value: fmt.Sprintf("%d", totalBindings)},
+			{Key: "QPS", Value: fmt.Sprintf("%f", qps)},
 		},
 		Sink: &measurement.Memory{
 			Stats: []stats.NamedStat{stats.P99(), stats.Avg()},
 		},
 	}
 
-	// Consumer workspaces start after the provider workspaces.
-	consumerStart := providerCount + 1
-	ts := tuningset.NewUniformQPS(qps, consumerCount, consumerStart)
+	// Iterate over all binding slots, starting sequence at 0.
+	ts := tuningset.NewUniformQPS(qps, totalBindings, 0)
 	section.Start()
 	action := func(ctx context.Context, seq int, s measurement.Sink) error {
 		defer measurement.RecordElapsedDurationMS(time.Now(), s)
 
-		consumerPath := wt.PathForSequenceNumber(seq)
-
-		// Round-robin: map consumer index to provider sequence number (1-based).
-		consumerIndex := seq - consumerStart
-		providerSeq := (consumerIndex % providerCount) + 1
+		consumerSeq, providerSeq := bindingSlot(seq, providerCount, bindingsPerConsumer)
+		consumerPath := wt.PathForSequenceNumber(consumerSeq)
 		providerPath := wt.PathForSequenceNumber(providerSeq)
 		exportName := fmt.Sprintf("loadtest-export-%d", providerSeq)
 		bindingName := fmt.Sprintf("loadtest-binding-%d", providerSeq)
@@ -281,15 +282,20 @@ func createAPIBindings(t *testing.T, client kcpclientset.ClusterInterface, wt tr
 }
 
 // crudCustomResources performs a Create/Get/Update/Delete cycle for a custom
-// resource in each consumer workspace. The resource type is determined by the
-// round-robin provider assignment.
-func crudCustomResources(t *testing.T, dynamicClient kcpdynamic.ClusterInterface, wt tree.WorkspaceTree, qps float64, providerCount, consumerCount int) measurement.Section {
+// resource in each consumer workspace for each of its bindings. The resource
+// type is determined by the provider assignment (same global round-robin as
+// createAPIBindings).
+func crudCustomResources(t *testing.T, dynamicClient kcpdynamic.ClusterInterface, wt tree.WorkspaceTree, qps float64, providerCount, consumerCount, bindingsPerConsumer int) measurement.Section {
 	t.Helper()
+
+	totalBindings := consumerCount * bindingsPerConsumer
 
 	section := measurement.Section{
 		Title: "Custom Resource CRUD",
 		Parameters: []measurement.Parameter{
 			{Key: "ConsumerWorkspaces", Value: fmt.Sprintf("%d", consumerCount)},
+			{Key: "BindingsPerConsumer", Value: fmt.Sprintf("%d", bindingsPerConsumer)},
+			{Key: "TotalCRUDOps", Value: fmt.Sprintf("%d", totalBindings)},
 			{Key: "QPS", Value: fmt.Sprintf("%f", qps*4)},
 		},
 		Sink: &measurement.Memory{
@@ -297,17 +303,13 @@ func crudCustomResources(t *testing.T, dynamicClient kcpdynamic.ClusterInterface
 		},
 	}
 
-	consumerStart := providerCount + 1
-	ts := tuningset.NewUniformQPS(qps, consumerCount, consumerStart)
+	ts := tuningset.NewUniformQPS(qps, totalBindings, 0)
 	section.Start()
 	action := func(ctx context.Context, seq int, s measurement.Sink) error {
 		defer measurement.RecordElapsedDurationMS(time.Now(), s)
 
-		consumerPath := wt.PathForSequenceNumber(seq)
-
-		// Determine which provider resource this consumer is bound to.
-		consumerIndex := seq - consumerStart
-		providerSeq := (consumerIndex % providerCount) + 1
+		consumerSeq, providerSeq := bindingSlot(seq, providerCount, bindingsPerConsumer)
+		consumerPath := wt.PathForSequenceNumber(consumerSeq)
 		resourceName := fmt.Sprintf("loadtestresources%d", providerSeq)
 
 		gvr := schema.GroupVersionResource{
@@ -317,7 +319,7 @@ func crudCustomResources(t *testing.T, dynamicClient kcpdynamic.ClusterInterface
 		}
 
 		resClient := dynamicClient.Cluster(consumerPath).Resource(gvr).Namespace("default")
-		objName := fmt.Sprintf("loadtest-cr-%d", seq)
+		objName := fmt.Sprintf("loadtest-cr-%d-%d", consumerSeq, providerSeq)
 
 		// Create
 		obj := &unstructured.Unstructured{
@@ -375,4 +377,15 @@ func crudCustomResources(t *testing.T, dynamicClient kcpdynamic.ClusterInterface
 	section.End()
 
 	return section
+}
+
+// bindingSlot maps a global slot index to the consumer sequence number and
+// provider sequence number. Providers are distributed via round-robin across
+// all slots (consumerCount * bindingsPerConsumer) so that each provider gets
+// an approximately equal share of bindings.
+func bindingSlot(globalSeq, providerCount, bindingsPerConsumer int) (consumerSeq, providerSeq int) {
+	// +1 because sequence numbers are 1-based: providers occupy 1..providerCount,
+	consumerSeq = providerCount + 1 + (globalSeq / bindingsPerConsumer)
+	providerSeq = (globalSeq % providerCount) + 1
+	return consumerSeq, providerSeq
 }

--- a/test/load/testing/workspace_apisharing_test.go
+++ b/test/load/testing/workspace_apisharing_test.go
@@ -20,24 +20,22 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	kcpdynamic "github.com/kcp-dev/client-go/dynamic"
-	apisv1alpha1 "github.com/kcp-dev/sdk/apis/apis/v1alpha1"
 	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
 	"github.com/kcp-dev/sdk/apis/third_party/conditions/util/conditions"
 	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
 
+	"github.com/kcp-dev/kcp/test/load/pkg/crgen"
 	"github.com/kcp-dev/kcp/test/load/pkg/framework"
 	"github.com/kcp-dev/kcp/test/load/pkg/measurement"
 	"github.com/kcp-dev/kcp/test/load/pkg/stats"
@@ -72,15 +70,16 @@ func TestAPISharing(t *testing.T) {
 	}
 
 	t.Logf("Creating APIExports in provider workspaces")
-	exportSection := createAPIExports(t, client, wt, params.CreateAPIExportQPS, params.ProviderWorkspacesCount)
+	dummy := crgen.NewDummy(params.CRLeafFields, params.CRListItems, params.CRTargetSizeBytes)
+	exportSection := createAPIExports(t, client, wt, params.CreateAPIExportQPS, params.ProviderWorkspacesCount, dummy)
 	sections = append(sections, exportSection)
 
 	t.Logf("Creating APIBindings in consumer workspaces")
-	bindingSection := createAPIBindings(t, client, wt, params.CreateAPIBindingQPS, params.ProviderWorkspacesCount, params.ConsumerWorkspacesCount, params.BindingsPerConsumer)
+	bindingSection := createAPIBindings(t, client, wt, params.CreateAPIBindingQPS, params.ProviderWorkspacesCount, params.ConsumerWorkspacesCount, params.BindingsPerConsumer, dummy)
 	sections = append(sections, bindingSection)
 
 	t.Logf("Running custom resource CRUD operations")
-	crudSection := crudCustomResources(t, dynamicClusterClient, wt, params.CRUDSharedAPIQPS, params.ProviderWorkspacesCount, params.ConsumerWorkspacesCount, params.BindingsPerConsumer)
+	crudSection := crudCustomResources(t, dynamicClusterClient, wt, params.CRUDSharedAPIQPS, params.ProviderWorkspacesCount, params.ConsumerWorkspacesCount, params.BindingsPerConsumer, dummy)
 	sections = append(sections, crudSection)
 
 	report := NewKCPReport(t.Context(), t, "API Sharing", cfg.FrontProxyKubeconfig)
@@ -94,7 +93,7 @@ func TestAPISharing(t *testing.T) {
 
 // createAPIExports creates an APIResourceSchema and APIExport in each of the
 // first providerCount workspaces in the tree.
-func createAPIExports(t *testing.T, client kcpclientset.ClusterInterface, wt tree.WorkspaceTree, qps float64, providerCount int) measurement.Section {
+func createAPIExports(t *testing.T, client kcpclientset.ClusterInterface, wt tree.WorkspaceTree, qps float64, providerCount int, dummy crgen.Dummy) measurement.Section {
 	t.Helper()
 
 	section := measurement.Section{
@@ -115,63 +114,17 @@ func createAPIExports(t *testing.T, client kcpclientset.ClusterInterface, wt tre
 
 		wsPath := wt.PathForSequenceNumber(seq)
 
-		schemaName := fmt.Sprintf("v1alpha1.loadtestresources%d.loadtest.kcp.io", seq)
-		resourceName := fmt.Sprintf("loadtestresources%d", seq)
-		exportName := fmt.Sprintf("loadtest-export-%d", seq)
-
 		// Create the APIResourceSchema.
-		schema := &apisv1alpha1.APIResourceSchema{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: schemaName,
-			},
-			Spec: apisv1alpha1.APIResourceSchemaSpec{
-				Group: "loadtest.kcp.io",
-				Names: apiextensionsv1.CustomResourceDefinitionNames{
-					Kind:     fmt.Sprintf("LoadTestResource%d", seq),
-					ListKind: fmt.Sprintf("LoadTestResource%dList", seq),
-					Plural:   resourceName,
-					Singular: fmt.Sprintf("loadtestresource%d", seq),
-				},
-				Scope: "Namespaced",
-				Versions: []apisv1alpha1.APIResourceVersion{
-					{
-						Name:    "v1alpha1",
-						Served:  true,
-						Storage: true,
-						Schema: runtime.RawExtension{
-							Raw: []byte(`{"type":"object","properties":{"apiVersion":{"type":"string"},"kind":{"type":"string"},"metadata":{"type":"object"},"spec":{"type":"object","properties":{"data":{"type":"string"}}}}}`),
-						},
-					},
-				},
-			},
-		}
-
+		apiSchema := dummy.GenerateAPIResourceSchema(strconv.Itoa(seq))
 		opStart := time.Now()
-		_, err := client.Cluster(wsPath).ApisV1alpha1().APIResourceSchemas().Create(ctx, schema, metav1.CreateOptions{})
+		_, err := client.Cluster(wsPath).ApisV1alpha1().APIResourceSchemas().Create(ctx, apiSchema, metav1.CreateOptions{})
 		if err != nil {
 			return fmt.Errorf("failed to create APIResourceSchema in %s: %w", wsPath, err)
 		}
 		s.Drop(measurement.Measurement{Name: "schema_create_duration_ms", Value: time.Since(opStart).Seconds() * 1000})
 
 		// Create the APIExport referencing the schema.
-		export := &apisv1alpha2.APIExport{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: exportName,
-			},
-			Spec: apisv1alpha2.APIExportSpec{
-				Resources: []apisv1alpha2.ResourceSchema{
-					{
-						Name:   resourceName,
-						Group:  "loadtest.kcp.io",
-						Schema: schemaName,
-						Storage: apisv1alpha2.ResourceSchemaStorage{
-							CRD: &apisv1alpha2.ResourceSchemaStorageCRD{},
-						},
-					},
-				},
-			},
-		}
-
+		export := dummy.GenerateAPIExport(strconv.Itoa(seq))
 		opStart = time.Now()
 		_, err = client.Cluster(wsPath).ApisV1alpha2().APIExports().Create(ctx, export, metav1.CreateOptions{})
 		if err != nil {
@@ -182,7 +135,7 @@ func createAPIExports(t *testing.T, client kcpclientset.ClusterInterface, wt tre
 		// Wait for the APIExport identity to become valid.
 		opStart = time.Now()
 		err = wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
-			got, err := client.Cluster(wsPath).ApisV1alpha2().APIExports().Get(ctx, exportName, metav1.GetOptions{})
+			got, err := client.Cluster(wsPath).ApisV1alpha2().APIExports().Get(ctx, export.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, nil //nolint:nilerr
 			}
@@ -206,7 +159,7 @@ func createAPIExports(t *testing.T, client kcpclientset.ClusterInterface, wt tre
 // numbers providerCount+1 through providerCount+consumerCount). Each consumer
 // gets bindingsPerConsumer bindings. Providers are assigned via a global
 // round-robin across all binding slots (consumerCount * bindingsPerConsumer).
-func createAPIBindings(t *testing.T, client kcpclientset.ClusterInterface, wt tree.WorkspaceTree, qps float64, providerCount, consumerCount, bindingsPerConsumer int) measurement.Section {
+func createAPIBindings(t *testing.T, client kcpclientset.ClusterInterface, wt tree.WorkspaceTree, qps float64, providerCount, consumerCount, bindingsPerConsumer int, dummy crgen.Dummy) measurement.Section {
 	t.Helper()
 
 	totalBindings := consumerCount * bindingsPerConsumer
@@ -234,23 +187,8 @@ func createAPIBindings(t *testing.T, client kcpclientset.ClusterInterface, wt tr
 		consumerSeq, providerSeq := bindingSlot(seq, providerCount, bindingsPerConsumer)
 		consumerPath := wt.PathForSequenceNumber(consumerSeq)
 		providerPath := wt.PathForSequenceNumber(providerSeq)
-		exportName := fmt.Sprintf("loadtest-export-%d", providerSeq)
-		bindingName := fmt.Sprintf("loadtest-binding-%d", providerSeq)
 
-		binding := &apisv1alpha2.APIBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: bindingName,
-			},
-			Spec: apisv1alpha2.APIBindingSpec{
-				Reference: apisv1alpha2.BindingReference{
-					Export: &apisv1alpha2.ExportBindingReference{
-						Path: providerPath.String(),
-						Name: exportName,
-					},
-				},
-			},
-		}
-
+		binding := dummy.GenerateAPIBinding(strconv.Itoa(providerSeq), providerPath.String())
 		opStart := time.Now()
 		_, err := client.Cluster(consumerPath).ApisV1alpha2().APIBindings().Create(ctx, binding, metav1.CreateOptions{})
 		if err != nil {
@@ -261,7 +199,7 @@ func createAPIBindings(t *testing.T, client kcpclientset.ClusterInterface, wt tr
 		// Wait for the binding to become bound.
 		opStart = time.Now()
 		err = wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
-			got, err := client.Cluster(consumerPath).ApisV1alpha2().APIBindings().Get(ctx, bindingName, metav1.GetOptions{})
+			got, err := client.Cluster(consumerPath).ApisV1alpha2().APIBindings().Get(ctx, binding.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, nil //nolint:nilerr
 			}
@@ -285,7 +223,7 @@ func createAPIBindings(t *testing.T, client kcpclientset.ClusterInterface, wt tr
 // resource in each consumer workspace for each of its bindings. The resource
 // type is determined by the provider assignment (same global round-robin as
 // createAPIBindings).
-func crudCustomResources(t *testing.T, dynamicClient kcpdynamic.ClusterInterface, wt tree.WorkspaceTree, qps float64, providerCount, consumerCount, bindingsPerConsumer int) measurement.Section {
+func crudCustomResources(t *testing.T, dynamicClient kcpdynamic.ClusterInterface, wt tree.WorkspaceTree, qps float64, providerCount, consumerCount, bindingsPerConsumer int, dummy crgen.Dummy) measurement.Section {
 	t.Helper()
 
 	totalBindings := consumerCount * bindingsPerConsumer
@@ -310,31 +248,15 @@ func crudCustomResources(t *testing.T, dynamicClient kcpdynamic.ClusterInterface
 
 		consumerSeq, providerSeq := bindingSlot(seq, providerCount, bindingsPerConsumer)
 		consumerPath := wt.PathForSequenceNumber(consumerSeq)
-		resourceName := fmt.Sprintf("loadtestresources%d", providerSeq)
 
-		gvr := schema.GroupVersionResource{
-			Group:    "loadtest.kcp.io",
-			Version:  "v1alpha1",
-			Resource: resourceName,
-		}
+		gvr := crgen.GVR(strconv.Itoa(providerSeq))
 
 		resClient := dynamicClient.Cluster(consumerPath).Resource(gvr).Namespace("default")
-		objName := fmt.Sprintf("loadtest-cr-%d-%d", consumerSeq, providerSeq)
 
 		// Create
-		obj := &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": "loadtest.kcp.io/v1alpha1",
-				"kind":       fmt.Sprintf("LoadTestResource%d", providerSeq),
-				"metadata": map[string]interface{}{
-					"name":      objName,
-					"namespace": "default",
-				},
-				"spec": map[string]interface{}{
-					"data": "initial-value",
-				},
-			},
-		}
+		providerID := strconv.Itoa(providerSeq)
+		instanceName := fmt.Sprintf("%d-%d", consumerSeq, providerSeq)
+		obj := dummy.GenerateCR(providerID, instanceName)
 
 		opStart := time.Now()
 		created, err := resClient.Create(ctx, obj, metav1.CreateOptions{})
@@ -345,7 +267,7 @@ func crudCustomResources(t *testing.T, dynamicClient kcpdynamic.ClusterInterface
 
 		// Get
 		opStart = time.Now()
-		_, err = resClient.Get(ctx, objName, metav1.GetOptions{})
+		_, err = resClient.Get(ctx, obj.GetName(), metav1.GetOptions{})
 		if err != nil {
 			return fmt.Errorf("failed to get custom resource in %s: %w", consumerPath, err)
 		}
@@ -364,7 +286,7 @@ func crudCustomResources(t *testing.T, dynamicClient kcpdynamic.ClusterInterface
 
 		// Delete
 		opStart = time.Now()
-		err = resClient.Delete(ctx, objName, metav1.DeleteOptions{})
+		err = resClient.Delete(ctx, obj.GetName(), metav1.DeleteOptions{})
 		if err != nil {
 			return fmt.Errorf("failed to delete custom resource in %s: %w", consumerPath, err)
 		}


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Adds the ability to specify sizes, complexity and number of bindings per workspace to mimic real-world use-cases better.

Specifically this allows creation of synthetic RessourceSchemas and their corresponding Exports and Bindings as well as objects.

This PR is chunked in two distinc commits to make reviewing it a bit easier, as it is quite large.

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->
/kind feature


## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
