### PR TITLE
Release CRD resource lock when the CRD is deleted

### DIFF
--- a/pkg/reconciler/apis/logicalclustercleanup/logicalclustercleanup_controller.go
+++ b/pkg/reconciler/apis/logicalclustercleanup/logicalclustercleanup_controller.go
@@ -308,9 +308,11 @@ func (c *controller) process(ctx context.Context, key string) error {
 			continue
 		}
 
-		// CRD doesn't exist.
-		if b.CRDExpiry != nil && time.Now().After(b.CRDExpiry.Time) {
-			logger.V(4).Info("removing expired CRD binding of non-existing CRD", "crd", gr)
+		// CRD doesn't exist (anymore): release the lock immediately if it was
+		// held without an expiry (the CRD was deleted), or once an existing
+		// expiry has passed.
+		if b.CRDExpiry == nil || time.Now().After(b.CRDExpiry.Time) {
+			logger.V(4).Info("removing CRD binding of non-existing CRD", "crd", gr)
 			delete(rbs, gr)
 		}
 	}

--- a/pkg/reconciler/apis/logicalclustercleanup/logicalclustercleanup_controller_test.go
+++ b/pkg/reconciler/apis/logicalclustercleanup/logicalclustercleanup_controller_test.go
@@ -97,6 +97,10 @@ func TestReconciler(t *testing.T) {
 			logicalCluster: &corev1alpha1.LogicalCluster{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
 				"internal.apis.kcp.io/resource-bindings": `{"as.group":{"n":"binding1"},"bs.group":{"n":"binding1"},"crd1s.group":{"c":true},"crd2s.group":{"c":true},"cs.group":{"n":"binding2"},"ds.group":{"n":"binding2"}}`,
 			}}},
+			crds: []*apiextensionsv1.CustomResourceDefinition{
+				withEstablished(newCRD("group", "crd1s")),
+				withEstablished(newCRD("group", "crd2s")),
+			},
 			apiBindings: []*apisv1alpha2.APIBinding{
 				&newAPIBinding().WithName("binding1").WithBoundResources("group", "as", "group", "bs").APIBinding,
 			},
@@ -113,6 +117,15 @@ func TestReconciler(t *testing.T) {
 			},
 			want: &corev1alpha1.LogicalCluster{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
 				"internal.apis.kcp.io/resource-bindings": fmt.Sprintf(`{"crd1s.group":{"c":true},"crd3s.group":{"c":true,"e":%q}}`, notExpired),
+			}}},
+		},
+		"deleted CRD whose lock has no expiry is removed": {
+			logicalCluster: &corev1alpha1.LogicalCluster{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				"internal.apis.kcp.io/resource-bindings": `{"crd1s.group":{"c":true}}`,
+			}}},
+			crds: []*apiextensionsv1.CustomResourceDefinition{},
+			want: &corev1alpha1.LogicalCluster{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				"internal.apis.kcp.io/resource-bindings": `{}`,
 			}}},
 		},
 	}


### PR DESCRIPTION
## Summary

The logicalclustercleanup controller clears a CRD locks expiry while the CRD exists, but the removal branch only fired for locks with a non-nil, passed expiry. So once an established CRD was deleted, its resource-bindings lock was never released, blocking new APIBindings for the same group-resource.

Release the lock when its CRD no longer exists and it has no expiry set.

## What Type of PR Is This?

/kind bug

## Related Issue(s)

Fixes #3799

## Release Notes

```release-note
NONE
```
