### PR TITLE
Clear synced 'extra annotations' after an APIExport is deleted

### DIFF
--- a/pkg/reconciler/apis/extraannotationsync/apibindingannotation_controller.go
+++ b/pkg/reconciler/apis/extraannotationsync/apibindingannotation_controller.go
@@ -115,6 +115,7 @@ func NewController(
 	_, _ = apiExportInformer.Informer().AddEventHandler(events.WithoutSyncs(cache.ResourceEventHandlerFuncs{
 		AddFunc:    func(obj interface{}) { c.enqueueAPIExport(obj, logger) },
 		UpdateFunc: func(_, obj interface{}) { c.enqueueAPIExport(obj, logger) },
+		DeleteFunc: func(obj interface{}) { c.enqueueAPIExport(obj, logger) },
 	}))
 
 	_, _ = apiBindingInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -247,15 +248,17 @@ func (c *controller) process(ctx context.Context, key string) error {
 	if path.Empty() {
 		path = clusterName.Path()
 	}
+
+	// If the APIExport is gone strip the previously synced extra annotations.
+	var exportAnnotations map[string]string
 	apiExport, err := c.getAPIExport(path, apiBinding.Spec.Reference.Export.Name)
-	if apierrors.IsNotFound(err) {
-		return nil
-	}
-	if err != nil {
+	if err == nil {
+		exportAnnotations = apiExport.Annotations
+	} else if !apierrors.IsNotFound(err) {
 		return err
 	}
 
-	patchBytes, err := syncExtraAnnotationPatch(apiExport.Annotations, apiBinding.Annotations)
+	patchBytes, err := syncExtraAnnotationPatch(exportAnnotations, apiBinding.Annotations)
 	if err != nil {
 		return err
 	}

--- a/pkg/reconciler/apis/extraannotationsync/apibindingannotation_controller_test.go
+++ b/pkg/reconciler/apis/extraannotationsync/apibindingannotation_controller_test.go
@@ -57,6 +57,12 @@ func TestSyncExtraAnnotationPatch(t *testing.T) {
 			apiBindingAnnotations: map[string]string{"key2": "value2", apisv1alpha1.AnnotationAPIExportExtraKeyPrefix + "test": "test1"},
 			wantPatch:             fmt.Sprintf(`{"metadata":{"annotations":{%q:"test"}}}`, apisv1alpha1.AnnotationAPIExportExtraKeyPrefix+"test"),
 		},
+		{
+			name:                  "strip extra annotations when export is gone",
+			apiExportAnnotations:  nil,
+			apiBindingAnnotations: map[string]string{"key2": "value2", apisv1alpha1.AnnotationAPIExportExtraKeyPrefix + "test": "test"},
+			wantPatch:             fmt.Sprintf(`{"metadata":{"annotations":{%q:null}}}`, apisv1alpha1.AnnotationAPIExportExtraKeyPrefix+"test"),
+		},
 	}
 
 	for _, scenario := range scenarios {


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

```
When the APIExport is missing the sync controller just returns early.
The extra annotations it had copied earlier become stale on the binding.
Clear the extra annotations on all binding that bound to that export
so that this reconciliation converges on a deterministic state.

Don't touch other user owned annotations; only clear the
extra annotations which are controller owned and taken from the
APIExport.

Add DeleteFunc() so that APIExport informer also enqueues
bindings on delete.
```

## What Type of PR Is This?

/kind bug cleanup

arguably not a bug.

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

part of #https://github.com/kcp-dev/kcp/issues/3925
but i did not make the finalizer or cascade deletion proposals from there.
that seems like a feature to me and maybe should be exposed with API knobs.

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
bugfix: on APIExport deletion, clear all managed 'extra annotations' from associated APIBindings.
```
