### PR TITLE
Re-create bound CRDs during LC migration

### DIFF
--- a/pkg/authorization/bootstrap/policy.go
+++ b/pkg/authorization/bootstrap/policy.go
@@ -18,6 +18,7 @@ package bootstrap
 
 import (
 	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authentication/user"
 	rbacv1helpers "k8s.io/kubernetes/pkg/apis/rbac/v1"
@@ -163,6 +164,11 @@ func clusterRoles() []rbacv1.ClusterRole {
 				rbacv1helpers.NewRule("create").Groups(migration.GroupName).Resources("logicalclusterdumps").RuleOrDie(),
 				// allows shards to update LogicalClusterMigrations wherever it is placed
 				rbacv1helpers.NewRule("get", "update", "patch").Groups(migration.GroupName).Resources("logicalclustermigrations", "logicalclustermigrations/status").RuleOrDie(),
+				// Allow restoring bounds CRDs.
+				rbacv1helpers.NewRule("list").Groups(apis.GroupName).Resources("apibindings").RuleOrDie(),
+				rbacv1helpers.NewRule("get").Groups(apis.GroupName).Resources("apiexports").RuleOrDie(),
+				rbacv1helpers.NewRule("get").Groups(apis.GroupName).Resources("apiresourceschemas").RuleOrDie(),
+				rbacv1helpers.NewRule("get", "create").Groups(apiextensions.GroupName).Resources("customresourcedefinitions").RuleOrDie(),
 			},
 		},
 	}

--- a/pkg/reconciler/apis/apibinding/apibinding_reconcile.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_reconcile.go
@@ -388,7 +388,7 @@ func (r *bindingReconciler) reconcile(ctx context.Context, apiBinding *apisv1alp
 		}
 
 		// Try to get the bound CRD
