### PR TITLE
Add e2e test for LC migration + APIExports

### DIFF
--- a/test/e2e/logicalclustermigration/apiresourceschema_tlsroutes.yaml
+++ b/test/e2e/logicalclustermigration/apiresourceschema_tlsroutes.yaml
@@ -1,0 +1,479 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIResourceSchema
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/891
+    gateway.networking.k8s.io/bundle-version: v0.5.0-dev
+    gateway.networking.k8s.io/channel: stable
+  name: latest.tlsroutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+      - gateway-api
+    kind: TLSRoute
+    listKind: TLSRouteList
+    plural: tlsroutes
+    singular: tlsroute
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha2
+      schema:
+        description: "The TLSRoute resource is similar to TCPRoute, but can be configured
+        to match against TLS-specific metadata. This allows more flexibility in
+        matching streams for a given TLS listener. \n If you need to forward traffic
+        to a single target for a TLS listener, you could choose to use a TCPRoute
+        with a TLS listener."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of TLSRoute.
+            properties:
+              hostnames:
+                description: "Hostnames defines a set of SNI names that should match
+                against the SNI attribute of TLS ClientHello message in TLS handshake.
+                This matches the RFC 1123 definition of a hostname with 2 notable
+                exceptions: \n 1. IPs are not allowed in SNI names per RFC 6066.
+                2. A hostname may be prefixed with a wildcard label (`*.`). The
+                wildcard    label must appear by itself as the first label. \n If
+                a hostname is specified by both the Listener and TLSRoute, there
+                must be at least one intersecting hostname for the TLSRoute to be
+                attached to the Listener. For example: \n * A Listener with `test.example.com`
+                as the hostname matches TLSRoutes   that have either not specified
+                any hostnames, or have specified at   least one of `test.example.com`
+                or `*.example.com`. * A Listener with `*.example.com` as the hostname
+                matches TLSRoutes   that have either not specified any hostnames
+                or have specified at least   one hostname that matches the Listener
+                hostname. For example,   `test.example.com` and `*.example.com`
+                would both match. On the other   hand, `example.com` and `test.example.net`
+                would not match. \n If both the Listener and TLSRoute have specified
+                hostnames, any TLSRoute hostnames that do not match the Listener
+                hostname MUST be ignored. For example, if a Listener specified `*.example.com`,
+                and the TLSRoute specified `test.example.com` and `test.example.net`,
+                `test.example.net` must not be considered for a match. \n If both
+                the Listener and TLSRoute have specified hostnames, and none match
+                with the criteria above, then the TLSRoute is not accepted. The
+                implementation must raise an 'Accepted' Condition with a status
+                of `False` in the corresponding RouteParentStatus. \n Support: Core"
+                items:
+                  description: "Hostname is the fully qualified domain name of a network
+                  host. This matches the RFC 1123 definition of a hostname with
+                  2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname
+                  may be prefixed with a wildcard label (`*.`). The wildcard    label
+                  must appear by itself as the first label. \n Hostname can be \"precise\"
+                  which is a domain name without the terminating dot of a network
+                  host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain
+                  name prefixed with a single wildcard label (e.g. `*.example.com`).
+                  \n Note that as per RFC1035 and RFC1123, a *label* must consist
+                  of lower case alphanumeric characters or '-', and must start and
+                  end with an alphanumeric character. No other punctuation is allowed."
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                maxItems: 16
+                type: array
+              parentRefs:
+                description: "ParentRefs references the resources (usually Gateways)
+                that a Route wants to be attached to. Note that the referenced parent
+                resource needs to allow this for the attachment to be complete.
+                For Gateways, that means the Gateway needs to allow attachment from
+                Routes of this kind and namespace. \n The only kind of parent resource
+                with \"Core\" support is Gateway. This API may be extended in the
+                future to support additional kinds of parent resources such as one
+                of the route kinds. \n It is invalid to reference an identical parent
+                more than once. It is valid to reference multiple distinct sections
+                within the same parent resource, such as 2 Listeners within a Gateway.
+                \n It is possible to separately reference multiple distinct objects
+                that may be collapsed by an implementation. For example, some implementations
+                may choose to merge compatible Gateway Listeners together. If that
+                is the case, the list of routes attached to those resources should
+                also be merged."
+                items:
+                  description: "ParentReference identifies an API object (usually
+                  a Gateway) that can be considered a parent of this resource (usually
+                  a route). The only kind of parent resource with \"Core\" support
+                  is Gateway. This API may be extended in the future to support
+                  additional kinds of parent resources, such as HTTPRoute. \n The
+                  API object must be valid in the cluster; the Group and Kind must
+                  be registered in the cluster for this reference to be valid."
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: "Group is the group of the referent. \n Support:
+                      Core"
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: "Kind is kind of the referent. \n Support: Core
+                      (Gateway) Support: Custom (Other Resources)"
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: "Name is the name of the referent. \n Support:
+                      Core"
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: "Namespace is the namespace of the referent. When
+                      unspecified (or empty string), this refers to the local namespace
+                      of the Route. \n Support: Core"
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    sectionName:
+                      description: "SectionName is the name of a section within the
+                      target resource. In the following resources, SectionName is
+                      interpreted as the following: \n * Gateway: Listener Name.
+                      When both Port (experimental) and SectionName are specified,
+                      the name and port of the selected listener must match both
+                      specified values. \n Implementations MAY choose to support
+                      attaching Routes to other resources. If that is the case,
+                      they MUST clearly document how SectionName is interpreted.
+                      \n When unspecified (empty string), this will reference the
+                      entire resource. For the purpose of status, an attachment
+                      is considered successful if at least one section in the parent
+                      resource accepts it. For example, Gateway listeners can restrict
+                      which Routes can attach to them by Route kind, namespace,
+                      or hostname. If 1 of 2 Gateway listeners accept attachment
+                      from the referencing Route, the Route MUST be considered successfully
+                      attached. If no Gateway listeners accept attachment from this
+                      Route, the Route MUST be considered detached from the Gateway.
+                      \n Support: Core"
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                    - name
+                  type: object
+                maxItems: 32
+                type: array
+              rules:
+                description: Rules are a list of TLS matchers and actions.
+                items:
+                  description: TLSRouteRule is the configuration for a given rule.
+                  properties:
+                    backendRefs:
+                      description: "BackendRefs defines the backend(s) where matching
+                      requests should be sent. If unspecified or invalid (refers
+                      to a non-existent resource or a Service with no endpoints),
+                      the rule performs no forwarding; if no filters are specified
+                      that would result in a response being sent, the underlying
+                      implementation must actively reject request attempts to this
+                      backend, by rejecting the connection or returning a 404 status
+                      code. Request rejections must respect weight; if an invalid
+                      backend is requested to have 80% of requests, then 80% of
+                      requests must be rejected instead. \n Support: Core for Kubernetes
+                      Service Support: Custom for any other resource \n Support
+                      for weight: Extended"
+                      items:
+                        description: "BackendRef defines how a Route should forward
+                        a request to a Kubernetes resource. \n Note that when a
+                        namespace is specified, a ReferencePolicy object is required
+                        in the referent namespace to allow that namespace's owner
+                        to accept the reference. See the ReferencePolicy documentation
+                        for details."
+                        properties:
+                          group:
+                            default: ""
+                            description: Group is the group of the referent. For example,
+                              "networking.k8s.io". When unspecified (empty string),
+                              core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: Kind is kind of the referent. For example
+                              "HTTPRoute" or "Service". Defaults to "Service" when
+                              not specified.
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: "Namespace is the namespace of the backend.
+                            When unspecified, the local namespace is inferred. \n
+                            Note that when a namespace is specified, a ReferencePolicy
+                            object is required in the referent namespace to allow
+                            that namespace's owner to accept the reference. See
+                            the ReferencePolicy documentation for details. \n Support:
+                            Core"
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: Port specifies the destination port number
+                              to use for this resource. Port is required when the
+                              referent is a Kubernetes Service. For other resources,
+                              destination port might be derived from the referent
+                              resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: "Weight specifies the proportion of requests
+                            forwarded to the referenced backend. This is computed
+                            as weight/(sum of all weights in this BackendRefs list).
+                            For non-zero values, there may be some epsilon from
+                            the exact proportion defined here depending on the precision
+                            an implementation supports. Weight is not a percentage
+                            and the sum of weights does not need to equal 100. \n
+                            If only one backend is specified and it has a weight
+                            greater than 0, 100% of the traffic is forwarded to
+                            that backend. If weight is set to 0, no traffic should
+                            be forwarded for this entry. If unspecified, weight
+                            defaults to 1. \n Support for this field varies based
+                            on the context where used."
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                          - name
+                        type: object
+                      maxItems: 16
+                      minItems: 1
+                      type: array
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+            required:
+              - rules
+            type: object
+          status:
+            description: Status defines the current state of TLSRoute.
+            properties:
+              parents:
+                description: "Parents is a list of parent resources (usually Gateways)
+                that are associated with the route, and the status of the route
+                with respect to each parent. When this route attaches to a parent,
+                the controller that manages the parent must add an entry to this
+                list when the controller first sees the route and should update
+                the entry as appropriate when the route or gateway is modified.
+                \n Note that parent references that cannot be resolved by an implementation
+                of this API will not be added to this list. Implementations of this
+                API can only populate Route status for the Gateways/parent resources
+                they are responsible for. \n A maximum of 32 Gateways will be represented
+                in this list. An empty list means the route has not been attached
+                to any Gateway."
+                items:
+                  description: RouteParentStatus describes the status of a route with
+                    respect to an associated Parent.
+                  properties:
+                    conditions:
+                      description: "Conditions describes the status of the route with
+                      respect to the Gateway. Note that the route's availability
+                      is also subject to the Gateway's own status conditions and
+                      listener status. \n If the Route's ParentRef specifies an
+                      existing Gateway that supports Routes of this kind AND that
+                      Gateway's controller has sufficient access, then that Gateway's
+                      controller MUST set the \"Accepted\" condition on the Route,
+                      to indicate whether the route has been accepted or rejected
+                      by the Gateway, and why. \n A Route MUST be considered \"Accepted\"
+                      if at least one of the Route's rules is implemented by the
+                      Gateway. \n There are a number of cases where the \"Accepted\"
+                      condition may not be set due to lack of controller visibility,
+                      that includes when: \n * The Route refers to a non-existent
+                      parent. * The Route is of a type that the controller does
+                      not support. * The Route is in a namespace the the controller
+                      does not have access to."
+                      items:
+                        description: "Condition contains details for one aspect of
+                        the current state of this API Resource. --- This struct
+                        is intended for direct use as an array at the field path
+                        .status.conditions.  For example, type FooStatus struct{
+                        \    // Represents the observations of a foo's current state.
+                        \    // Known .status.conditions.type are: \"Available\",
+                        \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                        \    // +patchStrategy=merge     // +listType=map     //
+                        +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                        patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                        \n     // other fields }"
+                        properties:
+                          lastTransitionTime:
+                            description: lastTransitionTime is the last time the condition
+                              transitioned from one status to another. This should
+                              be when the underlying condition changed.  If that is
+                              not known, then using the time when the API field changed
+                              is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: message is a human readable message indicating
+                              details about the transition. This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: observedGeneration represents the .metadata.generation
+                              that the condition was set based upon. For instance,
+                              if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                              is 9, the condition is out of date with respect to the
+                              current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. The value should
+                              be a CamelCase string. This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                              - "True"
+                              - "False"
+                              - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              --- Many .condition.type values are consistent across
+                              resources like Available, but because arbitrary conditions
+                              can be useful (see .node.status.conditions), the ability
+                              to deconflict is important. The regex it matches is
+                              (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                          - lastTransitionTime
+                          - message
+                          - reason
+                          - status
+                          - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: "ControllerName is a domain/path string that indicates
+                      the name of the controller that wrote this status. This corresponds
+                      with the controllerName field on GatewayClass. \n Example:
+                      \"example.net/gateway-controller\". \n The format of this
+                      field is DOMAIN \"/\" PATH, where DOMAIN and PATH are valid
+                      Kubernetes names (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+                      \n Controllers MUST populate this field when writing status.
+                      Controllers should ensure that entries to status populated
+                      with their ControllerName are cleaned up when they are no
+                      longer necessary."
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: ParentRef corresponds with a ParentRef in the spec
+                        that this RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: "Group is the group of the referent. \n Support:
+                          Core"
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: "Kind is kind of the referent. \n Support:
+                          Core (Gateway) Support: Custom (Other Resources)"
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: "Name is the name of the referent. \n Support:
+                          Core"
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: "Namespace is the namespace of the referent.
+                          When unspecified (or empty string), this refers to the
+                          local namespace of the Route. \n Support: Core"
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        sectionName:
+                          description: "SectionName is the name of a section within
+                          the target resource. In the following resources, SectionName
+                          is interpreted as the following: \n * Gateway: Listener
+                          Name. When both Port (experimental) and SectionName are
+                          specified, the name and port of the selected listener
+                          must match both specified values. \n Implementations MAY
+                          choose to support attaching Routes to other resources.
+                          If that is the case, they MUST clearly document how SectionName
+                          is interpreted. \n When unspecified (empty string), this
+                          will reference the entire resource. For the purpose of
+                          status, an attachment is considered successful if at least
+                          one section in the parent resource accepts it. For example,
+                          Gateway listeners can restrict which Routes can attach
+                          to them by Route kind, namespace, or hostname. If 1 of
+                          2 Gateway listeners accept attachment from the referencing
+                          Route, the Route MUST be considered successfully attached.
+                          If no Gateway listeners accept attachment from this Route,
+                          the Route MUST be considered detached from the Gateway.
+                          \n Support: Core"
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                        - name
+                      type: object
+                  required:
+                    - controllerName
+                    - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+            required:
+              - parents
+            type: object
+        required:
+          - spec
+        type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/test/e2e/logicalclustermigration/migration_test.go
+++ b/test/e2e/logicalclustermigration/migration_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -33,8 +34,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/ptr"
 
 	kcpdynamic "github.com/kcp-dev/client-go/dynamic"
 	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
@@ -42,10 +45,14 @@ import (
 	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
 	"github.com/kcp-dev/sdk/apis/core"
 	migrationv1alpha1 "github.com/kcp-dev/sdk/apis/migration/v1alpha1"
+	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
 	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
+	apisv1alpha2client "github.com/kcp-dev/sdk/client/clientset/versioned/typed/apis/v1alpha2"
 	kcptesting "github.com/kcp-dev/sdk/testing"
+	kcptestinghelpers "github.com/kcp-dev/sdk/testing/helpers"
 
 	"github.com/kcp-dev/kcp/config/helpers"
+	"github.com/kcp-dev/kcp/pkg/reconciler/committer"
 	wildwestv1alpha1 "github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/apis/wildwest/v1alpha1"
 	wildwestclientset "github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/client/clientset/versioned/cluster"
 	"github.com/kcp-dev/kcp/test/e2e/framework"
@@ -589,4 +596,511 @@ func TestFullMigrationAPIBindings(t *testing.T) {
 			require.True(t, cowboyNames[name], "Cowboy %s not found after migration", name)
 		}
 	})
+}
+
+func TestFullMigrationAPIExportVirtualWorkspace(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "control-plane")
+
+	server := kcptesting.SharedKcpServer(t)
+
+	if len(server.ShardNames()) < 2 {
+		t.Skip("requires multi-shard setup")
+	}
+
+	cfg := server.BaseConfig(t)
+	kcpClusterClient, err := kcpclientset.NewForConfig(cfg)
+	require.NoError(t, err)
+	dynamicClusterClient, err := kcpdynamic.NewForConfig(cfg)
+	require.NoError(t, err)
+
+	shardNames := server.ShardNames()
+	originShard := shardNames[0]
+	destinationShard := shardNames[1]
+
+	t.Logf("Using origin shard %q and destination shard %q", originShard, destinationShard)
+
+	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
+	providerPath, providerWs := kcptesting.NewWorkspaceFixture(t, server, orgPath, kcptesting.WithShard(originShard))
+	providerLCName := logicalcluster.Name(providerWs.Spec.Cluster)
+
+	t.Logf("Provider workspace: %s (logical cluster %s, shard %s)", providerPath, providerLCName, originShard)
+
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(kcpClusterClient.Cluster(providerPath).Discovery()))
+
+	t.Logf("Installing cowboys APIResourceSchema into provider workspace %s", providerPath)
+	err = helpers.CreateResourceFromFS(t.Context(), dynamicClusterClient.Cluster(providerPath), mapper, nil, "apiresourceschema_cowboys.yaml", testFiles)
+	require.NoError(t, err)
+
+	t.Logf("Creating cowboys APIExport in provider workspace %s", providerPath)
+	apiExport := &apisv1alpha2.APIExport{
+		ObjectMeta: metav1.ObjectMeta{Name: "today-cowboys"},
+		Spec: apisv1alpha2.APIExportSpec{
+			Resources: []apisv1alpha2.ResourceSchema{
+				{
+					Group:  "wildwest.dev",
+					Name:   "cowboys",
+					Schema: "today.cowboys.wildwest.dev",
+					Storage: apisv1alpha2.ResourceSchemaStorage{
+						CRD: &apisv1alpha2.ResourceSchemaStorageCRD{},
+					},
+				},
+			},
+			PermissionClaims: []apisv1alpha2.PermissionClaim{
+				{
+					GroupResource: apisv1alpha2.GroupResource{Group: "", Resource: "configmaps"},
+					Verbs:         []string{"get"},
+				},
+			},
+		},
+	}
+	_, err = kcpClusterClient.Cluster(providerPath).ApisV1alpha2().APIExports().Create(t.Context(), apiExport, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("Creating WorkspaceType with DefaultAPIBindings in provider workspace %s", providerPath)
+	workspaceType := tenancyv1alpha1.WorkspaceType{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-consumer-type"},
+		Spec: tenancyv1alpha1.WorkspaceTypeSpec{
+			DefaultChildWorkspaceType: &tenancyv1alpha1.WorkspaceTypeReference{
+				Name: "universal",
+				Path: "root",
+			},
+			Extend: tenancyv1alpha1.WorkspaceTypeExtension{
+				With: []tenancyv1alpha1.WorkspaceTypeReference{
+					{Name: "universal", Path: "root"},
+				},
+			},
+			DefaultAPIBindings: []tenancyv1alpha1.APIExportReference{
+				{Export: apiExport.GetName()},
+			},
+			DefaultAPIBindingLifecycle: ptr.To(tenancyv1alpha1.APIBindingLifecycleModeMaintain),
+		},
+	}
+	_, err = kcpClusterClient.Cluster(providerPath).TenancyV1alpha1().WorkspaceTypes().Create(t.Context(), &workspaceType, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	consumerPath, consumerWs := kcptesting.NewWorkspaceFixture(t, server, orgPath, kcptesting.WithType(providerPath, tenancyv1alpha1.WorkspaceTypeName(workspaceType.GetName())))
+	t.Logf("Consumer workspace: %s", consumerPath)
+
+	awaitAPIBinding := func(group, resource string, expectedPermissionClaims ...apisv1alpha2.PermissionClaim) {
+		kcptestinghelpers.Eventually(t, func() (bool, string) {
+			list, err := kcpClusterClient.Cluster(consumerPath).ApisV1alpha2().APIBindings().List(t.Context(), metav1.ListOptions{})
+			if err != nil {
+				return false, fmt.Sprintf("failed to list api bindings: %v", err)
+			}
+			for _, ab := range list.Items {
+				if !strings.HasPrefix(ab.GetName(), apiExport.GetName()) {
+					continue
+				}
+				hasBoundResource := slices.ContainsFunc(ab.Status.BoundResources, func(br apisv1alpha2.BoundAPIResource) bool {
+					return br.Group == group && br.Resource == resource
+				})
+				if !hasBoundResource {
+					continue
+				}
+				for _, epc := range expectedPermissionClaims {
+					hasAppliedClaim := slices.ContainsFunc(ab.Status.AppliedPermissionClaims, func(spc apisv1alpha2.ScopedPermissionClaim) bool {
+						return epc.Group == spc.Group && epc.Resource == spc.Resource
+					})
+					if !hasAppliedClaim {
+						return false, fmt.Sprintf("found api binding %q but missing permission claim %s/%s", ab.GetName(), epc.Group, epc.Resource)
+					}
+				}
+				return true, fmt.Sprintf("found api binding %q", ab.GetName())
+			}
+			return false, ""
+		}, wait.ForeverTestTimeout, time.Second*2, fmt.Sprintf("failed to wait for api binding with %q %q from export %q", group, resource, apiExport.GetName()))
+	}
+
+	t.Logf("Verifying initial APIBinding has cowboys and configmaps permission claim")
+	awaitAPIBinding("wildwest.dev", "cowboys",
+		apisv1alpha2.PermissionClaim{
+			GroupResource: apisv1alpha2.GroupResource{Group: "", Resource: "configmaps"},
+		},
+	)
+
+	t.Logf("Creating APIBinding for migration.kcp.io in %s", orgPath)
+	_, err = kcpClusterClient.Cluster(orgPath).ApisV1alpha2().APIBindings().Create(
+		t.Context(),
+		&apisv1alpha2.APIBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "migration"},
+			Spec: apisv1alpha2.APIBindingSpec{
+				Reference: apisv1alpha2.BindingReference{
+					Export: &apisv1alpha2.ExportBindingReference{
+						Path: core.RootCluster.Path().String(),
+						Name: "migration.kcp.io",
+					},
+				},
+			},
+		},
+		metav1.CreateOptions{},
+	)
+	require.NoError(t, err)
+
+	t.Logf("Waiting for migration APIBinding to be bound in %s", orgPath)
+	require.Eventually(t, func() bool {
+		binding, err := kcpClusterClient.Cluster(orgPath).ApisV1alpha2().APIBindings().Get(t.Context(), "migration", metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return binding.Status.Phase == apisv1alpha2.APIBindingPhaseBound
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "migration APIBinding never reached Bound phase")
+
+	t.Logf("Waiting for APIExportEndpointSlice in %s to have a virtual workspace URL for consumer %s", providerPath, consumerPath)
+	apiExportVWCfg := rest.CopyConfig(cfg)
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		slice, err := kcpClusterClient.Cluster(providerPath).ApisV1alpha1().APIExportEndpointSlices().Get(t.Context(), apiExport.GetName(), metav1.GetOptions{})
+		if err != nil {
+			return false, fmt.Sprintf("waiting on APIExportEndpointSlice: %v", err)
+		}
+		var found bool
+		apiExportVWCfg.Host, found, err = framework.VirtualWorkspaceURL(t.Context(), kcpClusterClient, consumerWs, framework.ExportVirtualWorkspaceURLs(slice))
+		require.NoError(t, err)
+		return found, fmt.Sprintf("waiting for VW URL: %v", slice.Status.APIExportEndpoints)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond)
+
+	wildwestVWClient, err := wildwestclientset.NewForConfig(apiExportVWCfg)
+	require.NoError(t, err)
+
+	t.Logf("Starting pre-migration watch on Cowboys via VW")
+	vwWatcher, err := wildwestVWClient.WildwestV1alpha1().Cowboys().Watch(t.Context(), metav1.ListOptions{})
+	require.NoError(t, err, "should be able to establish VW watch before provider migration")
+	t.Cleanup(vwWatcher.Stop)
+
+	t.Logf("Starting pre-migration informer on Cowboys via VW")
+	vwInformerStore, vwInformerController := cache.NewInformerWithOptions(cache.InformerOptions{
+		ListerWatcher: &cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				return wildwestVWClient.WildwestV1alpha1().Cowboys().List(t.Context(), options)
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				return wildwestVWClient.WildwestV1alpha1().Cowboys().Watch(t.Context(), options)
+			},
+		},
+		ObjectType: &wildwestv1alpha1.Cowboy{},
+		Handler:    cache.ResourceEventHandlerFuncs{},
+	})
+	vwInformerCtx, vwInformerCancel := context.WithCancel(t.Context())
+	t.Cleanup(vwInformerCancel)
+	go vwInformerController.Run(vwInformerCtx.Done())
+
+	t.Logf("Migrating provider logical cluster %s from %s to %s", providerLCName, originShard, destinationShard)
+	var lcm *migrationv1alpha1.LogicalClusterMigration
+	require.Eventually(t, func() bool {
+		var err error
+		lcm, err = kcpClusterClient.Cluster(orgPath).MigrationV1alpha1().LogicalClusterMigrations().Create(
+			t.Context(),
+			&migrationv1alpha1.LogicalClusterMigration{
+				ObjectMeta: metav1.ObjectMeta{Name: "provider-migration"},
+				Spec: migrationv1alpha1.LogicalClusterMigrationSpec{
+					LogicalCluster:   providerLCName.String(),
+					DestinationShard: destinationShard,
+				},
+			},
+			metav1.CreateOptions{},
+		)
+		if err != nil {
+			t.Logf("failed to create LogicalClusterMigration: %v", err)
+		}
+		return err == nil
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "failed to create LogicalClusterMigration")
+
+	t.Logf("Waiting for provider migration to complete")
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		migration, err := kcpClusterClient.Cluster(orgPath).MigrationV1alpha1().LogicalClusterMigrations().Get(t.Context(), lcm.Name, metav1.GetOptions{})
+		require.NoError(c, err)
+		t.Logf("migration phase: %q", migration.Status.Phase)
+		t.Logf("migration conditions: %#v", migration.Status.Conditions)
+		require.Equal(c, migrationv1alpha1.LogicalClusterMigrationPhaseCompleted, migration.Status.Phase)
+	}, wait.ForeverTestTimeout, 500*time.Millisecond, "waiting for provider migration to complete")
+
+	t.Logf("Verifying cowboys APIBinding is still bound after provider migration")
+	awaitAPIBinding("wildwest.dev", "cowboys",
+		apisv1alpha2.PermissionClaim{
+			GroupResource: apisv1alpha2.GroupResource{Group: "", Resource: "configmaps"},
+		},
+	)
+
+	t.Run("PreMigrateVWWatch", func(t *testing.T) {
+		t.Parallel()
+
+		wildwestClusterClient, err := wildwestclientset.NewForConfig(cfg)
+		require.NoError(t, err)
+		_, err = wildwestClusterClient.Cluster(consumerPath).WildwestV1alpha1().Cowboys("default").Create(
+			t.Context(),
+			&wildwestv1alpha1.Cowboy{
+				ObjectMeta: metav1.ObjectMeta{Name: "post-migration-vw-cowboy"},
+			},
+			metav1.CreateOptions{},
+		)
+		require.NoError(t, err)
+
+		for {
+			select {
+			case <-t.Context().Done():
+				t.Fatal("test context closed while waiting for VW watch event")
+			case event, ok := <-vwWatcher.ResultChan():
+				if !ok {
+					t.Fatal("VW watch closed unexpectedly after provider migration")
+				}
+				if event.Type == watch.Error {
+					continue
+				}
+				cowboy, ok := event.Object.(*wildwestv1alpha1.Cowboy)
+				if ok && cowboy.Name == "post-migration-vw-cowboy" {
+					return
+				}
+			case <-time.After(wait.ForeverTestTimeout):
+				t.Fatal("VW watch did not receive post-migration Cowboy event")
+			}
+		}
+	})
+
+	t.Run("PreMigrateVWInformer", func(t *testing.T) {
+		t.Parallel()
+
+		wildwestClusterClient, err := wildwestclientset.NewForConfig(cfg)
+		require.NoError(t, err)
+		_, err = wildwestClusterClient.Cluster(consumerPath).WildwestV1alpha1().Cowboys("default").Create(
+			t.Context(),
+			&wildwestv1alpha1.Cowboy{
+				ObjectMeta: metav1.ObjectMeta{Name: "post-migration-vw-informer-cowboy"},
+			},
+			metav1.CreateOptions{},
+		)
+		require.NoError(t, err)
+
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			_, exists, err := vwInformerStore.GetByKey("default/post-migration-vw-informer-cowboy")
+			assert.NoError(c, err)
+			assert.True(c, exists, "VW informer should have picked up post-migration-vw-informer-cowboy")
+		}, wait.ForeverTestTimeout, 500*time.Millisecond, "waiting for VW informer to pick up post-migration object")
+	})
+}
+
+func TestFullMigrationAPIExportUpdate(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "control-plane")
+
+	server := kcptesting.SharedKcpServer(t)
+
+	if len(server.ShardNames()) < 2 {
+		t.Skip("requires multi-shard setup")
+	}
+
+	cfg := server.BaseConfig(t)
+	kcpClusterClient, err := kcpclientset.NewForConfig(cfg)
+	require.NoError(t, err)
+	dynamicClusterClient, err := kcpdynamic.NewForConfig(cfg)
+	require.NoError(t, err)
+
+	shardNames := server.ShardNames()
+	originShard := shardNames[0]
+	destinationShard := shardNames[1]
+
+	t.Logf("Using origin shard %q and destination shard %q", originShard, destinationShard)
+
+	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
+	providerPath, providerWs := kcptesting.NewWorkspaceFixture(t, server, orgPath, kcptesting.WithShard(originShard))
+	providerLCName := logicalcluster.Name(providerWs.Spec.Cluster)
+
+	t.Logf("Provider workspace: %s (logical cluster %s, shard %s)", providerPath, providerLCName, originShard)
+
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(kcpClusterClient.Cluster(providerPath).Discovery()))
+
+	t.Logf("Installing cowboys APIResourceSchema into provider workspace %s", providerPath)
+	err = helpers.CreateResourceFromFS(t.Context(), dynamicClusterClient.Cluster(providerPath), mapper, nil, "apiresourceschema_cowboys.yaml", testFiles)
+	require.NoError(t, err)
+
+	t.Logf("Creating cowboys APIExport in provider workspace %s", providerPath)
+	apiExport := &apisv1alpha2.APIExport{
+		ObjectMeta: metav1.ObjectMeta{Name: "today-cowboys"},
+		Spec: apisv1alpha2.APIExportSpec{
+			Resources: []apisv1alpha2.ResourceSchema{
+				{
+					Group:  "wildwest.dev",
+					Name:   "cowboys",
+					Schema: "today.cowboys.wildwest.dev",
+					Storage: apisv1alpha2.ResourceSchemaStorage{
+						CRD: &apisv1alpha2.ResourceSchemaStorageCRD{},
+					},
+				},
+			},
+			PermissionClaims: []apisv1alpha2.PermissionClaim{
+				{
+					GroupResource: apisv1alpha2.GroupResource{Group: "", Resource: "configmaps"},
+					Verbs:         []string{"get"},
+				},
+			},
+		},
+	}
+	_, err = kcpClusterClient.Cluster(providerPath).ApisV1alpha2().APIExports().Create(t.Context(), apiExport, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("Creating WorkspaceType with DefaultAPIBindings in provider workspace %s", providerPath)
+	workspaceType := tenancyv1alpha1.WorkspaceType{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-consumer-type"},
+		Spec: tenancyv1alpha1.WorkspaceTypeSpec{
+			DefaultChildWorkspaceType: &tenancyv1alpha1.WorkspaceTypeReference{
+				Name: "universal",
+				Path: "root",
+			},
+			Extend: tenancyv1alpha1.WorkspaceTypeExtension{
+				With: []tenancyv1alpha1.WorkspaceTypeReference{
+					{Name: "universal", Path: "root"},
+				},
+			},
+			DefaultAPIBindings: []tenancyv1alpha1.APIExportReference{
+				{Export: apiExport.GetName()},
+			},
+			DefaultAPIBindingLifecycle: ptr.To(tenancyv1alpha1.APIBindingLifecycleModeMaintain),
+		},
+	}
+	_, err = kcpClusterClient.Cluster(providerPath).TenancyV1alpha1().WorkspaceTypes().Create(t.Context(), &workspaceType, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	consumerPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath, kcptesting.WithType(providerPath, tenancyv1alpha1.WorkspaceTypeName(workspaceType.GetName())))
+	t.Logf("Consumer workspace: %s", consumerPath)
+
+	awaitAPIBinding := func(group, resource string, expectedPermissionClaims ...apisv1alpha2.PermissionClaim) {
+		kcptestinghelpers.Eventually(t, func() (bool, string) {
+			list, err := kcpClusterClient.Cluster(consumerPath).ApisV1alpha2().APIBindings().List(t.Context(), metav1.ListOptions{})
+			if err != nil {
+				return false, fmt.Sprintf("failed to list api bindings: %v", err)
+			}
+			for _, ab := range list.Items {
+				if !strings.HasPrefix(ab.GetName(), apiExport.GetName()) {
+					continue
+				}
+				hasBoundResource := slices.ContainsFunc(ab.Status.BoundResources, func(br apisv1alpha2.BoundAPIResource) bool {
+					return br.Group == group && br.Resource == resource
+				})
+				if !hasBoundResource {
+					continue
+				}
+				for _, epc := range expectedPermissionClaims {
+					hasAppliedClaim := slices.ContainsFunc(ab.Status.AppliedPermissionClaims, func(spc apisv1alpha2.ScopedPermissionClaim) bool {
+						return epc.Group == spc.Group && epc.Resource == spc.Resource
+					})
+					if !hasAppliedClaim {
+						return false, fmt.Sprintf("found api binding %q but missing permission claim %s/%s", ab.GetName(), epc.Group, epc.Resource)
+					}
+				}
+				return true, fmt.Sprintf("found api binding %q", ab.GetName())
+			}
+			return false, ""
+		}, wait.ForeverTestTimeout, time.Second*2, fmt.Sprintf("failed to wait for api binding with %q %q from export %q", group, resource, apiExport.GetName()))
+	}
+
+	t.Logf("Verifying initial APIBinding has cowboys and configmaps permission claim")
+	awaitAPIBinding("wildwest.dev", "cowboys",
+		apisv1alpha2.PermissionClaim{
+			GroupResource: apisv1alpha2.GroupResource{Group: "", Resource: "configmaps"},
+		},
+	)
+
+	t.Logf("Creating APIBinding for migration.kcp.io in %s", orgPath)
+	_, err = kcpClusterClient.Cluster(orgPath).ApisV1alpha2().APIBindings().Create(
+		t.Context(),
+		&apisv1alpha2.APIBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "migration"},
+			Spec: apisv1alpha2.APIBindingSpec{
+				Reference: apisv1alpha2.BindingReference{
+					Export: &apisv1alpha2.ExportBindingReference{
+						Path: core.RootCluster.Path().String(),
+						Name: "migration.kcp.io",
+					},
+				},
+			},
+		},
+		metav1.CreateOptions{},
+	)
+	require.NoError(t, err)
+
+	t.Logf("Waiting for migration APIBinding to be bound in %s", orgPath)
+	require.Eventually(t, func() bool {
+		binding, err := kcpClusterClient.Cluster(orgPath).ApisV1alpha2().APIBindings().Get(t.Context(), "migration", metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return binding.Status.Phase == apisv1alpha2.APIBindingPhaseBound
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "migration APIBinding never reached Bound phase")
+
+	t.Logf("Migrating provider logical cluster %s from %s to %s", providerLCName, originShard, destinationShard)
+	var lcm *migrationv1alpha1.LogicalClusterMigration
+	require.Eventually(t, func() bool {
+		var err error
+		lcm, err = kcpClusterClient.Cluster(orgPath).MigrationV1alpha1().LogicalClusterMigrations().Create(
+			t.Context(),
+			&migrationv1alpha1.LogicalClusterMigration{
+				ObjectMeta: metav1.ObjectMeta{Name: "provider-migration"},
+				Spec: migrationv1alpha1.LogicalClusterMigrationSpec{
+					LogicalCluster:   providerLCName.String(),
+					DestinationShard: destinationShard,
+				},
+			},
+			metav1.CreateOptions{},
+		)
+		if err != nil {
+			t.Logf("failed to create LogicalClusterMigration: %v", err)
+		}
+		return err == nil
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "failed to create LogicalClusterMigration")
+
+	t.Logf("Waiting for provider migration to complete")
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		migration, err := kcpClusterClient.Cluster(orgPath).MigrationV1alpha1().LogicalClusterMigrations().Get(t.Context(), lcm.Name, metav1.GetOptions{})
+		require.NoError(c, err)
+		t.Logf("migration phase: %q", migration.Status.Phase)
+		t.Logf("migration conditions: %#v", migration.Status.Conditions)
+		require.Equal(c, migrationv1alpha1.LogicalClusterMigrationPhaseCompleted, migration.Status.Phase)
+	}, wait.ForeverTestTimeout, 500*time.Millisecond, "waiting for provider migration to complete")
+
+	t.Logf("Installing TLSRoutes APIResourceSchema into provider workspace %s", providerPath)
+	err = helpers.CreateResourceFromFS(t.Context(), dynamicClusterClient.Cluster(providerPath), mapper, nil, "apiresourceschema_tlsroutes.yaml", testFiles)
+	require.NoError(t, err)
+
+	t.Logf("Updating APIExport to add tlsroutes resource and secrets permission claim")
+	currentAPIExport, err := kcpClusterClient.Cluster(providerPath).ApisV1alpha2().APIExports().Get(t.Context(), apiExport.GetName(), metav1.GetOptions{})
+	require.NoError(t, err)
+
+	updatedAPIExport := currentAPIExport.DeepCopy()
+	updatedAPIExport.Spec.Resources = append(updatedAPIExport.Spec.Resources, apisv1alpha2.ResourceSchema{
+		Group:  "gateway.networking.k8s.io",
+		Name:   "tlsroutes",
+		Schema: "latest.tlsroutes.gateway.networking.k8s.io",
+		Storage: apisv1alpha2.ResourceSchemaStorage{
+			CRD: &apisv1alpha2.ResourceSchemaStorageCRD{},
+		},
+	})
+	updatedAPIExport.Spec.PermissionClaims = append(updatedAPIExport.Spec.PermissionClaims, apisv1alpha2.PermissionClaim{
+		GroupResource: apisv1alpha2.GroupResource{Group: "", Resource: "secrets"},
+		Verbs:         []string{"get"},
+	})
+
+	commitAPIExport := committer.NewCommitter[*apisv1alpha2.APIExport, apisv1alpha2client.APIExportInterface, *apisv1alpha2.APIExportSpec, *apisv1alpha2.APIExportStatus](kcpClusterClient.ApisV1alpha2().APIExports())
+	type apiExportResource = committer.Resource[*apisv1alpha2.APIExportSpec, *apisv1alpha2.APIExportStatus]
+	oldResource := &apiExportResource{ObjectMeta: currentAPIExport.ObjectMeta, Spec: &currentAPIExport.Spec, Status: &currentAPIExport.Status}
+	newResource := &apiExportResource{ObjectMeta: currentAPIExport.ObjectMeta, Spec: &updatedAPIExport.Spec, Status: &currentAPIExport.Status}
+	err = commitAPIExport(t.Context(), oldResource, newResource)
+	require.NoError(t, err)
+
+	t.Logf("Verifying APIBinding now has tlsroutes and secrets permission claim after provider migration and export update")
+	awaitAPIBinding("gateway.networking.k8s.io", "tlsroutes",
+		apisv1alpha2.PermissionClaim{
+			GroupResource: apisv1alpha2.GroupResource{Group: "", Resource: "configmaps"},
+		},
+		apisv1alpha2.PermissionClaim{
+			GroupResource: apisv1alpha2.GroupResource{Group: "", Resource: "secrets"},
+		},
+	)
+
+	t.Logf("Verifying tlsroutes appears in consumer workspace %q discovery", consumerPath)
+	consumerDiscoveryClient, err := kcpclientset.NewForConfig(cfg)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		resources, err := consumerDiscoveryClient.Cluster(consumerPath).Discovery().ServerResourcesForGroupVersion("gateway.networking.k8s.io/v1alpha2")
+		require.NoError(t, err, "error retrieving consumer workspace %q API discovery", consumerPath)
+		return resourceExists(resources, "tlsroutes")
+	}, wait.ForeverTestTimeout, time.Millisecond*100, "consumer workspace %q discovery is missing tlsroutes resource", consumerPath)
 }

--- a/test/e2e/logicalclustermigration/support.go
+++ b/test/e2e/logicalclustermigration/support.go
@@ -16,7 +16,20 @@ limitations under the License.
 
 package logicalclustermigration
 
-import "embed"
+import (
+	"embed"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 //go:embed *.yaml
 var testFiles embed.FS
+
+func resourceExists(list *metav1.APIResourceList, resource string) bool {
+	for _, r := range list.APIResources {
+		if r.Name == resource {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

This PR adds two e2e tests for LC Migration where the LC being migrated contains an APIExport with live APIBindings:

- `TestFullMigrationAPIExportVirtualWorkspace`: establishes a watch and an informer against an export's VW, and verifies that it keeps working after migration.
- `TestFullMigrationAPIExportUpdate`: performs the migration, updates the export with a new resource and perm claim, checks that bindings are updated.

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind feature

## Related Issue(s)

Part of https://github.com/kcp-dev/kcp/issues/4205

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
