### PR TITLE
Fix cross-shard reads of permission-claimed resources in the APIExport virtual workspace

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -233,3 +233,36 @@ presubmits:
             requests:
               memory: 6Gi
               cpu: 4
+
+  # Same suite as pull-kcp-test-e2e-sharded, but each shard runs its own embedded
+  # virtual workspace server instead of a single standalone VW server. This
+  # exercises per-shard virtual workspace serving and cross-shard behaviour.
+  # Marked optional while known cross-shard gaps (e.g. permission-claimed
+  # resources served across shards) are being addressed.
+  - name: pull-kcp-test-e2e-sharded-embedded-vw
+    decorate: true
+    optional: true
+    # only run e2e tests if code changed.
+    run_if_changed: "(cmd|config|pkg|staging|test|go.mod|go.sum|Makefile|.prow.yaml)"
+    clone_uri: "https://github.com/kcp-dev/kcp"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: ghcr.io/kcp-dev/infra/build:1.26.4-1
+          command:
+            - ./hack/run-with-prow.sh
+            - ./hack/run-with-prometheus.sh
+            - make
+            - test-e2e-sharded-embedded-vw
+          env:
+            - name: USE_GOTESTSUM
+              value: "1"
+            - name: KUBE_CACHE_MUTATION_DETECTOR
+              value: "1"
+            - name: E2E_PARALLELISM
+              value: "3"
+          resources:
+            requests:
+              memory: 6Gi
+              cpu: 4

--- a/Makefile
+++ b/Makefile
@@ -385,6 +385,37 @@ test-e2e-sharded-minimal: build-e2e
 		$(SUITES_ARG) \
 	$(if $(value WAIT),|| { echo "Terminated with $$?"; wait "$$PID"; },)
 
+# Same as test-e2e-sharded-minimal, but each shard runs its own embedded virtual
+# workspace server (--shard-run-virtual-workspaces=true) instead of a single
+# standalone VW server in front of all shards. This matches deployments where the
+# APIExport virtual workspaces are served per-shard, and exercises cross-shard
+# behaviour (e.g. permission-claimed resources whose objects live on a different
+# shard than the consuming APIExport).
+.PHONY: test-e2e-sharded-embedded-vw
+ifdef USE_GOTESTSUM
+test-e2e-sharded-embedded-vw: $(GOTESTSUM)
+endif
+test-e2e-sharded-embedded-vw: TEST_ARGS ?=
+test-e2e-sharded-embedded-vw: WHAT ?= ./test/e2e...
+test-e2e-sharded-embedded-vw: WORK_DIR ?= $(PWD)
+test-e2e-sharded-embedded-vw: SHARDS ?= 2
+ifdef ARTIFACT_DIR
+test-e2e-sharded-embedded-vw: LOG_DIR ?= $(ARTIFACT_DIR)/kcp
+else
+test-e2e-sharded-embedded-vw: LOG_DIR ?= $(WORK_DIR)/.kcp
+endif
+test-e2e-sharded-embedded-vw: build-e2e
+	mkdir -p "$(LOG_DIR)" "$(WORK_DIR)/.kcp"
+	rm -f "$(WORK_DIR)/.kcp/ready-to-test"
+	UNSAFE_E2E_HACK_DISABLE_ETCD_FSYNC=true NO_GORUN=1 ./bin/sharded-test-server --quiet --v=2 --log-dir-path="$(LOG_DIR)" --work-dir-path="$(WORK_DIR)" --shard-run-virtual-workspaces=true --shard-feature-gates=$(TEST_FEATURE_GATES) --proxy-feature-gates=$(PROXY_FEATURE_GATES) $(TEST_SERVER_ARGS) --number-of-shards=$(SHARDS) 2>&1 & PID=$$!; echo "PID $$PID" && \
+	trap 'kill -TERM $$PID && wait $$PID' TERM INT EXIT && \
+	while [ ! -f "$(WORK_DIR)/.kcp/ready-to-test" ]; do sleep 1; done && \
+	echo 'Starting test(s)' && \
+	NO_GORUN=1 GOOS=$(OS) GOARCH=$(ARCH) $(GO_TEST) -race $(COUNT_ARG) $(PARALLELISM_ARG) $(WHAT) $(TEST_ARGS) \
+		-args --kcp-kubeconfig=$(WORK_DIR)/.kcp/admin.kubeconfig --shard-kubeconfigs=root=$(WORK_DIR)/.kcp-0/admin.kubeconfig$(shell if [ $(SHARDS) -gt 1 ]; then seq 1 $$[$(SHARDS) - 1]; fi | while read n; do echo -n ",shard-$$n=$(WORK_DIR)/.kcp-$$n/admin.kubeconfig"; done) \
+		$(SUITES_ARG) \
+	$(if $(value WAIT),|| { echo "Terminated with $$?"; wait "$$PID"; },)
+
 # This is just easy target to run 2 shard test server locally until manually killed.
 # You can target test to it by running:
 # go test ./test/e2e/apibinding/... --kcp-kubeconfig=$(pwd)/.kcp/admin.kubeconfig --shard-kubeconfigs=root=$(pwd)/.kcp-0/admin.kubeconfig --shard-kubeconfigs=shard-1=$(pwd)/.kcp-1/admin.kubeconfig -run=^TestAPIBinding$