-		existingCRD, err := r.getCRD(SystemBoundCRDsClusterName, boundCRDName(sch))
+		existingCRD, err := r.getCRD(SystemBoundCRDsClusterName, BoundCRDName(sch))
 		if err != nil && !apierrors.IsNotFound(err) {
 			conditions.MarkFalse(
 				apiBinding,
@@ -400,7 +400,7 @@ func (r *bindingReconciler) reconcile(ctx context.Context, apiBinding *apisv1alp
 
 			return reconcileStatusContinue, fmt.Errorf(
 				"error getting CRD %s|%s for APIBinding %s|%s, APIExport %s|%s, APIResourceSchema %s|%s: %w",
-				SystemBoundCRDsClusterName, boundCRDName(sch),
+				SystemBoundCRDsClusterName, BoundCRDName(sch),
 				logicalcluster.From(apiBinding), apiBinding.Name,
 				apiExportPath, apiExport.Name,
 				apiExportPath, resourceSchema.Schema,
@@ -421,7 +421,7 @@ func (r *bindingReconciler) reconcile(ctx context.Context, apiBinding *apisv1alp
 			}
 		} else {
 			// Need to create bound CRD
-			crd, err := generateCRD(sch)
+			crd, err := GenerateBoundCRD(sch)
 			if err != nil {
 				logger.Error(err, "error generating CRD")
 
@@ -604,7 +604,8 @@ func (r *bindingReconciler) reconcile(ctx context.Context, apiBinding *apisv1alp
 	return reconcileStatusContinue, nil
 }
 
-func boundCRDName(schema *apisv1alpha1.APIResourceSchema) string {
+// BoundCRDName returns the name used for a bound CRD in system:bound-crds.
+func BoundCRDName(schema *apisv1alpha1.APIResourceSchema) string {
 	return string(schema.UID)
 }
 
@@ -714,7 +715,7 @@ func (r *permissionClaimMaterialiserReconciler) reconcile(ctx context.Context, a
 // any shard's apibinding controller. The CRD is named by the schema UID so that
 // concurrent creators converge on the same object.
 func (r *permissionClaimMaterialiserReconciler) ensurePermissionClaimBoundCRD(ctx context.Context, sch *apisv1alpha1.APIResourceSchema) error {
-	name := boundCRDName(sch)
+	name := BoundCRDName(sch)
 
 	if _, err := r.getCRD(SystemBoundCRDsClusterName, name); err == nil {
 		// Already there. Recreation only happens via the regular Resources path; here
@@ -726,7 +727,7 @@ func (r *permissionClaimMaterialiserReconciler) ensurePermissionClaimBoundCRD(ct
 		return err
 	}
 
-	crd, err := generateCRD(sch)
+	crd, err := GenerateBoundCRD(sch)
 	if err != nil {
 		return err
 	}
@@ -737,10 +738,11 @@ func (r *permissionClaimMaterialiserReconciler) ensurePermissionClaimBoundCRD(ct
 	return nil
 }
 
-func generateCRD(schema *apisv1alpha1.APIResourceSchema) (*apiextensionsv1.CustomResourceDefinition, error) {
+// GenerateBoundCRD creates a CRD object from an APIResourceSchema for use in system:bound-crds.
+func GenerateBoundCRD(schema *apisv1alpha1.APIResourceSchema) (*apiextensionsv1.CustomResourceDefinition, error) {
 	crd := &apiextensionsv1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: boundCRDName(schema),
+			Name: BoundCRDName(schema),
 			Annotations: map[string]string{
 				logicalcluster.AnnotationKey:            SystemBoundCRDsClusterName.String(),
 				apisv1alpha1.AnnotationBoundCRDKey:      "",

--- a/pkg/reconciler/apis/apibinding/apibinding_reconcile_test.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_reconcile_test.go
@@ -1180,7 +1180,7 @@ func TestCRDFromAPIResourceSchema(t *testing.T) {
 	for testName, tc := range tests {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
-			got, err := generateCRD(tc.schema)
+			got, err := GenerateBoundCRD(tc.schema)
 
 			if tc.wantErr != (err != nil) {
 				t.Fatalf("wantErr: %v, got %v", tc.wantErr, err)

--- a/pkg/reconciler/migration/logicalclustermigration/boundcrds.go
+++ b/pkg/reconciler/migration/logicalclustermigration/boundcrds.go
@@ -54,13 +54,13 @@ func (c *Controller) ensureBoundCRDs(ctx context.Context, lcName logicalcluster.
 			exportPath = logicalcluster.From(&binding).Path()
 		}
 
-		apiExport, err := c.kcpClusterClient.Cluster(exportPath).ApisV1alpha2().APIExports().Get(ctx, exportName, metav1.GetOptions{})
+		apiExport, err := c.getAPIExportByPath(exportPath, exportName)
 		if err != nil {
 			return fmt.Errorf("failed to get APIExport %s:%s for binding %s: %w", exportPath, exportName, binding.Name, err)
 		}
 
 		for _, resource := range apiExport.Spec.Resources {
-			schema, err := c.kcpClusterClient.Cluster(exportPath).ApisV1alpha1().APIResourceSchemas().Get(ctx, resource.Schema, metav1.GetOptions{})
+			schema, err := c.getAPIResourceSchema(logicalcluster.From(apiExport), resource.Schema)
 			if err != nil {
 				return fmt.Errorf("failed to get APIResourceSchema %s in %s: %w", resource.Schema, exportPath, err)
 			}
@@ -68,10 +68,7 @@ func (c *Controller) ensureBoundCRDs(ctx context.Context, lcName logicalcluster.
 			boundCRDName := apibinding.BoundCRDName(schema)
 
 			// Try to get the bound CRD.
-			existingCRD, err := c.crdClusterClient.
-				Cluster(apibinding.SystemBoundCRDsClusterName.Path()).
-				ApiextensionsV1().CustomResourceDefinitions().
-				Get(ctx, boundCRDName, metav1.GetOptions{})
+			existingCRD, err := c.getCRD(apibinding.SystemBoundCRDsClusterName, boundCRDName)
 			if err != nil && !apierrors.IsNotFound(err) {
 				return fmt.Errorf("error getting bound CRD %s: %w", boundCRDName, err)
 			}

--- a/pkg/reconciler/migration/logicalclustermigration/boundcrds.go
+++ b/pkg/reconciler/migration/logicalclustermigration/boundcrds.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logicalclustermigration
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apiextensions-apiserver/pkg/apihelpers"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	"github.com/kcp-dev/kcp/pkg/reconciler/apis/apibinding"
+)
+
+func (c *Controller) ensureBoundCRDs(ctx context.Context, lcName logicalcluster.Name) error {
+	logger := klog.FromContext(ctx)
+
+	bindings, err := c.kcpClusterClient.Cluster(lcName.Path()).ApisV1alpha2().APIBindings().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list APIBindings in %s: %w", lcName, err)
+	}
+
+	for _, binding := range bindings.Items {
+		if binding.Spec.Reference.Export == nil {
+			continue
+		}
+
+		exportName := binding.Spec.Reference.Export.Name
+		if exportName == "" {
+			continue
+		}
+
+		exportPath := logicalcluster.NewPath(binding.Spec.Reference.Export.Path)
+		if exportPath.Empty() {
+			exportPath = logicalcluster.From(&binding).Path()
+		}
+
+		apiExport, err := c.kcpClusterClient.Cluster(exportPath).ApisV1alpha2().APIExports().Get(ctx, exportName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to get APIExport %s:%s for binding %s: %w", exportPath, exportName, binding.Name, err)
+		}
+
+		for _, resource := range apiExport.Spec.Resources {
+			schema, err := c.kcpClusterClient.Cluster(exportPath).ApisV1alpha1().APIResourceSchemas().Get(ctx, resource.Schema, metav1.GetOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to get APIResourceSchema %s in %s: %w", resource.Schema, exportPath, err)
+			}
+
+			boundCRDName := apibinding.BoundCRDName(schema)
+
+			// Try to get the bound CRD.
+			existingCRD, err := c.crdClusterClient.
+				Cluster(apibinding.SystemBoundCRDsClusterName.Path()).
+				ApiextensionsV1().CustomResourceDefinitions().
+				Get(ctx, boundCRDName, metav1.GetOptions{})
+			if err != nil && !apierrors.IsNotFound(err) {
+				return fmt.Errorf("error getting bound CRD %s: %w", boundCRDName, err)
+			}
+
+			if err == nil {
+				// Bound CRD already exists. We need to wait until it reaches Established.
+				if !apihelpers.IsCRDConditionTrue(existingCRD, apiextensionsv1.Established) {
+					logger.V(4).Info("bound CRD is not yet established, requeueing", "crd", boundCRDName)
+					return fmt.Errorf("bound CRD %s is not yet established", boundCRDName)
+				}
+				if apihelpers.IsCRDConditionTrue(existingCRD, apiextensionsv1.Terminating) {
+					logger.V(4).Info("bound CRD is terminating, requeueing", "crd", boundCRDName)
+					return fmt.Errorf("bound CRD %s is terminating", boundCRDName)
+				}
+				logger.V(4).Info("bound CRD already exists and is established", "crd", boundCRDName)
+				continue
+			}
+
+			// Need to create bound CRD.
+			crd, err := apibinding.GenerateBoundCRD(schema)
+			if err != nil {
+				return fmt.Errorf("failed to generate bound CRD from schema %s: %w", resource.Schema, err)
+			}
+
+			logger.V(2).Info("creating bound CRD", "crd", crd.Name, "binding", binding.Name)
+			_, err = c.crdClusterClient.
+				Cluster(apibinding.SystemBoundCRDsClusterName.Path()).
+				ApiextensionsV1().CustomResourceDefinitions().
+				Create(ctx, crd, metav1.CreateOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to create bound CRD %s: %v", crd.Name, err)
+			}
+
+			return fmt.Errorf("bound CRD %s created, requeueing to wait for established", crd.Name)
+		}
+	}
+
+	return nil
+}

--- a/pkg/reconciler/migration/logicalclustermigration/controller.go
+++ b/pkg/reconciler/migration/logicalclustermigration/controller.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/klog/v2"
 
 	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
+	kcpapiextensionsclientset "github.com/kcp-dev/client-go/apiextensions/client"
 	"github.com/kcp-dev/logicalcluster/v3"
 	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 	migrationv1alpha1 "github.com/kcp-dev/sdk/apis/migration/v1alpha1"
@@ -60,6 +61,7 @@ const (
 func NewController(
 	shardName string,
 	kcpClusterClient kcpclientset.ClusterInterface,
+	crdClusterClient kcpapiextensionsclientset.ClusterInterface,
 	externalLogicalClusterAdminConfig *rest.Config,
 	etcdClient *clientv3.Client,
 	etcdStoragePrefix string,
@@ -79,6 +81,7 @@ func NewController(
 		),
 		shardName:                         shardName,
 		kcpClusterClient:                  kcpClusterClient,
+		crdClusterClient:                  crdClusterClient,
 		externalLogicalClusterAdminConfig: externalLogicalClusterAdminConfig,
 		etcdClient:                        etcdClient,
 		etcdStoragePrefix:                 etcdStoragePrefix,
@@ -113,6 +116,7 @@ type Controller struct {
 	shardName string
 
 	kcpClusterClient                  kcpclientset.ClusterInterface
+	crdClusterClient                  kcpapiextensionsclientset.ClusterInterface
 	externalLogicalClusterAdminConfig *rest.Config
 	etcdClient                        *clientv3.Client
 	etcdStoragePrefix                 string

--- a/pkg/reconciler/migration/logicalclustermigration/controller.go
+++ b/pkg/reconciler/migration/logicalclustermigration/controller.go
@@ -23,6 +23,7 @@ import (
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -35,15 +36,22 @@ import (
 
 	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
 	kcpapiextensionsclientset "github.com/kcp-dev/client-go/apiextensions/client"
+	kcpapiextensionsv1informers "github.com/kcp-dev/client-go/apiextensions/informers/apiextensions/v1"
 	"github.com/kcp-dev/logicalcluster/v3"
+	apisv1alpha1 "github.com/kcp-dev/sdk/apis/apis/v1alpha1"
+	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
 	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 	migrationv1alpha1 "github.com/kcp-dev/sdk/apis/migration/v1alpha1"
 	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
 	migrationv1alpha1client "github.com/kcp-dev/sdk/client/clientset/versioned/typed/migration/v1alpha1"
+	apisv1alpha1informers "github.com/kcp-dev/sdk/client/informers/externalversions/apis/v1alpha1"
+	apisv1alpha2informers "github.com/kcp-dev/sdk/client/informers/externalversions/apis/v1alpha2"
 	corev1alpha1informers "github.com/kcp-dev/sdk/client/informers/externalversions/core/v1alpha1"
 	migrationv1alpha1informers "github.com/kcp-dev/sdk/client/informers/externalversions/migration/v1alpha1"
+	apisv1alpha1listers "github.com/kcp-dev/sdk/client/listers/apis/v1alpha1"
 	corev1alpha1listers "github.com/kcp-dev/sdk/client/listers/core/v1alpha1"
 
+	"github.com/kcp-dev/kcp/pkg/indexers"
 	"github.com/kcp-dev/kcp/pkg/informer"
 	"github.com/kcp-dev/kcp/pkg/logging"
 	"github.com/kcp-dev/kcp/pkg/reconciler/committer"
@@ -68,6 +76,9 @@ func NewController(
 	cachedLogicalClusterMigrationInformer migrationv1alpha1informers.LogicalClusterMigrationClusterInformer,
 	localLogicalClusterInformer corev1alpha1informers.LogicalClusterClusterInformer,
 	cachedShardInformer corev1alpha1informers.ShardClusterInformer,
+	crdInformer kcpapiextensionsv1informers.CustomResourceDefinitionClusterInformer,
+	apiExportInformer, globalAPIExportInformer apisv1alpha2informers.APIExportClusterInformer,
+	apiResourceSchemaInformer, globalAPIResourceSchemaInformer apisv1alpha1informers.APIResourceSchemaClusterInformer,
 	migratingLogicalClusters *MigratingLogicalClusters,
 	cancelLogicalClusterConnections func(logicalcluster.Path, error),
 	ddsif *informer.DiscoveringDynamicSharedInformerFactory,
@@ -91,6 +102,13 @@ func NewController(
 		cancelLogicalClusterConnections:   cancelLogicalClusterConnections,
 		ddsif:                             ddsif,
 		commit:                            committer.NewCommitter[*migrationv1alpha1.LogicalClusterMigration, migrationv1alpha1client.LogicalClusterMigrationInterface, *migrationv1alpha1.LogicalClusterMigrationSpec, *migrationv1alpha1.LogicalClusterMigrationStatus](kcpClusterClient.MigrationV1alpha1().LogicalClusterMigrations()),
+		getAPIExportByPath: func(path logicalcluster.Path, name string) (*apisv1alpha2.APIExport, error) {
+			return indexers.ByPathAndNameWithFallback[*apisv1alpha2.APIExport](apisv1alpha2.Resource("apiexports"), apiExportInformer.Informer().GetIndexer(), globalAPIExportInformer.Informer().GetIndexer(), path, name)
+		},
+		getAPIResourceSchema: informer.NewScopedGetterWithFallback[*apisv1alpha1.APIResourceSchema, apisv1alpha1listers.APIResourceSchemaLister](apiResourceSchemaInformer.Lister(), globalAPIResourceSchemaInformer.Lister()),
+		getCRD: func(clusterName logicalcluster.Name, name string) (*apiextensionsv1.CustomResourceDefinition, error) {
+			return crdInformer.Lister().Cluster(clusterName).Get(name)
+		},
 	}
 
 	// Events are queued from the cache server as that is used to
@@ -129,6 +147,10 @@ type Controller struct {
 	ddsif                           *informer.DiscoveringDynamicSharedInformerFactory
 
 	commit func(ctx context.Context, old, new *logicalClusterMigrationResource) error
+
+	getAPIExportByPath   func(path logicalcluster.Path, name string) (*apisv1alpha2.APIExport, error)
+	getAPIResourceSchema func(clusterName logicalcluster.Name, name string) (*apisv1alpha1.APIResourceSchema, error)
+	getCRD               func(clusterName logicalcluster.Name, name string) (*apiextensionsv1.CustomResourceDefinition, error)
 }
 
 func (c *Controller) enqueue(obj interface{}) {

--- a/pkg/reconciler/migration/logicalclustermigration/reconciler.go
+++ b/pkg/reconciler/migration/logicalclustermigration/reconciler.go
@@ -250,6 +250,12 @@ func (c *Controller) reconcileDestinationFinalize(ctx context.Context, migration
 		}
 	}
 
+	// We need to re-create the bound CRDs for all APIBindings
+	// in the LC as they are not part of the dump.
+	if err := c.ensureBoundCRDs(ctx, lcName); err != nil {
+		return true, fmt.Errorf("failed to ensure bound CRDs for %s: %w", lcName, err)
+	}
+
 	// Migration is done, allow access to the logical cluster.
 	// Maybe needs some targeted relisting for api sharing before
 	// allowing access so the stateful objects (*EndpointSlice) are

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -1186,6 +1186,11 @@ func (s *Server) installLogicalClusterMigrationController(ctx context.Context, c
 		s.CacheKcpSharedInformerFactory.Migration().V1alpha1().LogicalClusterMigrations(),
 		s.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters(),
 		s.CacheKcpSharedInformerFactory.Core().V1alpha1().Shards(),
+		s.ApiExtensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions(),
+		s.KcpSharedInformerFactory.Apis().V1alpha2().APIExports(),
+		s.CacheKcpSharedInformerFactory.Apis().V1alpha2().APIExports(),
+		s.KcpSharedInformerFactory.Apis().V1alpha1().APIResourceSchemas(),
+		s.CacheKcpSharedInformerFactory.Apis().V1alpha1().APIResourceSchemas(),
 		s.MigratingLogicalClusters,
 		s.ClusterContextManager.Cancel,
 		s.PartialMetadataDDSIF,
@@ -1200,7 +1205,12 @@ func (s *Server) installLogicalClusterMigrationController(ctx context.Context, c
 			return wait.PollUntilContextCancel(ctx, waitPollInterval, true, func(ctx context.Context) (bool, error) {
 				return s.CacheKcpSharedInformerFactory.Migration().V1alpha1().LogicalClusterMigrations().Informer().HasSynced() &&
 					s.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters().Informer().HasSynced() &&
-					s.CacheKcpSharedInformerFactory.Core().V1alpha1().Shards().Informer().HasSynced(), nil
+					s.CacheKcpSharedInformerFactory.Core().V1alpha1().Shards().Informer().HasSynced() &&
+					s.ApiExtensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions().Informer().HasSynced() &&
+					s.KcpSharedInformerFactory.Apis().V1alpha2().APIExports().Informer().HasSynced() &&
+					s.CacheKcpSharedInformerFactory.Apis().V1alpha2().APIExports().Informer().HasSynced() &&
+					s.KcpSharedInformerFactory.Apis().V1alpha1().APIResourceSchemas().Informer().HasSynced() &&
+					s.CacheKcpSharedInformerFactory.Apis().V1alpha1().APIResourceSchemas().Informer().HasSynced(), nil
 			})
 		},
 		Runner: func(ctx context.Context) {

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -1155,11 +1155,18 @@ func (s *Server) installLogicalClusterCleanupController(ctx context.Context, con
 	})
 }
 
-func (s *Server) installLogicalClusterMigrationController(ctx context.Context) error {
+func (s *Server) installLogicalClusterMigrationController(ctx context.Context, config *rest.Config) error {
 	externalConfig := rest.CopyConfig(s.ExternalLogicalClusterAdminConfig)
 	externalConfig = rest.AddUserAgent(externalConfig, logicalclustermigration.ControllerName)
 
 	kcpClusterClient, err := kcpclientset.NewForConfig(externalConfig)
+	if err != nil {
+		return err
+	}
+
+	crdConfig := rest.CopyConfig(config)
+	crdConfig = rest.AddUserAgent(crdConfig, logicalclustermigration.ControllerName)
+	crdClusterClient, err := kcpapiextensionsclientset.NewForConfig(crdConfig)
 	if err != nil {
 		return err
 	}
@@ -1172,6 +1179,7 @@ func (s *Server) installLogicalClusterMigrationController(ctx context.Context) e
 	c, err := logicalclustermigration.NewController(
 		s.Options.Extra.ShardName,
 		kcpClusterClient,
+		crdClusterClient,
 		s.ExternalLogicalClusterAdminConfig,
 		etcdClient,
 		s.Options.GenericControlPlane.Etcd.StorageConfig.Prefix,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -313,7 +313,7 @@ func (s *Server) installControllers(ctx context.Context, controllerConfig *rest.
 	}
 
 	if kcpfeatures.DefaultFeatureGate.Enabled(kcpfeatures.LogicalClusterMigration) {
-		if err := s.installLogicalClusterMigrationController(ctx); err != nil {
+		if err := s.installLogicalClusterMigrationController(ctx, controllerConfig); err != nil {
 			return err
 		}
 	}

--- a/test/e2e/logicalclustermigration/apiresourceschema_cowboys.yaml
+++ b/test/e2e/logicalclustermigration/apiresourceschema_cowboys.yaml
@@ -1,0 +1,46 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIResourceSchema
+metadata:
+  name: today.cowboys.wildwest.dev
+spec:
+  group: wildwest.dev
+  names:
+    kind: Cowboy
+    listKind: CowboyList
+    plural: cowboys
+    singular: cowboy
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      description: Cowboy is part of the wild west
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CowboySpec holds the desired state of the Cowboy.
+          properties:
+            intent:
+              type: string
+          type: object
+        status:
+          description: CowboyStatus communicates the observed state of the Cowboy.
+          properties:
+            result:
+              type: string
+          type: object
+      type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/test/e2e/logicalclustermigration/migration_test.go
+++ b/test/e2e/logicalclustermigration/migration_test.go
@@ -19,6 +19,7 @@ package logicalclustermigration
 import (
 	"context"
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
@@ -31,8 +32,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/cache"
 
+	kcpdynamic "github.com/kcp-dev/client-go/dynamic"
 	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
 	"github.com/kcp-dev/logicalcluster/v3"
 	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
@@ -41,6 +45,9 @@ import (
 	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
 	kcptesting "github.com/kcp-dev/sdk/testing"
 
+	"github.com/kcp-dev/kcp/config/helpers"
+	wildwestv1alpha1 "github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/apis/wildwest/v1alpha1"
+	wildwestclientset "github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/client/clientset/versioned/cluster"
 	"github.com/kcp-dev/kcp/test/e2e/framework"
 )
 
@@ -302,4 +309,284 @@ func TestMigrationAPIBindingUnprivileged(t *testing.T) {
 		metav1.CreateOptions{},
 	)
 	require.True(t, errors.IsForbidden(err), "expected forbidden, got: %v", err)
+}
+
+func TestFullMigrationAPIBindings(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "control-plane")
+
+	server := kcptesting.SharedKcpServer(t)
+
+	if len(server.ShardNames()) < 2 {
+		t.Skip("requires multi-shard setup")
+	}
+
+	cfg := server.BaseConfig(t)
+	kcpClusterClient, err := kcpclientset.NewForConfig(cfg)
+	require.NoError(t, err)
+	dynamicClusterClient, err := kcpdynamic.NewForConfig(cfg)
+	require.NoError(t, err)
+	wildwestClusterClient, err := wildwestclientset.NewForConfig(cfg)
+	require.NoError(t, err)
+
+	shardNames := server.ShardNames()
+	originShard := shardNames[0]
+	destinationShard := shardNames[1]
+
+	t.Logf("Using origin shard %q and destination shard %q", originShard, destinationShard)
+
+	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path())
+	providerPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)
+	consumerPath, consumerWs := kcptesting.NewWorkspaceFixture(t, server, orgPath, kcptesting.WithShard(originShard))
+	lcName := logicalcluster.Name(consumerWs.Spec.Cluster)
+
+	t.Logf("Provider workspace: %s, Consumer workspace: %s (logical cluster %s, shard %s)", providerPath, consumerPath, lcName, originShard)
+
+	t.Logf("Installing Cowboys APIResourceSchema in provider workspace %s", providerPath)
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(kcpClusterClient.Cluster(providerPath).Discovery()))
+	err = helpers.CreateResourceFromFS(t.Context(), dynamicClusterClient.Cluster(providerPath), mapper, nil, "apiresourceschema_cowboys.yaml", testFiles)
+	require.NoError(t, err)
+
+	t.Logf("Creating Cowboys APIExport in provider workspace %s", providerPath)
+	_, err = kcpClusterClient.Cluster(providerPath).ApisV1alpha2().APIExports().Create(
+		t.Context(),
+		&apisv1alpha2.APIExport{
+			ObjectMeta: metav1.ObjectMeta{Name: "today-cowboys"},
+			Spec: apisv1alpha2.APIExportSpec{
+				Resources: []apisv1alpha2.ResourceSchema{
+					{
+						Name:   "cowboys",
+						Group:  "wildwest.dev",
+						Schema: "today.cowboys.wildwest.dev",
+						Storage: apisv1alpha2.ResourceSchemaStorage{
+							CRD: &apisv1alpha2.ResourceSchemaStorageCRD{},
+						},
+					},
+				},
+			},
+		},
+		metav1.CreateOptions{},
+	)
+	require.NoError(t, err)
+
+	t.Logf("Creating Cowboys APIBinding in consumer workspace %s", consumerPath)
+	require.Eventually(t, func() bool {
+		_, err := kcpClusterClient.Cluster(consumerPath).ApisV1alpha2().APIBindings().Create(
+			t.Context(),
+			&apisv1alpha2.APIBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "cowboys"},
+				Spec: apisv1alpha2.APIBindingSpec{
+					Reference: apisv1alpha2.BindingReference{
+						Export: &apisv1alpha2.ExportBindingReference{
+							Path: providerPath.String(),
+							Name: "today-cowboys",
+						},
+					},
+				},
+			},
+			metav1.CreateOptions{},
+		)
+		if err != nil {
+			t.Logf("failed to create Cowboys APIBinding: %v", err)
+		}
+		return err == nil
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "failed to create Cowboys APIBinding")
+
+	t.Logf("Waiting for Cowboys APIBinding to be bound in %s", consumerPath)
+	require.Eventually(t, func() bool {
+		binding, err := kcpClusterClient.Cluster(consumerPath).ApisV1alpha2().APIBindings().Get(t.Context(), "cowboys", metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return binding.Status.Phase == apisv1alpha2.APIBindingPhaseBound
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "Cowboys APIBinding never reached Bound phase")
+
+	t.Logf("Creating test Cowboys objects in consumer workspace %s", consumerPath)
+	numCowboys := 5
+	cowboyClient := wildwestClusterClient.Cluster(consumerPath).WildwestV1alpha1().Cowboys("default")
+	for i := range numCowboys {
+		_, err := cowboyClient.Create(
+			t.Context(),
+			&wildwestv1alpha1.Cowboy{
+				ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("test-cowboy-%d", i)},
+				Spec:       wildwestv1alpha1.CowboySpec{Intent: fmt.Sprintf("intent-%d", i)},
+			},
+			metav1.CreateOptions{},
+		)
+		require.NoError(t, err)
+	}
+
+	t.Log("Starting informer for post-migration verification")
+	informerStore, informerController := cache.NewInformerWithOptions(cache.InformerOptions{
+		ListerWatcher: &cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				return cowboyClient.List(t.Context(), options)
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				return cowboyClient.Watch(t.Context(), options)
+			},
+		},
+		ObjectType: &wildwestv1alpha1.Cowboy{},
+		Handler:    cache.ResourceEventHandlerFuncs{},
+	})
+	informerCtx, informerCancel := context.WithCancel(t.Context())
+	t.Cleanup(informerCancel)
+	go informerController.Run(informerCtx.Done())
+
+	t.Logf("Creating APIBinding for migration.kcp.io in %s", orgPath)
+	_, err = kcpClusterClient.Cluster(orgPath).ApisV1alpha2().APIBindings().Create(
+		t.Context(),
+		&apisv1alpha2.APIBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "migration"},
+			Spec: apisv1alpha2.APIBindingSpec{
+				Reference: apisv1alpha2.BindingReference{
+					Export: &apisv1alpha2.ExportBindingReference{
+						Path: core.RootCluster.Path().String(),
+						Name: "migration.kcp.io",
+					},
+				},
+			},
+		},
+		metav1.CreateOptions{},
+	)
+	require.NoError(t, err)
+
+	t.Logf("Waiting for migration APIBinding to be bound in %s", orgPath)
+	require.Eventually(t, func() bool {
+		binding, err := kcpClusterClient.Cluster(orgPath).ApisV1alpha2().APIBindings().Get(t.Context(), "migration", metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return binding.Status.Phase == apisv1alpha2.APIBindingPhaseBound
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "migration APIBinding never reached Bound phase")
+
+	t.Logf("Creating LogicalClusterMigration for %s from %s to %s", lcName, originShard, destinationShard)
+	var lcm *migrationv1alpha1.LogicalClusterMigration
+	require.Eventually(t, func() bool {
+		var err error
+		lcm, err = kcpClusterClient.Cluster(orgPath).MigrationV1alpha1().LogicalClusterMigrations().Create(
+			t.Context(),
+			&migrationv1alpha1.LogicalClusterMigration{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-migration-apibindings"},
+				Spec: migrationv1alpha1.LogicalClusterMigrationSpec{
+					LogicalCluster:   lcName.String(),
+					DestinationShard: destinationShard,
+				},
+			},
+			metav1.CreateOptions{},
+		)
+		if err != nil {
+			t.Logf("failed to create LogicalClusterMigration: %v", err)
+		}
+		return err == nil
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "failed to create LogicalClusterMigration")
+
+	t.Logf("Waiting for migration to complete")
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		migration, err := kcpClusterClient.Cluster(orgPath).MigrationV1alpha1().LogicalClusterMigrations().Get(t.Context(), lcm.Name, metav1.GetOptions{})
+		require.NoError(c, err)
+		t.Logf("migration phase: %q", migration.Status.Phase)
+		t.Logf("migration conditions: %#v", migration.Status.Conditions)
+		require.Equal(c, migrationv1alpha1.LogicalClusterMigrationPhaseCompleted, migration.Status.Phase)
+	}, wait.ForeverTestTimeout, 500*time.Millisecond, "waiting for migration to complete")
+
+	t.Logf("Cowboys resource must be already available once the migration is finished")
+	resources, err := wildwestClusterClient.Cluster(consumerPath).Discovery().ServerResourcesForGroupVersion("wildwest.dev/v1alpha1")
+	require.NoError(t, err, "resource discovery for wildwest.dev/v1alpha1 should succeed")
+	t.Logf("discovery for wildwest.dev/v1alpha1 has %d resources", len(resources.APIResources))
+	for _, res := range resources.APIResources {
+		t.Logf("Group: %q, Version: %q, Resource: %q", res.Group, res.Version, res.Group)
+	}
+	require.True(t, slices.ContainsFunc(resources.APIResources, func(res metav1.APIResource) bool {
+		return res.Name == "cowboys"
+	}), "resource discovery should contain cowboys")
+
+	t.Logf("Migration completed, running post-migration tests")
+
+	// Test that a client can access the consumer workspace after the migration.
+	t.Run("ClientAccess", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := cowboyClient.List(t.Context(), metav1.ListOptions{})
+		require.NoError(t, err, "LIST should succeed after migration")
+
+		_, err = cowboyClient.Get(t.Context(), "test-cowboy-0", metav1.GetOptions{})
+		require.NoError(t, err, "GET should succeed after migration")
+	})
+
+	// Verify that a watch established after migration can receive events.
+	t.Run("PreMigrateWatch", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := cowboyClient.Create(
+			t.Context(),
+			&wildwestv1alpha1.Cowboy{
+				ObjectMeta: metav1.ObjectMeta{Name: "post-migration-cowboy"},
+			},
+			metav1.CreateOptions{},
+		)
+		require.NoError(t, err)
+
+		postMigrationWatcher, err := cowboyClient.Watch(t.Context(), metav1.ListOptions{})
+		require.NoError(t, err, "should be able to establish a new watch after migration")
+		defer postMigrationWatcher.Stop()
+
+		for {
+			select {
+			case <-t.Context().Done():
+				t.Fatal("test context closed")
+			case event, ok := <-postMigrationWatcher.ResultChan():
+				if !ok {
+					t.Fatal("post-migration watch channel closed unexpectedly")
+				}
+				if event.Type == watch.Error {
+					continue
+				}
+				cowboy, ok := event.Object.(*wildwestv1alpha1.Cowboy)
+				if ok && cowboy.Name == "post-migration-cowboy" {
+					return
+				}
+			case <-time.After(wait.ForeverTestTimeout):
+				t.Fatal("post-migration watch did not receive event")
+			}
+		}
+	})
+
+	// Verify that an informer set up before migration picks up objects after migration.
+	t.Run("PreMigrateInformer", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := cowboyClient.Create(
+			t.Context(),
+			&wildwestv1alpha1.Cowboy{
+				ObjectMeta: metav1.ObjectMeta{Name: "post-migration-informer-cowboy"},
+			},
+			metav1.CreateOptions{},
+		)
+		require.NoError(t, err)
+
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			_, exists, err := informerStore.GetByKey("default/post-migration-informer-cowboy")
+			assert.NoError(c, err)
+			assert.True(c, exists, "informer should have picked up post-migration-informer-cowboy")
+		}, wait.ForeverTestTimeout, 500*time.Millisecond, "waiting for informer to pick up post-migration object")
+	})
+
+	// Check that all test Cowboys were transferred to the new shard.
+	t.Run("DataIntegrity", func(t *testing.T) {
+		t.Parallel()
+
+		cowboys, err := cowboyClient.List(t.Context(), metav1.ListOptions{})
+		require.NoError(t, err)
+
+		cowboyNames := make(map[string]bool, len(cowboys.Items))
+		for _, cowboy := range cowboys.Items {
+			cowboyNames[cowboy.Name] = true
+		}
+
+		for i := range numCowboys {
+			name := fmt.Sprintf("test-cowboy-%d", i)
+			require.True(t, cowboyNames[name], "Cowboy %s not found after migration", name)
+		}
+	})
 }

--- a/test/e2e/logicalclustermigration/support.go
+++ b/test/e2e/logicalclustermigration/support.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logicalclustermigration
+
+import "embed"
+
+//go:embed *.yaml
+var testFiles embed.FS


### PR DESCRIPTION
## Summary

During LC migration, all objects are moved to the new shard as-is. APIBindings depend on bound CRDs to function however. Since those are not part of the LC data dump, they need to be re-created in destination if they are missing.

This PR adds this re-creation logic, making bound APIs function transparently after migration.

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind feature

## Related Issue(s)

Part of https://github.com/kcp-dev/kcp/issues/4205

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
