### PR TITLE
Add pentester setup for AI testing

### DIFF
--- a/contrib/tilt/pentest/README.md
+++ b/contrib/tilt/pentest/README.md
@@ -1,0 +1,188 @@
+# kcp pen-test scenario
+
+A small "two tenants, one attacker" world for probing **privilege escalation**
+and **workspace (tenant) isolation** in kcp. It gives you a low-privilege
+kubeconfig you can hand to an AI/red-teamer with a concrete escalation goal, on
+top of the local `make tilt-kind-up` dev cluster.
+
+It is deliberately generic: the attacker is just a normal authenticated kcp user
+with access to its own workspace and nothing else. Use it to test any isolation
+or authorization property — cross-workspace reads, becoming `system:masters`,
+abusing impersonation, warrants, scopes, service accounts, virtual workspaces,
+etc.
+
+## What the scenario sets up
+
+| Workspace     | attacker's access            | contents                          |
+|---------------|------------------------------|-----------------------------------|
+| `:root:alpha` | `cluster-admin` (legit home) | —                                 |
+| `:root:bravo` | **none**                     | `secret/crown-jewels` (the flag)  |
+
+Identities (kubeconfigs written to the repo root):
+
+| File                          | Identity                                  |
+|-------------------------------|-------------------------------------------|
+| `tilt-frontproxy.kubeconfig`  | `kcp-admin`, `system:masters` (the admin) |
+| `pentest-attacker.kubeconfig` | `attacker`, group `pentest:tenants`       |
+
+The attacker can do anything in `alpha` and, by RBAC, nothing in `bravo`. Any
+path that lets it read `bravo`'s flag, enter another tenant, or gain
+`system:masters` is a finding.
+
+### Second flag: a provider tenant (optional, run after `setup.sh`)
+
+`provider.sh` adds a third tenant that **publishes an API** and binds it into
+both existing tenants — exercising kcp's `APIExport` / `APIBinding` surface. The
+export also **claims `core/secrets`** (a realistic provider-overreach: "let me
+manage TLS material for your widgets"), which `alpha` and `bravo` accept:
+
+| Workspace        | attacker's access                  | contents                              |
+|------------------|------------------------------------|---------------------------------------|
+| `:root:provider` | **none**                           | `APIExport/widgets` (claims secrets), `secret/provider-jewels` (2nd flag) |
+| `:root:alpha`    | `cluster-admin` (legit home)       | binds `widgets`, accepted secrets claim |
+| `:root:bravo`    | none                               | binds `widgets`, accepted secrets claim |
+
+The attacker is a legitimate **consumer** of the provider's `widgets` API in
+`alpha`. Consuming an API must not let it act **as** the provider. The second
+flag therefore has two capture paths, both findings:
+
+1. read `secret/provider-jewels` in `:root:provider` (the provider's own flag), or
+2. reach the provider's `widgets` **APIExport virtual workspace** and read
+   secrets in another tenant — the same `crown-jewels` from the first scenario.
+   The provider legitimately can (consumers accepted the claim); a mere consumer
+   must not.
+
+Either path — via the export/binding relationship, the export's identity or
+virtual workspace, the bound API's storage, or any impersonation trick — is a
+finding.
+
+## Files
+
+| File                              | Purpose                                                              |
+|-----------------------------------|----------------------------------------------------------------------|
+| `attacker-kubeconfig.yaml`        | kcp-operator `Kubeconfig` CR that mints the attacker's client cert   |
+| `setup.sh`                         | Builds the workspaces, RBAC, flag, and attacker kubeconfig           |
+| `attacker-creds.sh`               | Extracts the attacker's raw client cert/key for curl-level probing   |
+| `provider.sh`                     | Adds the provider tenant + second flag (run after `setup.sh`)        |
+| `provider-apiresourceschema.yaml` | `APIResourceSchema` for the provider's `Widget` API                  |
+| `provider-apiexport.yaml`         | `APIExport` that publishes `widgets` for alpha/bravo to bind         |
+
+## Prerequisites
+
+- A running dev cluster from `make tilt-kind-up` (see `../README.md`), including
+  the `/etc/hosts` entry so `kcp.localhost` resolves to `127.0.0.1`.
+- On `PATH`: `kubectl`, `kubectl-ws` (from `bin/`), `curl`, `base64`.
+
+## Usage
+
+```bash
+# 1. Bring up kcp (from the repo root) and wait for it to go green.
+make tilt-kind-up
+
+# 2. Build the scenario.
+./contrib/tilt/pentest/setup.sh
+
+# 3. (optional) Add the provider tenant + second flag.
+./contrib/tilt/pentest/provider.sh
+
+# 4. (optional) Pull the attacker's raw client cert/key for curl-level probing.
+./contrib/tilt/pentest/attacker-creds.sh
+```
+
+`setup.sh` finishes with a sanity check confirming admin can read the flag, the
+attacker can reach its home (`alpha`), and the attacker is denied in `bravo`
+with no tricks. `provider.sh` likewise confirms the attacker can *consume* the
+`widgets` API in `alpha` but is denied in `:root:provider`.
+
+## The AI challenge
+
+Hand the model **only** `pentest-attacker.kubeconfig`. Pick the prompt for the
+scenario you built.
+
+**First flag** (`setup.sh`) — tenant isolation:
+
+> You hold `attacker.kubeconfig`, a low-privilege kcp tenant (group
+> `pentest:tenants`). The kcp API is at `https://kcp.localhost:8443`. Read the
+> `flag` from `secret/crown-jewels` in workspace `:root:bravo`, cross into
+> another tenant's workspace, or gain `system:masters` on the shard. You only
+> control your own client and HTTP requests.
+
+**Second flag** (`provider.sh`) — APIExport / provider isolation:
+
+> You hold `attacker.kubeconfig`, a low-privilege kcp tenant, and you are
+> `cluster-admin` in your home workspace `:root:alpha`. You legitimately consume
+> the provider's `widgets` API there, and your tenant accepted that export's
+> permission claim on `secrets`. The kcp API is at `https://kcp.localhost:8443`.
+> Consuming an API must not let you act **as** the provider. Either read the
+> `flag` from `secret/provider-jewels` in `:root:provider`, or reach the
+> provider's `widgets` APIExport virtual workspace and read a secret in another
+> tenant (e.g. `crown-jewels` in `:root:bravo`). Abuse the APIExport/APIBinding
+> relationship, the export's identity or virtual workspace, the bound API's
+> storage, or any impersonation path. You only control your own client and HTTP
+> requests.
+
+For probing beyond what `kubectl` exposes (custom headers, raw paths, verb
+tunnelling, watch streams), `attacker-creds.sh` writes the attacker's client
+cert/key to PEM files and prints ready-to-edit `curl` examples. You can also
+`eval "$(./contrib/tilt/pentest/attacker-creds.sh -e)"` to export
+`$KCP_PROXY` / `$ATTACKER_CERT` / `$ATTACKER_KEY` into your shell.
+
+DO NOT USE ANY OF THE ADMIN KUBECONFIGS OR THE FRONT-PROXY KUBECONFIG. The attacker is only allowed to use its own identity. If you do, you will be testing the wrong thing
+
+To access shards, you need to use SNI:
+curl -sk https://theseus.kcp.localhost:8443/healthz   # -> ok
+curl -sk https://root.kcp.localhost:8443/healthz      # -> ok
+
+
+## How identities are minted
+
+The kcp-operator `Kubeconfig` CR turns `spec.username` into the client-cert CN
+(the kcp username) and `spec.groups` into the cert Organization values (the kcp
+groups), signs it with the front proxy's client CA, and writes a ready-to-use
+kubeconfig into a secret. The attacker CR sets **no** privileged groups, so the
+user can authenticate but — absent an escalation — can reach only what RBAC
+grants it.
+
+To add more tenants or identities, copy `attacker-kubeconfig.yaml`, change the
+name / `username` / `groups`, apply it to the host (kind) cluster, and extract
+the secret the same way `setup.sh` does. To grant a user access to a workspace,
+create a `ClusterRoleBinding` *inside* that workspace to `system:kcp:workspace:access`
+(read) or `cluster-admin` (admin).
+
+## Customizing the scenario
+
+`setup.sh` is intentionally short — edit it to fit your test:
+
+- **More workspaces / tenants:** add `kubectl ws create <name>` calls.
+- **Different starting privilege:** change the `ClusterRoleBinding` in step 3
+  (e.g. bind `system:kcp:workspace:access` instead of `cluster-admin`, or none).
+- **Different target:** change what gets planted in step 4 (a different secret,
+  an APIExport, RBAC objects, a LogicalCluster, ...).
+- **Sharded targets:** workspaces may land on the `root` or `theseus` shard;
+  use a cross-shard target to test shard-boundary isolation.
+
+## Cleanup
+
+```bash
+# Remove the attacker identity from the host (kind) cluster:
+kubectl --context kind-kcp-tilt delete -f contrib/tilt/pentest/attacker-kubeconfig.yaml
+
+# Remove the generated artifacts:
+rm -rf pentest-attacker.kubeconfig pentest-attacker-creds
+
+# The workspaces live inside kcp; drop them with the admin kubeconfig:
+KUBECONFIG=tilt-frontproxy.kubeconfig kubectl ws use :root
+KUBECONFIG=tilt-frontproxy.kubeconfig kubectl delete workspace alpha bravo provider
+```
+
+(`provider` only exists if you ran `provider.sh`.)
+
+Or `kind delete cluster --name kcp-tilt` to tear the whole environment down.
+
+## Notes
+
+- The default Tilt install does **not** deploy dex/OIDC, so this scenario uses
+  client certs. (If you wire up `contrib/kcp-dex`, you can mint OIDC-based
+  attacker identities instead — the scenario is otherwise identical.)
+- These files are a local testing aid and are untracked by default; `git add`
+  them only if you want to commit the scenario.

--- a/contrib/tilt/pentest/attacker-creds.sh
+++ b/contrib/tilt/pentest/attacker-creds.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The kcp Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Static variant of kind.sh: brings up a kind cluster and runs Tilt against
+# Tiltfile.static, which installs the upstream kcp-operator and deploys the
+# upstream kcp images instead of building them from local sources.
+#
+# Extract the attacker's raw client cert/key from pentest-attacker.kubeconfig so
+# you can probe the kcp front proxy with curl (or any HTTP tool) directly —
+# useful for anything kubectl won't let you express (custom headers, malformed
+# paths, verb tunnelling, raw watch streams, etc.).
+#
+# Usage:
+#   ./contrib/tilt/pentest/attacker-creds.sh            # write PEMs + print examples
+#   eval "$(./contrib/tilt/pentest/attacker-creds.sh -e)"  # export env vars into your shell
+#
+# Run after contrib/tilt/pentest/setup.sh.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+ATTACKER_KCFG="$REPO_ROOT/pentest-attacker.kubeconfig"
+OUT_DIR="$REPO_ROOT/pentest-attacker-creds"
+PROXY="https://kcp.localhost:8443"
+
+[[ -f "$ATTACKER_KCFG" ]] || { echo "run contrib/tilt/pentest/setup.sh first" >&2; exit 1; }
+
+mkdir -p "$OUT_DIR"
+kubectl --kubeconfig "$ATTACKER_KCFG" config view --raw \
+  -o jsonpath='{.users[0].user.client-certificate-data}' | base64 -d > "$OUT_DIR/tls.crt"
+kubectl --kubeconfig "$ATTACKER_KCFG" config view --raw \
+  -o jsonpath='{.users[0].user.client-key-data}' | base64 -d > "$OUT_DIR/tls.key"
+chmod 600 "$OUT_DIR/tls.key"
+
+# -e: emit shell exports and nothing else.
+if [[ "${1:-}" == "-e" ]]; then
+  echo "export KCP_PROXY='$PROXY'"
+  echo "export ATTACKER_CERT='$OUT_DIR/tls.crt'"
+  echo "export ATTACKER_KEY='$OUT_DIR/tls.key'"
+  exit 0
+fi
+
+cat <<EOF
+Wrote attacker client credentials:
+  cert : $OUT_DIR/tls.crt
+  key  : $OUT_DIR/tls.key
+  proxy: $PROXY
+
+Raw API examples (the attacker authenticates by client cert):
+
+  # Who does the shard think you are?
+  curl -sk --cert "$OUT_DIR/tls.crt" --key "$OUT_DIR/tls.key" \\
+    -X POST "$PROXY/clusters/root:alpha/apis/authentication.k8s.io/v1/selfsubjectreviews" \\
+    -H 'Content-Type: application/json' \\
+    -d '{"apiVersion":"authentication.k8s.io/v1","kind":"SelfSubjectReview"}'
+
+  # Try to read the flag in a workspace you have no RBAC for (expect 403):
+  curl -sk --cert "$OUT_DIR/tls.crt" --key "$OUT_DIR/tls.key" \\
+    "$PROXY/clusters/root:bravo/api/v1/namespaces/default/secrets/crown-jewels"
+
+Add -H 'Header: value' to experiment with request shaping.
+EOF

--- a/contrib/tilt/pentest/attacker-kubeconfig.yaml
+++ b/contrib/tilt/pentest/attacker-kubeconfig.yaml
@@ -1,0 +1,26 @@
+# Low-privilege "attacker" tenant identity for the kcp pen-test scenario.
+#
+# The kcp-operator mints a CLIENT CERTIFICATE from this CR: spec.username
+# becomes the cert CN (the kcp username) and spec.groups become the cert
+# Organization values (the kcp groups). The cert is signed by the front-proxy's
+# client CA and the resulting kubeconfig talks to the front-proxy at
+# https://kcp.localhost:8443.
+#
+# The groups list contains NO system:masters and NO system:* privilege — just a
+# benign tenant marker. This user can authenticate, but by RBAC can reach only
+# what is explicitly granted to it. That makes it a realistic starting point for
+# any escalation / tenant-isolation test: a normal authenticated kcp user.
+apiVersion: operator.kcp.io/v1alpha1
+kind: Kubeconfig
+metadata:
+  name: attacker
+spec:
+  username: attacker
+  groups:
+    - pentest:tenants
+  validity: 8766h
+  secretRef:
+    name: kcp-attacker-kubeconfig
+  target:
+    frontProxyRef:
+      name: frontproxy

--- a/contrib/tilt/pentest/provider-apiexport.yaml
+++ b/contrib/tilt/pentest/provider-apiexport.yaml
@@ -1,0 +1,20 @@
+apiVersion: apis.kcp.io/v1alpha2
+kind: APIExport
+metadata:
+  name: widgets
+spec:
+  resources:
+    - name: widgets
+      group: pentest.dev
+      schema: v1.widgets.pentest.dev
+      storage:
+        crd: {}
+  # Realistic provider-overreach surface: the provider asks consumers for access
+  # to their Secrets (e.g. "to manage TLS material for your widgets"). Consumers
+  # that accept this claim let the provider read their secrets THROUGH the
+  # APIExport virtual workspace. That VW is owned by the provider workspace, so a
+  # mere consumer (the attacker in :root:alpha) must NOT be able to reach it.
+  permissionClaims:
+    - group: ""
+      resource: secrets
+      verbs: ["*"]

--- a/contrib/tilt/pentest/provider-apiresourceschema.yaml
+++ b/contrib/tilt/pentest/provider-apiresourceschema.yaml
@@ -1,0 +1,44 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIResourceSchema
+metadata:
+  name: v1.widgets.pentest.dev
+spec:
+  group: pentest.dev
+  names:
+    kind: Widget
+    listKind: WidgetList
+    plural: widgets
+    singular: widget
+    shortNames:
+      - wid
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        description: Widget is an example API published by the provider workspace.
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: WidgetSpec holds the desired state of the Widget.
+            type: object
+            properties:
+              note:
+                description: A free-form note carried by the widget.
+                type: string
+          status:
+            description: WidgetStatus communicates the observed state of the Widget.
+            type: object
+            properties:
+              phase:
+                description: The observed phase of the widget.
+                type: string

--- a/contrib/tilt/pentest/provider.sh
+++ b/contrib/tilt/pentest/provider.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The kcp Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Second-flag extension of the pen-test scenario (see setup.sh first).
+#
+# Adds a provider tenant that publishes an API and binds it into both existing
+# tenants, then plants a flag in the PROVIDER's own workspace:
+#
+#   :root:provider  <- publishes APIExport 'widgets'; holds secret/provider-jewels
+#   :root:alpha     <- attacker's home; BINDS widgets (legitimate consumer)
+#   :root:bravo     <- BINDS widgets (legitimate consumer)
+#
+# The 'widgets' APIExport additionally CLAIMS core/secrets (a realistic
+# provider-overreach: "let me manage TLS material for your widgets"). alpha and
+# bravo accept the claim, so the provider can read their secrets THROUGH the
+# APIExport virtual workspace. That VW is owned by :root:provider.
+#
+# The attacker is a normal consumer of the provider's API in :root:alpha.
+# Consuming an API must NOT grant any access to the provider workspace nor to
+# the provider's export virtual workspace. Two paths count as a finding:
+#   1. read secret/provider-jewels in :root:provider (the provider's own flag), or
+#   2. reach the provider's 'widgets' export VW and read consumer secrets across
+#      tenants (e.g. crown-jewels in :root:bravo) — see setup.sh's first flag.
+#
+# Run AFTER setup.sh (it reuses :root:alpha / :root:bravo and the attacker
+# kubeconfig that setup.sh produced).
+#
+# Prereqs on PATH: kubectl, kubectl-ws, kubectl-kcp (bin/), base64.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$REPO_ROOT"
+
+PENTEST_DIR="$REPO_ROOT/contrib/tilt/pentest"
+# Admin access to kcp itself (system:masters via the front proxy).
+ADMIN_KCFG="$REPO_ROOT/tilt-frontproxy.kubeconfig"
+# Low-privilege attacker identity minted by setup.sh.
+ATTACKER_KCFG="$REPO_ROOT/pentest-attacker.kubeconfig"
+
+FLAG="KCP{provider_isolation_$(date +%s)}"
+
+say() { printf '\n\033[1;36m==> %s\033[0m\n' "$*"; }
+
+[[ -f "$ADMIN_KCFG" ]]    || { echo "missing $ADMIN_KCFG — run 'make tilt-kind-up' first"; exit 1; }
+[[ -f "$ATTACKER_KCFG" ]] || { echo "missing $ATTACKER_KCFG — run ./contrib/tilt/pentest/setup.sh first"; exit 1; }
+
+export KUBECONFIG="$ADMIN_KCFG"
+
+# ---------------------------------------------------------------------------
+say "1/6  Create provider workspace :root:provider (as admin)"
+kubectl ws use :root
+kubectl ws create provider --ignore-existing
+
+# ---------------------------------------------------------------------------
+say "2/6  Publish the Widget API (APIResourceSchema + APIExport, claims secrets)"
+kubectl ws use :root:provider
+kubectl apply -f "$PENTEST_DIR/provider-apiresourceschema.yaml"
+kubectl apply -f "$PENTEST_DIR/provider-apiexport.yaml"
+kubectl wait apiexport/widgets --for=condition=IdentityValid --timeout=2m 2>/dev/null || true
+
+# ---------------------------------------------------------------------------
+say "3/6  Plant the provider flag in :root:provider (the second flag)"
+# This secret lives in the provider workspace. No consumer has access here.
+kubectl create secret generic provider-jewels \
+  --from-literal=flag="$FLAG" -n default \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# ---------------------------------------------------------------------------
+say "4/6  Bind widgets into :root:alpha and :root:bravo, accepting secrets claim"
+# Consumers accept the provider's secrets permission claim (matchAll). This is
+# what lets the provider read their secrets via the export virtual workspace.
+for ws in alpha bravo; do
+  echo "- binding into :root:$ws (accepting secrets.core)"
+  kubectl ws use ":root:$ws"
+  kubectl delete apibinding widgets --ignore-not-found >/dev/null 2>&1
+  bin/kubectl-kcp bind apiexport root:provider:widgets --name widgets \
+    --accept-permission-claim secrets.core
+  kubectl wait apibinding/widgets --for=condition=Ready --timeout=2m 2>/dev/null || true
+done
+
+# ---------------------------------------------------------------------------
+say "5/6  Sanity checks (admin side)"
+kubectl ws use :root:provider
+echo "- admin can read the provider flag:"
+kubectl get secret provider-jewels -n default -o jsonpath='{.data.flag}' | base64 -d; echo
+
+echo "- widgets API is usable by the attacker in its home (alpha):"
+if KUBECONFIG="$ATTACKER_KCFG" kubectl ws use :root:alpha >/dev/null 2>&1 \
+   && KUBECONFIG="$ATTACKER_KCFG" kubectl get widgets -A >/dev/null 2>&1; then
+  echo "  OK (attacker can consume the bound Widget API)"
+else
+  echo "  !! attacker cannot use the bound API in alpha — binding may not be Ready"
+fi
+
+echo "- provider (export owner) CAN read consumer secrets across tenants via the"
+echo "  'widgets' export virtual workspace (this is the claimed power):"
+# The endpoint slice exposes one VW URL per shard; consumers may live on either,
+# so probe every endpoint for the cross-tenant secret.
+saw_xtenant=""
+while read -r url; do
+  [[ -z "$url" ]] && continue
+  if kubectl --insecure-skip-tls-verify --server="${url}/clusters/*" \
+       get secrets -A 2>/dev/null | grep -q crown-jewels; then
+    saw_xtenant="$url"
+    break
+  fi
+done < <(kubectl get apiexportendpointslice widgets \
+           -o jsonpath='{range .status.endpoints[*]}{.url}{"\n"}{end}')
+if [[ -n "$saw_xtenant" ]]; then
+  echo "  OK (provider read bravo's crown-jewels through its export VW)"
+else
+  echo "  (cross-tenant secret not visible yet — claim may still be propagating)"
+fi
+
+# ---------------------------------------------------------------------------
+say "6/6  Attacker must be DENIED — both flag #2 paths"
+echo "- attacker should NOT reach :root:provider or read provider-jewels:"
+if KUBECONFIG="$ATTACKER_KCFG" kubectl ws use :root:provider >/dev/null 2>&1 \
+   && KUBECONFIG="$ATTACKER_KCFG" kubectl get secret provider-jewels -n default >/dev/null 2>&1; then
+  echo "  !! attacker READ the provider flag with no tricks — isolation broken"
+else
+  echo "  OK (denied without escalation)"
+fi
+
+echo "- attacker should NOT reach the provider's export VW (even with the URL):"
+vw_url="$(kubectl get apiexportendpointslice widgets \
+           -o jsonpath='{.status.endpoints[0].url}' 2>/dev/null)"
+if [[ -n "$vw_url" ]] && KUBECONFIG="$ATTACKER_KCFG" kubectl --insecure-skip-tls-verify \
+     --server="${vw_url}/clusters/*" get secrets -A >/dev/null 2>&1; then
+  echo "  !! attacker listed secrets via the export VW — export VW exposed to consumers"
+else
+  echo "  OK (denied at the export virtual workspace)"
+fi
+
+cat <<EOF
+
+============================================================================
+ Provider scenario ready (second flag).
+
+   Workspaces:
+     :root:provider   publishes APIExport 'widgets' (claims core/secrets);
+                      holds secret/provider-jewels
+     :root:alpha      attacker home; binds 'widgets', accepted secrets claim
+     :root:bravo      binds 'widgets', accepted secrets claim
+
+ SECOND FLAG, two capture paths:
+   a) secret/provider-jewels in :root:provider (the provider's own flag), or
+   b) reach the 'widgets' export virtual workspace and read consumer secrets
+      across tenants (the provider can; a consumer must not).
+
+ CHALLENGE for the AI / red-teamer (still ONLY the attacker kubeconfig):
+   "You consume the provider's 'widgets' API in :root:alpha, and your tenant
+    accepted the export's permission claim on secrets. Consuming an API must
+    not let you act AS the provider. Either read secret/provider-jewels in
+    :root:provider, or reach the provider's 'widgets' APIExport virtual
+    workspace and read secrets in another tenant (e.g. crown-jewels in
+    :root:bravo). Abuse the APIExport/APIBinding relationship, the export's
+    identity or virtual workspace, the bound API's storage, or any
+    impersonation path. You only control your own client and HTTP requests."
+============================================================================
+EOF

--- a/contrib/tilt/pentest/setup.sh
+++ b/contrib/tilt/pentest/setup.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The kcp Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Static variant of kind.sh: brings up a kind cluster and runs Tilt against
+# Tiltfile.static, which installs the upstream kcp-operator and deploys the
+# upstream kcp images instead of building them from local sources.
+#
+# Pen-test scenario bootstrap for kcp.
+#
+# Builds a "two tenants, one attacker" world on top of `make tilt-kind-up` that
+# you can use to probe privilege escalation and tenant (workspace) isolation:
+#
+#   :root:alpha   <- attacker is a legitimate admin here (its home workspace)
+#   :root:bravo   <- attacker has NO access; holds a flag the attacker must NOT read
+#
+# The attacker holds a low-privilege client-cert kubeconfig (no system:masters).
+# Hand ONLY that kubeconfig to an AI/red-teamer and challenge it to read the flag
+# in :root:bravo, cross into another tenant, or gain system:masters on the shard
+# by any means.
+#
+# Run from the kcp repo root AFTER `make tilt-kind-up` has finished and
+# tilt-frontproxy.kubeconfig exists.
+#
+# Prereqs on PATH: kubectl, kubectl-ws (bin/), base64.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$REPO_ROOT"
+
+# kcp-operator CRs (RootShard, Kubeconfig, ...) live in the KIND host cluster.
+KIND_CTX="kind-kcp-tilt"
+# Admin access to kcp itself (system:masters via the front proxy).
+ADMIN_KCFG="$REPO_ROOT/tilt-frontproxy.kubeconfig"
+# Where the attacker kubeconfig will be written.
+ATTACKER_KCFG="$REPO_ROOT/pentest-attacker.kubeconfig"
+
+FLAG="KCP{tenant_isolation_$(date +%s)}"
+
+say() { printf '\n\033[1;36m==> %s\033[0m\n' "$*"; }
+
+[[ -f "$ADMIN_KCFG" ]] || { echo "missing $ADMIN_KCFG — run 'make tilt-kind-up' first"; exit 1; }
+
+# ---------------------------------------------------------------------------
+say "1/5  Mint low-privilege attacker identity (client cert via kcp-operator)"
+kubectl --context "$KIND_CTX" apply -f "$REPO_ROOT/contrib/tilt/pentest/attacker-kubeconfig.yaml"
+kubectl --context "$KIND_CTX" wait kubeconfig/attacker --for=condition=Available --timeout=5m
+kubectl --context "$KIND_CTX" wait secret/kcp-attacker-kubeconfig --for=create --timeout=5m
+kubectl --context "$KIND_CTX" get secret/kcp-attacker-kubeconfig \
+  -o jsonpath='{.data.kubeconfig}' | base64 -d > "$ATTACKER_KCFG"
+echo "wrote $ATTACKER_KCFG"
+
+# ---------------------------------------------------------------------------
+say "2/5  Create workspaces :root:alpha and :root:bravo (as admin)"
+export KUBECONFIG="$ADMIN_KCFG"
+kubectl ws use :root
+kubectl ws create alpha --ignore-existing
+kubectl ws create bravo --ignore-existing
+
+# ---------------------------------------------------------------------------
+say "3/5  Grant attacker ADMIN in :root:alpha (its legitimate home)"
+kubectl ws use :root:alpha
+kubectl create clusterrolebinding attacker-admin \
+  --clusterrole=cluster-admin --user=attacker \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# ---------------------------------------------------------------------------
+say "4/5  Plant the flag in :root:bravo (attacker has NO binding here)"
+kubectl ws use :root:bravo
+kubectl create secret generic crown-jewels \
+  --from-literal=flag="$FLAG" -n default \
+  --dry-run=client -o yaml | kubectl apply -f -
+# Deliberately NO ClusterRoleBinding for attacker in bravo.
+
+# ---------------------------------------------------------------------------
+say "5/5  Sanity checks"
+echo "- admin can read the flag in bravo:"
+kubectl ws use :root:bravo
+kubectl get secret crown-jewels -n default -o jsonpath='{.data.flag}' | base64 -d; echo
+
+echo "- attacker CAN access its home (alpha):"
+KUBECONFIG="$ATTACKER_KCFG" kubectl ws use :root:alpha >/dev/null && echo "  OK (alpha reachable)"
+
+echo "- attacker should be DENIED in bravo (expected on a hardened build):"
+if KUBECONFIG="$ATTACKER_KCFG" kubectl ws use :root:bravo >/dev/null 2>&1 \
+   && KUBECONFIG="$ATTACKER_KCFG" kubectl get secret crown-jewels -n default >/dev/null 2>&1; then
+  echo "  !! attacker READ the flag with no tricks — RBAC misconfigured"
+else
+  echo "  OK (denied without escalation)"
+fi
+
+cat <<EOF
+
+============================================================================
+ Scenario ready.
+
+   Admin kubeconfig    : $ADMIN_KCFG          (system:masters)
+   Attacker kubeconfig : $ATTACKER_KCFG       (user 'attacker', group 'pentest:tenants')
+
+   Workspaces:
+     :root:alpha   attacker = cluster-admin (home)
+     :root:bravo   attacker = no access; holds secret/crown-jewels (the flag)
+
+ CHALLENGE for the AI / red-teamer (give it ONLY the attacker kubeconfig):
+   "You hold attacker.kubeconfig, a low-privilege kcp tenant. Read the
+    'flag' value from secret/crown-jewels in workspace :root:bravo, cross
+    into another tenant's workspace, or gain system:masters on the shard.
+    You only control your own client and HTTP requests."
+
+ The kcp API is reached through the front proxy at https://kcp.localhost:8443.
+ Use contrib/tilt/pentest/attacker-creds.sh to extract the attacker's client
+ cert/key for raw curl-level probing beyond what kubectl exposes.
+============================================================================
+EOF

--- a/contrib/tilt/pentest/setup.sh
+++ b/contrib/tilt/pentest/setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2021 The kcp Authors.
+# Copyright 2026 The kcp Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

This is a tilt-based setup, which can be used by AI agents to test kcp isolation. 

## What Type of PR Is This?
/kind feature

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Add AI pen testing framework
```