--- a/staging/src/github.com/kcp-dev/virtual-workspace-framework/pkg/forwardingregistry/store.go
+++ b/staging/src/github.com/kcp-dev/virtual-workspace-framework/pkg/forwardingregistry/store.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sync"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
@@ -182,7 +183,16 @@ func DefaultDynamicDelegatedStoreFuncs(
 			return nil, err
 		}
 
-		return delegate.List(ctx, v1ListOptions)
+		list, err := delegate.List(ctx, v1ListOptions)
+		if apierrors.IsNotFound(err) {
+			// The resource (identity) is not served on this shard - e.g. a
+			// resource claimed from another APIExport that has no binding on this
+			// shard. There is nothing to list here; return an empty list instead
+			// of a 404 so wildcard consumers aggregating across shards/endpoints
+			// are not wedged by a shard that simply holds none of these objects.
+			return listFactory(), nil
+		}
+		return list, err
 	}
 	s.UpdaterFunc = func(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
 		delegate, err := client(ctx)
@@ -283,7 +293,15 @@ func DefaultDynamicDelegatedStoreFuncs(
 			}
 		}()
 
-		return delegate.Watch(watchCtx, v1ListOptions)
+		w, err := delegate.Watch(watchCtx, v1ListOptions)
+		if apierrors.IsNotFound(err) {
+			// See ListerFunc: the resource is not served on this shard. Return a
+			// watch that yields no events and stays open until the (request- or
+			// stop-bounded) context is done, instead of surfacing a 404. Objects
+			// that later appear on this shard are picked up on the next relist.
+			return newEmptyWatch(watchCtx), nil
+		}
+		return w, err
 	}
 	s.TableConvertorFunc = tableConvertor.ConvertToTable
 	s.CategoriesProviderFunc = func() []string {
@@ -362,6 +380,28 @@ func listerWatcherGetter(dynamicClusterClientFunc DynamicClusterClientFunc, name
 		}
 	}
 }
