### PR TITLE
Prevent marking an LC as inactive when it is not ready

### DIFF
--- a/pkg/admission/logicalcluster/admission.go
+++ b/pkg/admission/logicalcluster/admission.go
@@ -193,6 +193,15 @@ func (o *plugin) Validate(ctx context.Context, a admission.Attributes, _ admissi
 			return admission.NewForbidden(a, fmt.Errorf("cannot transition from %q to %q", old.Status.Phase, logicalCluster.Status.Phase))
 		}
 
+		// Prevent marking a cluster as inactive when it is not in phase ready.
+		// Doing so can lead to undefined behaviour, as the cluster might be in the process of being initialized or terminated.
+		// Both require access to the LC, which the inactive annotation would prevent, deadlocking processes.
+		wasInactive := corev1alpha1.IsLogicalClusterInactive(old.Annotations)
+		isInactive := corev1alpha1.IsLogicalClusterInactive(logicalCluster.Annotations)
+		if logicalCluster.Status.Phase != corev1alpha1.LogicalClusterPhaseReady && !wasInactive && isInactive {
+			return admission.NewForbidden(a, fmt.Errorf("LogicalCluster can only be marked inactive in phase %q, but is in phase %q", corev1alpha1.LogicalClusterPhaseReady, logicalCluster.Status.Phase))
+		}
+
 		return nil
 
 	case admission.Delete:

--- a/pkg/admission/logicalcluster/admission_test.go
+++ b/pkg/admission/logicalcluster/admission_test.go
@@ -318,6 +318,68 @@ func TestValidate(t *testing.T) {
 			wantErr: "cannot transition from",
 		},
 		{
+			name:        "fails to mark inactive while initializing",
+			clusterName: "root:org:ws",
+			attr: updateAttr(
+				newLogicalCluster("root:org:ws").inactive().withStatus(corev1alpha1.LogicalClusterStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseInitializing,
+				}).LogicalCluster,
+				newLogicalCluster("root:org:ws").withStatus(corev1alpha1.LogicalClusterStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseInitializing,
+				}).LogicalCluster,
+			),
+			wantErr: "can only be marked inactive in phase",
+		},
+		{
+			name:        "fails to mark inactive while scheduling",
+			clusterName: "root:org:ws",
+			attr: updateAttr(
+				newLogicalCluster("root:org:ws").inactive().withStatus(corev1alpha1.LogicalClusterStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseScheduling,
+				}).LogicalCluster,
+				newLogicalCluster("root:org:ws").withStatus(corev1alpha1.LogicalClusterStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseScheduling,
+				}).LogicalCluster,
+			),
+			wantErr: "can only be marked inactive in phase",
+		},
+		{
+			name:        "passes marking inactive when ready",
+			clusterName: "root:org:ws",
+			attr: updateAttr(
+				newLogicalCluster("root:org:ws").inactive().withStatus(corev1alpha1.LogicalClusterStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseReady,
+				}).LogicalCluster,
+				newLogicalCluster("root:org:ws").withStatus(corev1alpha1.LogicalClusterStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseReady,
+				}).LogicalCluster,
+			),
+		},
+		{
+			name:        "passes reactivating (removing inactive) while not ready",
+			clusterName: "root:org:ws",
+			attr: updateAttr(
+				newLogicalCluster("root:org:ws").withStatus(corev1alpha1.LogicalClusterStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseInitializing,
+				}).LogicalCluster,
+				newLogicalCluster("root:org:ws").inactive().withStatus(corev1alpha1.LogicalClusterStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseInitializing,
+				}).LogicalCluster,
+			),
+		},
+		{
+			name:        "passes updates on an already inactive cluster",
+			clusterName: "root:org:ws",
+			attr: updateAttr(
+				newLogicalCluster("root:org:ws").inactive().withStatus(corev1alpha1.LogicalClusterStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseInactive,
+				}).LogicalCluster,
+				newLogicalCluster("root:org:ws").inactive().withStatus(corev1alpha1.LogicalClusterStatus{
+					Phase: corev1alpha1.LogicalClusterPhaseInactive,
+				}).LogicalCluster,
+			),
+		},
+		{
 			name:        "fails deletion as another user",
 			clusterName: "root:org:ws",
 			attr:        deleteAttr(newLogicalCluster("root:org:ws").LogicalCluster, &kuser.DefaultInfo{}),
@@ -432,6 +494,14 @@ func (b thisWsBuilder) directlyDeletable() thisWsBuilder {
 
 func (b thisWsBuilder) withStatus(status corev1alpha1.LogicalClusterStatus) thisWsBuilder {
 	b.Status = status
+	return b
+}
+
+func (b thisWsBuilder) inactive() thisWsBuilder {
+	if b.Annotations == nil {
+		b.Annotations = map[string]string{}
+	}
+	b.Annotations[corev1alpha1.LogicalClusterInactiveAnnotationKey] = "true"
 	return b
 }
 


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

I was looking at this failure and remembered that I was thinking that this could be a problem when I was working on LC migration.
Basically if an LC is marked inactive while it is initializing all further connections to the cluster are forbidden, so it never finishes initializing.

https://public-prow.kcp.k8c.io/view/s3/prow-public-data/pr-logs/pull/kcp-dev_kcp/4209/pull-kcp-test-e2e-multiple-runs/2068641561582768128

That's the flake :shrug:

## What Type of PR Is This?

/kind flake

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
