### PR TITLE
Support selectableFields on APIResourceSchema

### DIFF
--- a/config/crds/apis.kcp.io_apiresourceschemas.yaml
+++ b/config/crds/apis.kcp.io_apiresourceschemas.yaml
@@ -283,6 +283,31 @@ spec:
                       type: object
                       x-kubernetes-map-type: atomic
                       x-kubernetes-preserve-unknown-fields: true
+                    selectableFields:
+                      description: |-
+                        selectableFields specifies paths to fields that may be used as field selectors.
+                        A maximum of 8 selectable fields are allowed.
+                        See https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors
+                      items:
+                        description: SelectableField specifies the JSON path of a
+                          field that may be used with field selectors.
+                        properties:
+                          jsonPath:
+                            description: |-
+                              jsonPath is a simple JSON path which is evaluated against each custom resource to produce a
+                              field selector value.
+                              Only JSON paths without the array notation are allowed.
+                              Must point to a field of type string, boolean or integer. Types with enum values
+                              and strings with formats are allowed.
+                              If jsonPath refers to absent field in a resource, the jsonPath evaluates to an empty string.
+                              Must not point to metdata fields.
+                              Required.
+                            type: string
+                        required:
+                        - jsonPath
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
                     served:
                       default: true
                       description: served is a flag enabling/disabling this version

--- a/pkg/admission/apiresourceschema/admission_test.go
+++ b/pkg/admission/apiresourceschema/admission_test.go
@@ -164,6 +164,113 @@ spec:
 				"spec.group: Invalid value: \"core\": must be empty string for the core group",
 			},
 		},
+		{
+			name: "selectableFields are accepted",
+			attr: createAttr(unmarshalOrDie(`
+apiVersion: apis.kcp.sh/v1alpha1
+kind: APIResourceSchema
+metadata:
+  name: july.cowboys.wild.west
+spec:
+  group: wild.west
+  names:
+    plural: cowboys
+    singular: cowboy
+    kind: Cowboy
+    listKind: CowboyList
+  scope: Cluster
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      type: object
+      properties:
+        spec:
+          type: object
+          properties:
+            color:
+              type: string
+    selectableFields:
+    - jsonPath: .spec.color
+            `)),
+		},
+		{
+			name: "too many selectableFields are rejected",
+			attr: createAttr(unmarshalOrDie(`
+apiVersion: apis.kcp.sh/v1alpha1
+kind: APIResourceSchema
+metadata:
+  name: july.cowboys.wild.west
+spec:
+  group: wild.west
+  names:
+    plural: cowboys
+    singular: cowboy
+    kind: Cowboy
+    listKind: CowboyList
+  scope: Cluster
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      type: object
+      properties:
+        spec:
+          type: object
+          properties:
+            c0: {type: string}
+            c1: {type: string}
+            c2: {type: string}
+            c3: {type: string}
+            c4: {type: string}
+            c5: {type: string}
+            c6: {type: string}
+            c7: {type: string}
+            c8: {type: string}
+    selectableFields:
+    - jsonPath: .spec.c0
+    - jsonPath: .spec.c1
+    - jsonPath: .spec.c2
+    - jsonPath: .spec.c3
+    - jsonPath: .spec.c4
+    - jsonPath: .spec.c5
+    - jsonPath: .spec.c6
+    - jsonPath: .spec.c7
+    - jsonPath: .spec.c8
+            `)),
+			expectedErrors: []string{
+				"spec.versions[0].selectableFields: Too many: 9: must have at most 8 items",
+			},
+		},
+		{
+			name: "selectableFields without a schema are rejected",
+			attr: createAttr(unmarshalOrDie(`
+apiVersion: apis.kcp.sh/v1alpha1
+kind: APIResourceSchema
+metadata:
+  name: july.cowboys.wild.west
+spec:
+  group: wild.west
+  names:
+    plural: cowboys
+    singular: cowboy
+    kind: Cowboy
+    listKind: CowboyList
+  scope: Cluster
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    selectableFields:
+    - jsonPath: .spec.color
+            `)),
+			expectedErrors: []string{
+				"spec.versions[0].schema: Required value",
+				"spec.versions[0].selectableFields: Invalid value: \"\": may only be set when `version.schema.openAPIV3Schema` is not included",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/admission/apiresourceschema/validation.go
+++ b/pkg/admission/apiresourceschema/validation.go
@@ -28,6 +28,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	crdvalidation "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation"
+	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
@@ -193,12 +194,12 @@ func ValidateAPIResourceVersion(ctx context.Context, version *apisv1alpha1.APIRe
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("deprecationWarning"), version.DeprecationWarning, err))
 	}
 
