### PR TITLE
VAP/MAP improvements

### DIFF
--- a/pkg/admission/initializers/initializer.go
+++ b/pkg/admission/initializers/initializer.go
@@ -24,9 +24,11 @@ import (
 	kcpdynamic "github.com/kcp-dev/client-go/dynamic"
 	kcpkubernetesinformers "github.com/kcp-dev/client-go/informers"
 	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
+	"github.com/kcp-dev/logicalcluster/v3"
 	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
 	kcpinformers "github.com/kcp-dev/sdk/client/informers/externalversions"
 
+	"github.com/kcp-dev/kcp/pkg/contextmanager"
 	"github.com/kcp-dev/kcp/pkg/reconciler/dynamicrestmapper"
 )
 
@@ -197,5 +199,19 @@ func NewDynamicRESTMapperInitializer(dynamicRESTMapper *dynamicrestmapper.Dynami
 func (i *dynamicRESTMapperInitializer) Initialize(plugin admission.Interface) {
 	if wants, ok := plugin.(WantsDynamicRESTMapper); ok {
 		wants.SetDynamicRESTMapper(i.dynamicRESTMapper)
+	}
+}
+
+type clusterContextManagerInitializer struct {
+	clusterContextManager *contextmanager.Manager[logicalcluster.Path]
+}
+
+func NewClusterContextManagerInitializer(mgr *contextmanager.Manager[logicalcluster.Path]) *clusterContextManagerInitializer {
+	return &clusterContextManagerInitializer{clusterContextManager: mgr}
+}
+
+func (i *clusterContextManagerInitializer) Initialize(plugin admission.Interface) {
+	if wants, ok := plugin.(WantsClusterContextManager); ok {
+		wants.SetClusterContextManager(i.clusterContextManager)
 	}
 }

--- a/pkg/admission/initializers/interfaces.go
+++ b/pkg/admission/initializers/interfaces.go
@@ -20,11 +20,19 @@ import (
 	kcpdynamic "github.com/kcp-dev/client-go/dynamic"
 	kcpkubernetesinformers "github.com/kcp-dev/client-go/informers"
 	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
+	"github.com/kcp-dev/logicalcluster/v3"
 	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
 	kcpinformers "github.com/kcp-dev/sdk/client/informers/externalversions"
 
+	"github.com/kcp-dev/kcp/pkg/contextmanager"
 	"github.com/kcp-dev/kcp/pkg/reconciler/dynamicrestmapper"
 )
+
+// WantsClusterContextManager interface should be implemented by admission plugins that
+// need a per-logical-cluster context.
+type WantsClusterContextManager interface {
+	SetClusterContextManager(*contextmanager.Manager[logicalcluster.Path])
+}
 
 // WantsKcpInformers interface should be implemented by admission plugins
 // that want to have both local and global kcp informer factories injected.

--- a/pkg/admission/mutatingadmissionpolicy/mutating_admission_policy.go
+++ b/pkg/admission/mutatingadmissionpolicy/mutating_admission_policy.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/admission/initializer"
 	"k8s.io/apiserver/pkg/admission/plugin/policy/generic"
+	"k8s.io/apiserver/pkg/admission/plugin/policy/matching"
 	"k8s.io/apiserver/pkg/admission/plugin/policy/mutating"
 	"k8s.io/apiserver/pkg/admission/plugin/policy/mutating/patch"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
@@ -266,9 +267,29 @@ func (k *KubeMutatingAdmissionPolicy) getOrCreateDelegate(policyClusterName, tar
 		}
 	}()
 