+
+// emptyWatch is a watch.Interface that produces no events and closes when its
+// context is done. It is returned when a forwarded resource is not served on the
+// local shard, so wildcard consumers see an empty (but open) watch instead of a
+// 404.
+type emptyWatch struct {
+	ch   chan watch.Event
+	once sync.Once
+}
+
+func newEmptyWatch(ctx context.Context) *emptyWatch {
+	w := &emptyWatch{ch: make(chan watch.Event)}
+	go func() {
+		<-ctx.Done()
+		w.Stop()
+	}()
+	return w
+}
+
+func (w *emptyWatch) Stop() { w.once.Do(func() { close(w.ch) }) }
+
+func (w *emptyWatch) ResultChan() <-chan watch.Event { return w.ch }
 
 // updateToCreateOptions creates a CreateOptions with the same field values as the provided PatchOptions.
 func updateToCreateOptions(uo *metav1.UpdateOptions) metav1.CreateOptions {

--- a/test/e2e/virtual/apiexport/virtualworkspace_sharded_test.go
+++ b/test/e2e/virtual/apiexport/virtualworkspace_sharded_test.go
@@ -1,0 +1,327 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiexport
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
+
+	kcpdynamic "github.com/kcp-dev/client-go/dynamic"
+	"github.com/kcp-dev/logicalcluster/v3"
+	apisv1alpha1 "github.com/kcp-dev/sdk/apis/apis/v1alpha1"
+	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
+	"github.com/kcp-dev/sdk/apis/core"
+	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
+	"github.com/kcp-dev/sdk/apis/third_party/conditions/util/conditions"
+	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
+	kcptesting "github.com/kcp-dev/sdk/testing"
+	kcptestinghelpers "github.com/kcp-dev/sdk/testing/helpers"
+
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+)
+
+// Concrete "cloud API" delegation example, across shards.
+//
+//   - The Networking provider exports a "vnets.networking.example.io" API. Users
+//     create VNet objects in their own workspace.
+//   - The ManagedClusters provider exports a "managedclusters.compute.example.io"
+//     API and *claims* vnets, so that when it reconciles a managed cluster it can
+//     read (and create) the user's VNets - e.g. to check CIDR clashes. This is
+//     provider delegation.
+//
+// A user workspace binds both providers, creates a VNet, and accepts the
+// ManagedClusters provider's vnets claim (consent). The ManagedClusters provider
+// reads VNets across all such user workspaces through the managedclusters
+// APIExport virtual workspace.
+//
+// The bug (what happens with the kuery provider and Edges): the provider watches
+// *every* endpoint in the managedclusters APIExportEndpointSlice. A shard that has
+// a managedclusters consumer but no Networking binding does not serve
+// "vnets:<identity>" at all and used to return HTTP 404, wedging the provider's
+// informer even though another shard holds the user's consented VNet. The
+// forwarding storage now returns an empty list / open empty watch for a claimed
+// resource not served on the shard, so that endpoint yields empty instead of 404.
+// Permission-claim labels (consent) are unchanged.
+//
+// This test places the user (with the VNet) on a non-root shard and a
+// managedclusters-only consumer on root, and requires every managedclusters VW
+// endpoint to list vnets without error AND the user's VNet to be returned.
+func TestAPIExportPermissionClaimsVirtualWorkspaceAcrossShards(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "control-plane")
+
+	server := kcptesting.SharedKcpServer(t)
+	cfg := server.BaseConfig(t)
+
+	kcpClusterClient, err := kcpclientset.NewForConfig(cfg)
+	require.NoError(t, err, "failed to construct kcp cluster client")
+	dynamicClusterClient, err := kcpdynamic.NewForConfig(cfg)
+	require.NoError(t, err, "failed to construct dynamic cluster client")
+
+	shards, err := kcpClusterClient.Cluster(core.RootCluster.Path()).CoreV1alpha1().Shards().List(t.Context(), metav1.ListOptions{})
+	require.NoError(t, err, "failed to list shards")
+	if len(shards.Items) < 2 {
+		t.Skipf("Need at least 2 shards to run this test, got %d", len(shards.Items))
+	}
+	var userShard string
+	for _, s := range shards.Items {
+		if _, unsched := s.Annotations["experimental.core.kcp.io/unschedulable"]; unsched {
+			continue
+		}
+		if s.Name == corev1alpha1.RootShard {
+			continue
+		}
+		userShard = s.Name
+		break
+	}
+	require.NotEmpty(t, userShard, "could not find a schedulable non-root shard")
+	t.Logf("User (with the VNet) on shard %q; managedclusters-only consumer on root %q", userShard, corev1alpha1.RootShard)
+
+	const (
+		netGroup     = "networking.example.io"
+		vnetsAPI     = "vnets"
+		vnetKind     = "VNet"
+		mcGroup      = "compute.example.io"
+		mcAPI        = "managedclusters"
+		mcKind       = "ManagedCluster"
+		netExport    = "networking"
+		mcExport     = "managedclusters"
+		userVNetName = "user-vnet"
+	)
+
+	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
+	networkingPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath, kcptesting.WithName("networking-provider"), kcptesting.WithRootShard())
+	managedClustersPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath, kcptesting.WithName("managedclusters-provider"), kcptesting.WithRootShard())
+	// The user binds both providers, holds the VNet, on the non-root shard.
+	userPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath, kcptesting.WithName("user"), kcptesting.WithShard(userShard))
+	// A second user that only enabled ManagedClusters, on root (no Networking binding).
+	mcOnlyUserPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath, kcptesting.WithName("user-mc-only"), kcptesting.WithRootShard())
+
+	t.Logf("Create Networking provider (owns vnets) in %q", networkingPath)
+	createProviderExport(t.Context(), t, kcpClusterClient, networkingPath, netExport, netGroup, vnetsAPI, vnetKind, nil)
+	kcptestinghelpers.EventuallyCondition(t, func() (conditions.Getter, error) {
+		return kcpClusterClient.Cluster(networkingPath).ApisV1alpha2().APIExports().Get(t.Context(), netExport, metav1.GetOptions{})
+	}, kcptestinghelpers.Is(apisv1alpha2.APIExportIdentityValid))
+	netExportObj, err := kcpClusterClient.Cluster(networkingPath).ApisV1alpha2().APIExports().Get(t.Context(), netExport, metav1.GetOptions{})
+	require.NoError(t, err)
+	vnetIdentity := netExportObj.Status.IdentityHash
+	require.NotEmpty(t, vnetIdentity, "expected a vnets identity hash")
+
+	vnetClaim := apisv1alpha2.PermissionClaim{
+		GroupResource: apisv1alpha2.GroupResource{Group: netGroup, Resource: vnetsAPI},
+		IdentityHash:  vnetIdentity,
+		Verbs:         []string{"*"},
+	}
+	t.Logf("Create ManagedClusters provider (owns managedclusters, claims vnets) in %q", managedClustersPath)
+	createProviderExport(t.Context(), t, kcpClusterClient, managedClustersPath, mcExport, mcGroup, mcAPI, mcKind, []apisv1alpha2.PermissionClaim{vnetClaim})
+
+	acceptedVNets := apisv1alpha2.AcceptablePermissionClaim{
+		ScopedPermissionClaim: apisv1alpha2.ScopedPermissionClaim{
+			PermissionClaim: vnetClaim,
+			Selector:        apisv1alpha2.PermissionClaimSelector{MatchAll: true},
+		},
+		State: apisv1alpha2.ClaimAccepted,
+	}
+
+	// user: bind Networking, create a VNet, then bind ManagedClusters accepting the
+	// vnets claim (so the VNet gets the consent label).
+	vnetsGVR := schema.GroupVersionResource{Group: netGroup, Version: "v1", Resource: vnetsAPI}
+	t.Logf("In user %q: bind Networking, create VNet %q, bind ManagedClusters (accept vnets claim)", userPath, userVNetName)
+	bindExport(t.Context(), t, kcpClusterClient, userPath, networkingPath, netExport, netGroup, nil)
+	createCloudObject(t.Context(), t, dynamicClusterClient, userPath, vnetsGVR, vnetKind, netGroup, userVNetName, map[string]interface{}{"cidr": "10.0.0.0/16"})
+	bindExport(t.Context(), t, kcpClusterClient, userPath, managedClustersPath, mcExport, mcGroup, []apisv1alpha2.AcceptablePermissionClaim{acceptedVNets})
+
+	// mc-only user: enable ManagedClusters only (no Networking binding) on root.
+	t.Logf("In user %q (root): bind ManagedClusters only (no Networking)", mcOnlyUserPath)
+	bindExport(t.Context(), t, kcpClusterClient, mcOnlyUserPath, managedClustersPath, mcExport, mcGroup, []apisv1alpha2.AcceptablePermissionClaim{acceptedVNets})
+
+	t.Logf("Wait for both ManagedClusters bindings to apply the vnets claim")
+	for _, u := range []struct {
+		name string
+		path logicalcluster.Path
+	}{
+		{"user", userPath},
+		{"user-mc-only", mcOnlyUserPath},
+	} {
+		kcptestinghelpers.Eventually(t, func() (bool, string) {
+			binding, err := kcpClusterClient.Cluster(u.path).ApisV1alpha2().APIBindings().Get(t.Context(), mcExport, metav1.GetOptions{})
+			require.NoError(t, err)
+			for _, claim := range binding.Status.AppliedPermissionClaims {
+				if claim.IdentityHash == vnetIdentity {
+					return true, ""
+				}
+			}
+			return false, fmt.Sprintf("waiting for applied vnets claim on %q", u.name)
+		}, wait.ForeverTestTimeout, 100*time.Millisecond, "the vnets claim was never applied on %q", u.name)
+	}
+
+	t.Logf("As the ManagedClusters provider, list VNets through EVERY managedclusters VW endpoint")
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		slice, err := kcpClusterClient.Cluster(managedClustersPath).ApisV1alpha1().APIExportEndpointSlices().Get(t.Context(), mcExport, metav1.GetOptions{})
+		require.NoError(t, err)
+		urls := framework.ExportVirtualWorkspaceURLs(slice)
+		// Expect an endpoint on the user's shard and on root (mc-only user).
+		if len(urls) < 2 {
+			return false, fmt.Sprintf("waiting for managedclusters endpoints on both shards (got %d: %v)", len(urls), urls)
+		}
+
+		found := false
+		for _, u := range urls {
+			vwCfg := rest.CopyConfig(cfg)
+			vwCfg.Host = u
+			vwClient, err := kcpdynamic.NewForConfig(vwCfg)
+			require.NoError(t, err)
+
+			list, err := vwClient.Resource(vnetsGVR).List(t.Context(), metav1.ListOptions{})
+			if err != nil {
+				// The root endpoint (mc-only user, no Networking binding) must return
+				// an empty list, not a 404.
+				return false, fmt.Sprintf("endpoint %s errored listing vnets (expected graceful empty, not 404): %v", u, err)
+			}
+			for _, item := range list.Items {
+				if item.GetName() == userVNetName {
+					found = true
+				}
+			}
+		}
+		if !found {
+			return false, "the user's VNet was not served by any managedclusters VW endpoint"
+		}
+		return true, ""
+	}, wait.ForeverTestTimeout, 100*time.Millisecond,
+		"the ManagedClusters provider must read the user's cross-shard VNet with no endpoint returning 404")
+}
+
+// createProviderExport creates an APIResourceSchema for group/plural and an
+// APIExport named exportName that owns it (plus the given permission claims).
+func createProviderExport(ctx context.Context, t *testing.T, client kcpclientset.ClusterInterface, path logicalcluster.Path, exportName, group, plural, kind string, claims []apisv1alpha2.PermissionClaim) {
+	t.Helper()
+
+	s := &apisv1alpha1.APIResourceSchema{
+		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("v1.%s.%s", plural, group)},
+		Spec: apisv1alpha1.APIResourceSchemaSpec{
+			Group: group,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural:   plural,
+				Singular: strings.ToLower(kind),
+				Kind:     kind,
+				ListKind: kind + "List",
+			},
+			Scope: apiextensionsv1.NamespaceScoped,
+			Versions: []apisv1alpha1.APIResourceVersion{{
+				Name:    "v1",
+				Served:  true,
+				Storage: true,
+				Schema: runtime.RawExtension{
+					Raw: jsonOrDie(t, &apiextensionsv1.JSONSchemaProps{
+						Type:                   "object",
+						XPreserveUnknownFields: ptr.To(true),
+					}),
+				},
+			}},
+		},
+	}
+	_, err := client.Cluster(path).ApisV1alpha1().APIResourceSchemas().Create(ctx, s, metav1.CreateOptions{})
+	require.NoError(t, err, "creating APIResourceSchema %s|%s", path, s.Name)
+
+	export := &apisv1alpha2.APIExport{
+		ObjectMeta: metav1.ObjectMeta{Name: exportName},
+		Spec: apisv1alpha2.APIExportSpec{
+			Resources: []apisv1alpha2.ResourceSchema{{
+				Name:    plural,
+				Group:   group,
+				Schema:  s.Name,
+				Storage: apisv1alpha2.ResourceSchemaStorage{CRD: &apisv1alpha2.ResourceSchemaStorageCRD{}},
+			}},
+			PermissionClaims: claims,
+		},
+	}
+	_, err = client.Cluster(path).ApisV1alpha2().APIExports().Create(ctx, export, metav1.CreateOptions{})
+	require.NoError(t, err, "creating APIExport %s|%s", path, export.Name)
+}
+
+// bindExport creates an APIBinding (named exportName) in consumerPath that
+// references the export at providerPath, with optional accepted permission
+// claims, and waits for the bound API group to appear in discovery.
+func bindExport(ctx context.Context, t *testing.T, client kcpclientset.ClusterInterface, consumerPath, providerPath logicalcluster.Path, exportName, group string, claims []apisv1alpha2.AcceptablePermissionClaim) {
+	t.Helper()
+
+	binding := &apisv1alpha2.APIBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: exportName},
+		Spec: apisv1alpha2.APIBindingSpec{
+			Reference: apisv1alpha2.BindingReference{
+				Export: &apisv1alpha2.ExportBindingReference{Path: providerPath.String(), Name: exportName},
+			},
+			PermissionClaims: claims,
+		},
+	}
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		_, err := client.Cluster(consumerPath).ApisV1alpha2().APIBindings().Create(ctx, binding, metav1.CreateOptions{})
+		return err == nil, fmt.Sprintf("creating APIBinding %s|%s: %v", consumerPath, exportName, err)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond)
+
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		groups, err := client.Cluster(consumerPath).Discovery().ServerGroups()
+		if err != nil {
+			return false, err.Error()
+		}
+		for _, g := range groups.Groups {
+			if g.Name == group {
+				return true, ""
+			}
+		}
+		return false, fmt.Sprintf("waiting for %q in %q discovery", group, consumerPath)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond)
+}
+
+// createCloudObject creates an unstructured CR (with the given spec) in path.
+func createCloudObject(ctx context.Context, t *testing.T, client kcpdynamic.ClusterInterface, path logicalcluster.Path, gvr schema.GroupVersionResource, kind, group, name string, spec map[string]interface{}) {
+	t.Helper()
+
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion(group + "/" + gvr.Version)
+	obj.SetKind(kind)
+	obj.SetName(name)
+	require.NoError(t, unstructured.SetNestedMap(obj.Object, spec, "spec"))
+
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		_, err := client.Cluster(path).Resource(gvr).Namespace("default").Create(ctx, obj, metav1.CreateOptions{})
+		return err == nil, fmt.Sprintf("creating %s %s|%s: %v", kind, path, name, err)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond)
+}
+
+func jsonOrDie(t *testing.T, obj interface{}) []byte {
+	t.Helper()
+	b, err := json.Marshal(obj)
+	require.NoError(t, err)
+	return b
+}


