### PR TITLE
Restore mounted workspace access through the front-proxy

### DIFF
--- a/cmd/sharded-test-server/frontproxy.go
+++ b/cmd/sharded-test-server/frontproxy.go
@@ -133,6 +133,19 @@ func startFrontProxy(
 		fmt.Sprintf("--root-kubeconfig=%s", filepath.Join(workDirPath, ".kcp", "root.kubeconfig")),
 		fmt.Sprintf("--shards-kubeconfig=%s", filepath.Join(workDirPath, ".kcp-front-proxy", "shards.kubeconfig")),
 		fmt.Sprintf("--client-ca-file=%s", filepath.Join(workDirPath, ".kcp", "client-ca.crt")),
+		// Trust requestheader-CA-signed clients (e.g. a shard's local proxy re-entering
+		// the front-proxy while forwarding a mounted workspace) to assert identity via
+		// X-Remote-* headers. Without this the front-proxy cannot authenticate the
+		// forwarded identity on that hop and clears the headers, breaking mounts.
+		fmt.Sprintf("--requestheader-client-ca-file=%s", filepath.Join(workDirPath, ".kcp", "requestheader-ca.crt")),
+		"--requestheader-username-headers=X-Remote-User",
+		"--requestheader-group-headers=X-Remote-Group",
+		"--requestheader-extra-headers-prefix=X-Remote-Extra-",
+		// Restrict which requestheader-CA-signed client certs may assert identity to the
+		// known infra CNs (the front-proxy itself and the shards' local proxy). This keeps
+		// the front-proxy stricter than the shards: only these certs can forward headers,
+		// not any cert the requestheader CA happens to sign.
+		"--requestheader-allowed-names=kcp-front-proxy,kcp-mounts-proxy",
 		fmt.Sprintf("--tls-cert-file=%s", filepath.Join(workDirPath, ".kcp-front-proxy", "apiserver.crt")),
 		fmt.Sprintf("--tls-private-key-file=%s", filepath.Join(workDirPath, ".kcp-front-proxy", "apiserver.key")),
 		"--secure-port=6443",

--- a/cmd/sharded-test-server/main.go
+++ b/cmd/sharded-test-server/main.go
@@ -104,6 +104,21 @@ func start(proxyFlags, shardFlags []string, logDirPath, workDirPath string, numb
 		return fmt.Errorf("failed to create requestheader client cert: %w", err)
 	}
 
+	// Client cert (signed by the requestheader CA) that a shard's local proxy presents
+	// when it forwards a request for a mounted workspace back to the front-proxy. The
+	// front-proxy's requestheader authenticator verifies this cert and then takes the
+	// identity from the forwarded X-Remote-* headers. The CN must be listed in the
+	// front-proxy's --requestheader-allowed-names (see frontproxy.go).
+	_, _, err = requestHeaderCA.EnsureClientCertificate(
+		filepath.Join(workDirPath, ".kcp", "mounts-proxy.crt"),
+		filepath.Join(workDirPath, ".kcp", "mounts-proxy.key"),
+		&kuser.DefaultInfo{Name: "kcp-mounts-proxy"},
+		365,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create mounts proxy client cert: %w", err)
+	}
+
 	// create client CA and kcp-admin client cert to connect through front-proxy
 	clientCA, _, err := crypto.EnsureCA(
 		filepath.Join(workDirPath, ".kcp", "client-ca.crt"),

--- a/cmd/sharded-test-server/shard.go
+++ b/cmd/sharded-test-server/shard.go
@@ -120,6 +120,8 @@ func newShard(ctx context.Context, n int, args []string, standaloneVW bool, serv
 		fmt.Sprintf("--shard-client-cert-file=%s", shardClientCert),
 		fmt.Sprintf("--shard-client-key-file=%s", shardClientCertKey),
 		fmt.Sprintf("--shard-virtual-workspace-ca-file=%s", filepath.Join(kcpDir, "serving-ca.crt")),
+		fmt.Sprintf("--mount-proxy-client-cert-file=%s", filepath.Join(kcpDir, "mounts-proxy.crt")),
+		fmt.Sprintf("--mount-proxy-client-key-file=%s", filepath.Join(kcpDir, "mounts-proxy.key")),
 	)
 	if len(cacheServerConfigPath) > 0 {
 		args = append(args, fmt.Sprintf("--cache-kubeconfig=%s", cacheServerConfigPath))

--- a/pkg/proxy/options/authentication.go
+++ b/pkg/proxy/options/authentication.go
@@ -115,6 +115,18 @@ func (c *Authentication) ApplyTo(ctx context.Context, authenticationInfo *generi
 		}
 	}
 
+	// Also advertise and verify the requestheader CA on the serving side. This unions
+	// the requestheader CA into the TLS CertificateRequest's acceptable-CA list, so a
+	// trusted upstream (e.g. a shard's mount proxy re-entering the front-proxy) actually
+	// presents its requestheader-CA-signed client cert. Without this, the Go TLS client
+	// finds no cert matching the advertised CAs and sends none, the requestheader
+	// authenticator never runs, and forwarded identity headers get cleared.
+	if authenticatorConfig.RequestHeaderConfig != nil && authenticatorConfig.RequestHeaderConfig.CAContentProvider != nil {
+		if err = authenticationInfo.ApplyClientCert(authenticatorConfig.RequestHeaderConfig.CAContentProvider, servingInfo); err != nil {
+			return fmt.Errorf("unable to load requestheader CA file: %w", err)
+		}
+	}
+
 	// Set for service account auth, if enabled
 	if c.serviceAccountAuthEnabled() {
 		authenticationInfo.APIAudiences = c.BuiltInOptions.APIAudiences

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -453,6 +453,26 @@ func NewConfig(ctx context.Context, opts kcpserveroptions.CompletedOptions) (*Co
 		virtualWorkspaceServerProxyTransport = transport
 	}
 
+	// Transport used by the local proxy when it forwards a request for a mounted
+	// workspace back to the front-proxy. It presents a requestheader-CA-signed client
+	// certificate so the front-proxy authenticates the forwarded identity headers
+	// (via its requestheader authenticator) instead of clearing them.
+	var mountProxyTransport http.RoundTripper
+	if opts.Extra.MountProxyClientCertFile != "" && opts.Extra.MountProxyClientKeyFile != "" {
+		cert, err := tls.LoadX509KeyPair(opts.Extra.MountProxyClientCertFile, opts.Extra.MountProxyClientKeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load mount proxy client certificate %q or key %q: %w", opts.Extra.MountProxyClientCertFile, opts.Extra.MountProxyClientKeyFile, err)
+		}
+
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.TLSClientConfig = &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			// TODO: verify the front-proxy serving cert here instead of skipping, once a CA is wired through in dev mode.
+			InsecureSkipVerify: true,
+		}
+		mountProxyTransport = transport
+	}
+
 	// Prepare a local cluster index that can be used both by the LocalProxy, as well as the authenticator
 	// (the authenticator cannot always use the data the localproxy puts into the context because the
 	// authentication rest storage provider calls the authenticator outside of the handler chain).
@@ -624,7 +644,7 @@ func NewConfig(ctx context.Context, opts kcpserveroptions.CompletedOptions) (*Co
 		// whether shard-wide URLs like /metrics may be served. Workspace-scoped
 		// requests are 501'd; top-level requests are evaluated against root RBAC.
 		apiHandler = kcpfilters.WithShardLevelPaths(apiHandler)
-		apiHandler, err = WithLocalProxy(apiHandler, opts.Extra.ShardName, opts.Extra.AdditionalMappingsFile, clusterIndex)
+		apiHandler, err = WithLocalProxy(apiHandler, opts.Extra.ShardName, opts.Extra.AdditionalMappingsFile, clusterIndex, mountProxyTransport)
 		if err != nil {
 			panic(err) // shouldn't happen due to flag validation
 		}

--- a/pkg/server/localproxy.go
+++ b/pkg/server/localproxy.go
@@ -105,6 +105,7 @@ func WithLocalProxy(
 	handler http.Handler,
 	shardName, additionalMappingsFile string,
 	clusterIndex *index.State,
+	mountProxyTransport http.RoundTripper,
 ) (http.Handler, error) {
 	defaultHandlerFunc := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
@@ -175,11 +176,17 @@ func WithLocalProxy(
 			}
 			logger.WithValues("from", path, "to", r.URL).V(4).Info("mounting cluster")
 			proxy := httputil.NewSingleHostReverseProxy(u)
-			// TODO(mjudeikis): remove this once we have a real cert wired in dev mode
-			proxy.Transport = &http.Transport{
-				TLSClientConfig: &tls.Config{
-					InsecureSkipVerify: true,
-				},
+			if mountProxyTransport != nil {
+				// Present a requestheader-CA-signed client certificate so the front-proxy
+				// authenticates the forwarded identity headers instead of clearing them.
+				proxy.Transport = mountProxyTransport
+			} else {
+				// TODO(mjudeikis): remove this once we have a real cert wired in dev mode
+				proxy.Transport = &http.Transport{
+					TLSClientConfig: &tls.Config{
+						InsecureSkipVerify: true,
+					},
+				}
 			}
 
 			proxy.ServeHTTP(w, req)

--- a/pkg/server/localproxy_test.go
+++ b/pkg/server/localproxy_test.go
@@ -60,7 +60,7 @@ func TestWithLocalProxy_UnresolvablePathIsRejected(t *testing.T) {
 	// that the original bug exploited.
 	emptyIndex := index.New(nil)
 
-	h, err := WithLocalProxy(downstream, "test-shard", "", emptyIndex)
+	h, err := WithLocalProxy(downstream, "test-shard", "", emptyIndex, nil)
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodGet,
@@ -89,7 +89,7 @@ func TestWithLocalProxy_BareNameIsForwarded(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	h, err := WithLocalProxy(downstream, "test-shard", "", index.New(nil))
+	h, err := WithLocalProxy(downstream, "test-shard", "", index.New(nil), nil)
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodGet,

--- a/pkg/server/options/options.go
+++ b/pkg/server/options/options.go
@@ -56,16 +56,22 @@ type Options struct {
 }
 
 type ExtraOptions struct {
-	ProfilerAddress                       string
-	ShardKubeconfigFile                   string
-	RootShardKubeconfigFile               string
-	ShardBaseURL                          string
-	ShardExternalURL                      string
-	ShardName                             string
-	ShardVirtualWorkspaceURL              string
-	ShardClientCertFile                   string
-	ShardClientKeyFile                    string
-	ShardVirtualWorkspaceCAFile           string
+	ProfilerAddress             string
+	ShardKubeconfigFile         string
+	RootShardKubeconfigFile     string
+	ShardBaseURL                string
+	ShardExternalURL            string
+	ShardName                   string
+	ShardVirtualWorkspaceURL    string
+	ShardClientCertFile         string
+	ShardClientKeyFile          string
+	ShardVirtualWorkspaceCAFile string
+	// MountProxyClientCertFile / MountProxyClientKeyFile point to a client certificate
+	// (signed by the front-proxy requestheader CA) that the local proxy presents when it
+	// forwards a request for a mounted workspace back to the front-proxy. This lets the
+	// front-proxy trust the forwarded identity headers instead of clearing them.
+	MountProxyClientCertFile              string
+	MountProxyClientKeyFile               string
 	DiscoveryPollInterval                 time.Duration
 	ExperimentalBindFreePort              bool
 	LogicalClusterAdminKubeconfig         string
@@ -176,6 +182,8 @@ func (o *Options) AddFlags(fss *cliflag.NamedFlagSets) {
 	fs.StringVar(&o.Extra.ShardVirtualWorkspaceURL, "shard-virtual-workspace-url", o.Extra.ShardVirtualWorkspaceURL, "An external URL address of a virtual workspace server associated with this shard. Defaults to shard's base address.")
 	fs.StringVar(&o.Extra.ShardClientCertFile, "shard-client-cert-file", o.Extra.ShardClientCertFile, "Path to a client certificate file the shard uses to communicate with other system components.")
 	fs.StringVar(&o.Extra.ShardClientKeyFile, "shard-client-key-file", o.Extra.ShardClientKeyFile, "Path to a client certificate key file the shard uses to communicate with other system components.")
+	fs.StringVar(&o.Extra.MountProxyClientCertFile, "mount-proxy-client-cert-file", o.Extra.MountProxyClientCertFile, "Path to a client certificate file (signed by the front-proxy requestheader CA) the local proxy presents when forwarding a request for a mounted workspace back to the front-proxy.")
+	fs.StringVar(&o.Extra.MountProxyClientKeyFile, "mount-proxy-client-key-file", o.Extra.MountProxyClientKeyFile, "Path to the key file for --mount-proxy-client-cert-file.")
 	fs.StringVar(&o.Extra.LogicalClusterAdminKubeconfig, "logical-cluster-admin-kubeconfig", o.Extra.LogicalClusterAdminKubeconfig, "Kubeconfig holding system:kcp:logical-cluster-admin credentials for connecting to other shards. Defaults to the loopback client")
 	fs.StringVar(&o.Extra.ExternalLogicalClusterAdminKubeconfig, "external-logical-cluster-admin-kubeconfig", o.Extra.ExternalLogicalClusterAdminKubeconfig, "Kubeconfig holding system:kcp:external-logical-cluster-admin credentials for connecting to the external address (e.g. the front-proxy). Defaults to the loopback client")
 	fs.StringVar(&o.Extra.RootIdentitiesFile, "root-identities-file", "", "Path to a YAML file used to bootstrap APIExport identities inside the root workspace. The YAML file must be structured as {\"identities\": [ {\"export\": \"<APIExport name>\", \"identity\": \"<APIExport identity>\"}, ... ]}. If a secret with matching APIExport name already exists inside kcp-system namespace, it will be left unchanged. Defaults to empty, i.e. no identities are bootstrapped.")

--- a/test/e2e/mounts/mounts_machinery_test.go
+++ b/test/e2e/mounts/mounts_machinery_test.go
@@ -60,8 +60,6 @@ var testFiles embed.FS
 // symbolic links fashion.
 
 func TestMountsMachinery(t *testing.T) {
-	t.Skip("This test is disabled because kcp 0.32.2 introduced authentication changes that break this test/functionality.")
-
 	t.Parallel()
 	framework.Suite(t, "control-plane")
 


### PR DESCRIPTION
## Summary

Fixes a regression where requests to mounted workspaces fail with `Unauthorized` in sharded deployments. The regression was introduced by the fix for GHSA-c8w2-fgvx-vhv4, which made the front-proxy unconditionally strip inbound `X-Remote-*` identity headers when a request is not authenticated.

A mounted-workspace request crosses the front-proxy twice: the source shard's local proxy forwards
the request to the destination workspace's canonical URL, which is the front-proxy itself. That second hop previously carried no client certificate, so the front-proxy could not authenticate it and (correctly, per the CVE fix) cleared the forwarded identity headers — leaving the destination shard with no identity and returning 401.

This restores mounts without weakening the CVE fix, by authenticating the second hop the standard Kubernetes "trusted front proxy" way instead of trusting unauthenticated headers:

- The shard's local proxy now presents a requestheader-CA-signed client certificate when forwarding back to the front-proxy (new `--mount-proxy-client-cert-file` / `--mount-proxy-client-key-file` shard flags; the transport falls back to the previous behavior when unset).
- The front-proxy now runs its requestheader authenticator and unions the requestheader CA into its serving client-CA bundle, so it advertises that CA in the TLS handshake (otherwise the proxy never presents its cert) and authenticates the *original* user from the forwarded headers.
- The header-scrubbing logic from the CVE fix (`ClearAuthHeaders` / `SetAuthHeaders`) is left untouched: inbound `X-Remote-*` headers are still always cleared and re-stamped only from an authenticated identity. Trust is granted solely to certificates signed by the requestheader CA — which shards already trust — and is bounded further by `--requestheader-allowed-names`.

The change is opt-in and backward compatible: with the new flags unset, behavior is unchanged.

The `sharded-test-server` dev harness is updated to mint the mount-proxy certificate and pass the corresponding flags to the shards and the front-proxy.

## What Type of PR Is This?

/kind regression

## Release Notes

```release-note
Fixed mounted workspace access failing with `Unauthorized` in sharded deployments, a regression introduced by the fix for GHSA-c8w2-fgvx-vhv4. Enabling mounts now requires configuring the front-proxy with `--requestheader-client-ca-file` and each shard with `--mount-proxy-client-cert-file`/`--mount-proxy-client-key-file`.
```

/assign @xrstf @mjudeikis 