-	plugin, err := mutating.NewPlugin(nil)
-	if err != nil {
-		return nil, err
+	tcm := k.getOrCreateTypeConverterManager(targetClusterName)
+
+	handler := admission.NewHandler(admission.Create, admission.Update, admission.Connect)
+	plugin := &mutating.Plugin{
+		Plugin: generic.NewPlugin(
+			handler,
+			func(_ informers.SharedInformerFactory, _ kubernetes.Interface, dynamicClient dynamic.Interface, restMapper meta.RESTMapper, cn logicalcluster.Name) generic.Source[mutating.PolicyHook] {
+				return generic.NewPolicySource(
+					k.globalKubeSharedInformerFactory.Admissionregistration().V1().MutatingAdmissionPolicies().Informer().Cluster(cn),
+					k.globalKubeSharedInformerFactory.Admissionregistration().V1().MutatingAdmissionPolicyBindings().Informer().Cluster(cn),
+					mutating.NewMutatingAdmissionPolicyAccessor,
+					mutating.NewMutatingAdmissionPolicyBindingAccessor,
+					mutating.CompilePolicy,
+					&deferredInformerFactory{},
+					dynamicClient,
+					restMapper,
+					cn,
+				)
+			},
+			func(authz authorizer.Authorizer, m *matching.Matcher, _ kubernetes.Interface) generic.Dispatcher[mutating.PolicyHook] {
+				return mutating.NewDispatcher(authz, m, tcm)
+			},
+		),
 	}
 
 	// Default to enable MAP, but honour the feature gate if available.
@@ -291,19 +312,6 @@ func (k *KubeMutatingAdmissionPolicy) getOrCreateDelegate(policyClusterName, tar
 	plugin.SetDrainedNotification(ctx.Done())
 	plugin.SetAuthorizer(k.authorizer)
 	plugin.SetClusterName(policyClusterName)
-	plugin.SetSourceFactory(func(_ informers.SharedInformerFactory, client kubernetes.Interface, dynamicClient dynamic.Interface, restMapper meta.RESTMapper, cn logicalcluster.Name) generic.Source[mutating.PolicyHook] {
-		return generic.NewPolicySource(
-			k.globalKubeSharedInformerFactory.Admissionregistration().V1().MutatingAdmissionPolicies().Informer().Cluster(cn),
-			k.globalKubeSharedInformerFactory.Admissionregistration().V1().MutatingAdmissionPolicyBindings().Informer().Cluster(cn),
-			mutating.NewMutatingAdmissionPolicyAccessor,
-			mutating.NewMutatingAdmissionPolicyBindingAccessor,
-			mutating.CompilePolicy,
-			&deferredInformerFactory{},
-			dynamicClient,
-			restMapper,
-			cn,
-		)
-	})
 
 	if err := plugin.ValidateInitialization(); err != nil {
 		cancel()

--- a/pkg/admission/mutatingadmissionpolicy/mutating_admission_policy.go
+++ b/pkg/admission/mutatingadmissionpolicy/mutating_admission_policy.go
@@ -32,11 +32,9 @@ import (
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/features"
-	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/component-base/featuregate"
 	"k8s.io/klog/v2"
@@ -53,6 +51,7 @@ import (
 	"github.com/kcp-dev/kcp/pkg/admission/initializers"
 	"github.com/kcp-dev/kcp/pkg/admission/kubequota"
 	kcpfeatures "github.com/kcp-dev/kcp/pkg/features"
+	"github.com/kcp-dev/kcp/pkg/reconciler/dynamicrestmapper"
 )
 
 const PluginName = "KCPMutatingAdmissionPolicy"
@@ -96,6 +95,8 @@ type KubeMutatingAdmissionPolicy struct {
 
 	featureGates featuregate.FeatureGate
 
+	dynamicRESTMapper *dynamicrestmapper.DynamicRESTMapper
+
 	delegatesLock sync.RWMutex
 	delegates     map[delegateKey]*stoppableMutatingAdmissionPolicy
 
@@ -108,6 +109,7 @@ var _ = initializers.WantsKubeInformers(&KubeMutatingAdmissionPolicy{})
 var _ = initializers.WantsKcpInformers(&KubeMutatingAdmissionPolicy{})
 var _ = initializers.WantsServerShutdownChannel(&KubeMutatingAdmissionPolicy{})
 var _ = initializers.WantsDynamicClusterClient(&KubeMutatingAdmissionPolicy{})
+var _ = initializers.WantsDynamicRESTMapper(&KubeMutatingAdmissionPolicy{})
 var _ = initializer.WantsAuthorizer(&KubeMutatingAdmissionPolicy{})
 var _ = initializer.WantsFeatures(&KubeMutatingAdmissionPolicy{})
 var _ = admission.InitializationValidator(&KubeMutatingAdmissionPolicy{})
@@ -158,6 +160,10 @@ func (k *KubeMutatingAdmissionPolicy) SetServerShutdownChannel(ch <-chan struct{
 
 func (k *KubeMutatingAdmissionPolicy) SetDynamicClusterClient(c kcpdynamic.ClusterInterface) {
 	k.dynamicClusterClient = c
+}
+
+func (k *KubeMutatingAdmissionPolicy) SetDynamicRESTMapper(dynRESTMapper *dynamicrestmapper.DynamicRESTMapper) {
+	k.dynamicRESTMapper = dynRESTMapper
 }
 
 func (k *KubeMutatingAdmissionPolicy) SetAuthorizer(authz authorizer.Authorizer) {
@@ -267,9 +273,7 @@ func (k *KubeMutatingAdmissionPolicy) getOrCreateDelegate(policyClusterName, tar
 	plugin.SetNamespaceInformer(k.localKubeSharedInformerFactory.Core().V1().Namespaces().Cluster(targetClusterName))
 	plugin.SetExternalKubeClientSet(k.kubeClusterClient.Cluster(targetClusterName.Path()))
 
-	discoveryClient := memory.NewMemCacheClient(k.kubeClusterClient.Cluster(policyClusterName.Path()).Discovery())
-	restMapper := restmapper.NewDeferredDiscoveryRESTMapper(discoveryClient)
-	plugin.SetRESTMapper(restMapper)
+	plugin.SetRESTMapper(k.dynamicRESTMapper.ForCluster(policyClusterName))
 
 	plugin.SetDynamicClient(k.dynamicClusterClient.Cluster(policyClusterName.Path()))
 	plugin.SetDrainedNotification(ctx.Done())

--- a/pkg/admission/mutatingadmissionpolicy/mutating_admission_policy.go
+++ b/pkg/admission/mutatingadmissionpolicy/mutating_admission_policy.go
@@ -54,6 +54,7 @@ import (
 
 	"github.com/kcp-dev/kcp/pkg/admission/initializers"
 	"github.com/kcp-dev/kcp/pkg/admission/kubequota"
+	"github.com/kcp-dev/kcp/pkg/contextmanager"
 	kcpfeatures "github.com/kcp-dev/kcp/pkg/features"
 	"github.com/kcp-dev/kcp/pkg/reconciler/dynamicrestmapper"
 )
@@ -102,6 +103,8 @@ type KubeMutatingAdmissionPolicy struct {
 
 	dynamicRESTMapper *dynamicrestmapper.DynamicRESTMapper
 
+	clusterContextManager *contextmanager.Manager[logicalcluster.Path]
+
 	delegatesLock sync.RWMutex
 	delegates     map[delegateKey]*stoppableMutatingAdmissionPolicy
 
@@ -119,6 +122,7 @@ var _ = initializers.WantsKcpInformers(&KubeMutatingAdmissionPolicy{})
 var _ = initializers.WantsServerShutdownChannel(&KubeMutatingAdmissionPolicy{})
 var _ = initializers.WantsDynamicClusterClient(&KubeMutatingAdmissionPolicy{})
 var _ = initializers.WantsDynamicRESTMapper(&KubeMutatingAdmissionPolicy{})
+var _ = initializers.WantsClusterContextManager(&KubeMutatingAdmissionPolicy{})
 var _ = initializer.WantsAuthorizer(&KubeMutatingAdmissionPolicy{})
 var _ = initializer.WantsFeatures(&KubeMutatingAdmissionPolicy{})
 var _ = admission.InitializationValidator(&KubeMutatingAdmissionPolicy{})
@@ -177,6 +181,10 @@ func (k *KubeMutatingAdmissionPolicy) SetDynamicClusterClient(c kcpdynamic.Clust
 
 func (k *KubeMutatingAdmissionPolicy) SetDynamicRESTMapper(dynRESTMapper *dynamicrestmapper.DynamicRESTMapper) {
 	k.dynamicRESTMapper = dynRESTMapper
+}
+
+func (k *KubeMutatingAdmissionPolicy) SetClusterContextManager(mgr *contextmanager.Manager[logicalcluster.Path]) {
+	k.clusterContextManager = mgr
 }
 
 func (k *KubeMutatingAdmissionPolicy) SetAuthorizer(authz authorizer.Authorizer) {
@@ -242,7 +250,7 @@ func (k *KubeMutatingAdmissionPolicy) getSourceClusterForGroupResource(clusterNa
 	return clusterName, nil
 }
 
-// hasMutatingPolicies returns true if the given cluster has hasMutatingPolicies or MutatingAdmissionPolicyBindings.
+// hasMutatingPolicies returns true if the given cluster has any MutatingAdmissionPolicy or MutatingAdmissionPolicyBinding.
 func (k *KubeMutatingAdmissionPolicy) hasMutatingPolicies(ctx context.Context, clusterName logicalcluster.Name) (bool, error) {
 	policyInformer := k.globalKubeSharedInformerFactory.Admissionregistration().V1().MutatingAdmissionPolicies().Informer()
 	bindingInformer := k.globalKubeSharedInformerFactory.Admissionregistration().V1().MutatingAdmissionPolicyBindings().Informer()
@@ -380,7 +388,8 @@ func (k *KubeMutatingAdmissionPolicy) logicalClusterDeleted(clusterName logicalc
 	k.typeConverterManagersLock.Unlock()
 }
 
-// getOrCreateTypeConverterManager returns a TypeConverterManager for the given cluster.
+// getOrCreateTypeConverterManager returns the running TypeConverterManager for the given target cluster, starting one on first use.
+// The manager is shared by all delegates for the same cluster.
 func (k *KubeMutatingAdmissionPolicy) getOrCreateTypeConverterManager(clusterName logicalcluster.Name) patch.TypeConverterManager {
 	k.typeConverterManagersLock.RLock()
 	tcm := k.typeConverterManagers[clusterName]
@@ -401,14 +410,7 @@ func (k *KubeMutatingAdmissionPolicy) getOrCreateTypeConverterManager(clusterNam
 		created := patch.NewTypeConverterManager(nil, openapiClient)
 		k.typeConverterManagers[clusterName] = created
 
-		ctx, cancel := context.WithCancel(context.Background())
-		go func() {
-			select {
-			case <-ctx.Done():
-			case <-k.serverDone:
-				cancel()
-			}
-		}()
+		ctx, _ := k.clusterContextManager.Context(context.Background(), clusterName.Path())
 		go created.Run(ctx)
 
 		return created, nil

--- a/pkg/admission/mutatingadmissionpolicy/mutating_admission_policy.go
+++ b/pkg/admission/mutatingadmissionpolicy/mutating_admission_policy.go
@@ -207,6 +207,16 @@ func (k *KubeMutatingAdmissionPolicy) Admit(ctx context.Context, a admission.Att
 		return err
 	}
 
+	// Only spin up a MAP delegate when needed, because MAP requires the
+	// TypeConverterManager, which polls the OpenAPI endpoint every 5s.
+	hasPolicies, err := k.hasMutatingPolicies(ctx, sourceCluster)
+	if err != nil {
+		return err
+	}
+	if !hasPolicies {
+		return nil
+	}
+
 	delegate, err := k.getOrCreateDelegate(sourceCluster, cluster.Name)
 	if err != nil {
 		return err
@@ -230,6 +240,27 @@ func (k *KubeMutatingAdmissionPolicy) getSourceClusterForGroupResource(clusterNa
 	}
 
 	return clusterName, nil
+}
+
+// hasMutatingPolicies returns true if the given cluster has hasMutatingPolicies or MutatingAdmissionPolicyBindings.
+func (k *KubeMutatingAdmissionPolicy) hasMutatingPolicies(ctx context.Context, clusterName logicalcluster.Name) (bool, error) {
+	policyInformer := k.globalKubeSharedInformerFactory.Admissionregistration().V1().MutatingAdmissionPolicies().Informer()
+	bindingInformer := k.globalKubeSharedInformerFactory.Admissionregistration().V1().MutatingAdmissionPolicyBindings().Informer()
+	if !cache.WaitForCacheSync(ctx.Done(), policyInformer.HasSynced, bindingInformer.HasSynced) {
+		return false, ctx.Err()
+	}
+	policies, err := k.globalKubeSharedInformerFactory.Admissionregistration().V1().MutatingAdmissionPolicies().Lister().Cluster(clusterName).List(labels.Everything())
+	if err != nil {
+		return false, err
+	}
+	if len(policies) > 0 {
+		return true, nil
+	}
+	bindings, err := k.globalKubeSharedInformerFactory.Admissionregistration().V1().MutatingAdmissionPolicyBindings().Lister().Cluster(clusterName).List(labels.Everything())
+	if err != nil {
+		return false, err
+	}
+	return len(bindings) > 0, nil
 }
 
 // getOrCreateDelegate creates an actual plugin for policyClusterName (where policies are defined).

--- a/pkg/admission/mutatingadmissionpolicy/mutating_admission_policy.go
+++ b/pkg/admission/mutatingadmissionpolicy/mutating_admission_policy.go
@@ -74,9 +74,8 @@ func Register(plugins *admission.Plugins) {
 
 func NewKubeMutatingAdmissionPolicy() *KubeMutatingAdmissionPolicy {
 	return &KubeMutatingAdmissionPolicy{
-		Handler:               admission.NewHandler(admission.Connect, admission.Create, admission.Delete, admission.Update),
-		delegates:             make(map[delegateKey]*stoppableMutatingAdmissionPolicy),
-		typeConverterManagers: make(map[logicalcluster.Name]patch.TypeConverterManager),
+		Handler:   admission.NewHandler(admission.Connect, admission.Create, admission.Delete, admission.Update),
+		delegates: make(map[delegateKey]*stoppableMutatingAdmissionPolicy),
 	}
 }
 
@@ -108,8 +107,7 @@ type KubeMutatingAdmissionPolicy struct {
 	delegatesLock sync.RWMutex
 	delegates     map[delegateKey]*stoppableMutatingAdmissionPolicy
 
-	typeConverterManagersLock sync.RWMutex
-	typeConverterManagers     map[logicalcluster.Name]patch.TypeConverterManager
+	typeConverterManagers     sync.Map
 	typeConverterManagerGroup singleflight.Group
 
 	logicalClusterDeletionMonitorStarter sync.Once
@@ -158,9 +156,7 @@ func (k *KubeMutatingAdmissionPolicy) SetKcpInformers(local, global kcpinformers
 					}
 				}
 
-				k.typeConverterManagersLock.Lock()
-				delete(k.typeConverterManagers, clName)
-				k.typeConverterManagersLock.Unlock()
+				k.typeConverterManagers.Delete(clName)
 			},
 		},
 	)
@@ -383,39 +379,34 @@ func (k *KubeMutatingAdmissionPolicy) logicalClusterDeleted(clusterName logicalc
 		logger.V(3).Info("received event to stop mutating admission policy for logical cluster, but it wasn't in the map")
 	}
 
-	k.typeConverterManagersLock.Lock()
-	delete(k.typeConverterManagers, clusterName)
-	k.typeConverterManagersLock.Unlock()
+	k.typeConverterManagers.Delete(clusterName)
 }
 
 // getOrCreateTypeConverterManager returns the running TypeConverterManager for the given target cluster, starting one on first use.
 // The manager is shared by all delegates for the same cluster.
 func (k *KubeMutatingAdmissionPolicy) getOrCreateTypeConverterManager(clusterName logicalcluster.Name) patch.TypeConverterManager {
-	k.typeConverterManagersLock.RLock()
-	tcm := k.typeConverterManagers[clusterName]
-	k.typeConverterManagersLock.RUnlock()
-	if tcm != nil {
-		return tcm
+	stored, loaded := k.typeConverterManagers.Load(clusterName)
+	if loaded {
+		return stored.(patch.TypeConverterManager)
 	}
 
-	v, _, _ := k.typeConverterManagerGroup.Do(string(clusterName), func() (interface{}, error) {
-		k.typeConverterManagersLock.Lock()
-		defer k.typeConverterManagersLock.Unlock()
-
-		if existing := k.typeConverterManagers[clusterName]; existing != nil {
-			return existing, nil
+	created, _, _ := k.typeConverterManagerGroup.Do(clusterName.String(), func() (any, error) {
+		stored, loaded := k.typeConverterManagers.Load(clusterName)
+		if loaded {
+			return stored, nil
 		}
 
 		openapiClient := k.kubeClusterClient.Cluster(clusterName.Path()).Discovery().OpenAPIV3()
 		created := patch.NewTypeConverterManager(nil, openapiClient)
-		k.typeConverterManagers[clusterName] = created
+		k.typeConverterManagers.Store(clusterName, created)
 
 		ctx, _ := k.clusterContextManager.Context(context.Background(), clusterName.Path())
 		go created.Run(ctx)
 
 		return created, nil
 	})
-	return v.(patch.TypeConverterManager)
+
+	return created.(patch.TypeConverterManager)
 }
 
 type stoppableMutatingAdmissionPolicy struct {

--- a/pkg/admission/mutatingadmissionpolicy/mutating_admission_policy.go
+++ b/pkg/admission/mutatingadmissionpolicy/mutating_admission_policy.go
@@ -22,6 +22,8 @@ import (
 	"io"
 	"sync"
 
+	"golang.org/x/sync/singleflight"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -29,6 +31,7 @@ import (
 	"k8s.io/apiserver/pkg/admission/initializer"
 	"k8s.io/apiserver/pkg/admission/plugin/policy/generic"
 	"k8s.io/apiserver/pkg/admission/plugin/policy/mutating"
+	"k8s.io/apiserver/pkg/admission/plugin/policy/mutating/patch"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/features"
@@ -69,8 +72,9 @@ func Register(plugins *admission.Plugins) {
 
 func NewKubeMutatingAdmissionPolicy() *KubeMutatingAdmissionPolicy {
 	return &KubeMutatingAdmissionPolicy{
-		Handler:   admission.NewHandler(admission.Connect, admission.Create, admission.Delete, admission.Update),
-		delegates: make(map[delegateKey]*stoppableMutatingAdmissionPolicy),
+		Handler:               admission.NewHandler(admission.Connect, admission.Create, admission.Delete, admission.Update),
+		delegates:             make(map[delegateKey]*stoppableMutatingAdmissionPolicy),
+		typeConverterManagers: make(map[logicalcluster.Name]patch.TypeConverterManager),
 	}
 }
 
@@ -99,6 +103,10 @@ type KubeMutatingAdmissionPolicy struct {
 
 	delegatesLock sync.RWMutex
 	delegates     map[delegateKey]*stoppableMutatingAdmissionPolicy
+
+	typeConverterManagersLock sync.RWMutex
+	typeConverterManagers     map[logicalcluster.Name]patch.TypeConverterManager
+	typeConverterManagerGroup singleflight.Group
 
 	logicalClusterDeletionMonitorStarter sync.Once
 }
@@ -144,6 +152,10 @@ func (k *KubeMutatingAdmissionPolicy) SetKcpInformers(local, global kcpinformers
 						delegate.stop()
 					}
 				}
+
+				k.typeConverterManagersLock.Lock()
+				delete(k.typeConverterManagers, clName)
+				k.typeConverterManagersLock.Unlock()
 			},
 		},
 	)
@@ -323,6 +335,46 @@ func (k *KubeMutatingAdmissionPolicy) logicalClusterDeleted(clusterName logicalc
 	if !found {
 		logger.V(3).Info("received event to stop mutating admission policy for logical cluster, but it wasn't in the map")
 	}
+
+	k.typeConverterManagersLock.Lock()
+	delete(k.typeConverterManagers, clusterName)
+	k.typeConverterManagersLock.Unlock()
+}
+
+// getOrCreateTypeConverterManager returns a TypeConverterManager for the given cluster.
+func (k *KubeMutatingAdmissionPolicy) getOrCreateTypeConverterManager(clusterName logicalcluster.Name) patch.TypeConverterManager {
+	k.typeConverterManagersLock.RLock()
+	tcm := k.typeConverterManagers[clusterName]
+	k.typeConverterManagersLock.RUnlock()
+	if tcm != nil {
+		return tcm
+	}
+
+	v, _, _ := k.typeConverterManagerGroup.Do(string(clusterName), func() (interface{}, error) {
+		k.typeConverterManagersLock.Lock()
+		defer k.typeConverterManagersLock.Unlock()
+
+		if existing := k.typeConverterManagers[clusterName]; existing != nil {
+			return existing, nil
+		}
+
+		openapiClient := k.kubeClusterClient.Cluster(clusterName.Path()).Discovery().OpenAPIV3()
+		created := patch.NewTypeConverterManager(nil, openapiClient)
+		k.typeConverterManagers[clusterName] = created
+
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			select {
+			case <-ctx.Done():
+			case <-k.serverDone:
+				cancel()
+			}
+		}()
+		go created.Run(ctx)
+
+		return created, nil
+	})
+	return v.(patch.TypeConverterManager)
 }
 
 type stoppableMutatingAdmissionPolicy struct {

--- a/pkg/admission/mutatingadmissionpolicy/mutating_admission_policy.go
+++ b/pkg/admission/mutatingadmissionpolicy/mutating_admission_policy.go
@@ -95,6 +95,7 @@ type KubeMutatingAdmissionPolicy struct {
 	globalKubeSharedInformerFactory kcpkubernetesinformers.SharedInformerFactory
 	serverDone                      <-chan struct{}
 	authorizer                      authorizer.Authorizer
+	cacheSyncOnce                   sync.Once
 
 	getAPIBindings func(clusterName logicalcluster.Name) ([]*apisv1alpha2.APIBinding, error)
 
@@ -250,9 +251,17 @@ func (k *KubeMutatingAdmissionPolicy) getSourceClusterForGroupResource(clusterNa
 func (k *KubeMutatingAdmissionPolicy) hasMutatingPolicies(ctx context.Context, clusterName logicalcluster.Name) (bool, error) {
 	policyInformer := k.globalKubeSharedInformerFactory.Admissionregistration().V1().MutatingAdmissionPolicies().Informer()
 	bindingInformer := k.globalKubeSharedInformerFactory.Admissionregistration().V1().MutatingAdmissionPolicyBindings().Informer()
-	if !cache.WaitForCacheSync(ctx.Done(), policyInformer.HasSynced, bindingInformer.HasSynced) {
-		return false, ctx.Err()
-	}
+
+	// Waiting here for the cache sync isn't great.
+	// However not starting would cause MAP/MAPB to not be applied until they are synced.
+	// And starting them can cause issues on shards with 1000s of LCs, causing 1000s of
+	// delegates to be started.
+	// The once ensures that during shard startup the informers were synced once before
+	// deciding to start a delegate for a cluster.
+	k.cacheSyncOnce.Do(func() {
+		cache.WaitForCacheSync(ctx.Done(), policyInformer.HasSynced, bindingInformer.HasSynced)
+	})
+
 	policies, err := k.globalKubeSharedInformerFactory.Admissionregistration().V1().MutatingAdmissionPolicies().Lister().Cluster(clusterName).List(labels.Everything())
 	if err != nil {
 		return false, err

--- a/pkg/admission/validatingadmissionpolicy/validating_admission_policy.go
+++ b/pkg/admission/validatingadmissionpolicy/validating_admission_policy.go
@@ -31,11 +31,9 @@ import (
 	"k8s.io/apiserver/pkg/admission/plugin/policy/validating"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
-	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
@@ -50,6 +48,7 @@ import (
 
 	"github.com/kcp-dev/kcp/pkg/admission/initializers"
 	"github.com/kcp-dev/kcp/pkg/admission/kubequota"
+	"github.com/kcp-dev/kcp/pkg/reconciler/dynamicrestmapper"
 )
 
 const PluginName = "KCPValidatingAdmissionPolicy"
@@ -88,6 +87,8 @@ type KubeValidatingAdmissionPolicy struct {
 
 	getAPIBindings func(clusterName logicalcluster.Name) ([]*apisv1alpha2.APIBinding, error)
 
+	dynamicRESTMapper *dynamicrestmapper.DynamicRESTMapper
+
 	delegatesLock sync.RWMutex
 	delegates     map[delegateKey]*stoppableValidatingAdmissionPolicy
 
@@ -100,6 +101,7 @@ var _ = initializers.WantsKubeInformers(&KubeValidatingAdmissionPolicy{})
 var _ = initializers.WantsKcpInformers(&KubeValidatingAdmissionPolicy{})
 var _ = initializers.WantsServerShutdownChannel(&KubeValidatingAdmissionPolicy{})
 var _ = initializers.WantsDynamicClusterClient(&KubeValidatingAdmissionPolicy{})
+var _ = initializers.WantsDynamicRESTMapper(&KubeValidatingAdmissionPolicy{})
 var _ = initializer.WantsAuthorizer(&KubeValidatingAdmissionPolicy{})
 var _ = admission.InitializationValidator(&KubeValidatingAdmissionPolicy{})
 
@@ -149,6 +151,10 @@ func (k *KubeValidatingAdmissionPolicy) SetServerShutdownChannel(ch <-chan struc
 
 func (k *KubeValidatingAdmissionPolicy) SetDynamicClusterClient(c kcpdynamic.ClusterInterface) {
 	k.dynamicClusterClient = c
+}
+
+func (k *KubeValidatingAdmissionPolicy) SetDynamicRESTMapper(dynRESTMapper *dynamicrestmapper.DynamicRESTMapper) {
+	k.dynamicRESTMapper = dynRESTMapper
 }
 
 func (k *KubeValidatingAdmissionPolicy) SetAuthorizer(authz authorizer.Authorizer) {
@@ -260,10 +266,7 @@ func (k *KubeValidatingAdmissionPolicy) getOrCreateDelegate(policyClusterName, t
 	plugin.SetNamespaceInformer(k.localKubeSharedInformerFactory.Core().V1().Namespaces().Cluster(targetClusterName))
 	plugin.SetExternalKubeClientSet(k.kubeClusterClient.Cluster(policyClusterName.Path()))
 
-	// TODO(ncdc): this is super inefficient to do per workspace
-	discoveryClient := memory.NewMemCacheClient(k.kubeClusterClient.Cluster(policyClusterName.Path()).Discovery())
-	restMapper := restmapper.NewDeferredDiscoveryRESTMapper(discoveryClient)
-	plugin.SetRESTMapper(restMapper)
+	plugin.SetRESTMapper(k.dynamicRESTMapper.ForCluster(policyClusterName))
 
 	plugin.SetDynamicClient(k.dynamicClusterClient.Cluster(policyClusterName.Path()))
 	plugin.SetDrainedNotification(ctx.Done())

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -658,6 +658,7 @@ func NewConfig(ctx context.Context, opts kcpserveroptions.CompletedOptions) (*Co
 		kcpadmissioninitializers.NewServerShutdownInitializer(c.quotaAdmissionStopCh),
 		kcpadmissioninitializers.NewDynamicClusterClientInitializer(c.DynamicClusterClient),
 		kcpadmissioninitializers.NewDynamicRESTMapperInitializer(c.DynamicRESTMapper),
+		kcpadmissioninitializers.NewClusterContextManagerInitializer(c.ClusterContextManager),
 	}
 
 	c.ShardBaseURL = func() string {


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Thank you for noticing the branch name. Yes, I am a comedic genius.

1. VAP and MAP use dynamic rest mapper
2. MAP shared the underyling TypeConverterManager per ~source policy~ target cluster bounded by its per-cluster context

Doesn't quite fix #4216 but kinda does.



## What Type of PR Is This?

/kind bug
/kind feature

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