+	var crdSchemaInternal apiextensionsinternal.CustomResourceValidation
 	if len(version.Schema.Raw) == 0 || string(version.Schema.Raw) == "null" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("schema"), ""))
 	} else {
 		statusEnabled := version.Subresources.Status != nil
 		var crdSchemaV1 apiextensionsv1.CustomResourceValidation
-		var crdSchemaInternal apiextensionsinternal.CustomResourceValidation
 		if err := json.Unmarshal(version.Schema.Raw, &crdSchemaV1.OpenAPIV3Schema); err != nil {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("schema"), string(version.Schema.Raw), fmt.Sprintf("invalid JSON: %v", err)))
 		} else if err := apiextensionsv1.Convert_v1_CustomResourceValidation_To_apiextensions_CustomResourceValidation(&crdSchemaV1, &crdSchemaInternal, nil); err != nil {
@@ -221,6 +222,25 @@ func ValidateAPIResourceVersion(ctx context.Context, version *apisv1alpha1.APIRe
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("additionalPrinterColumns").Index(i), version.Subresources, err.Error()))
 		} else {
 			allErrs = append(allErrs, crdvalidation.ValidateCustomResourceColumnDefinition(&crdColumn, fldPath.Child("additionalPrinterColumns").Index(i))...)
+		}
+	}
+
+	if len(version.SelectableFields) > 0 {
+		if crdSchemaInternal.OpenAPIV3Schema == nil {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("selectableFields"), "", "may only be set when `version.schema.openAPIV3Schema` is not included"))
+		} else {
+			structural, err := structuralschema.NewStructural(crdSchemaInternal.OpenAPIV3Schema)
+			if err != nil {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("schema").Child("openAPIV3Schema"), "", err.Error()))
+			}
+			crdSelectableFields := make([]apiextensionsinternal.SelectableField, len(version.SelectableFields))
+			for i := range version.SelectableFields {
+				if err := apiextensionsv1.Convert_v1_SelectableField_To_apiextensions_SelectableField(&version.SelectableFields[i], &crdSelectableFields[i], nil); err != nil {
+					allErrs = append(allErrs, field.Invalid(fldPath.Child("selectableFields").Index(i), version.SelectableFields[i], err.Error()))
+				}
+			}
+
+			allErrs = append(allErrs, crdvalidation.ValidateCustomResourceSelectableFields(crdSelectableFields, structural, fldPath.Child("selectableFields"), defaultValidationOpts, version.Name)...)
 		}
 	}
 

--- a/pkg/reconciler/apis/apibinding/apibinding_reconcile.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_reconcile.go
@@ -778,6 +778,7 @@ func generateCRD(schema *apisv1alpha1.APIResourceSchema) (*apiextensionsv1.Custo
 			DeprecationWarning:       version.DeprecationWarning,
 			Subresources:             &version.Subresources,
 			AdditionalPrinterColumns: version.AdditionalPrinterColumns,
+			SelectableFields:         version.SelectableFields,
 		}
 
 		var validation apiextensionsv1.CustomResourceValidation

