### PR TITLE
prevent LogicalCluster condition races between initializer controllers

### DIFF
--- a/pkg/reconciler/committer/conditions_committer.go
+++ b/pkg/reconciler/committer/conditions_committer.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package committer
+
+import (
+	"context"
+
+	conditionsv1alpha1 "github.com/kcp-dev/sdk/apis/third_party/conditions/apis/conditions/v1alpha1"
+	"github.com/kcp-dev/sdk/apis/third_party/conditions/util/conditions"
+)
+
+// ConditionsCommitFunc commits the owned-condition delta between old and new, optionally applying mutate to the same object.
+type ConditionsCommitFunc[T conditions.Setter] func(ctx context.Context, old, new T, mutate func(T) bool) error
+
+// NewConditionsCommitter returns a function that applies the owned conditions onto a copy of old and persists it via update.
+func NewConditionsCommitter[T conditions.Setter](owned []conditionsv1alpha1.ConditionType, update func(context.Context, T) error) ConditionsCommitFunc[T] {
+	return func(ctx context.Context, old, new T, mutate func(T) bool) error {
+		condPatch := conditions.NewPatch(old, new)
+
+		latest := old.DeepCopyObject().(T)
+		changed := mutate != nil && mutate(latest)
+
+		if condPatch.IsZero() && !changed {
+			return nil
+		}
+
+		if err := condPatch.Apply(latest, conditions.WithOwnedConditions(owned...)); err != nil {
+			return err
+		}
+
+		return update(ctx, latest)
+	}
+}

--- a/pkg/reconciler/tenancy/defaultapibindinglifecycle/default_apibinding_lifecycle_controller.go
+++ b/pkg/reconciler/tenancy/defaultapibindinglifecycle/default_apibinding_lifecycle_controller.go
@@ -38,9 +38,9 @@ import (
 	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
 	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
+	conditionsv1alpha1 "github.com/kcp-dev/sdk/apis/third_party/conditions/apis/conditions/v1alpha1"
 	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
 	apisv1alpha2client "github.com/kcp-dev/sdk/client/clientset/versioned/typed/apis/v1alpha2"
-	corev1alpha1client "github.com/kcp-dev/sdk/client/clientset/versioned/typed/core/v1alpha1"
 	apisv1alpha2informers "github.com/kcp-dev/sdk/client/informers/externalversions/apis/v1alpha2"
 	corev1alpha1informers "github.com/kcp-dev/sdk/client/informers/externalversions/core/v1alpha1"
 	tenancyv1alpha1informers "github.com/kcp-dev/sdk/client/informers/externalversions/tenancy/v1alpha1"
@@ -115,8 +115,15 @@ func NewDefaultAPIBindingController(
 			return indexers.ByPathAndNameWithFallback[*apisv1alpha2.APIExport](apisv1alpha2.Resource("apiexports"), apiExportsInformer.Informer().GetIndexer(), globalAPIExportsInformer.Informer().GetIndexer(), path, name)
 		},
 
-		commitApiBinding:     committer.NewCommitter[*apisv1alpha2.APIBinding, apisv1alpha2client.APIBindingInterface, *apisv1alpha2.APIBindingSpec, *apisv1alpha2.APIBindingStatus](kcpClusterClient.ApisV1alpha2().APIBindings()),
-		commitLogicalCluster: committer.NewCommitter[*corev1alpha1.LogicalCluster, corev1alpha1client.LogicalClusterInterface, *corev1alpha1.LogicalClusterSpec, *corev1alpha1.LogicalClusterStatus](kcpClusterClient.CoreV1alpha1().LogicalClusters()),
+		commitApiBinding: committer.NewCommitter[*apisv1alpha2.APIBinding, apisv1alpha2client.APIBindingInterface, *apisv1alpha2.APIBindingSpec, *apisv1alpha2.APIBindingStatus](kcpClusterClient.ApisV1alpha2().APIBindings()),
+
+		commitConditions: committer.NewConditionsCommitter[*corev1alpha1.LogicalCluster](
+			[]conditionsv1alpha1.ConditionType{tenancyv1alpha1.WorkspaceAPIBindingsReconciled},
+			func(ctx context.Context, lc *corev1alpha1.LogicalCluster) error {
+				_, err := kcpClusterClient.Cluster(logicalcluster.From(lc).Path()).CoreV1alpha1().LogicalClusters().UpdateStatus(ctx, lc, metav1.UpdateOptions{})
+				return err
+			},
+		),
 	}
 
 	c.transitiveTypeResolver = admission.NewTransitiveTypeResolver(c.getWorkspaceType)
