### PR TITLE
deduplicate URL path for workspacemigration VW

### DIFF
--- a/pkg/server/filters/migrationdump.go
+++ b/pkg/server/filters/migrationdump.go
@@ -18,16 +18,16 @@ package filters
 
 import (
 	"net/http"
-)
 
-const migrationDumpHandlerPath = "/apis/migration.kcp.io/v1alpha1/logicalclusterdumps"
+	"github.com/kcp-dev/kcp/pkg/virtual/migratingworkspaces"
+)
 
 // WithMigrationDumpHandler intercepts POSTs to the LogicalClusterDump path
 // before the kube REST chain rejects the unknown migration.kcp.io API group
 // with a 503. All other requests fall through to next.
 func WithMigrationDumpHandler(next http.Handler, dump http.Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		if req.Method == http.MethodPost && req.URL.Path == migrationDumpHandlerPath {
+		if req.Method == http.MethodPost && req.URL.Path == migratingworkspaces.HandlerPath {
 			dump.ServeHTTP(w, req)
 			return
 		}

--- a/pkg/server/filters/perclustercontext.go
+++ b/pkg/server/filters/perclustercontext.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kcp-dev/logicalcluster/v3"
 
 	"github.com/kcp-dev/kcp/pkg/contextmanager"
+	"github.com/kcp-dev/kcp/pkg/virtual/migratingworkspaces"
 )
 
 // WithPerClusterContext injects a multiple-parent context for each request
@@ -47,7 +48,7 @@ func WithPerClusterContext(handler http.Handler, mgr *contextmanager.Manager[log
 		// Skip adding contexts to requests with LogicalClusterDump,
 		// contexts for migrating LCs are cancelled and stay cancelled
 		// until they are migrated.
-		migrationDumpHandlerPath,
+		migratingworkspaces.HandlerPath,
 	}
 
 	return func(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
## Summary
This removes a duplicate of the URL. Simple stuff. I chose this way because there is precedence: pkg/server already  uses `initializingworkspaces.URLFor()`, i.e. the server already uses code from the virtual workspaces.

## What Type of PR Is This?
/kind cleanup

## Related Issue(s)
Fixes #4204

## Release Notes
```release-note
NONE
```