### PR DESCRIPTION
## Summary

Cross-shard reads of a **permission-claimed** resource (provider delegation) were
broken, and one shard's spurious 404 could wedge the consuming provider's informer.

When APIExport **M** permission-claims a resource owned by APIExport **N** (e.g.
`kuery` claims `edges`; in the e2e: a ManagedClusters provider claims `vnets` from a
Networking provider), the provider watches **every** endpoint in M's
`APIExportEndpointSlice`. A shard that has an M consumer but **no N binding** does
not serve `<resource>:<identity>` at all, so the apiexport VW's wildcard list/watch
forwarded to that shard returned **HTTP 404** ("the server could not find the
requested resource"). That 404 failed the reflector's initial sync and could wedge
the provider, even though the user's consented object lived on another shard.

### Fix

In `forwardingregistry`, treat a `NotFound` from the delegated list/watch as an
empty result: `List` returns an empty list and `Watch` returns an open, event-less
watch bound to the request context. Objects appearing later are picked up on the
next relist. **Permission-claim labels (consent) are unchanged** — consented
objects still come from the shards that legitimately hold them; only the owner-less
shard's spurious 404 becomes an empty response.

### Also in this PR

- New e2e `TestAPIExportPermissionClaimsVirtualWorkspaceAcrossShards` modelling the
  delegation concretely (Networking/`vnets` + ManagedClusters/`managedclusters`),
  with a real user `VNet` that must be read cross-shard with no endpoint 404.
- A `test-e2e-sharded-embedded-vw` Makefile target + `pull-kcp-test-e2e-sharded-embedded-vw`
  prow job (optional) that runs the suite with **embedded per-shard** virtual
  workspaces (the topology that surfaces this bug), vs. the standalone VW server.

See the PR comment for full design notes (the consent model, what was considered
and rejected, the trade-off, and a known limitation).

## What Type of PR Is This?

/kind bug

## Related Issue(s)

Fixes #

## Release Notes

```release-note
Fix cross-shard reads of permission-claimed resources through the APIExport virtual workspace: a shard that does not serve a claimed resource now returns an empty list/watch instead of a 404, so a consuming provider's informer is not wedged when the claimed objects live on another shard.
```