@@ -144,7 +151,6 @@ func NewDefaultAPIBindingController(
 }
 
 type apiBindingResource = committer.Resource[*apisv1alpha2.APIBindingSpec, *apisv1alpha2.APIBindingStatus]
-type logicalClusterResource = committer.Resource[*corev1alpha1.LogicalClusterSpec, *corev1alpha1.LogicalClusterStatus]
 
 // DefaultAPIBindingController is a controller which instantiates APIBindings and waits for them to be fully bound
 // in new Workspaces.
@@ -161,8 +167,9 @@ type DefaultAPIBindingController struct {
 	createAPIBinding func(ctx context.Context, clusterName logicalcluster.Path, binding *apisv1alpha2.APIBinding) (*apisv1alpha2.APIBinding, error)
 	getAPIExport     func(clusterName logicalcluster.Path, name string) (*apisv1alpha2.APIExport, error)
 
-	commitApiBinding     func(ctx context.Context, old, new *apiBindingResource) error
-	commitLogicalCluster func(ctx context.Context, old, new *logicalClusterResource) error
+	commitApiBinding func(ctx context.Context, old, new *apiBindingResource) error
+
+	commitConditions committer.ConditionsCommitFunc[*corev1alpha1.LogicalCluster]
 
 	transitiveTypeResolver transitiveTypeResolver
 }
@@ -309,11 +316,14 @@ func (c *DefaultAPIBindingController) process(ctx context.Context, key string) e
 		errs = append(errs, err)
 	}
 
