### PR TITLE
Reject client-supplied kcp impersonation extras in the gatekeeper

### DIFF
--- a/pkg/server/filters/impersonation.go
+++ b/pkg/server/filters/impersonation.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
@@ -109,6 +110,23 @@ func WithImpersonationGatekeeper(handler http.Handler) http.Handler {
 		ctx = context.WithValue(ctx, originalUserContextKey, requester)
 		req = req.WithContext(ctx)
 
+		// validImpersonation only inspects impersonated *groups*. Impersonation
+		// extras such as the warrant and scope keys (authorization.kcp.io/warrant,
+		// authentication.kcp.io/scopes, authentication.kcp.io/cluster-name) are
+		// authority-granting and are populated only by trusted authenticators
+		// server-side; a client must never be able to set them via an
+		// Impersonate-Extra-* header. Trusted superusers (system:masters, e.g. the
+		// in-process virtual-workspace client that legitimately attaches a warrant)
+		// are exempt, mirroring the short-circuit in validImpersonation.
+		if !sets.New(requester.GetGroups()...).Has(authorizationbootstrap.SystemMastersGroup) {
+			if key, found := forbiddenImpersonationExtra(req.Header); found {
+				responsewriters.ErrorNegotiated(
+					apierrors.NewForbidden(schema.GroupResource{}, "", fmt.Errorf("impersonating the extra key %q is not allowed for the requestor", key)),
+					errorCodecs, schema.GroupVersion{}, w, req)
+				return
+			}
+		}
+
 		if validImpersonation(requester.GetGroups(), req.Header[authenticationv1.ImpersonateGroupHeader]) {
 			handler.ServeHTTP(w, req)
 			return
@@ -178,6 +196,31 @@ func WithImpersonationScoping(handler http.Handler) http.Handler {
 
 		handler.ServeHTTP(w, req.WithContext(request.WithUser(req.Context(), userScoped)))
 	})
+}
+
+// forbiddenImpersonationExtra reports whether the request carries an
+// Impersonate-Extra-* header for a kcp-reserved extra key (any key containing
+// "kcp.io", e.g. authorization.kcp.io/warrant or authentication.kcp.io/scopes).
+// Such extras grant authority and must only ever be set by trusted
+// authenticators, never asserted by a client. The header key suffix is
+// percent-encoded by clients (e.g. authorization.kcp.io%2Fwarrant), so it is
+// unescaped before matching. This mirrors the ExtraFilter DropExtraKeyContains
+// applied to workspace-local authenticators in pkg/authentication.
+func forbiddenImpersonationExtra(header http.Header) (string, bool) {
+	for name := range header {
+		if !strings.HasPrefix(name, authenticationv1.ImpersonateUserExtraHeaderPrefix) {
+			continue
+		}
+		raw := name[len(authenticationv1.ImpersonateUserExtraHeaderPrefix):]
+		key, err := url.PathUnescape(raw)
+		if err != nil {
+			key = raw
+		}
+		if strings.Contains(strings.ToLower(key), "kcp.io") {
+			return key, true
+		}
+	}
+	return "", false
 }
 
 // validImpersonation checks if a user can impersonate all requested groups.

--- a/pkg/server/filters/impersonation_test.go
+++ b/pkg/server/filters/impersonation_test.go
@@ -309,6 +309,54 @@ func TestWithImpersonationGatekeeper(t *testing.T) {
 			expectedOriginalUser:     true,
 			handlerCalled:            true,
 		},
+		{
+			name:                  "Unprivileged requestor cannot inject a kcp warrant extra",
+			impersonateUserHeader: "puppet",
+			otherHeaders: map[string]string{
+				// percent-encoded key, as a client sends it: authorization.kcp.io/warrant
+				"Impersonate-Extra-authorization.kcp.io%2Fwarrant": `{"groups":["system:masters"]}`,
+			},
+			user: &mockUser{
+				Name:   "requester",
+				UID:    "uid-202",
+				Groups: []string{"group1", user.AllAuthenticated},
+				Extra:  nil,
+			},
+			expectedStatus: http.StatusForbidden,
+			handlerCalled:  false,
+		},
+		{
+			name:                  "Unprivileged requestor cannot inject a kcp scopes extra",
+			impersonateUserHeader: "puppet",
+			otherHeaders: map[string]string{
+				"Impersonate-Extra-authentication.kcp.io%2Fscopes": "cluster:other",
+			},
+			user: &mockUser{
+				Name:   "requester",
+				UID:    "uid-203",
+				Groups: []string{"group1"},
+				Extra:  nil,
+			},
+			expectedStatus: http.StatusForbidden,
+			handlerCalled:  false,
+		},
+		{
+			name:                  "system:masters requestor may carry a kcp warrant extra (trusted VW path)",
+			impersonateUserHeader: "puppet",
+			otherHeaders: map[string]string{
+				"Impersonate-Extra-authorization.kcp.io%2Fwarrant": `{"groups":["system:kcp:admin"]}`,
+			},
+			user: &mockUser{
+				Name:   "requester",
+				UID:    "uid-204",
+				Groups: []string{authorizationbootstrap.SystemMastersGroup},
+				Extra:  nil,
+			},
+			expectedStatus:           http.StatusOK,
+			expectedImpersonationKey: true,
+			expectedOriginalUser:     true,
+			handlerCalled:            true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

`WithImpersonationGatekeeper` only validated impersonated groups and left the `Impersonate-Extra-*` headers unchecked. A caller without `system:masters` could attach an `authorization.kcp.io/warrant` (or `authentication.kcp.io/scopes`) impersonation extra and have the warrant authorizer grant it that identity's authority, escalating past the group-only validImpersonation check.

Reject any `Impersonate-Extra-*` header whose percent-decoded key contains "kcp.io" when the requestor is not `system:masters`. Trusted superusers stay exempt so the in-process APIExport virtual-workspace client, which authenticates as `system:masters` and legitimately attaches a warrant while impersonating the caller, keeps working. This mirrors the `ExtraFilter` `DropExtraKeyContains` used for workspace-local authenticators and runs at both the front proxy and the shard.


## What Type of PR Is This?
/kind chore

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Enhance security on shards when parsing user request headers
