### PR TITLE
Paginate LogicalClusterDump to avoid whole-cluster etcd transfers

### DIFF
--- a/config/crds/migration.kcp.io_logicalclusterdumps.yaml
+++ b/config/crds/migration.kcp.io_logicalclusterdumps.yaml
@@ -43,23 +43,49 @@ spec:
           metadata:
             type: object
           spec:
-            description: |
+            description: |-
               LogicalClusterDumpSpec is the desired state for a dump request.
 
               The logical cluster to dump is taken from the request's cluster context
-              (i.e. the URL the request arrived on). No fields are required today.
+              (i.e. the URL the request arrived on).
+            properties:
+              continue:
+                description: |-
+                  continue is the token returned by a previous LogicalClusterDump's
+                  status.continue. If set, the scan resumes right after the last key
+                  returned by that page. If empty, the scan starts from the
+                  beginning of the logical cluster's etcd keyspace.
+                type: string
+              limit:
+                description: |-
+                  limit caps the number of entries returned in a single page. If
+                  zero, the server picks a default page size.
+                format: int64
+                type: integer
+              maxBytes:
+                description: |-
+                  maxBytes caps the total size, in bytes, of entry values returned in
+                  a single page. The scan stops and returns a continue token as soon
+                  as this budget is exceeded, even if limit hasn't been reached yet.
+                  If zero, the server picks a default byte budget.
+                format: int64
+                type: integer
             type: object
           status:
             description: LogicalClusterDumpStatus carries the dump payload populated
               by the server.
             properties:
+              continue:
+                description: |-
+                  continue is set when there are more entries to fetch. Pass it as
+                  spec.continue on the next LogicalClusterDump request to get the
+                  next page. Empty means this was the last page.
+                type: string
               entries:
                 description: |-
-                  entries is the full set of etcd key/value pairs belonging to the
+                  entries is the page of etcd key/value pairs belonging to the
                   logical cluster, in the origin shard's etcd encoding (proto for
                   built-ins, JSON for CRs).
-
-                  becomes a concern.
                 items:
                   description: EtcdEntry is a single etcd key/value pair from the
                     origin shard.

--- a/config/crds/migration.kcp.io_logicalclustermigrations.yaml
+++ b/config/crds/migration.kcp.io_logicalclustermigrations.yaml
@@ -29,6 +29,10 @@ spec:
       jsonPath: .spec.destinationShard
       name: Destination
       type: string
+    - description: Number of etcd entries copied so far
+      jsonPath: .status.entriesCopied
+      name: Entries Copied
+      type: integer
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -119,6 +123,20 @@ spec:
                   - type
                   type: object
                 type: array
+              dumpContinue:
+                description: |-
+                  dumpContinue is the continue token for the next LogicalClusterDump
+                  page to fetch from the origin shard. Set by the destination shard
+                  controller as it works through the data copy, and cleared once the
+                  copy is complete. Used to resume the copy from where it left off
+                  after a destination shard restart, instead of starting over.
+                type: string
+              entriesCopied:
+                description: |-
+                  entriesCopied is the number of etcd entries copied from the origin
+                  shard to the destination shard so far during the Migrating phase.
+                format: int64
+                type: integer
               originShard:
                 description: |-
                   originShard is the name of the shard to migrate the logical cluster from.

--- a/config/root-phase0/apiexport-migration.kcp.io.yaml
+++ b/config/root-phase0/apiexport-migration.kcp.io.yaml
@@ -6,12 +6,12 @@ spec:
   resources:
   - group: migration.kcp.io
     name: logicalclusterdumps
-    schema: v260604-70219e163.logicalclusterdumps.migration.kcp.io
+    schema: v260702-7381341f5.logicalclusterdumps.migration.kcp.io
     storage:
       crd: {}
   - group: migration.kcp.io
     name: logicalclustermigrations
-    schema: v260604-70219e163.logicalclustermigrations.migration.kcp.io
+    schema: v260702-7381341f5.logicalclustermigrations.migration.kcp.io
     storage:
       crd: {}
 status: {}

--- a/config/root-phase0/apiresourceschema-logicalclusterdumps.migration.kcp.io.yaml
+++ b/config/root-phase0/apiresourceschema-logicalclusterdumps.migration.kcp.io.yaml
@@ -1,7 +1,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v260604-70219e163.logicalclusterdumps.migration.kcp.io
+  name: v260702-7381341f5.logicalclusterdumps.migration.kcp.io
 spec:
   group: migration.kcp.io
   names:
@@ -39,23 +39,49 @@ spec:
         metadata:
           type: object
         spec:
-          description: |
+          description: |-
             LogicalClusterDumpSpec is the desired state for a dump request.
 
             The logical cluster to dump is taken from the request's cluster context
-            (i.e. the URL the request arrived on). No fields are required today.
+            (i.e. the URL the request arrived on).
+          properties:
+            continue:
+              description: |-
+                continue is the token returned by a previous LogicalClusterDump's
+                status.continue. If set, the scan resumes right after the last key
+                returned by that page. If empty, the scan starts from the
+                beginning of the logical cluster's etcd keyspace.
+              type: string
+            limit:
+              description: |-
+                limit caps the number of entries returned in a single page. If
+                zero, the server picks a default page size.
+              format: int64
+              type: integer
+            maxBytes:
+              description: |-
+                maxBytes caps the total size, in bytes, of entry values returned in
+                a single page. The scan stops and returns a continue token as soon
+                as this budget is exceeded, even if limit hasn't been reached yet.
+                If zero, the server picks a default byte budget.
+              format: int64
+              type: integer
           type: object
         status:
           description: LogicalClusterDumpStatus carries the dump payload populated
             by the server.
           properties:
+            continue:
+              description: |-
+                continue is set when there are more entries to fetch. Pass it as
+                spec.continue on the next LogicalClusterDump request to get the
+                next page. Empty means this was the last page.
+              type: string
             entries:
               description: |-
-                entries is the full set of etcd key/value pairs belonging to the
+                entries is the page of etcd key/value pairs belonging to the
                 logical cluster, in the origin shard's etcd encoding (proto for
                 built-ins, JSON for CRs).
-
-                becomes a concern.
               items:
                 description: EtcdEntry is a single etcd key/value pair from the origin
                   shard.

--- a/config/root-phase0/apiresourceschema-logicalclustermigrations.migration.kcp.io.yaml
+++ b/config/root-phase0/apiresourceschema-logicalclustermigrations.migration.kcp.io.yaml
@@ -1,7 +1,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v260604-70219e163.logicalclustermigrations.migration.kcp.io
+  name: v260702-7381341f5.logicalclustermigrations.migration.kcp.io
 spec:
   group: migration.kcp.io
   names:
@@ -26,6 +26,10 @@ spec:
       jsonPath: .spec.destinationShard
       name: Destination
       type: string
+    - description: Number of etcd entries copied so far
+      jsonPath: .status.entriesCopied
+      name: Entries Copied
+      type: integer
     name: v1alpha1
     schema:
       description: LogicalClusterMigration describes a migration of a logical cluster
@@ -114,6 +118,20 @@ spec:
                 - type
                 type: object
               type: array
+            dumpContinue:
+              description: |-
+                dumpContinue is the continue token for the next LogicalClusterDump
+                page to fetch from the origin shard. Set by the destination shard
+                controller as it works through the data copy, and cleared once the
+                copy is complete. Used to resume the copy from where it left off
+                after a destination shard restart, instead of starting over.
+              type: string
+            entriesCopied:
+              description: |-
+                entriesCopied is the number of etcd entries copied from the origin
+                shard to the destination shard so far during the Migrating phase.
+              format: int64
+              type: integer
             originShard:
               description: |-
                 originShard is the name of the shard to migrate the logical cluster from.