--- a/pkg/reconciler/apis/apibinding/apibinding_reconcile_test.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_reconcile_test.go
@@ -887,6 +887,94 @@ func TestCRDFromAPIResourceSchema(t *testing.T) {
 		want    *apiextensionsv1.CustomResourceDefinition
 		wantErr bool
 	}{
+		"selectable fields are propagated to the bound CRD": {
+			schema: &apisv1alpha1.APIResourceSchema{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						logicalcluster.AnnotationKey: "my-cluster",
+					},
+					Name: "my-name",
+					UID:  types.UID("my-uuid"),
+				},
+				Spec: apisv1alpha1.APIResourceSchemaSpec{
+					Group: "my-group",
+					Names: apiextensionsv1.CustomResourceDefinitionNames{
+						Plural:   "widgets",
+						Singular: "widget",
+						Kind:     "Widget",
+						ListKind: "WidgetList",
+					},
+					Scope: apiextensionsv1.NamespaceScoped,
+					Versions: []apisv1alpha1.APIResourceVersion{
+						{
+							Name:    "v1",
+							Served:  true,
+							Storage: true,
+							Schema: runtime.RawExtension{
+								Raw: []byte(`
+{
+	"description": "foo",
+	"type": "object"
+}
+								`),
+							},
+							SelectableFields: []apiextensionsv1.SelectableField{
+								{
+									JSONPath: ".spec.color",
+								},
+								{
+									JSONPath: ".spec.size",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &apiextensionsv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-uuid",
+					Annotations: map[string]string{
+						logicalcluster.AnnotationKey:            SystemBoundCRDsClusterName.String(),
+						apisv1alpha1.AnnotationBoundCRDKey:      "",
+						apisv1alpha1.AnnotationSchemaClusterKey: "my-cluster",
+						apisv1alpha1.AnnotationSchemaNameKey:    "my-name",
+					},
+				},
+				Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+					Group: "my-group",
+					Names: apiextensionsv1.CustomResourceDefinitionNames{
+						Plural:   "widgets",
+						Singular: "widget",
+						Kind:     "Widget",
+						ListKind: "WidgetList",
+					},
+					Scope: apiextensionsv1.NamespaceScoped,
+					Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+						{
+							Name:    "v1",
+							Served:  true,
+							Storage: true,
+							Schema: &apiextensionsv1.CustomResourceValidation{
+								OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+									Description: "foo",
+									Type:        "object",
+								},
+							},
+							Subresources: &apiextensionsv1.CustomResourceSubresources{},
+							SelectableFields: []apiextensionsv1.SelectableField{
+								{
+									JSONPath: ".spec.color",
+								},
+								{
+									JSONPath: ".spec.size",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
 		"full schema": {
 			schema: &apisv1alpha1.APIResourceSchema{
 				ObjectMeta: metav1.ObjectMeta{

--- a/staging/src/github.com/kcp-dev/sdk/apis/apis/v1alpha1/crd_to_apiresourceschema.go
+++ b/staging/src/github.com/kcp-dev/sdk/apis/apis/v1alpha1/crd_to_apiresourceschema.go
@@ -94,6 +94,7 @@ func CRDToAPIResourceSchema(crd *apiextensionsv1.CustomResourceDefinition, prefi
 			Deprecated:               crdVersion.Deprecated,
 			DeprecationWarning:       crdVersion.DeprecationWarning,
 			AdditionalPrinterColumns: crdVersion.AdditionalPrinterColumns,
+			SelectableFields:         crdVersion.SelectableFields,
 		}
 
 		if crdVersion.Schema != nil && crdVersion.Schema.OpenAPIV3Schema != nil {

--- a/staging/src/github.com/kcp-dev/sdk/apis/apis/v1alpha1/types_apiresourceschema.go
+++ b/staging/src/github.com/kcp-dev/sdk/apis/apis/v1alpha1/types_apiresourceschema.go
@@ -150,6 +150,14 @@ type APIResourceVersion struct {
 	// +listType=map
 	// +listMapKey=name
 	AdditionalPrinterColumns []apiextensionsv1.CustomResourceColumnDefinition `json:"additionalPrinterColumns,omitempty"`
+
+	// selectableFields specifies paths to fields that may be used as field selectors.
+	// A maximum of 8 selectable fields are allowed.
+	// See https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors
+	//
+	// +optional
+	// +listType=atomic
+	SelectableFields []apiextensionsv1.SelectableField `json:"selectableFields,omitempty"`
 }
 
 // CustomResourceConversion describes how to convert different versions of a CR.

--- a/staging/src/github.com/kcp-dev/sdk/apis/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/staging/src/github.com/kcp-dev/sdk/apis/apis/v1alpha1/zz_generated.deepcopy.go
@@ -610,6 +610,11 @@ func (in *APIResourceVersion) DeepCopyInto(out *APIResourceVersion) {
 		*out = make([]v1.CustomResourceColumnDefinition, len(*in))
 		copy(*out, *in)
 	}
+	if in.SelectableFields != nil {
+		in, out := &in.SelectableFields, &out.SelectableFields
+		*out = make([]v1.SelectableField, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/staging/src/github.com/kcp-dev/sdk/client/applyconfiguration/apis/v1alpha1/apiresourceversion.go
+++ b/staging/src/github.com/kcp-dev/sdk/client/applyconfiguration/apis/v1alpha1/apiresourceversion.go
@@ -54,6 +54,10 @@ type APIResourceVersionApplyConfiguration struct {
 	// See https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables for details.
 	// If no columns are specified, a single column displaying the age of the custom resource is used.
 	AdditionalPrinterColumns []v1.CustomResourceColumnDefinition `json:"additionalPrinterColumns,omitempty"`
+	// selectableFields specifies paths to fields that may be used as field selectors.
+	// A maximum of 8 selectable fields are allowed.
+	// See https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors
+	SelectableFields []v1.SelectableField `json:"selectableFields,omitempty"`
 }
 
 // APIResourceVersionApplyConfiguration constructs a declarative configuration of the APIResourceVersion type for use with
@@ -124,6 +128,16 @@ func (b *APIResourceVersionApplyConfiguration) WithSubresources(value v1.CustomR
 func (b *APIResourceVersionApplyConfiguration) WithAdditionalPrinterColumns(values ...v1.CustomResourceColumnDefinition) *APIResourceVersionApplyConfiguration {
 	for i := range values {
 		b.AdditionalPrinterColumns = append(b.AdditionalPrinterColumns, values[i])
+	}
+	return b
+}
+
+// WithSelectableFields adds the given value to the SelectableFields field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the SelectableFields field.
+func (b *APIResourceVersionApplyConfiguration) WithSelectableFields(values ...v1.SelectableField) *APIResourceVersionApplyConfiguration {
+	for i := range values {
+		b.SelectableFields = append(b.SelectableFields, values[i])
 	}
 	return b
 }

--- a/staging/src/github.com/kcp-dev/sdk/openapi/zz_generated.openapi.go
+++ b/staging/src/github.com/kcp-dev/sdk/openapi/zz_generated.openapi.go
@@ -1302,12 +1302,31 @@ func schema_sdk_apis_apis_v1alpha1_APIResourceVersion(ref common.ReferenceCallba
 							},
 						},
 					},
+					"selectableFields": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "selectableFields specifies paths to fields that may be used as field selectors. A maximum of 8 selectable fields are allowed. See https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.SelectableField"),
+									},
+								},
+							},
+						},
+					},
 				},
 				Required: []string{"name", "served", "storage", "schema"},
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.CustomResourceColumnDefinition", "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.CustomResourceSubresources", runtime.RawExtension{}.OpenAPIModelName()},
+			"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.CustomResourceColumnDefinition", "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.CustomResourceSubresources", "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.SelectableField", runtime.RawExtension{}.OpenAPIModelName()},
 	}
 }
 


### PR DESCRIPTION
## Summary

APIResourceSchema could not declare selectableFields, so APIs bound from an APIExport could not expose the field selectors that the embedded apiextensions-apiserver already supports for regular CRDs.

Add a SelectableFields field to APIResourceVersion and wire it through:
- propagate it into the bound CustomResourceDefinition in generateCRD
- carry it back in CRDToAPIResourceSchema
- validate it in the apiresourceschema admission plugin, mirroring the apiextensions-apiserver structural-schema validation (jsonPath/type/ uniqueness and the 8-field maximum), guarding that a schema is present

## What Type of PR Is This?

/kind feature
/kind api-change

## Release Notes

```release-note
Support selectableFields on APIResourceSchema
```
