### PR TITLE
e2e: StartMockOIDC creates unique CA cert and key files

### DIFF
--- a/test/e2e/authentication/workspace_test.go
+++ b/test/e2e/authentication/workspace_test.go
@@ -59,13 +59,13 @@ func TestWorkspaceOIDC(t *testing.T) {
 
 	// start two mock OIDC servers that will listen on random ports
 	// (only for discovery and keyset handling, no actual login workflows)
-	mockA, ca := authfixtures.StartMockOIDC(t, server)
-	mockB, _ := authfixtures.StartMockOIDC(t, server)
+	mockA, caA := authfixtures.StartMockOIDC(t, server)
+	mockB, caB := authfixtures.StartMockOIDC(t, server)
 
 	// setup a new workspace auth config that uses mockoidc's server, one for
 	// each of our mockoidc servers
-	authConfigA := authfixtures.CreateWorkspaceOIDCAuthentication(t, t.Context(), kcpClusterClient, baseWsPath, mockA, ca, nil)
-	authConfigB := authfixtures.CreateWorkspaceOIDCAuthentication(t, t.Context(), kcpClusterClient, baseWsPath, mockB, ca, nil)
+	authConfigA := authfixtures.CreateWorkspaceOIDCAuthentication(t, t.Context(), kcpClusterClient, baseWsPath, mockA, caA, nil)
+	authConfigB := authfixtures.CreateWorkspaceOIDCAuthentication(t, t.Context(), kcpClusterClient, baseWsPath, mockB, caB, nil)
 
 	// use these configs in new WorkspaceTypes and create one extra workspace type that allows
 	// both mockoidc issuers

--- a/test/e2e/fixtures/authfixtures/mockoidc.go
+++ b/test/e2e/fixtures/authfixtures/mockoidc.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"os"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -32,6 +33,7 @@ import (
 	"github.com/xrstf/mockoidc"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 
@@ -46,8 +48,9 @@ func StartMockOIDC(t *testing.T, server kcptestingserver.RunningServer) (*mockoi
 	// start a mock OIDC server that will listen on a random port
 	// (only for discovery and keyset handling, no actual login workflows)
 	caDir := server.CADirectory()
-	caCertFile := filepath.Join(caDir, "mockoidc-ca.crt")
-	caKeyFile := filepath.Join(caDir, "mockoidc-ca.key")
+	caUniqueNameSuffix := fmt.Sprintf("%s-%s", t.Name(), utilrand.String(8))
+	caCertFile := filepath.Join(caDir, "mockoidc-ca-"+caUniqueNameSuffix+".crt")
+	caKeyFile := filepath.Join(caDir, "mockoidc-ca-"+caUniqueNameSuffix+".key")
 
 	ca, _, err := crypto.EnsureCA(caCertFile, caKeyFile, "", "mockoidc-ca", 1)
 	require.NoError(t, err)
@@ -87,6 +90,8 @@ func StartMockOIDC(t *testing.T, server kcptestingserver.RunningServer) (*mockoi
 	// necessary shutdown code already.
 	t.Cleanup(func() {
 		require.NoError(t, m.Shutdown())
+		os.Remove(caCertFile)
+		os.Remove(caKeyFile)
 	})
 
 	return m, ca


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

StartMockOIDC previously used a hard-coded filename. Each test, running in parallel or not, would overwrite the same file, causing the test(s) to fail. Similarly, if a test creates multiple MockOIDC servers, they'd end up with CAs overwritten.

E.g.: https://public-prow.kcp.k8c.io/view/s3/prow-public-data/pr-logs/pull/kcp-dev_kcp/4224/pull-kcp-test-e2e-sharded-embedded-vw/2069434965233242112

This PR generates unique filenames for cert&key (and cleans it up after the test finishes), so that they don't collide.


## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind flake

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