--- a/pkg/etcd/keys.go
+++ b/pkg/etcd/keys.go
@@ -25,6 +25,11 @@ import (
 // ScanPageSize is the page size used in etcd range scans.
 const ScanPageSize int64 = 1000
 
+// DumpMaxBytes is the default cap on the total size of entry values
+// returned in a single LogicalClusterDump page, used when the request
+// doesn't specify spec.maxBytes.
+const DumpMaxBytes int64 = 2 * 1024 * 1024
+
 // KeyParts holds the parsed components of an etcd key produced by SplitKey.
 type KeyParts struct {
 	Group    string

--- a/pkg/reconciler/migration/logicalclustermigration/controller.go
+++ b/pkg/reconciler/migration/logicalclustermigration/controller.go
@@ -19,6 +19,7 @@ package logicalclustermigration
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -42,6 +43,7 @@ import (
 	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
 	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 	migrationv1alpha1 "github.com/kcp-dev/sdk/apis/migration/v1alpha1"
+	kcpsdkclient "github.com/kcp-dev/sdk/client/clientset/versioned"
 	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
 	migrationv1alpha1client "github.com/kcp-dev/sdk/client/clientset/versioned/typed/migration/v1alpha1"
 	apisv1alpha1informers "github.com/kcp-dev/sdk/client/informers/externalversions/apis/v1alpha1"
@@ -109,6 +111,7 @@ func NewController(
 		getCRD: func(clusterName logicalcluster.Name, name string) (*apiextensionsv1.CustomResourceDefinition, error) {
 			return crdInformer.Lister().Cluster(clusterName).Get(name)
 		},
+		originClients: make(map[originClientKey]kcpsdkclient.Interface),
 	}
 	c.copyPageFromOrigin = c.copyPageFromOriginViaHTTP
 
@@ -158,6 +161,21 @@ type Controller struct {
 	// copyPageFromOriginViaHTTP) so reconcileMigrating's pagination and
 	// requeue logic can be unit-tested without a live origin shard.
 	copyPageFromOrigin func(ctx context.Context, lcName logicalcluster.Name, originShardName, continueToken string) (int64, string, error)
+
+	// originClientsMu guards originClients.
+	originClientsMu sync.Mutex
+	// originClients caches one client per (origin shard, logical cluster)
+	// pair so a paginated copy reuses the same underlying HTTP transport
+	// and connection pool across pages, instead of building a new one
+	// per page.
+	originClients map[originClientKey]kcpsdkclient.Interface
+}
+
+// originClientKey identifies a cached origin client for one migration's
+// data copy.
+type originClientKey struct {
+	originShardName string
+	lcName          logicalcluster.Name
 }
 
 func (c *Controller) enqueue(obj interface{}) {

--- a/pkg/reconciler/migration/logicalclustermigration/controller.go
+++ b/pkg/reconciler/migration/logicalclustermigration/controller.go
@@ -110,6 +110,7 @@ func NewController(
 			return crdInformer.Lister().Cluster(clusterName).Get(name)
 		},
 	}
+	c.copyPageFromOrigin = c.copyPageFromOriginViaHTTP
 
 	// Events are queued from the cache server as that is used to
 	// coordinate the migration between the participating shards.
@@ -151,6 +152,12 @@ type Controller struct {
 	getAPIExportByPath   func(path logicalcluster.Path, name string) (*apisv1alpha2.APIExport, error)
 	getAPIResourceSchema func(clusterName logicalcluster.Name, name string) (*apisv1alpha1.APIResourceSchema, error)
 	getCRD               func(clusterName logicalcluster.Name, name string) (*apiextensionsv1.CustomResourceDefinition, error)
+
+	// copyPageFromOrigin fetches and writes a single page of a
+	// LogicalClusterDump. Extracted as a field (defaulting to
+	// copyPageFromOriginViaHTTP) so reconcileMigrating's pagination and
+	// requeue logic can be unit-tested without a live origin shard.
+	copyPageFromOrigin func(ctx context.Context, lcName logicalcluster.Name, originShardName, continueToken string) (int64, string, error)
 }
 
 func (c *Controller) enqueue(obj interface{}) {

--- a/pkg/reconciler/migration/logicalclustermigration/datacopy.go
+++ b/pkg/reconciler/migration/logicalclustermigration/datacopy.go
@@ -47,20 +47,9 @@ import (
 func (c *Controller) copyPageFromOriginViaHTTP(ctx context.Context, lcName logicalcluster.Name, originShardName, continueToken string) (int64, string, error) {
 	logger := klog.FromContext(ctx)
 
-	originShard, err := c.shardLister.Cluster(core.RootCluster).Get(originShardName)
+	client, err := c.originClient(lcName, originShardName)
 	if err != nil {
-		return 0, "", fmt.Errorf("failed to get origin shard %q: %w", originShardName, err)
-	}
-	if originShard.Spec.VirtualWorkspaceURL == "" {
-		return 0, "", fmt.Errorf("origin shard %q has no VirtualWorkspaceURL", originShardName)
-	}
-
-	cfg := rest.CopyConfig(c.externalLogicalClusterAdminConfig)
-	cfg.Host = originShard.Spec.VirtualWorkspaceURL + migratingworkspaces.URLFor() + "/clusters/" + string(lcName)
-
-	client, err := kcpsdkclient.NewForConfig(cfg)
-	if err != nil {
-		return 0, "", fmt.Errorf("failed to create origin migrating client: %w", err)
+		return 0, "", err
 	}
 
 	logger.V(2).Info("requesting logical cluster dump page from origin", "logicalCluster", lcName, "originShard", originShardName, "continue", continueToken)
@@ -92,4 +81,47 @@ func (c *Controller) copyPageFromOriginViaHTTP(ctx context.Context, lcName logic
 	}
 
 	return int64(len(dump.Status.Entries)), dump.Status.Continue, nil
+}
+
+// originClient returns the cached client for requesting LogicalClusterDump
+// pages of lcName from originShardName, creating and caching one if none
+// exists yet. Reusing the client across pages of the same copy avoids
+// building a new HTTP transport and connection pool per page.
+func (c *Controller) originClient(lcName logicalcluster.Name, originShardName string) (kcpsdkclient.Interface, error) {
+	key := originClientKey{originShardName: originShardName, lcName: lcName}
+
+	c.originClientsMu.Lock()
+	defer c.originClientsMu.Unlock()
+
+	if client, ok := c.originClients[key]; ok {
+		return client, nil
+	}
+
+	originShard, err := c.shardLister.Cluster(core.RootCluster).Get(originShardName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get origin shard %q: %w", originShardName, err)
+	}
+	if originShard.Spec.VirtualWorkspaceURL == "" {
+		return nil, fmt.Errorf("origin shard %q has no VirtualWorkspaceURL", originShardName)
+	}
+
+	cfg := rest.CopyConfig(c.externalLogicalClusterAdminConfig)
+	cfg.Host = originShard.Spec.VirtualWorkspaceURL + migratingworkspaces.URLFor() + "/clusters/" + string(lcName)
+
+	client, err := kcpsdkclient.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create origin migrating client: %w", err)
+	}
+
+	c.originClients[key] = client
+	return client, nil
+}
+
+// evictOriginClient drops the cached client for lcName/originShardName once
+// its data copy is done, so the migration's HTTP transport doesn't linger
+// forever in the cache.
+func (c *Controller) evictOriginClient(lcName logicalcluster.Name, originShardName string) {
+	c.originClientsMu.Lock()
+	defer c.originClientsMu.Unlock()
+	delete(c.originClients, originClientKey{originShardName: originShardName, lcName: lcName})
 }

--- a/pkg/reconciler/migration/logicalclustermigration/datacopy.go
+++ b/pkg/reconciler/migration/logicalclustermigration/datacopy.go
@@ -33,18 +33,26 @@ import (
 	"github.com/kcp-dev/kcp/pkg/virtual/migratingworkspaces"
 )
 
-// copyDataFromOrigin requests a LogicalClusterDump from the origin shard's
-// migrating virtual workspace and writes the returned etcd entries directly
-// to the local shard's etcd.
-func (c *Controller) copyDataFromOrigin(ctx context.Context, lcName logicalcluster.Name, originShardName string) error {
+// copyPageFromOriginViaHTTP requests a single page of a LogicalClusterDump
+// from the origin shard's migrating virtual workspace, starting after
+// continueToken, and writes the returned etcd entries directly to the local
+// shard's etcd.
+//
+// It returns the number of entries written and the continue token for the
+// next page. An empty next continue token means the copy is complete.
+//
+// This is assigned to Controller.copyPageFromOrigin at construction time;
+// reconcileMigrating calls that field rather than this method directly so
+// tests can substitute a fake.
+func (c *Controller) copyPageFromOriginViaHTTP(ctx context.Context, lcName logicalcluster.Name, originShardName, continueToken string) (int64, string, error) {
 	logger := klog.FromContext(ctx)
 
 	originShard, err := c.shardLister.Cluster(core.RootCluster).Get(originShardName)
 	if err != nil {
-		return fmt.Errorf("failed to get origin shard %q: %w", originShardName, err)
+		return 0, "", fmt.Errorf("failed to get origin shard %q: %w", originShardName, err)
 	}
 	if originShard.Spec.VirtualWorkspaceURL == "" {
-		return fmt.Errorf("origin shard %q has no VirtualWorkspaceURL", originShardName)
+		return 0, "", fmt.Errorf("origin shard %q has no VirtualWorkspaceURL", originShardName)
 	}
 
 	cfg := rest.CopyConfig(c.externalLogicalClusterAdminConfig)
@@ -52,14 +60,18 @@ func (c *Controller) copyDataFromOrigin(ctx context.Context, lcName logicalclust
 
 	client, err := kcpsdkclient.NewForConfig(cfg)
 	if err != nil {
-		return fmt.Errorf("failed to create origin migrating client: %w", err)
+		return 0, "", fmt.Errorf("failed to create origin migrating client: %w", err)
 	}
 
-	logger.V(2).Info("requesting logical cluster dump from origin", "logicalCluster", lcName, "originShard", originShardName)
+	logger.V(2).Info("requesting logical cluster dump page from origin", "logicalCluster", lcName, "originShard", originShardName, "continue", continueToken)
 
-	dump, err := client.MigrationV1alpha1().LogicalClusterDumps().Create(ctx, &migrationv1alpha1.LogicalClusterDump{}, metav1.CreateOptions{})
+	dump, err := client.MigrationV1alpha1().LogicalClusterDumps().Create(ctx, &migrationv1alpha1.LogicalClusterDump{
+		Spec: migrationv1alpha1.LogicalClusterDumpSpec{
+			Continue: continueToken,
+		},
+	}, metav1.CreateOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to dump logical cluster from origin: %w", err)
+		return 0, "", fmt.Errorf("failed to dump logical cluster from origin: %w", err)
 	}
 
 	destPrefix := c.etcdStoragePrefix
@@ -67,17 +79,17 @@ func (c *Controller) copyDataFromOrigin(ctx context.Context, lcName logicalclust
 		destPrefix += "/"
 	}
 
-	logger.V(2).Info("writing dump entries to local etcd", "logicalCluster", lcName, "entries", len(dump.Status.Entries))
+	logger.V(2).Info("writing dump page entries to local etcd", "logicalCluster", lcName, "entries", len(dump.Status.Entries))
 
 	for _, entry := range dump.Status.Entries {
 		if err := ctx.Err(); err != nil {
-			return err
+			return 0, "", err
 		}
 		key := destPrefix + strings.TrimPrefix(entry.Key, "/")
 		if _, err := c.etcdClient.Put(ctx, key, string(entry.Value)); err != nil {
-			return fmt.Errorf("failed to write etcd key %q: %w", key, err)
+			return 0, "", fmt.Errorf("failed to write etcd key %q: %w", key, err)
 		}
 	}
 
-	return nil
+	return int64(len(dump.Status.Entries)), dump.Status.Continue, nil
 }

--- a/pkg/reconciler/migration/logicalclustermigration/reconciler.go
+++ b/pkg/reconciler/migration/logicalclustermigration/reconciler.go
@@ -174,7 +174,12 @@ func (c *Controller) reconcileMigrating(ctx context.Context, migration *migratio
 	// be safe.
 	c.ddsif.PurgeCluster(lcName)
 
-	if err := c.copyDataFromOrigin(ctx, lcName, migration.Status.OriginShard); err != nil {
+	// Copy one page of data per reconcile. status.dumpContinue and
+	// status.entriesCopied are persisted after every call, so a shard
+	// restart resumes from the last completed page instead of starting
+	// the copy over.
+	copied, nextContinue, err := c.copyPageFromOrigin(ctx, lcName, migration.Status.OriginShard, migration.Status.DumpContinue)
+	if err != nil {
 		conditions.MarkFalse(
 			migration,
 			migrationv1alpha1.LCMigrationDataCopied,
@@ -184,13 +189,35 @@ func (c *Controller) reconcileMigrating(ctx context.Context, migration *migratio
 		)
 		return true, err
 	}
+	requeue := applyDumpPageResult(migration, copied, nextContinue)
+	if requeue {
+		logger.V(2).Info("copied data page, more remaining", "logicalCluster", lcName, "entriesCopied", migration.Status.EntriesCopied)
+	} else {
+		logger.V(2).Info("data copied, transitioning to OriginCleanup", "logicalCluster", lcName, "entriesCopied", migration.Status.EntriesCopied)
+	}
+	return requeue, nil
+}
 
-	// Transition to OriginCleanup.
+// applyDumpPageResult records the result of copying one LogicalClusterDump
+// page onto migration.Status and reports whether reconcileMigrating should
+// requeue for another page.
+//
+// status.entriesCopied and status.dumpContinue are updated unconditionally,
+// so they're persisted by the controller's commit step after every
+// reconcile - including ones where the shard is about to be restarted -
+// letting the next reconcile resume from status.dumpContinue instead of
+// restarting the copy.
+func applyDumpPageResult(migration *migrationv1alpha1.LogicalClusterMigration, copied int64, nextContinue string) (requeue bool) {
+	migration.Status.EntriesCopied += copied
+	migration.Status.DumpContinue = nextContinue
+
+	if nextContinue != "" {
+		return true
+	}
+
 	conditions.MarkTrue(migration, migrationv1alpha1.LCMigrationDataCopied)
 	migration.Status.Phase = migrationv1alpha1.LogicalClusterMigrationPhaseOriginCleanup
-
-	logger.V(2).Info("data copied, transitioning to OriginCleanup", "logicalCluster", lcName)
-	return false, nil
+	return false
 }
 
 func (c *Controller) reconcileOriginCleanup(ctx context.Context, migration *migrationv1alpha1.LogicalClusterMigration) (bool, error) {

--- a/pkg/reconciler/migration/logicalclustermigration/reconciler.go
+++ b/pkg/reconciler/migration/logicalclustermigration/reconciler.go
@@ -193,6 +193,9 @@ func (c *Controller) reconcileMigrating(ctx context.Context, migration *migratio
 	if requeue {
 		logger.V(2).Info("copied data page, more remaining", "logicalCluster", lcName, "entriesCopied", migration.Status.EntriesCopied)
 	} else {
+		// Copy is done, drop the cached origin client for this migration
+		// rather than keeping its HTTP transport around indefinitely.
+		c.evictOriginClient(lcName, migration.Status.OriginShard)
 		logger.V(2).Info("data copied, transitioning to OriginCleanup", "logicalCluster", lcName, "entriesCopied", migration.Status.EntriesCopied)
 	}
 	return requeue, nil
@@ -207,9 +210,16 @@ func (c *Controller) reconcileMigrating(ctx context.Context, migration *migratio
 // reconcile - including ones where the shard is about to be restarted -
 // letting the next reconcile resume from status.dumpContinue instead of
 // restarting the copy.
+//
+// A page only reaches this function once it has been copied successfully,
+// so any CopyFailed condition left over from an earlier failed attempt on
+// this migration no longer applies and is cleared here - otherwise it
+// would stay stuck at False while later pages keep succeeding, right up
+// until the copy happens to finish.
 func applyDumpPageResult(migration *migrationv1alpha1.LogicalClusterMigration, copied int64, nextContinue string) (requeue bool) {
 	migration.Status.EntriesCopied += copied
 	migration.Status.DumpContinue = nextContinue
+	conditions.Delete(migration, migrationv1alpha1.LCMigrationDataCopied)
 
 	if nextContinue != "" {
 		return true

--- a/pkg/reconciler/migration/logicalclustermigration/reconciler_test.go
+++ b/pkg/reconciler/migration/logicalclustermigration/reconciler_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	migrationv1alpha1 "github.com/kcp-dev/sdk/apis/migration/v1alpha1"
+	conditionsv1alpha1 "github.com/kcp-dev/sdk/apis/third_party/conditions/apis/conditions/v1alpha1"
 	"github.com/kcp-dev/sdk/apis/third_party/conditions/util/conditions"
 )
 
@@ -68,6 +69,29 @@ func TestApplyDumpPageResult_accumulatesEntriesCopiedAcrossMultiplePages(t *test
 
 	require.Equal(t, int64(30), migration.Status.EntriesCopied)
 	require.Equal(t, migrationv1alpha1.LogicalClusterMigrationPhaseOriginCleanup, migration.Status.Phase)
+}
+
+// TestApplyDumpPageResult_clearsStaleCopyFailedConditionOnLaterSuccess covers
+// a bug where a transient failure on one page (which marks DataCopied
+// False/CopyFailed) would leave that condition stuck at False forever,
+// even after a later page copy succeeded, because only the final page used
+// to touch the condition.
+func TestApplyDumpPageResult_clearsStaleCopyFailedConditionOnLaterSuccess(t *testing.T) {
+	t.Parallel()
+
+	migration := &migrationv1alpha1.LogicalClusterMigration{}
+	conditions.MarkFalse(
+		migration,
+		migrationv1alpha1.LCMigrationDataCopied,
+		"CopyFailed",
+		conditionsv1alpha1.ConditionSeverityError,
+		"some transient error",
+	)
+
+	requeue := applyDumpPageResult(migration, 10, "more-to-come")
+
+	require.True(t, requeue)
+	require.Nil(t, conditions.Get(migration, migrationv1alpha1.LCMigrationDataCopied), "a successful page must clear the stale CopyFailed condition even if the copy isn't done yet")
 }
 
 // TestApplyDumpPageResult_resumesAfterSimulatedRestart mimics a destination

--- a/pkg/reconciler/migration/logicalclustermigration/reconciler_test.go
+++ b/pkg/reconciler/migration/logicalclustermigration/reconciler_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logicalclustermigration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	migrationv1alpha1 "github.com/kcp-dev/sdk/apis/migration/v1alpha1"
+	"github.com/kcp-dev/sdk/apis/third_party/conditions/util/conditions"
+)
+
+func TestApplyDumpPageResult_requeuesWhileContinueTokenPresent(t *testing.T) {
+	t.Parallel()
+
+	migration := &migrationv1alpha1.LogicalClusterMigration{}
+
+	requeue := applyDumpPageResult(migration, 100, "some-continue-token")
+
+	require.True(t, requeue)
+	require.Equal(t, int64(100), migration.Status.EntriesCopied)
+	require.Equal(t, "some-continue-token", migration.Status.DumpContinue)
+	require.Empty(t, migration.Status.Phase, "phase must not transition while a page remains")
+	require.Nil(t, conditions.Get(migration, migrationv1alpha1.LCMigrationDataCopied))
+}
+
+func TestApplyDumpPageResult_transitionsToOriginCleanupWhenDone(t *testing.T) {
+	t.Parallel()
+
+	migration := &migrationv1alpha1.LogicalClusterMigration{}
+	migration.Status.Phase = migrationv1alpha1.LogicalClusterMigrationPhaseMigrating
+
+	requeue := applyDumpPageResult(migration, 42, "")
+
+	require.False(t, requeue)
+	require.Equal(t, int64(42), migration.Status.EntriesCopied)
+	require.Empty(t, migration.Status.DumpContinue)
+	require.Equal(t, migrationv1alpha1.LogicalClusterMigrationPhaseOriginCleanup, migration.Status.Phase)
+
+	cond := conditions.Get(migration, migrationv1alpha1.LCMigrationDataCopied)
+	require.NotNil(t, cond)
+	require.Equal(t, "True", string(cond.Status))
+}
+
+func TestApplyDumpPageResult_accumulatesEntriesCopiedAcrossMultiplePages(t *testing.T) {
+	t.Parallel()
+
+	migration := &migrationv1alpha1.LogicalClusterMigration{}
+
+	require.True(t, applyDumpPageResult(migration, 10, "token-1"))
+	require.True(t, applyDumpPageResult(migration, 15, "token-2"))
+	require.False(t, applyDumpPageResult(migration, 5, ""))
+
+	require.Equal(t, int64(30), migration.Status.EntriesCopied)
+	require.Equal(t, migrationv1alpha1.LogicalClusterMigrationPhaseOriginCleanup, migration.Status.Phase)
+}
+
+// TestApplyDumpPageResult_resumesAfterSimulatedRestart mimics a destination
+// shard restart between two pages: only migration.Status survives (as it
+// would across a controller process restart, since it's persisted to
+// etcd), and a fresh copy of the object picks up from status.dumpContinue.
+func TestApplyDumpPageResult_resumesAfterSimulatedRestart(t *testing.T) {
+	t.Parallel()
+
+	migration := &migrationv1alpha1.LogicalClusterMigration{}
+	requeue := applyDumpPageResult(migration, 20, "resume-here")
+	require.True(t, requeue)
+	require.Equal(t, "resume-here", migration.Status.DumpContinue)
+
+	// Simulate a shard restart: only the persisted status survives, a
+	// brand new in-memory object is reconstructed from it.
+	restarted := &migrationv1alpha1.LogicalClusterMigration{Status: migration.Status}
+	require.Equal(t, "resume-here", restarted.Status.DumpContinue, "resume token must survive the simulated restart")
+
+	requeue = applyDumpPageResult(restarted, 30, "")
+	require.False(t, requeue)
+	require.Equal(t, int64(50), restarted.Status.EntriesCopied, "entries from before and after the restart must both be counted")
+	require.Empty(t, restarted.Status.DumpContinue)
+	require.Equal(t, migrationv1alpha1.LogicalClusterMigrationPhaseOriginCleanup, restarted.Status.Phase)
+}

--- a/pkg/server/migrationdump/server.go
+++ b/pkg/server/migrationdump/server.go
@@ -47,6 +47,11 @@ var (
 	errorCodecs = serializer.NewCodecFactory(errorScheme)
 )
 
+// defaultDumpMaxBytes is the default cap on the total size of entry values
+// returned in a single LogicalClusterDump page, used when the request
+// doesn't specify spec.maxBytes.
+const defaultDumpMaxBytes int64 = 2 * 1024 * 1024
+
 func init() {
 	errorScheme.AddUnversionedTypes(metav1.Unversioned, &metav1.Status{})
 }
@@ -131,9 +136,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	logger.V(2).Info("dumping logical cluster from etcd", "cluster", cluster.Name)
+	logger.V(2).Info("dumping logical cluster page from etcd", "cluster", cluster.Name, "continue", dump.Spec.Continue)
 
-	entries, err := scanEtcdEntries(ctx, h.etcdClient, h.etcdStoragePrefix, cluster.Name)
+	entries, nextContinue, err := scanEtcdEntries(ctx, h.etcdClient, h.etcdStoragePrefix, cluster.Name, dump.Spec.Continue, dump.Spec.Limit, dump.Spec.MaxBytes)
 	if err != nil {
 		writeError(w, r, apierrors.NewInternalError(fmt.Errorf("failed to dump logical cluster: %w", err)))
 		return
@@ -146,7 +151,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		},
 		ObjectMeta: dump.ObjectMeta,
 		Status: migrationv1alpha1.LogicalClusterDumpStatus{
-			Entries: entries,
+			Entries:  entries,
+			Continue: nextContinue,
 		},
 	}
 
@@ -157,53 +163,68 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// scanEtcdEntries returns every etcd key/value pair belonging to the given
-// logical cluster.
+// scanEtcdEntries returns a single page of etcd key/value pairs belonging
+// to the given logical cluster, resuming right after continueToken if set.
 //
-// TODO: stream entries as NDJSON so the response doesn't have to be buffered
-// in memory.
+// The page stops growing once it holds limit entries or once adding another
+// entry would push the accumulated value size past maxBytes, whichever
+// happens first (a single entry larger than maxBytes is still returned
+// alone, so the scan always makes progress). If limit or maxBytes is zero
+// or negative, a default is used.
 //
-// TODO: paginate via spec.Continue / status.Continue so a single dump call
-// doesn't have to hold all keys in memory.
-func scanEtcdEntries(ctx context.Context, etcdClient *clientv3.Client, storagePrefix string, target logicalcluster.Name) ([]migrationv1alpha1.EtcdEntry, error) {
+// The second return value is the continue token for the next page, or the
+// empty string if the scan reached the end of the logical cluster's
+// keyspace.
+func scanEtcdEntries(ctx context.Context, kv clientv3.KV, storagePrefix string, target logicalcluster.Name, continueToken string, limit, maxBytes int64) ([]migrationv1alpha1.EtcdEntry, string, error) {
 	prefix := storagePrefix
 	if !strings.HasSuffix(prefix, "/") {
 		prefix += "/"
 	}
 
-	var entries []migrationv1alpha1.EtcdEntry
+	if limit <= 0 {
+		limit = kcpetcd.ScanPageSize
+	}
+	if maxBytes <= 0 {
+		maxBytes = defaultDumpMaxBytes
+	}
+
 	key := prefix
+	if continueToken != "" {
+		key = prefix + strings.TrimPrefix(continueToken, "/")
+	}
+
+	var entries []migrationv1alpha1.EtcdEntry
+	var totalBytes int64
 	for {
-		resp, err := etcdClient.Get(ctx, key,
+		resp, err := kv.Get(ctx, key,
 			clientv3.WithRange(clientv3.GetPrefixRangeEnd(prefix)),
 			clientv3.WithLimit(kcpetcd.ScanPageSize),
 		)
 		if err != nil {
-			return nil, fmt.Errorf("failed to list etcd keys: %w", err)
+			return nil, "", fmt.Errorf("failed to list etcd keys: %w", err)
 		}
 
-		for _, kv := range resp.Kvs {
+		for _, entry := range resp.Kvs {
 			if err := ctx.Err(); err != nil {
-				return nil, err
+				return nil, "", err
 			}
-			// TODO(ntnn): This isn't super efficient. For large LCs
-			// this will re-parse thousands of keys. It would be better
-			// to cache the known-good prefixes and to continue from
-			// there, however considering that this should move towards
-			// pagination or streaming it seems like premature
-			// optimization. Just something to keep in mind when working
-			// on this.
-			if !kcpetcd.BelongsToCluster(prefix, string(kv.Key), target) {
+			if !kcpetcd.BelongsToCluster(prefix, string(entry.Key), target) {
 				continue
 			}
+
+			if int64(len(entries)) >= limit || (len(entries) > 0 && totalBytes+int64(len(entry.Value)) > maxBytes) {
+				return entries, strings.TrimPrefix(string(entry.Key), prefix), nil
+			}
+
 			entries = append(entries, migrationv1alpha1.EtcdEntry{
-				Key:   strings.TrimPrefix(string(kv.Key), prefix),
-				Value: append([]byte(nil), kv.Value...),
+				Key:   strings.TrimPrefix(string(entry.Key), prefix),
+				Value: append([]byte(nil), entry.Value...),
 			})
+			totalBytes += int64(len(entry.Value))
 		}
 
 		if !resp.More {
-			return entries, nil
+			return entries, "", nil
 		}
 		key = string(resp.Kvs[len(resp.Kvs)-1].Key) + "\x00"
 	}

--- a/pkg/server/migrationdump/server.go
+++ b/pkg/server/migrationdump/server.go
@@ -47,11 +47,6 @@ var (
 	errorCodecs = serializer.NewCodecFactory(errorScheme)
 )
 
-// defaultDumpMaxBytes is the default cap on the total size of entry values
-// returned in a single LogicalClusterDump page, used when the request
-// doesn't specify spec.maxBytes.
-const defaultDumpMaxBytes int64 = 2 * 1024 * 1024
-
 func init() {
 	errorScheme.AddUnversionedTypes(metav1.Unversioned, &metav1.Status{})
 }
@@ -185,7 +180,7 @@ func scanEtcdEntries(ctx context.Context, kv clientv3.KV, storagePrefix string, 
 		limit = kcpetcd.ScanPageSize
 	}
 	if maxBytes <= 0 {
-		maxBytes = defaultDumpMaxBytes
+		maxBytes = kcpetcd.DumpMaxBytes
 	}
 
 	key := prefix
@@ -193,12 +188,20 @@ func scanEtcdEntries(ctx context.Context, kv clientv3.KV, storagePrefix string, 
 		key = prefix + strings.TrimPrefix(continueToken, "/")
 	}
 
+	// Cap the raw etcd scan chunk size at the caller's requested page
+	// limit (but never above ScanPageSize) so a small page request
+	// doesn't pull more keys from etcd than it can possibly use.
+	etcdScanLimit := limit
+	if etcdScanLimit > kcpetcd.ScanPageSize {
+		etcdScanLimit = kcpetcd.ScanPageSize
+	}
+
 	var entries []migrationv1alpha1.EtcdEntry
 	var totalBytes int64
 	for {
 		resp, err := kv.Get(ctx, key,
 			clientv3.WithRange(clientv3.GetPrefixRangeEnd(prefix)),
-			clientv3.WithLimit(kcpetcd.ScanPageSize),
+			clientv3.WithLimit(etcdScanLimit),
 		)
 		if err != nil {
 			return nil, "", fmt.Errorf("failed to list etcd keys: %w", err)

--- a/pkg/server/migrationdump/server_test.go
+++ b/pkg/server/migrationdump/server_test.go
@@ -1,0 +1,248 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrationdump
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/api/v3/mvccpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+	migrationv1alpha1 "github.com/kcp-dev/sdk/apis/migration/v1alpha1"
+)
+
+func TestScanEtcdEntries_singlePageReturnsEverythingWhenItFits(t *testing.T) {
+	t.Parallel()
+
+	prefix := "/registry/"
+	target := logicalcluster.Name("root:ws")
+
+	kv := newFakeKV(map[string]string{
+		"/registry/apps/deployments/root:ws/default/foo": "v1",
+		"/registry/core/configmaps/root:ws/default/cm1":  "v2",
+		// other cluster, must not be returned
+		"/registry/apps/deployments/root:other/default/x": "v3",
+	})
+
+	entries, next, err := scanEtcdEntries(context.Background(), kv, prefix, target, "", 0, 0)
+	require.NoError(t, err)
+	require.Empty(t, next)
+
+	got := entryKeys(entries)
+	sort.Strings(got)
+	require.Equal(t, []string{
+		"apps/deployments/root:ws/default/foo",
+		"core/configmaps/root:ws/default/cm1",
+	}, got)
+}
+
+func TestScanEtcdEntries_limitPaginatesAndCoversAllEntriesAcrossPages(t *testing.T) {
+	t.Parallel()
+
+	prefix := "/registry/"
+	target := logicalcluster.Name("root:ws")
+
+	kvs := map[string]string{
+		"/registry/apps/deployments/root:ws/default/a": "v",
+		"/registry/apps/deployments/root:ws/default/b": "v",
+		"/registry/apps/deployments/root:ws/default/c": "v",
+		"/registry/apps/deployments/root:ws/default/d": "v",
+		"/registry/apps/deployments/root:ws/default/e": "v",
+	}
+	kv := newFakeKV(kvs)
+
+	var got []string
+	continueToken := ""
+	pages := 0
+	for {
+		pages++
+		require.LessOrEqual(t, pages, len(kvs)+1, "too many pages, pagination is likely stuck")
+
+		entries, next, err := scanEtcdEntries(context.Background(), kv, prefix, target, continueToken, 2, 0)
+		require.NoError(t, err)
+		require.LessOrEqual(t, len(entries), 2)
+
+		got = append(got, entryKeys(entries)...)
+
+		if next == "" {
+			break
+		}
+		continueToken = next
+	}
+
+	require.Equal(t, 3, pages, "5 entries with a page limit of 2 should take 3 pages")
+	sort.Strings(got)
+	require.Equal(t, []string{
+		"apps/deployments/root:ws/default/a",
+		"apps/deployments/root:ws/default/b",
+		"apps/deployments/root:ws/default/c",
+		"apps/deployments/root:ws/default/d",
+		"apps/deployments/root:ws/default/e",
+	}, got)
+}
+
+func TestScanEtcdEntries_maxBytesStopsPageBeforeLimit(t *testing.T) {
+	t.Parallel()
+
+	prefix := "/registry/"
+	target := logicalcluster.Name("root:ws")
+
+	// Each value is 10 bytes. A 25 byte budget should only fit 2 of them
+	// even though limit allows far more.
+	kv := newFakeKV(map[string]string{
+		"/registry/apps/deployments/root:ws/default/a": "0123456789",
+		"/registry/apps/deployments/root:ws/default/b": "0123456789",
+		"/registry/apps/deployments/root:ws/default/c": "0123456789",
+	})
+
+	entries, next, err := scanEtcdEntries(context.Background(), kv, prefix, target, "", 1000, 25)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+	require.NotEmpty(t, next)
+}
+
+func TestScanEtcdEntries_singleEntryLargerThanMaxBytesIsStillReturnedAlone(t *testing.T) {
+	t.Parallel()
+
+	prefix := "/registry/"
+	target := logicalcluster.Name("root:ws")
+
+	kv := newFakeKV(map[string]string{
+		"/registry/apps/deployments/root:ws/default/big":    fmt.Sprintf("%0100d", 0),
+		"/registry/apps/deployments/root:ws/default/small1": "v",
+		"/registry/apps/deployments/root:ws/default/small2": "v",
+	})
+
+	entries, next, err := scanEtcdEntries(context.Background(), kv, prefix, target, "", 1000, 10)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "the oversized entry must be returned alone, not dropped")
+	require.NotEmpty(t, next, "pagination must continue after the oversized entry")
+}
+
+func TestScanEtcdEntries_resumesFromContinueTokenWithoutDuplicatesOrGaps(t *testing.T) {
+	t.Parallel()
+
+	prefix := "/registry/"
+	target := logicalcluster.Name("root:ws")
+
+	kv := newFakeKV(map[string]string{
+		"/registry/apps/deployments/root:ws/default/a": "v",
+		"/registry/apps/deployments/root:ws/default/b": "v",
+		"/registry/apps/deployments/root:ws/default/c": "v",
+		"/registry/apps/deployments/root:ws/default/d": "v",
+	})
+
+	first, next, err := scanEtcdEntries(context.Background(), kv, prefix, target, "", 2, 0)
+	require.NoError(t, err)
+	require.Len(t, first, 2)
+	require.NotEmpty(t, next)
+
+	second, next2, err := scanEtcdEntries(context.Background(), kv, prefix, target, next, 1000, 0)
+	require.NoError(t, err)
+	require.Empty(t, next2)
+
+	all := append(entryKeys(first), entryKeys(second)...)
+	sort.Strings(all)
+	require.Equal(t, []string{
+		"apps/deployments/root:ws/default/a",
+		"apps/deployments/root:ws/default/b",
+		"apps/deployments/root:ws/default/c",
+		"apps/deployments/root:ws/default/d",
+	}, all)
+}
+
+func TestScanEtcdEntries_ignoresOtherClusters(t *testing.T) {
+	t.Parallel()
+
+	prefix := "/registry/"
+	target := logicalcluster.Name("root:ws")
+
+	kv := newFakeKV(map[string]string{
+		"/registry/apps/deployments/root:other/default/a": "v",
+		"/registry/core/configmaps/root:other/default/b":  "v",
+	})
+
+	entries, next, err := scanEtcdEntries(context.Background(), kv, prefix, target, "", 0, 0)
+	require.NoError(t, err)
+	require.Empty(t, next)
+	require.Empty(t, entries)
+}
+
+func entryKeys(entries []migrationv1alpha1.EtcdEntry) []string {
+	keys := make([]string, len(entries))
+	for i, e := range entries {
+		keys[i] = e.Key
+	}
+	return keys
+}
+
+// fakeKV is a minimal in-memory fake of clientv3.KV for unit-testing range
+// scans, mirroring the one used in
+// pkg/reconciler/migration/logicalclustermigration/datacleanup_test.go. It
+// supports only the operations scanEtcdEntries uses: Get with a range end
+// and an optional limit. Other methods are not implemented and panic if
+// called.
+type fakeKV struct {
+	kvs map[string]string
+}
+
+func newFakeKV(kvs map[string]string) *fakeKV { return &fakeKV{kvs: kvs} }
+
+func (f *fakeKV) Get(_ context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
+	op := clientv3.OpGet(key, opts...)
+	rangeEnd := string(op.RangeBytes())
+	limit := op.Limit()
+
+	keys := make([]string, 0, len(f.kvs))
+	for k := range f.kvs {
+		if k >= key && (rangeEnd == "" || k < rangeEnd) {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+
+	more := false
+	if limit > 0 && int64(len(keys)) > limit {
+		keys = keys[:limit]
+		more = true
+	}
+
+	resp := &clientv3.GetResponse{More: more}
+	for _, k := range keys {
+		resp.Kvs = append(resp.Kvs, &mvccpb.KeyValue{Key: []byte(k), Value: []byte(f.kvs[k])})
+	}
+	return resp, nil
+}
+
+func (f *fakeKV) Put(context.Context, string, string, ...clientv3.OpOption) (*clientv3.PutResponse, error) {
+	panic("not implemented")
+}
+func (f *fakeKV) Delete(context.Context, string, ...clientv3.OpOption) (*clientv3.DeleteResponse, error) {
+	panic("not implemented")
+}
+func (f *fakeKV) Compact(context.Context, int64, ...clientv3.CompactOption) (*clientv3.CompactResponse, error) {
+	panic("not implemented")
+}
+func (f *fakeKV) Do(context.Context, clientv3.Op) (clientv3.OpResponse, error) {
+	panic("not implemented")
+}
+func (f *fakeKV) Txn(context.Context) clientv3.Txn { panic("not implemented") }

--- a/staging/src/github.com/kcp-dev/sdk/apis/migration/v1alpha1/types_logicalclusterdump.go
+++ b/staging/src/github.com/kcp-dev/sdk/apis/migration/v1alpha1/types_logicalclusterdump.go
@@ -45,23 +45,46 @@ type LogicalClusterDump struct {
 // LogicalClusterDumpSpec is the desired state for a dump request.
 //
 // The logical cluster to dump is taken from the request's cluster context
-// (i.e. the URL the request arrived on). No fields are required today.
-//
-// TODO: add Continue string for pagination.
-type LogicalClusterDumpSpec struct{}
+// (i.e. the URL the request arrived on).
+type LogicalClusterDumpSpec struct {
+	// continue is the token returned by a previous LogicalClusterDump's
+	// status.continue. If set, the scan resumes right after the last key
+	// returned by that page. If empty, the scan starts from the
+	// beginning of the logical cluster's etcd keyspace.
+	//
+	// +optional
+	Continue string `json:"continue,omitempty"`
+
+	// limit caps the number of entries returned in a single page. If
+	// zero, the server picks a default page size.
+	//
+	// +optional
+	Limit int64 `json:"limit,omitempty"`
+
+	// maxBytes caps the total size, in bytes, of entry values returned in
+	// a single page. The scan stops and returns a continue token as soon
+	// as this budget is exceeded, even if limit hasn't been reached yet.
+	// If zero, the server picks a default byte budget.
+	//
+	// +optional
+	MaxBytes int64 `json:"maxBytes,omitempty"`
+}
 
 // LogicalClusterDumpStatus carries the dump payload populated by the server.
 type LogicalClusterDumpStatus struct {
-	// entries is the full set of etcd key/value pairs belonging to the
+	// entries is the page of etcd key/value pairs belonging to the
 	// logical cluster, in the origin shard's etcd encoding (proto for
 	// built-ins, JSON for CRs).
 	//
-	// TODO: support pagination via a Continue token on Spec/Status.
-	// TODO: switch to NDJSON streaming once entry count or total size
-	// becomes a concern.
-	//
 	// +optional
 	Entries []EtcdEntry `json:"entries,omitempty"`
+
+	// continue is set when there are more entries to fetch. Pass it as
+	// spec.continue on the next LogicalClusterDump request to get the
+	// next page. Empty means this was the last page.
+	//
+	// +optional
+	Continue string `json:"continue,omitempty"`
 }
 
 // EtcdEntry is a single etcd key/value pair from the origin shard.

--- a/staging/src/github.com/kcp-dev/sdk/apis/migration/v1alpha1/types_logicalclustermigration.go
+++ b/staging/src/github.com/kcp-dev/sdk/apis/migration/v1alpha1/types_logicalclustermigration.go
@@ -34,6 +34,7 @@ import (
 // +kubebuilder:printcolumn:name="Logical Cluster",type=string,JSONPath=`.spec.logicalCluster`,description="The logical cluster being migrated"
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`,description="The current phase of the migration"
 // +kubebuilder:printcolumn:name="Destination",type=string,JSONPath=`.spec.destinationShard`,description="The destination shard"
+// +kubebuilder:printcolumn:name="Entries Copied",type=integer,JSONPath=`.status.entriesCopied`,description="Number of etcd entries copied so far"
 type LogicalClusterMigration struct {
 	v1.TypeMeta `json:",inline"`
 	// +optional
@@ -88,6 +89,21 @@ type LogicalClusterMigrationStatus struct {
 	//
 	// +optional
 	OriginShard string `json:"originShard,omitempty"`
+
+	// entriesCopied is the number of etcd entries copied from the origin
+	// shard to the destination shard so far during the Migrating phase.
+	//
+	// +optional
+	EntriesCopied int64 `json:"entriesCopied,omitempty"`
+
+	// dumpContinue is the continue token for the next LogicalClusterDump
+	// page to fetch from the origin shard. Set by the destination shard
+	// controller as it works through the data copy, and cleared once the
+	// copy is complete. Used to resume the copy from where it left off
+	// after a destination shard restart, instead of starting over.
+	//
+	// +optional
+	DumpContinue string `json:"dumpContinue,omitempty"`
 
 	// Current processing state of the migration.
 	// +optional

--- a/staging/src/github.com/kcp-dev/sdk/client/applyconfiguration/migration/v1alpha1/logicalclustermigrationstatus.go
+++ b/staging/src/github.com/kcp-dev/sdk/client/applyconfiguration/migration/v1alpha1/logicalclustermigrationstatus.go
@@ -33,6 +33,15 @@ type LogicalClusterMigrationStatusApplyConfiguration struct {
 	// originShard is the name of the shard to migrate the logical cluster from.
 	// Set by the origin shard controller during preparation.
 	OriginShard *string `json:"originShard,omitempty"`
+	// entriesCopied is the number of etcd entries copied from the origin
+	// shard to the destination shard so far during the Migrating phase.
+	EntriesCopied *int64 `json:"entriesCopied,omitempty"`
+	// dumpContinue is the continue token for the next LogicalClusterDump
+	// page to fetch from the origin shard. Set by the destination shard
+	// controller as it works through the data copy, and cleared once the
+	// copy is complete. Used to resume the copy from where it left off
+	// after a destination shard restart, instead of starting over.
+	DumpContinue *string `json:"dumpContinue,omitempty"`
 	// Current processing state of the migration.
 	Conditions *conditionsv1alpha1.Conditions `json:"conditions,omitempty"`
 }
@@ -56,6 +65,22 @@ func (b *LogicalClusterMigrationStatusApplyConfiguration) WithPhase(value migrat
 // If called multiple times, the OriginShard field is set to the value of the last call.
 func (b *LogicalClusterMigrationStatusApplyConfiguration) WithOriginShard(value string) *LogicalClusterMigrationStatusApplyConfiguration {
 	b.OriginShard = &value
+	return b
+}
+
+// WithEntriesCopied sets the EntriesCopied field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the EntriesCopied field is set to the value of the last call.
+func (b *LogicalClusterMigrationStatusApplyConfiguration) WithEntriesCopied(value int64) *LogicalClusterMigrationStatusApplyConfiguration {
+	b.EntriesCopied = &value
+	return b
+}
+
+// WithDumpContinue sets the DumpContinue field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the DumpContinue field is set to the value of the last call.
+func (b *LogicalClusterMigrationStatusApplyConfiguration) WithDumpContinue(value string) *LogicalClusterMigrationStatusApplyConfiguration {
+	b.DumpContinue = &value
 	return b
 }
 

--- a/staging/src/github.com/kcp-dev/sdk/openapi/zz_generated.openapi.go
+++ b/staging/src/github.com/kcp-dev/sdk/openapi/zz_generated.openapi.go
@@ -4197,8 +4197,31 @@ func schema_sdk_apis_migration_v1alpha1_LogicalClusterDumpSpec(ref common.Refere
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "LogicalClusterDumpSpec is the desired state for a dump request.\n\nThe logical cluster to dump is taken from the request's cluster context (i.e. the URL the request arrived on). No fields are required today.",
+				Description: "LogicalClusterDumpSpec is the desired state for a dump request.\n\nThe logical cluster to dump is taken from the request's cluster context (i.e. the URL the request arrived on).",
 				Type:        []string{"object"},
+				Properties: map[string]spec.Schema{
+					"continue": {
+						SchemaProps: spec.SchemaProps{
+							Description: "continue is the token returned by a previous LogicalClusterDump's status.continue. If set, the scan resumes right after the last key returned by that page. If empty, the scan starts from the beginning of the logical cluster's etcd keyspace.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"limit": {
+						SchemaProps: spec.SchemaProps{
+							Description: "limit caps the number of entries returned in a single page. If zero, the server picks a default page size.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+					"maxBytes": {
+						SchemaProps: spec.SchemaProps{
+							Description: "maxBytes caps the total size, in bytes, of entry values returned in a single page. The scan stops and returns a continue token as soon as this budget is exceeded, even if limit hasn't been reached yet. If zero, the server picks a default byte budget.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+				},
 			},
 		},
 	}
@@ -4213,7 +4236,7 @@ func schema_sdk_apis_migration_v1alpha1_LogicalClusterDumpStatus(ref common.Refe
 				Properties: map[string]spec.Schema{
 					"entries": {
 						SchemaProps: spec.SchemaProps{
-							Description: "entries is the full set of etcd key/value pairs belonging to the logical cluster, in the origin shard's etcd encoding (proto for built-ins, JSON for CRs).\n\nbecomes a concern.",
+							Description: "entries is the page of etcd key/value pairs belonging to the logical cluster, in the origin shard's etcd encoding (proto for built-ins, JSON for CRs).",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -4223,6 +4246,13 @@ func schema_sdk_apis_migration_v1alpha1_LogicalClusterDumpStatus(ref common.Refe
 									},
 								},
 							},
+						},
+					},
+					"continue": {
+						SchemaProps: spec.SchemaProps{
+							Description: "continue is set when there are more entries to fetch. Pass it as spec.continue on the next LogicalClusterDump request to get the next page. Empty means this was the last page.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
@@ -4376,6 +4406,20 @@ func schema_sdk_apis_migration_v1alpha1_LogicalClusterMigrationStatus(ref common
 					"originShard": {
 						SchemaProps: spec.SchemaProps{
 							Description: "originShard is the name of the shard to migrate the logical cluster from. Set by the origin shard controller during preparation.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"entriesCopied": {
+						SchemaProps: spec.SchemaProps{
+							Description: "entriesCopied is the number of etcd entries copied from the origin shard to the destination shard so far during the Migrating phase.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+					"dumpContinue": {
+						SchemaProps: spec.SchemaProps{
+							Description: "dumpContinue is the continue token for the next LogicalClusterDump page to fetch from the origin shard. Set by the destination shard controller as it works through the data copy, and cleared once the copy is complete. Used to resume the copy from where it left off after a destination shard restart, instead of starting over.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/test/e2e/logicalclustermigration/migration_test.go
+++ b/test/e2e/logicalclustermigration/migration_test.go
@@ -172,15 +172,26 @@ func TestFullMigration(t *testing.T) {
 	}, wait.ForeverTestTimeout, 100*time.Millisecond, "failed to create LogicalClusterMigration")
 
 	t.Logf("Waiting for migration to complete")
+	var completedMigration *migrationv1alpha1.LogicalClusterMigration
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		migration, err := kcpClusterClient.Cluster(orgPath).MigrationV1alpha1().LogicalClusterMigrations().Get(t.Context(), lcm.Name, metav1.GetOptions{})
 		require.NoError(c, err)
-		t.Logf("migration phase: %q", migration.Status.Phase)
+		t.Logf("migration phase: %q, entriesCopied: %d", migration.Status.Phase, migration.Status.EntriesCopied)
 		t.Logf("migration conditions: %#v", migration.Status.Conditions)
 		require.Equal(c, migrationv1alpha1.LogicalClusterMigrationPhaseCompleted, migration.Status.Phase)
+		completedMigration = migration
 	}, wait.ForeverTestTimeout, 500*time.Millisecond, "waiting for migration to complete")
 
 	t.Logf("Migration completed, running post-migration tests")
+
+	// The paginated dump copy should have made progress and left no
+	// dangling continue token once the copy finished.
+	t.Run("DumpProgressReporting", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Positive(t, completedMigration.Status.EntriesCopied, "status.entriesCopied should reflect the copied etcd entries")
+		assert.Empty(t, completedMigration.Status.DumpContinue, "status.dumpContinue should be cleared once the copy is complete")
+	})
 
 	// Test that a client can access the lc after the migration.
 	t.Run("ClientAccess", func(t *testing.T) {


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary
- Paginate `LogicalClusterDump` so migrations no longer transfer an entire logical cluster's etcd data in a single blocking request/response.
- Add `spec.continue`, `spec.limit`, and `spec.maxBytes` to `LogicalClusterDump`, and `status.continue` for the returned page's resume token.
- Add `status.entriesCopied` and `status.dumpContinue` to `LogicalClusterMigration` so copy progress is visible and a shard restart resumes from the last completed page instead of re-copying everything.
- `reconcileMigrating` now copies one page per reconcile and requeues until the origin reports no more pages, instead of blocking on the full copy in one call.
- Addressed review: fixed the `DataCopied` condition getting stuck at `False` after a transient error even once later pages succeed, cache the origin HTTP client per migration instead of rebuilding it on every page, and moved the page byte-size default next to `ScanPageSize` in `pkg/etcd`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/reconciler/migration/... ./pkg/server/migrationdump/... ./pkg/etcd/...`
- [x] New unit tests for page-boundary scanning (limit, byte budget, oversized entry, continue-token resume, cluster filtering)
- [x] New unit tests for reconciler requeue/resume-after-restart behavior, and for the fixed stuck-condition bug
- [x] `make test-e2e-sharded-minimal WHAT=./test/e2e/logicalclustermigration/... TEST_ARGS="-run TestFullMigration -v"` — verifies `status.entriesCopied`/`status.dumpContinue` on a real 2-shard migration

## What Type of PR Is This?
/kind feature
<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #4207

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
LogicalClusterDump is now paginated. Origin shard sends the data in pages (limited by entry count and total size), not the whole logical cluster in one response. LogicalClusterMigration status now shows entriesCopied and dumpContinue, so if destination shard restarts, it continues the copy from where it stopped instead of starting again.
```