-	// If the object being reconciled changed as a result, update it.
-	oldResource := &logicalClusterResource{ObjectMeta: old.ObjectMeta, Spec: &old.Spec, Status: &old.Status}
-	newResource := &logicalClusterResource{ObjectMeta: logicalCluster.ObjectMeta, Spec: &logicalCluster.Spec, Status: &logicalCluster.Status}
-	if err := c.commitLogicalCluster(ctx, oldResource, newResource); err != nil {
-		errs = append(errs, err)
+	err = c.commitConditions(ctx, old, logicalCluster, nil)
+	if err != nil {
+		if apierrors.IsConflict(err) {
+			logger.V(4).Info("conflict updating LogicalCluster status, requeuing")
+			c.queue.AddRateLimited(key)
+		} else {
+			errs = append(errs, err)
+		}
 	}
 
 	return utilerrors.NewAggregate(errs)

--- a/pkg/reconciler/tenancy/defaultapibindinglifecycle/default_apibinding_lifecycle_reconcile_test.go
+++ b/pkg/reconciler/tenancy/defaultapibindinglifecycle/default_apibinding_lifecycle_reconcile_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The kcp Authors.
+Copyright 2026 The kcp Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,13 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package initialization
+package defaultapibindinglifecycle
 
 import (
 	"context"
 	"errors"
-	"regexp"
-	"strings"
 	"testing"
 	"time"
 
@@ -42,67 +40,8 @@ import (
 	"github.com/kcp-dev/kcp/pkg/reconciler/committer"
 )
 
-func TestGenerateAPIBindingName(t *testing.T) {
-	t.Parallel()
-
-	tests := map[string]struct {
-		exportName           string
-		expectedPrefixLength int
-	}{
-		"short export name": {
-			exportName:           "a",
-			expectedPrefixLength: 1,
-		},
-		"max length without truncation": {
-			exportName:           strings.Repeat("a", 247),
-			expectedPrefixLength: 247,
-		},
-		"over max length": {
-			exportName:           strings.Repeat("a", 248),
-			expectedPrefixLength: 247,
-		},
-	}
-
-	re := regexp.MustCompile(`^(a+)-(.+)$`)
-
-	for testName, tc := range tests {
-		t.Run(testName, func(t *testing.T) {
-			t.Parallel()
-			clusterName := logicalcluster.Name("root:some:ws")
-			exportPath := "root:some:export:ws"
-
-			generated := generateAPIBindingName(clusterName, exportPath, tc.exportName)
-			t.Logf("generated: %s", generated)
-
-			matches := re.FindStringSubmatch(generated)
-			require.Len(t, matches, 3)
-			require.Len(t, matches[1], tc.expectedPrefixLength)
-			require.Len(t, matches[2], 5)
-		})
-	}
-}
-
-func TestGenerateAPIBindingNameWithMultipleSimilarLongNames(t *testing.T) {
-	t.Parallel()
-
-	clusterName := logicalcluster.Name("root:some:ws")
-	exportPath := "root:some:export:ws"
-
-	// 252 chars
-	longName1 := "thisisareallylongnamethisisareallylongnamethisisareallylongnamethisisareallylongnamethisisareallylongnamethisisareallylongnamethisisareallylongnamethisisareallylongnamethisisareallylongnamethisisareallylongnamethisisareallylongnamethisisareallylongname"
-	// 263 chars
-	longName2 := "thisisareallylongnamethisisareallylongnamethisisareallylongnamethisisareallylongnamethisisareallylongnamethisisareallylongnamethisisareallylongnamethisisareallylongnamethisisareallylongnamethisisareallylongnamethisisareallylongnamethisisareallylongnamethatdiffers"
-	generated1 := generateAPIBindingName(clusterName, exportPath, longName1)
-	t.Logf("generated1: %s", generated1)
-	generated2 := generateAPIBindingName(clusterName, exportPath, longName2)
-	t.Logf("generated2: %s", generated2)
-	require.Len(t, generated1, 253)
-	require.Len(t, generated2, 253)
-	require.NotEqual(t, generated1, generated2, "expected different generated names")
-}
-
-func newTestAPIBinder(cached *corev1alpha1.LogicalCluster, update func(context.Context, *corev1alpha1.LogicalCluster) error) *APIBinder {
-	b := &APIBinder{
+func newTestController(cached *corev1alpha1.LogicalCluster, update func(context.Context, *corev1alpha1.LogicalCluster) error) *DefaultAPIBindingController {
+	c := &DefaultAPIBindingController{
 		getLogicalCluster: func(logicalcluster.Name) (*corev1alpha1.LogicalCluster, error) {
 			return cached, nil
 		},
@@ -110,10 +49,12 @@ func newTestAPIBinder(cached *corev1alpha1.LogicalCluster, update func(context.C
 			return nil, apierrors.NewNotFound(schema.GroupResource{}, "")
 		},
 		getWorkspaceType: func(logicalcluster.Path, string) (*tenancyv1alpha1.WorkspaceType, error) {
-			return nil, apierrors.NewNotFound(schema.GroupResource{}, "")
+			return &tenancyv1alpha1.WorkspaceType{}, nil
 		},
 		listLogicalClusters: func() ([]*corev1alpha1.LogicalCluster, error) { return nil, nil },
-		listAPIBindings:     func(logicalcluster.Name) ([]*apisv1alpha2.APIBinding, error) { return nil, nil },
+		listAPIBindings: func(logicalcluster.Name) ([]*apisv1alpha2.APIBinding, error) {
+			return nil, nil
+		},
 		getAPIBinding: func(logicalcluster.Name, string) (*apisv1alpha2.APIBinding, error) {
 			return nil, apierrors.NewNotFound(schema.GroupResource{}, "")
 		},
@@ -123,11 +64,14 @@ func newTestAPIBinder(cached *corev1alpha1.LogicalCluster, update func(context.C
 		getAPIExport: func(logicalcluster.Path, string) (*apisv1alpha2.APIExport, error) {
 			return nil, apierrors.NewNotFound(schema.GroupResource{}, "")
 		},
+		commitApiBinding: func(context.Context, *apiBindingResource, *apiBindingResource) error {
+			return nil
+		},
 		commitConditions: committer.NewConditionsCommitter[*corev1alpha1.LogicalCluster](
-			[]conditionsv1alpha1.ConditionType{tenancyv1alpha1.WorkspaceAPIBindingsInitialized}, update),
+			[]conditionsv1alpha1.ConditionType{tenancyv1alpha1.WorkspaceAPIBindingsReconciled}, update),
+		transitiveTypeResolver: &noopResolver{},
 	}
-	b.transitiveTypeResolver = &noopResolver{}
-	return b
+	return c
 }
 
 func testCachedLogicalCluster() *corev1alpha1.LogicalCluster {
@@ -145,30 +89,35 @@ func testCachedLogicalCluster() *corev1alpha1.LogicalCluster {
 func TestProcessConditionIsolation(t *testing.T) {
 	t.Parallel()
 
+	// The cached object already carries a condition written by a different controller
+	// (WorkspaceAPIBindingsInitialized). After our controller runs, that foreign condition
+	// must still be present on the object we submit.
 	cached := testCachedLogicalCluster()
 	conditions.Set(cached, &conditionsv1alpha1.Condition{
-		Type:               tenancyv1alpha1.WorkspaceAPIBindingsReconciled,
+		Type:               tenancyv1alpha1.WorkspaceAPIBindingsInitialized,
 		Status:             corev1.ConditionTrue,
 		LastTransitionTime: metav1.Now(),
 	})
 
 	var updateStatusCalled bool
 	var receivedLC *corev1alpha1.LogicalCluster
-	b := newTestAPIBinder(cached, func(_ context.Context, lc *corev1alpha1.LogicalCluster) error {
+	c := newTestController(cached, func(_ context.Context, lc *corev1alpha1.LogicalCluster) error {
 		updateStatusCalled = true
 		receivedLC = lc.DeepCopy()
 		return nil
 	})
 
-	err := b.process(context.Background(), "root:ws|cluster")
+	err := c.process(context.Background(), "root:ws|cluster")
 	require.NoError(t, err)
 
 	require.True(t, updateStatusCalled, "updateLCStatus should have been called")
 
-	ownedCond := conditions.Get(receivedLC, tenancyv1alpha1.WorkspaceAPIBindingsInitialized)
-	require.NotNil(t, ownedCond, "owned condition WorkspaceAPIBindingsInitialized must be set")
+	// The condition this controller owns must be present.
+	ownedCond := conditions.Get(receivedLC, tenancyv1alpha1.WorkspaceAPIBindingsReconciled)
+	require.NotNil(t, ownedCond, "owned condition WorkspaceAPIBindingsReconciled must be set")
 
-	foreignCond := conditions.Get(receivedLC, tenancyv1alpha1.WorkspaceAPIBindingsReconciled)
+	// The foreign condition must not have been removed.
+	foreignCond := conditions.Get(receivedLC, tenancyv1alpha1.WorkspaceAPIBindingsInitialized)
 	require.NotNil(t, foreignCond, "foreign condition must be preserved")
 	require.Equal(t, corev1.ConditionTrue, foreignCond.Status)
 }
@@ -176,17 +125,17 @@ func TestProcessConditionIsolation(t *testing.T) {
 func TestProcessConflictRequeues(t *testing.T) {
 	t.Parallel()
 
-	b := newTestAPIBinder(testCachedLogicalCluster(), func(_ context.Context, _ *corev1alpha1.LogicalCluster) error {
+	c := newTestController(testCachedLogicalCluster(), func(_ context.Context, _ *corev1alpha1.LogicalCluster) error {
 		return apierrors.NewConflict(corev1alpha1.Resource("logicalclusters"), corev1alpha1.LogicalClusterName, errors.New("resourceVersion changed"))
 	})
-	b.queue = workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]())
-	t.Cleanup(b.queue.ShutDown)
+	c.queue = workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]())
+	t.Cleanup(c.queue.ShutDown)
 
 	const key = "root:ws|cluster"
-	err := b.process(context.Background(), key)
+	err := c.process(context.Background(), key)
 	require.NoError(t, err, "a conflict must not be returned as a hard error")
 
-	require.Eventually(t, func() bool { return b.queue.Len() == 1 }, time.Second, 5*time.Millisecond,
+	require.Eventually(t, func() bool { return c.queue.Len() == 1 }, time.Second, 5*time.Millisecond,
 		"the key should be requeued after a conflict")
 }
 

--- a/pkg/reconciler/tenancy/initialization/apibinder_initializer_controller.go
+++ b/pkg/reconciler/tenancy/initialization/apibinder_initializer_controller.go
@@ -19,6 +19,7 @@ package initialization
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -37,9 +38,10 @@ import (
 	"github.com/kcp-dev/logicalcluster/v3"
 	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
 	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
+	sdkinitialization "github.com/kcp-dev/sdk/apis/tenancy/initialization"
 	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
+	conditionsv1alpha1 "github.com/kcp-dev/sdk/apis/third_party/conditions/apis/conditions/v1alpha1"
 	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
-	corev1alpha1client "github.com/kcp-dev/sdk/client/clientset/versioned/typed/core/v1alpha1"
 	apisv1alpha2informers "github.com/kcp-dev/sdk/client/informers/externalversions/apis/v1alpha2"
 	corev1alpha1informers "github.com/kcp-dev/sdk/client/informers/externalversions/core/v1alpha1"
 	tenancyv1alpha1informers "github.com/kcp-dev/sdk/client/informers/externalversions/tenancy/v1alpha1"
@@ -112,7 +114,13 @@ func NewAPIBinder(
 			return indexers.ByPathAndNameWithFallback[*apisv1alpha2.APIExport](apisv1alpha2.Resource("apiexports"), apiExportsInformer.Informer().GetIndexer(), globalAPIExportsInformer.Informer().GetIndexer(), path, name)
 		},
 
-		commit: committer.NewCommitter[*corev1alpha1.LogicalCluster, corev1alpha1client.LogicalClusterInterface, *corev1alpha1.LogicalClusterSpec, *corev1alpha1.LogicalClusterStatus](kcpClusterClient.CoreV1alpha1().LogicalClusters()),
+		commitConditions: committer.NewConditionsCommitter[*corev1alpha1.LogicalCluster](
+			[]conditionsv1alpha1.ConditionType{tenancyv1alpha1.WorkspaceAPIBindingsInitialized},
+			func(ctx context.Context, lc *corev1alpha1.LogicalCluster) error {
+				_, err := kcpClusterClient.Cluster(logicalcluster.From(lc).Path()).CoreV1alpha1().LogicalClusters().UpdateStatus(ctx, lc, metav1.UpdateOptions{})
+				return err
+			},
+		),
 	}
 
 	c.transitiveTypeResolver = admission.NewTransitiveTypeResolver(c.getWorkspaceType)
@@ -158,8 +166,6 @@ func NewAPIBinder(
 	return c, nil
 }
 
-type logicalClusterResource = committer.Resource[*corev1alpha1.LogicalClusterSpec, *corev1alpha1.LogicalClusterStatus]
-
 // APIBinder is a controller which instantiates APIBindings and waits for them to be fully bound
 // in new Workspaces.
 type APIBinder struct {
@@ -178,8 +184,7 @@ type APIBinder struct {
 
 	transitiveTypeResolver transitiveTypeResolver
 
-	// commit creates a patch and submits it, if needed.
-	commit func(ctx context.Context, old, new *logicalClusterResource) error
+	commitConditions committer.ConditionsCommitFunc[*corev1alpha1.LogicalCluster]
 }
 
 type transitiveTypeResolver interface {
@@ -311,8 +316,7 @@ func (b *APIBinder) process(ctx context.Context, key string) error {
 		if !apierrors.IsNotFound(err) {
 			logger.Error(err, "failed to get LogicalCluster from lister", "cluster", clusterName)
 		}
-
-		return nil // nothing we can do here
+		return nil
 	}
 
 	old := logicalCluster
@@ -327,11 +331,23 @@ func (b *APIBinder) process(ctx context.Context, key string) error {
 		errs = append(errs, err)
 	}
 
-	// If the object being reconciled changed as a result, update it.
-	oldResource := &logicalClusterResource{ObjectMeta: old.ObjectMeta, Spec: &old.Spec, Status: &old.Status}
-	newResource := &logicalClusterResource{ObjectMeta: logicalCluster.ObjectMeta, Spec: &logicalCluster.Spec, Status: &logicalCluster.Status}
-	if err := b.commit(ctx, oldResource, newResource); err != nil {
-		errs = append(errs, err)
+	initializerRemoved := slices.Contains(old.Status.Initializers, tenancyv1alpha1.WorkspaceAPIBindingsInitializer) &&
+		!slices.Contains(logicalCluster.Status.Initializers, tenancyv1alpha1.WorkspaceAPIBindingsInitializer)
+
+	err = b.commitConditions(ctx, old, logicalCluster, func(lc *corev1alpha1.LogicalCluster) bool {
+		if !initializerRemoved {
+			return false
+		}
+		lc.Status.Initializers = sdkinitialization.EnsureInitializerAbsent(tenancyv1alpha1.WorkspaceAPIBindingsInitializer, lc.Status.Initializers)
+		return true
+	})
+	if err != nil {
+		if apierrors.IsConflict(err) {
+			logger.V(4).Info("conflict updating LogicalCluster status, requeuing")
+			b.queue.AddRateLimited(key)
+		} else {
+			errs = append(errs, err)
+		}
 	}
 
 	return utilerrors.NewAggregate(errs)


### PR DESCRIPTION

<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

```
Quoted from ticket 3924:

"Both APIBinderInitializerController and DefaultAPIBindingLifecycleController
write conditions on the LogicalCluster. If the APIBindingReconciler resets
InitialBindingCompleted to False (because resource-bindings annotation
is missing), it triggers the APIBinderInitializer to re-reconcile
LogicalCluster."
```
```
APIBinderInitializerController and DefaultAPIBindingLifecycleController
both write LogicalCluster status via JSON merge patch, causing last-writer-
wins data loss on the conditions array.

- Add a new special commiter for statuses that handles the problem.
- Add a couple of tests that make sure the clash no longer happens.

It might be worth updating NewCommiter* to SSA, but that would
mean for Conditions we would need listType=map.
Not done in this PR as the delta is bigger.
```

## What Type of PR Is This?

/kind bug

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #3924

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
bugfix: prevent ordering-dependent LogicalCluster status conditions race between multiple controllers.
```
