### PR TITLE
Add LogicalCluster level quota

### DIFF
--- a/docs/content/concepts/workspaces/object-count-limit.md
+++ b/docs/content/concepts/workspaces/object-count-limit.md
@@ -1,0 +1,65 @@
+---
+description: >
+  Enforce a hard limit on the total number of objects in a workspace.
+---
+
+# Total Object Count Limit
+
+kcp can enforce a hard limit on the total number of objects (across all resource types)
+in a logical cluster. This protects a shard from a single workspace creating so many
+objects that it degrades or takes down the shard. It complements the standard Kubernetes
+`ResourceQuota` support, which can only limit counts per resource type
+(`count/<resource>.<group>`), not the total across all types.
+
+## Configuration
+
+Enforcement is off by default and can be enabled two ways:
+
+* **Shard-wide default**: start kcp with `--logical-cluster-total-object-limit=<N>`.
+  Every logical cluster on the shard is then limited to `N` objects, unless overridden
+  per logical cluster. The default does **not** apply to the `root` and `system:*`
+  logical clusters: the shard writes bootstrap content there, and a default limit
+  must never break shard bootstrapping or upgrades. Use the annotation to bound
+  `root` explicitly if desired.
+* **Per logical cluster**: set the `core.kcp.io/max-total-objects` annotation on the
+  `LogicalCluster` object of a workspace. The annotation always takes precedence over
+  the shard-wide default, and works even when no shard-wide default is configured.
+  A value of `0` (or any value `<= 0`) disables the limit for that logical cluster.
+
+The annotation is protected by the `apis.kcp.io/ReservedMetadata` admission plugin:
+only privileged system users (e.g. shard admins) can set or change it. Workspace users
+cannot raise their own limit.
+
+```sh
+# example: limit the workspace to 1000 objects total
+kubectl annotate logicalcluster cluster core.kcp.io/max-total-objects=1000 --overwrite
+```
+
+## Semantics
+
+* Only object creation is limited. **Deletes are always allowed** (and free up capacity),
+  as are updates and subresource requests.
+* Enforcement only starts once the logical cluster is `Ready`; workspace bootstrapping
+  and initialization are never blocked.
+* `Events` (both `v1` and `events.k8s.io`) are neither counted nor blocked, so an
+  exhausted workspace can still be debugged.
+* When the limit is reached, create requests are rejected with `403 Forbidden` and a
+  message that includes the current count and the limit.
+
+## Accuracy
+
+This is deliberately a "poor man's quota": object counts are maintained per shard by a
+periodic etcd scan (`--logical-cluster-object-count-scan-interval`, default `60s`)
+combined with in-memory bookkeeping between scans. As a consequence:
+
+* Small, short-lived overshoots of the limit are possible under highly concurrent writes.
+* Drift (e.g. from writes that fail after admission) self-corrects within one scan interval.
+* After enabling enforcement (flag or first annotation), it becomes active within one
+  scan interval.
+
+## Metrics
+
+The shard publishes two gauges, `kcp_logicalcluster_object_count` and
+`kcp_logicalcluster_object_limit` (labels: `shard`, `cluster`), **only** for logical
+clusters at or above 90% of their effective limit. This keeps the metric cardinality
+bounded while still alerting on workspaces that are about to run out of capacity.

--- a/pkg/admission/initializers/initializer.go
+++ b/pkg/admission/initializers/initializer.go
@@ -29,6 +29,7 @@ import (
 	kcpinformers "github.com/kcp-dev/sdk/client/informers/externalversions"
 
 	"github.com/kcp-dev/kcp/pkg/contextmanager"
+	"github.com/kcp-dev/kcp/pkg/objectcount"
 	"github.com/kcp-dev/kcp/pkg/reconciler/dynamicrestmapper"
 )
 
@@ -199,6 +200,24 @@ func NewDynamicRESTMapperInitializer(dynamicRESTMapper *dynamicrestmapper.Dynami
 func (i *dynamicRESTMapperInitializer) Initialize(plugin admission.Interface) {
 	if wants, ok := plugin.(WantsDynamicRESTMapper); ok {
 		wants.SetDynamicRESTMapper(i.dynamicRESTMapper)
+	}
+}
+
+// NewObjectCountRegistryInitializer returns an admission plugin initializer that
+// injects the per-logical-cluster object count registry into admission plugins.
+func NewObjectCountRegistryInitializer(registry *objectcount.Registry) *objectCountRegistryInitializer {
+	return &objectCountRegistryInitializer{
+		registry: registry,
+	}
+}
+
+type objectCountRegistryInitializer struct {
+	registry *objectcount.Registry
+}
+
+func (i *objectCountRegistryInitializer) Initialize(plugin admission.Interface) {
+	if wants, ok := plugin.(WantsObjectCountRegistry); ok {
+		wants.SetObjectCountRegistry(i.registry)
 	}
 }
 

--- a/pkg/admission/initializers/interfaces.go
+++ b/pkg/admission/initializers/interfaces.go
@@ -25,6 +25,7 @@ import (
 	kcpinformers "github.com/kcp-dev/sdk/client/informers/externalversions"
 
 	"github.com/kcp-dev/kcp/pkg/contextmanager"
+	"github.com/kcp-dev/kcp/pkg/objectcount"
 	"github.com/kcp-dev/kcp/pkg/reconciler/dynamicrestmapper"
 )
 
@@ -80,4 +81,10 @@ type WantsDynamicClusterClient interface {
 // WantsDynamicRESTMapper is an interface that should be implemented by admission plugins that need the DynamicRESTMapper.
 type WantsDynamicRESTMapper interface {
 	SetDynamicRESTMapper(dynRESTMapper *dynamicrestmapper.DynamicRESTMapper)
+}
+
+// WantsObjectCountRegistry interface should be implemented by admission plugins
+// that want to have the per-logical-cluster object count registry injected.
+type WantsObjectCountRegistry interface {
+	SetObjectCountRegistry(*objectcount.Registry)
 }

--- a/pkg/admission/objectcountlimit/objectcountlimit_admission.go
+++ b/pkg/admission/objectcountlimit/objectcountlimit_admission.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package objectcountlimit
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apiserver/pkg/admission"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/klog/v2"
+
+	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
+	kcpinformers "github.com/kcp-dev/sdk/client/informers/externalversions"
+	corev1alpha1listers "github.com/kcp-dev/sdk/client/listers/core/v1alpha1"
+
+	"github.com/kcp-dev/kcp/pkg/admission/initializers"
+	"github.com/kcp-dev/kcp/pkg/objectcount"
+)
+
+// PluginName is the name of this admission plugin.
+const PluginName = "core.kcp.io/LogicalClusterObjectCountLimit"
+
+// Register registers this admission plugin.
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName,
+		func(_ io.Reader) (admission.Interface, error) {
+			return &objectCountLimit{
+				Handler: admission.NewHandler(admission.Create, admission.Delete),
+			}, nil
+		},
+	)
+}
+
+// objectCountLimit is a validating admission plugin enforcing a hard limit on
+// the total number of objects in a logical cluster. The current count is
+// tracked by the objectcount.Registry: an authoritative base from a periodic
+// etcd scan plus a delta maintained here (+1 per admitted create, -1 per
+// delete). The limit is resolved from the core.kcp.io/max-total-objects
+// annotation on the LogicalCluster, falling back to the shard-wide default.
+type objectCountLimit struct {
+	*admission.Handler
+
+	registry             *objectcount.Registry
+	logicalClusterLister corev1alpha1listers.LogicalClusterClusterLister
+}
+
+var _ admission.ValidationInterface = &objectCountLimit{}
+var _ = initializers.WantsKcpInformers(&objectCountLimit{})
+var _ = initializers.WantsObjectCountRegistry(&objectCountLimit{})
+
+// ValidateInitialization validates all the expected fields are set.
+func (o *objectCountLimit) ValidateInitialization() error {
+	if o.registry == nil {
+		return fmt.Errorf("missing objectCountRegistry")
+	}
+	if o.logicalClusterLister == nil {
+		return fmt.Errorf("missing logicalClusterLister")
+	}
+	return nil
+}
+
+// Validate enforces the total object count limit of the logical cluster of
+// the request. Deletes are always allowed and decrement the tracked count.
+func (o *objectCountLimit) Validate(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
+	if !o.registry.EnforcementActive() {
+		return nil
+	}
+
+	// Only persisted objects count; subresource requests never create objects.
+	if a.GetSubresource() != "" {
+		return nil
+	}
+
+	// Skip workspace bootstrapping resources (like the kubequota plugin does)
+	// and events, which are short-lived and needed to debug an exhausted
+	// logical cluster.
+	switch a.GetResource().GroupResource() {
+	case corev1alpha1.SchemeGroupVersion.WithResource("logicalclusters").GroupResource():
+		return nil
+	case rbacv1.SchemeGroupVersion.WithResource("clusterrolebindings").GroupResource():
+		if a.GetName() == "workspace-admin" {
+			return nil
+		}
+	case corev1.SchemeGroupVersion.WithResource("events").GroupResource(),
+		eventsv1.SchemeGroupVersion.WithResource("events").GroupResource():
+		return nil
+	}
+
+	cluster, err := genericapirequest.ValidClusterFrom(ctx)
+	if err != nil {
+		return err
+	}
+
+	if a.GetOperation() == admission.Delete {
+		o.registry.Dec(cluster.Name)
+		return nil
+	}
+
+	// The scan corrects overcounting from writes that fail after admission,
+	// so count the create optimistically in all allowed paths below.
+	logicalCluster, err := o.logicalClusterLister.Cluster(cluster.Name).Get(corev1alpha1.LogicalClusterName)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			// Fail open: enforcing quota is less important than availability.
+			klog.FromContext(ctx).Error(err, "failed to get LogicalCluster, skipping object count limit", "cluster", cluster.Name)
+		}
+		o.registry.Inc(cluster.Name)
+		return nil
+	}
+
+	// Don't enforce before the logical cluster is fully bootstrapped.
+	if logicalCluster.Status.Phase != corev1alpha1.LogicalClusterPhaseReady {
+		o.registry.Inc(cluster.Name)
+		return nil
+	}
+
+	limit := o.registry.LimitFor(cluster.Name, logicalCluster.Annotations)
+	if limit <= 0 {
+		o.registry.Inc(cluster.Name)
+		return nil
+	}
+
+	if count := o.registry.Count(cluster.Name); count >= limit {
+		return admission.NewForbidden(a, fmt.Errorf(
+			"logical cluster %q has reached its total object count limit (%d/%d objects); delete objects to free up capacity",
+			cluster.Name, count, limit))
+	}
+
+	o.registry.Inc(cluster.Name)
+	return nil
+}
+
+func (o *objectCountLimit) SetKcpInformers(local, _ kcpinformers.SharedInformerFactory) {
+	logicalClusterInformer := local.Core().V1alpha1().LogicalClusters()
+	o.logicalClusterLister = logicalClusterInformer.Lister()
+	o.SetReadyFunc(logicalClusterInformer.Informer().HasSynced)
+}
+
+func (o *objectCountLimit) SetObjectCountRegistry(registry *objectcount.Registry) {
+	o.registry = registry
+}

--- a/pkg/admission/objectcountlimit/objectcountlimit_admission_test.go
+++ b/pkg/admission/objectcountlimit/objectcountlimit_admission_test.go
@@ -1,0 +1,291 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package objectcountlimit
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/authentication/user"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
+	corev1alpha1listers "github.com/kcp-dev/sdk/client/listers/core/v1alpha1"
+
+	"github.com/kcp-dev/kcp/pkg/objectcount"
+)
+
+const testCluster = logicalcluster.Name("root:ws")
+
+func newAttr(gvr schema.GroupVersionResource, name string, op admission.Operation, subresource string) admission.Attributes {
+	return admission.NewAttributesRecord(
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"}},
+		nil,
+		gvr.GroupVersion().WithKind("ConfigMap"),
+		"default",
+		name,
+		gvr,
+		subresource,
+		op,
+		nil,
+		false,
+		&user.DefaultInfo{Name: "user"},
+	)
+}
+
+func configMapCreate(name string) admission.Attributes {
+	return newAttr(corev1.SchemeGroupVersion.WithResource("configmaps"), name, admission.Create, "")
+}
+
+func newPlugin(registry *objectcount.Registry, logicalClusters ...*corev1alpha1.LogicalCluster) *objectCountLimit {
+	return &objectCountLimit{
+		Handler:              admission.NewHandler(admission.Create, admission.Delete),
+		registry:             registry,
+		logicalClusterLister: fakeLogicalClusterClusterLister(logicalClusters),
+	}
+}
+
+func newLogicalCluster(phase corev1alpha1.LogicalClusterPhaseType, annotations map[string]string) *corev1alpha1.LogicalCluster {
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[logicalcluster.AnnotationKey] = string(testCluster)
+	return &corev1alpha1.LogicalCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        corev1alpha1.LogicalClusterName,
+			Annotations: annotations,
+		},
+		Status: corev1alpha1.LogicalClusterStatus{
+			Phase: phase,
+		},
+	}
+}
+
+func ctxWithCluster(t *testing.T) context.Context {
+	t.Helper()
+	return genericapirequest.WithCluster(context.Background(), genericapirequest.Cluster{Name: testCluster})
+}
+
+func TestValidateInactiveFastPath(t *testing.T) {
+	t.Parallel()
+
+	registry := objectcount.NewRegistry(1)
+	// enforcement not activated by the scanner
+
+	p := newPlugin(registry, newLogicalCluster(corev1alpha1.LogicalClusterPhaseReady, nil))
+	require.NoError(t, p.Validate(ctxWithCluster(t), configMapCreate("cm"), nil))
+	require.Equal(t, int64(0), registry.Count(testCluster), "inactive plugin must not track deltas")
+}
+
+func TestValidateRejectsOverLimit(t *testing.T) {
+	t.Parallel()
+
+	registry := objectcount.NewRegistry(2)
+	registry.SetEnforcementActive(true)
+
+	p := newPlugin(registry, newLogicalCluster(corev1alpha1.LogicalClusterPhaseReady, nil))
+	ctx := ctxWithCluster(t)
+
+	require.NoError(t, p.Validate(ctx, configMapCreate("cm1"), nil))
+	require.NoError(t, p.Validate(ctx, configMapCreate("cm2"), nil))
+
+	err := p.Validate(ctx, configMapCreate("cm3"), nil)
+	require.Error(t, err)
+	require.True(t, apierrors.IsForbidden(err))
+	require.Contains(t, err.Error(), "total object count limit")
+	require.Contains(t, err.Error(), "2/2")
+}
+
+func TestValidateDeleteAlwaysAllowedAndDecrements(t *testing.T) {
+	t.Parallel()
+
+	registry := objectcount.NewRegistry(2)
+	registry.SetEnforcementActive(true)
+
+	p := newPlugin(registry, newLogicalCluster(corev1alpha1.LogicalClusterPhaseReady, nil))
+	ctx := ctxWithCluster(t)
+
+	require.NoError(t, p.Validate(ctx, configMapCreate("cm1"), nil))
+	require.NoError(t, p.Validate(ctx, configMapCreate("cm2"), nil))
+	require.Error(t, p.Validate(ctx, configMapCreate("cm3"), nil))
+
+	del := newAttr(corev1.SchemeGroupVersion.WithResource("configmaps"), "cm1", admission.Delete, "")
+	require.NoError(t, p.Validate(ctx, del, nil))
+
+	require.NoError(t, p.Validate(ctx, configMapCreate("cm3"), nil), "delete must free up capacity")
+}
+
+func TestValidateSkips(t *testing.T) {
+	t.Parallel()
+
+	registry := objectcount.NewRegistry(1)
+	registry.SetEnforcementActive(true)
+
+	p := newPlugin(registry, newLogicalCluster(corev1alpha1.LogicalClusterPhaseReady, nil))
+	ctx := ctxWithCluster(t)
+
+	// fill up the quota
+	require.NoError(t, p.Validate(ctx, configMapCreate("cm1"), nil))
+	require.Error(t, p.Validate(ctx, configMapCreate("cm2"), nil))
+
+	tests := []struct {
+		name string
+		attr admission.Attributes
+	}{
+		{
+			name: "subresource",
+			attr: newAttr(corev1.SchemeGroupVersion.WithResource("configmaps"), "cm", admission.Create, "status"),
+		},
+		{
+			name: "logicalclusters",
+			attr: newAttr(corev1alpha1.SchemeGroupVersion.WithResource("logicalclusters"), "cluster", admission.Create, ""),
+		},
+		{
+			name: "workspace-admin clusterrolebinding",
+			attr: newAttr(schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"}, "workspace-admin", admission.Create, ""),
+		},
+		{
+			name: "core events",
+			attr: newAttr(corev1.SchemeGroupVersion.WithResource("events"), "ev", admission.Create, ""),
+		},
+		{
+			name: "events.k8s.io events",
+			attr: newAttr(schema.GroupVersionResource{Group: "events.k8s.io", Version: "v1", Resource: "events"}, "ev", admission.Create, ""),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.NoError(t, p.Validate(ctx, tt.attr, nil))
+		})
+	}
+}
+
+func TestValidateAllowsWithoutLogicalCluster(t *testing.T) {
+	t.Parallel()
+
+	registry := objectcount.NewRegistry(1)
+	registry.SetEnforcementActive(true)
+
+	p := newPlugin(registry) // no LogicalCluster object
+	ctx := ctxWithCluster(t)
+
+	require.NoError(t, p.Validate(ctx, configMapCreate("cm1"), nil))
+	require.NoError(t, p.Validate(ctx, configMapCreate("cm2"), nil), "bootstrap writes must be allowed")
+	require.Equal(t, int64(2), registry.Count(testCluster), "creates must still be tracked")
+}
+
+func TestValidateAllowsNonReadyLogicalCluster(t *testing.T) {
+	t.Parallel()
+
+	registry := objectcount.NewRegistry(1)
+	registry.SetEnforcementActive(true)
+
+	p := newPlugin(registry, newLogicalCluster(corev1alpha1.LogicalClusterPhaseInitializing, nil))
+	ctx := ctxWithCluster(t)
+
+	require.NoError(t, p.Validate(ctx, configMapCreate("cm1"), nil))
+	require.NoError(t, p.Validate(ctx, configMapCreate("cm2"), nil), "initialization writes must be allowed")
+}
+
+func TestValidateAnnotationOverride(t *testing.T) {
+	t.Parallel()
+
+	t.Run("raises the default", func(t *testing.T) {
+		t.Parallel()
+
+		registry := objectcount.NewRegistry(1)
+		registry.SetEnforcementActive(true)
+
+		p := newPlugin(registry, newLogicalCluster(corev1alpha1.LogicalClusterPhaseReady,
+			map[string]string{corev1alpha1.LogicalClusterMaxTotalObjectsAnnotationKey: "3"}))
+		ctx := ctxWithCluster(t)
+
+		require.NoError(t, p.Validate(ctx, configMapCreate("cm1"), nil))
+		require.NoError(t, p.Validate(ctx, configMapCreate("cm2"), nil))
+		require.NoError(t, p.Validate(ctx, configMapCreate("cm3"), nil))
+		require.Error(t, p.Validate(ctx, configMapCreate("cm4"), nil))
+	})
+
+	t.Run("zero opts out", func(t *testing.T) {
+		t.Parallel()
+
+		registry := objectcount.NewRegistry(1)
+		registry.SetEnforcementActive(true)
+
+		p := newPlugin(registry, newLogicalCluster(corev1alpha1.LogicalClusterPhaseReady,
+			map[string]string{corev1alpha1.LogicalClusterMaxTotalObjectsAnnotationKey: "0"}))
+		ctx := ctxWithCluster(t)
+
+		require.NoError(t, p.Validate(ctx, configMapCreate("cm1"), nil))
+		require.NoError(t, p.Validate(ctx, configMapCreate("cm2"), nil))
+	})
+}
+
+func TestValidateInitialization(t *testing.T) {
+	t.Parallel()
+
+	p := &objectCountLimit{Handler: admission.NewHandler(admission.Create, admission.Delete)}
+	require.Error(t, p.ValidateInitialization())
+
+	p.registry = objectcount.NewRegistry(0)
+	require.Error(t, p.ValidateInitialization())
+
+	p.logicalClusterLister = fakeLogicalClusterClusterLister{}
+	require.NoError(t, p.ValidateInitialization())
+}
+
+type fakeLogicalClusterClusterLister []*corev1alpha1.LogicalCluster
+
+func (l fakeLogicalClusterClusterLister) List(_ labels.Selector) ([]*corev1alpha1.LogicalCluster, error) {
+	return l, nil
+}
+
+func (l fakeLogicalClusterClusterLister) Cluster(cluster logicalcluster.Name) corev1alpha1listers.LogicalClusterLister {
+	var perCluster []*corev1alpha1.LogicalCluster
+	for _, lc := range l {
+		if logicalcluster.From(lc) == cluster {
+			perCluster = append(perCluster, lc)
+		}
+	}
+	return fakeLogicalClusterLister(perCluster)
+}
+
+type fakeLogicalClusterLister []*corev1alpha1.LogicalCluster
+
+func (l fakeLogicalClusterLister) List(_ labels.Selector) ([]*corev1alpha1.LogicalCluster, error) {
+	return l, nil
+}
+
+func (l fakeLogicalClusterLister) Get(name string) (*corev1alpha1.LogicalCluster, error) {
+	for _, lc := range l {
+		if lc.Name == name {
+			return lc, nil
+		}
+	}
+	return nil, apierrors.NewNotFound(corev1alpha1.Resource("logicalclusters"), name)
+}

--- a/pkg/admission/plugins.go
+++ b/pkg/admission/plugins.go
@@ -61,6 +61,7 @@ import (
 	kcpmutatingadmissionpolicy "github.com/kcp-dev/kcp/pkg/admission/mutatingadmissionpolicy"
 	kcpmutatingwebhook "github.com/kcp-dev/kcp/pkg/admission/mutatingwebhook"
 	workspacenamespacelifecycle "github.com/kcp-dev/kcp/pkg/admission/namespacelifecycle"
+	"github.com/kcp-dev/kcp/pkg/admission/objectcountlimit"
 	"github.com/kcp-dev/kcp/pkg/admission/pathannotation"
 	"github.com/kcp-dev/kcp/pkg/admission/permissionclaims"
 	"github.com/kcp-dev/kcp/pkg/admission/reservedcrdannotations"
@@ -101,6 +102,7 @@ var AllOrderedPlugins = beforeWebhooks(
 	reservedmetadata.PluginName,
 	permissionclaims.PluginName,
 	pathannotation.PluginName,
+	objectcountlimit.PluginName,
 	kubequota.PluginName,
 	mutatingadmissionpolicy.PluginName,
 	cachedresource.PluginName,
@@ -143,6 +145,7 @@ func RegisterAllKcpAdmissionPlugins(plugins *admission.Plugins) {
 	reservedmetadata.Register(plugins)
 	permissionclaims.Register(plugins)
 	pathannotation.Register(plugins)
+	objectcountlimit.Register(plugins)
 	kubequota.Register(plugins)
 	cachedresource.Register(plugins)
 }
@@ -174,6 +177,7 @@ var defaultOnPluginsInKcp = sets.New[string](
 	reservednames.PluginName,
 	permissionclaims.PluginName,
 	pathannotation.PluginName,
+	objectcountlimit.PluginName,
 	kubequota.PluginName,
 	cachedresource.PluginName,
 )

--- a/pkg/etcd/keys.go
+++ b/pkg/etcd/keys.go
@@ -104,6 +104,45 @@ func SplitKey(prefix, key string, lc logicalcluster.Name) (KeyParts, bool) {
 	return ret, true
 }
 
+// ClusterOf returns the logical cluster a storage key belongs to. Unlike
+// SplitKey it does not require a target logical cluster: the ambiguous
+// 5-segment case (group/resource/cluster/namespace/name for built-in
+// namespaced resources vs. group/resource/identity/cluster/name for
+// identity-based cluster-scoped resources) is resolved via isCluster, which
+// reports whether the given segment is a known logical cluster name.
+func ClusterOf(prefix, key string, isCluster func(string) bool) (logicalcluster.Name, bool) {
+	if !strings.HasPrefix(key, prefix) {
+		return "", false
+	}
+	rest := strings.TrimPrefix(key, prefix)
+	rest = strings.TrimPrefix(rest, "/")
+
+	parts := strings.SplitN(rest, "/", 6)
+
+	// key too short
+	if len(parts) < 3 {
+		return "", false
+	}
+
+	if parts[2] == "customresources" || len(parts) == 6 {
+		// group/resource/"customresources"/cluster/[namespace/]name
+		// group/resource/identity/cluster/namespace/name
+		if len(parts) < 4 {
+			return "", false
+		}
+		return logicalcluster.Name(parts[3]), true
+	}
+
+	if len(parts) == 5 && !isCluster(parts[2]) {
+		// group/resource/identity/cluster/name
+		return logicalcluster.Name(parts[3]), true
+	}
+
+	// group/resource/cluster/[namespace/]name
+	// group/resource/cluster/namespace/name
+	return logicalcluster.Name(parts[2]), true
+}
+
 // BelongsToCluster reports whether key belongs to logical cluster lc.
 // It checks both the built-in (parts[2]) and CRD/identity-based (parts[3])
 // cluster positions via SplitKey.

--- a/pkg/etcd/keys_test.go
+++ b/pkg/etcd/keys_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package etcd
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -117,6 +118,101 @@ func TestSplitKey(t *testing.T) {
 				return
 			}
 			assert.Equal(t, tt.wantKeyParts, keyParts)
+		})
+	}
+}
+
+func TestClusterOf(t *testing.T) {
+	t.Parallel()
+
+	knownClusters := map[string]bool{
+		"root:ws":    true,
+		"root:other": true,
+	}
+	isCluster := func(segment string) bool {
+		return strings.HasPrefix(segment, "system:") || knownClusters[segment]
+	}
+
+	tests := []struct {
+		name        string
+		prefix      string
+		key         string
+		wantOK      bool
+		wantCluster logicalcluster.Name
+	}{
+		{
+			name:        "built-in namespaced resource",
+			prefix:      "/registry/",
+			key:         "/registry/apps/deployments/root:ws/default/my-deploy",
+			wantOK:      true,
+			wantCluster: "root:ws",
+		},
+		{
+			name:        "built-in cluster-scoped resource",
+			prefix:      "/registry/",
+			key:         "/registry/rbac.authorization.k8s.io/clusterroles/root:ws/my-role",
+			wantOK:      true,
+			wantCluster: "root:ws",
+		},
+		{
+			name:        "CRD namespaced resource",
+			prefix:      "/registry/",
+			key:         "/registry/mygroup.io/widgets/customresources/root:ws/default/my-widget",
+			wantOK:      true,
+			wantCluster: "root:ws",
+		},
+		{
+			name:        "CRD cluster-scoped resource",
+			prefix:      "/registry/",
+			key:         "/registry/mygroup.io/widgets/customresources/root:ws/my-widget",
+			wantOK:      true,
+			wantCluster: "root:ws",
+		},
+		{
+			name:        "identity-based namespaced resource",
+			prefix:      "/registry/",
+			key:         "/registry/mygroup.io/widgets/abc123def/root:ws/default/my-widget",
+			wantOK:      true,
+			wantCluster: "root:ws",
+		},
+		{
+			name:        "identity-based cluster-scoped resource (ambiguous 5 segments)",
+			prefix:      "/registry/",
+			key:         "/registry/mygroup.io/widgets/abc123def/root:ws/my-widget",
+			wantOK:      true,
+			wantCluster: "root:ws",
+		},
+		{
+			name:        "system cluster",
+			prefix:      "/registry/",
+			key:         "/registry/core/configmaps/system:admin/default/cm",
+			wantOK:      true,
+			wantCluster: "system:admin",
+		},
+		{
+			name:   "key too short",
+			prefix: "/registry/",
+			key:    "/registry/apps/deployments",
+			wantOK: false,
+		},
+		{
+			name:   "no prefix match",
+			prefix: "/registry/",
+			key:    "/other/apps/deployments/root:ws/my-deploy",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cluster, ok := ClusterOf(tt.prefix, tt.key, isCluster)
+			require.Equal(t, tt.wantOK, ok)
+			if !ok {
+				return
+			}
+			assert.Equal(t, tt.wantCluster, cluster)
 		})
 	}
 }

--- a/pkg/objectcount/registry.go
+++ b/pkg/objectcount/registry.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package objectcount
+
+import (
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+	"github.com/kcp-dev/sdk/apis/core"
+	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
+)
+
+// Registry tracks the total number of objects per logical cluster on this
+// shard. A periodic etcd scan provides the authoritative base counts, and the
+// admission plugin applies deltas (+1 per admitted create, -1 per delete)
+// between scans. The effective count is base + delta. Every completed scan
+// replaces the base and resets all deltas, so any drift (e.g. from writes that
+// failed after admission) self-corrects within one scan interval.
+type Registry struct {
+	defaultLimit int64
+	active       atomic.Bool
+
+	mu    sync.RWMutex
+	base  map[logicalcluster.Name]int64
+	delta map[logicalcluster.Name]*atomic.Int64
+}
+
+// NewRegistry creates a Registry with the given shard-wide default limit.
+// A defaultLimit <= 0 means no default limit is enforced.
+func NewRegistry(defaultLimit int64) *Registry {
+	return &Registry{
+		defaultLimit: defaultLimit,
+		base:         map[logicalcluster.Name]int64{},
+		delta:        map[logicalcluster.Name]*atomic.Int64{},
+	}
+}
+
+// DefaultLimit returns the shard-wide default limit.
+func (r *Registry) DefaultLimit() int64 {
+	return r.defaultLimit
+}
+
+// EnforcementActive reports whether any limit is potentially in effect on
+// this shard. It is maintained by the scanner and serves as a cheap fast path
+// for admission when the feature is unused.
+func (r *Registry) EnforcementActive() bool {
+	return r.active.Load()
+}
+
+// SetEnforcementActive is called by the scanner to enable or disable
+// enforcement.
+func (r *Registry) SetEnforcementActive(active bool) {
+	r.active.Store(active)
+}
+
+// Count returns the effective object count for the given logical cluster.
+func (r *Registry) Count(cluster logicalcluster.Name) int64 {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	count := r.base[cluster]
+	if d, ok := r.delta[cluster]; ok {
+		count += d.Load()
+	}
+	return count
+}
+
+// Inc records an admitted object creation in the given logical cluster.
+func (r *Registry) Inc(cluster logicalcluster.Name) {
+	r.deltaFor(cluster).Add(1)
+}
+
+// Dec records an object deletion in the given logical cluster.
+func (r *Registry) Dec(cluster logicalcluster.Name) {
+	r.deltaFor(cluster).Add(-1)
+}
+
+func (r *Registry) deltaFor(cluster logicalcluster.Name) *atomic.Int64 {
+	r.mu.RLock()
+	d, ok := r.delta[cluster]
+	r.mu.RUnlock()
+	if ok {
+		return d
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if d, ok := r.delta[cluster]; ok {
+		return d
+	}
+	d = &atomic.Int64{}
+	r.delta[cluster] = d
+	return d
+}
+
+// ReplaceBase replaces the authoritative base counts with the result of a
+// completed scan and resets all deltas.
+func (r *Registry) ReplaceBase(counts map[logicalcluster.Name]int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.base = counts
+	r.delta = map[logicalcluster.Name]*atomic.Int64{}
+}
+
+// LimitFor resolves the effective limit for a logical cluster from its
+// annotations, falling back to the shard-wide default. A return value <= 0
+// means no limit is enforced. An unparseable annotation value falls back to
+// the default.
+//
+// The shard-wide default does not apply to the root and system logical
+// clusters: the shard writes bootstrap content there after they are ready,
+// and a default limit would break shard bootstrapping (and upgrades adding
+// new root content). They can still be limited with an explicit annotation.
+func (r *Registry) LimitFor(cluster logicalcluster.Name, annotations map[string]string) int64 {
+	if v, ok := annotations[corev1alpha1.LogicalClusterMaxTotalObjectsAnnotationKey]; ok {
+		if limit, err := strconv.ParseInt(v, 10, 64); err == nil {
+			return limit
+		}
+	}
+	if cluster == core.RootCluster || strings.HasPrefix(string(cluster), "system:") {
+		return 0
+	}
+	return r.defaultLimit
+}

--- a/pkg/objectcount/registry_test.go
+++ b/pkg/objectcount/registry_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package objectcount
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+	"github.com/kcp-dev/sdk/apis/core"
+	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
+)
+
+func TestRegistryCountIncDec(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry(10)
+	ws := logicalcluster.Name("root:ws")
+
+	require.Equal(t, int64(0), r.Count(ws))
+
+	r.Inc(ws)
+	r.Inc(ws)
+	require.Equal(t, int64(2), r.Count(ws))
+
+	r.Dec(ws)
+	require.Equal(t, int64(1), r.Count(ws))
+
+	// other clusters are unaffected
+	require.Equal(t, int64(0), r.Count(logicalcluster.Name("root:other")))
+}
+
+func TestRegistryReplaceBaseResetsDeltas(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry(10)
+	ws := logicalcluster.Name("root:ws")
+	gone := logicalcluster.Name("root:gone")
+
+	r.Inc(ws)
+	r.Inc(gone)
+	require.Equal(t, int64(1), r.Count(ws))
+	require.Equal(t, int64(1), r.Count(gone))
+
+	r.ReplaceBase(map[logicalcluster.Name]int64{ws: 5})
+
+	require.Equal(t, int64(5), r.Count(ws), "base must replace delta")
+	require.Equal(t, int64(0), r.Count(gone), "disappeared clusters must reset to zero")
+
+	r.Inc(ws)
+	require.Equal(t, int64(6), r.Count(ws), "delta must apply on top of the new base")
+}
+
+func TestRegistryLimitFor(t *testing.T) {
+	t.Parallel()
+
+	ws := logicalcluster.Name("root:ws")
+
+	tests := []struct {
+		name         string
+		defaultLimit int64
+		cluster      logicalcluster.Name
+		annotations  map[string]string
+		want         int64
+	}{
+		{
+			name:         "no annotation falls back to default",
+			defaultLimit: 100,
+			cluster:      ws,
+			annotations:  nil,
+			want:         100,
+		},
+		{
+			name:         "annotation overrides default",
+			defaultLimit: 100,
+			cluster:      ws,
+			annotations:  map[string]string{corev1alpha1.LogicalClusterMaxTotalObjectsAnnotationKey: "5"},
+			want:         5,
+		},
+		{
+			name:         "annotation zero opts out",
+			defaultLimit: 100,
+			cluster:      ws,
+			annotations:  map[string]string{corev1alpha1.LogicalClusterMaxTotalObjectsAnnotationKey: "0"},
+			want:         0,
+		},
+		{
+			name:         "negative annotation opts out",
+			defaultLimit: 100,
+			cluster:      ws,
+			annotations:  map[string]string{corev1alpha1.LogicalClusterMaxTotalObjectsAnnotationKey: "-1"},
+			want:         -1,
+		},
+		{
+			name:         "unparseable annotation falls back to default",
+			defaultLimit: 100,
+			cluster:      ws,
+			annotations:  map[string]string{corev1alpha1.LogicalClusterMaxTotalObjectsAnnotationKey: "many"},
+			want:         100,
+		},
+		{
+			name:         "annotation enforces even without default",
+			defaultLimit: 0,
+			cluster:      ws,
+			annotations:  map[string]string{corev1alpha1.LogicalClusterMaxTotalObjectsAnnotationKey: "42"},
+			want:         42,
+		},
+		{
+			name:         "default does not apply to root",
+			defaultLimit: 100,
+			cluster:      core.RootCluster,
+			annotations:  nil,
+			want:         0,
+		},
+		{
+			name:         "default does not apply to system clusters",
+			defaultLimit: 100,
+			cluster:      logicalcluster.Name("system:admin"),
+			annotations:  nil,
+			want:         0,
+		},
+		{
+			name:         "annotation still applies to root",
+			defaultLimit: 100,
+			cluster:      core.RootCluster,
+			annotations:  map[string]string{corev1alpha1.LogicalClusterMaxTotalObjectsAnnotationKey: "7"},
+			want:         7,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			r := NewRegistry(tt.defaultLimit)
+			require.Equal(t, tt.want, r.LimitFor(tt.cluster, tt.annotations))
+		})
+	}
+}
+
+func TestRegistryConcurrentInc(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry(0)
+	ws := logicalcluster.Name("root:ws")
+
+	const goroutines = 20
+	const perGoroutine = 100
+
+	var wg sync.WaitGroup
+	for range goroutines {
+		wg.Go(func() {
+			for range perGoroutine {
+				r.Inc(ws)
+			}
+		})
+	}
+	wg.Wait()
+
+	require.Equal(t, int64(goroutines*perGoroutine), r.Count(ws))
+}

--- a/pkg/objectcount/scanner.go
+++ b/pkg/objectcount/scanner.go
@@ -1,0 +1,197 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package objectcount
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+	corev1alpha1listers "github.com/kcp-dev/sdk/client/listers/core/v1alpha1"
+
+	kcpetcd "github.com/kcp-dev/kcp/pkg/etcd"
+	"github.com/kcp-dev/kcp/pkg/server/metrics"
+)
+
+// Scanner periodically counts all objects per logical cluster on this shard
+// by scanning etcd keys and feeds the results into a Registry.
+type Scanner struct {
+	kv       clientv3.KV
+	prefix   string
+	interval time.Duration
+	registry *Registry
+	lcLister corev1alpha1listers.LogicalClusterClusterLister
+	shard    string
+
+	// published tracks the logical clusters currently exposed as metrics so
+	// their label sets can be deleted when they drop below the threshold.
+	published sets.Set[logicalcluster.Name]
+}
+
+// NewScanner creates a Scanner. prefix is the etcd storage prefix of this
+// shard.
+func NewScanner(
+	kv clientv3.KV,
+	prefix string,
+	interval time.Duration,
+	registry *Registry,
+	lcLister corev1alpha1listers.LogicalClusterClusterLister,
+	shardName string,
+) *Scanner {
+	if !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+	return &Scanner{
+		kv:        kv,
+		prefix:    prefix,
+		interval:  interval,
+		registry:  registry,
+		lcLister:  lcLister,
+		shard:     shardName,
+		published: sets.New[logicalcluster.Name](),
+	}
+}
+
+// Start runs the scanner until ctx is done.
+func (s *Scanner) Start(ctx context.Context) {
+	logger := klog.FromContext(ctx).WithValues("component", "objectcount-scanner")
+	ctx = klog.NewContext(ctx, logger)
+	wait.UntilWithContext(ctx, s.tick, s.interval)
+}
+
+func (s *Scanner) tick(ctx context.Context) {
+	logger := klog.FromContext(ctx)
+
+	lcs, err := s.lcLister.List(labels.Everything())
+	if err != nil {
+		logger.Error(err, "failed to list logical clusters, skipping object count scan")
+		return
+	}
+
+	// Limits per logical cluster and the set of known cluster names, used both
+	// for enforcement gating and for disambiguating etcd keys.
+	limits := make(map[logicalcluster.Name]int64, len(lcs))
+	clusterNames := sets.New[string]()
+	anyLimited := false
+	for _, lc := range lcs {
+		name := logicalcluster.From(lc)
+		clusterNames.Insert(string(name))
+		limit := s.registry.LimitFor(name, lc.Annotations)
+		limits[name] = limit
+		if limit > 0 {
+			anyLimited = true
+		}
+	}
+
+	active := s.registry.DefaultLimit() > 0 || anyLimited
+	s.registry.SetEnforcementActive(active)
+	if !active {
+		// Feature unused on this shard: skip the etcd scan and retract all
+		// published metrics.
+		for cluster := range s.published {
+			metrics.DeleteLogicalClusterObjectCount(s.shard, string(cluster))
+		}
+		s.published = sets.New[logicalcluster.Name]()
+		return
+	}
+
+	counts, err := s.scanOnce(ctx, clusterNames)
+	if err != nil {
+		logger.Error(err, "failed to scan etcd for object counts, keeping previous counts")
+		return
+	}
+
+	s.registry.ReplaceBase(counts)
+	s.publishMetrics(counts, limits)
+}
+
+// scanOnce performs one keys-only paginated pass over the whole storage
+// prefix and buckets object counts per logical cluster.
+func (s *Scanner) scanOnce(ctx context.Context, clusterNames sets.Set[string]) (map[logicalcluster.Name]int64, error) {
+	isCluster := func(segment string) bool {
+		return strings.HasPrefix(segment, "system:") || clusterNames.Has(segment)
+	}
+
+	counts := map[logicalcluster.Name]int64{}
+
+	key := s.prefix
+	for {
+		resp, err := s.kv.Get(ctx, key,
+			clientv3.WithRange(clientv3.GetPrefixRangeEnd(s.prefix)),
+			clientv3.WithKeysOnly(),
+			clientv3.WithLimit(kcpetcd.ScanPageSize),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list etcd keys: %w", err)
+		}
+
+		for _, kv := range resp.Kvs {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+
+			key := string(kv.Key)
+			// Events are not counted by the admission plugin either: they are
+			// short-lived, auto-generated, and needed to debug an exhausted
+			// logical cluster.
+			if rest := strings.TrimPrefix(key, s.prefix); strings.HasPrefix(rest, "core/events/") || strings.HasPrefix(rest, "events.k8s.io/events/") {
+				continue
+			}
+
+			cluster, ok := kcpetcd.ClusterOf(s.prefix, key, isCluster)
+			if !ok {
+				continue
+			}
+			counts[cluster]++
+		}
+
+		if !resp.More {
+			return counts, nil
+		}
+		key = string(resp.Kvs[len(resp.Kvs)-1].Key) + "\x00"
+	}
+}
+
+// publishMetrics publishes count/limit gauges for logical clusters at or
+// above 90% of their limit and retracts gauges for all others.
+func (s *Scanner) publishMetrics(counts map[logicalcluster.Name]int64, limits map[logicalcluster.Name]int64) {
+	published := sets.New[logicalcluster.Name]()
+	for cluster, limit := range limits {
+		if limit <= 0 {
+			continue
+		}
+		count := counts[cluster]
+		if count*10 >= limit*9 {
+			metrics.SetLogicalClusterObjectCount(s.shard, string(cluster), count, limit)
+			published.Insert(cluster)
+		}
+	}
+
+	for cluster := range s.published.Difference(published) {
+		metrics.DeleteLogicalClusterObjectCount(s.shard, string(cluster))
+	}
+	s.published = published
+}

--- a/pkg/objectcount/scanner_test.go
+++ b/pkg/objectcount/scanner_test.go
@@ -1,0 +1,228 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package objectcount
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/api/v3/mvccpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
+	corev1alpha1listers "github.com/kcp-dev/sdk/client/listers/core/v1alpha1"
+
+	kcpetcd "github.com/kcp-dev/kcp/pkg/etcd"
+)
+
+func TestScannerScanOnce(t *testing.T) {
+	t.Parallel()
+
+	kv := newFakeKV(map[string]string{
+		// built-in namespaced
+		"/registry/core/configmaps/root:ws/default/cm1": "v",
+		"/registry/core/configmaps/root:ws/default/cm2": "v",
+		// built-in cluster-scoped
+		"/registry/rbac.authorization.k8s.io/clusterroles/root:ws/role1": "v",
+		// CRD
+		"/registry/mygroup.io/widgets/customresources/root:ws/default/w1": "v",
+		// identity-based cluster-scoped (ambiguous 5 segments)
+		"/registry/mygroup.io/things/abc123def/root:ws/t1": "v",
+		// events must not be counted
+		"/registry/core/events/root:ws/default/ev1":          "v",
+		"/registry/events.k8s.io/events/root:ws/default/ev2": "v",
+		// other clusters
+		"/registry/core/configmaps/root:other/default/cm": "v",
+		"/registry/core/secrets/system:admin/default/s":   "v",
+	})
+
+	s := newTestScanner(kv, NewRegistry(0))
+
+	counts, err := s.scanOnce(context.Background(), sets.New("root:ws", "root:other"))
+	require.NoError(t, err)
+
+	require.Equal(t, map[logicalcluster.Name]int64{
+		"root:ws":      5,
+		"root:other":   1,
+		"system:admin": 1,
+	}, counts)
+}
+
+func TestScannerScanOncePaginates(t *testing.T) {
+	t.Parallel()
+
+	// More keys than one page (ScanPageSize = 1000) to force pagination.
+	kvs := map[string]string{}
+	total := int(kcpetcd.ScanPageSize) + 500
+	for i := range total {
+		kvs[fmt.Sprintf("/registry/core/configmaps/root:ws/default/cm-%05d", i)] = "v"
+	}
+	kv := newFakeKV(kvs)
+
+	s := newTestScanner(kv, NewRegistry(0))
+
+	counts, err := s.scanOnce(context.Background(), sets.New("root:ws"))
+	require.NoError(t, err)
+	require.Equal(t, map[logicalcluster.Name]int64{"root:ws": int64(total)}, counts)
+}
+
+func TestScannerTickGatesOnConfiguration(t *testing.T) {
+	t.Parallel()
+
+	kv := newFakeKV(map[string]string{
+		"/registry/core/configmaps/root:ws/default/cm1": "v",
+	})
+
+	tests := []struct {
+		name         string
+		defaultLimit int64
+		annotations  map[string]string
+		wantActive   bool
+		wantCount    int64
+	}{
+		{
+			name:         "disabled without default limit and annotations",
+			defaultLimit: 0,
+			wantActive:   false,
+			wantCount:    0,
+		},
+		{
+			name:         "enabled via default limit",
+			defaultLimit: 10,
+			wantActive:   true,
+			wantCount:    1,
+		},
+		{
+			name:         "enabled via annotation only",
+			defaultLimit: 0,
+			annotations:  map[string]string{corev1alpha1.LogicalClusterMaxTotalObjectsAnnotationKey: "10"},
+			wantActive:   true,
+			wantCount:    1,
+		},
+		{
+			name:         "annotation opt-out only does not enable",
+			defaultLimit: 0,
+			annotations:  map[string]string{corev1alpha1.LogicalClusterMaxTotalObjectsAnnotationKey: "0"},
+			wantActive:   false,
+			wantCount:    0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			registry := NewRegistry(tt.defaultLimit)
+			s := newTestScanner(kv, registry)
+			s.lcLister = fakeLogicalClusterClusterLister{
+				newLogicalCluster("root:ws", tt.annotations),
+			}
+
+			s.tick(context.Background())
+
+			require.Equal(t, tt.wantActive, registry.EnforcementActive())
+			require.Equal(t, tt.wantCount, registry.Count(logicalcluster.Name("root:ws")))
+		})
+	}
+}
+
+func newTestScanner(kv clientv3.KV, registry *Registry) *Scanner {
+	return NewScanner(kv, "/registry", time.Minute, registry, fakeLogicalClusterClusterLister{}, "root")
+}
+
+func newLogicalCluster(cluster logicalcluster.Name, annotations map[string]string) *corev1alpha1.LogicalCluster {
+	all := map[string]string{logicalcluster.AnnotationKey: string(cluster)}
+	maps.Copy(all, annotations)
+	return &corev1alpha1.LogicalCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        corev1alpha1.LogicalClusterName,
+			Annotations: all,
+		},
+	}
+}
+
+type fakeLogicalClusterClusterLister []*corev1alpha1.LogicalCluster
+
+func (l fakeLogicalClusterClusterLister) List(_ labels.Selector) ([]*corev1alpha1.LogicalCluster, error) {
+	return l, nil
+}
+
+func (l fakeLogicalClusterClusterLister) Cluster(cluster logicalcluster.Name) corev1alpha1listers.LogicalClusterLister {
+	panic("not implemented")
+}
+
+// fakeKV implements clientv3.KV for range reads with pagination, mirroring the
+// harness used by the logicalclustermigration data cleanup tests.
+type fakeKV struct {
+	kvs map[string]string
+}
+
+func newFakeKV(kvs map[string]string) *fakeKV { return &fakeKV{kvs: kvs} }
+
+func (f *fakeKV) Get(_ context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
+	op := clientv3.OpGet(key, opts...)
+	rangeEnd := string(op.RangeBytes())
+	limit := op.Limit()
+
+	keys := make([]string, 0, len(f.kvs))
+	for k := range f.kvs {
+		if k >= key && (rangeEnd == "" || k < rangeEnd) {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+
+	more := false
+	if limit > 0 && int64(len(keys)) > limit {
+		keys = keys[:limit]
+		more = true
+	}
+
+	resp := &clientv3.GetResponse{More: more}
+	for _, k := range keys {
+		resp.Kvs = append(resp.Kvs, &mvccpb.KeyValue{Key: []byte(k), Value: []byte(f.kvs[k])})
+	}
+	return resp, nil
+}
+
+func (f *fakeKV) Put(context.Context, string, string, ...clientv3.OpOption) (*clientv3.PutResponse, error) {
+	panic("not implemented")
+}
+
+func (f *fakeKV) Delete(context.Context, string, ...clientv3.OpOption) (*clientv3.DeleteResponse, error) {
+	panic("not implemented")
+}
+
+func (f *fakeKV) Compact(context.Context, int64, ...clientv3.CompactOption) (*clientv3.CompactResponse, error) {
+	panic("not implemented")
+}
+
+func (f *fakeKV) Do(context.Context, clientv3.Op) (clientv3.OpResponse, error) {
+	panic("not implemented")
+}
+
+func (f *fakeKV) Txn(context.Context) clientv3.Txn { panic("not implemented") }

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -73,6 +73,7 @@ import (
 	"github.com/kcp-dev/kcp/pkg/indexers"
 	"github.com/kcp-dev/kcp/pkg/informer"
 	"github.com/kcp-dev/kcp/pkg/network"
+	"github.com/kcp-dev/kcp/pkg/objectcount"
 	"github.com/kcp-dev/kcp/pkg/reconciler/dynamicrestmapper"
 	"github.com/kcp-dev/kcp/pkg/reconciler/migration/logicalclustermigration"
 	"github.com/kcp-dev/kcp/pkg/server/aggregatingcrdversiondiscovery"
@@ -140,6 +141,11 @@ type ExtraConfig struct {
 	MigrationDumpHandler     *migrationdump.Handler
 	openAPIv3Controller      *openapiv3.Controller
 	openAPIv3ServiceCache    *openapiv3.ServiceCache
+
+	// ObjectCountRegistry tracks the total object count per logical cluster on
+	// this shard, fed by a periodic etcd scan and admission-time deltas. It is
+	// shared between the objectcountlimit admission plugin and the scanner.
+	ObjectCountRegistry *objectcount.Registry
 
 	// URL getters depending on genericspiserver.ExternalAddress which is initialized on server run
 	ShardBaseURL             func() string
@@ -662,12 +668,14 @@ func NewConfig(ctx context.Context, opts kcpserveroptions.CompletedOptions) (*Co
 
 	c.ExtraConfig.quotaAdmissionStopCh = make(chan struct{})
 	c.ExtraConfig.MigratingLogicalClusters = logicalclustermigration.NewMigratingLogicalClusters()
+	c.ExtraConfig.ObjectCountRegistry = objectcount.NewRegistry(opts.Extra.LogicalClusterTotalObjectLimit)
 
 	// DynamicRESTMapper is initialized here, but it starts to be populated only once its controller starts.
 	c.DynamicRESTMapper = dynamicrestmapper.NewDynamicRESTMapper()
 
 	admissionPluginInitializers := []admission.PluginInitializer{ //nolint:prealloc
 		kcpadmissioninitializers.NewKcpInformersInitializer(c.KcpSharedInformerFactory, c.CacheKcpSharedInformerFactory),
+		kcpadmissioninitializers.NewObjectCountRegistryInitializer(c.ObjectCountRegistry),
 		kcpadmissioninitializers.NewKubeInformersInitializer(c.KubeSharedInformerFactory, c.CacheKubeSharedInformerFactory),
 		kcpadmissioninitializers.NewKubeClusterClientInitializer(c.KubeClusterClient),
 		kcpadmissioninitializers.NewKcpClusterClientInitializer(c.KcpClusterClient),

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -68,6 +68,7 @@ import (
 	cacheclient "github.com/kcp-dev/kcp/pkg/cache/client"
 	kcpfeatures "github.com/kcp-dev/kcp/pkg/features"
 	"github.com/kcp-dev/kcp/pkg/informer"
+	"github.com/kcp-dev/kcp/pkg/objectcount"
 	permissionclaimlabler "github.com/kcp-dev/kcp/pkg/permissionclaim"
 	"github.com/kcp-dev/kcp/pkg/reconciler/apis/apibinding"
 	"github.com/kcp-dev/kcp/pkg/reconciler/apis/apibindingdeletion"
@@ -1216,6 +1217,40 @@ func (s *Server) installLogicalClusterMigrationController(ctx context.Context, c
 		Runner: func(ctx context.Context) {
 			defer etcdClient.Close()
 			c.Start(ctx, 2)
+		},
+	})
+}
+
+// installObjectCountScanner starts the periodic etcd scan feeding the
+// per-logical-cluster object count registry used by the
+// core.kcp.io/LogicalClusterObjectCountLimit admission plugin. It runs on
+// every replica because the registry is per-process, in-memory state the
+// local admission chain depends on.
+func (s *Server) installObjectCountScanner(_ context.Context) error {
+	etcdClient, err := s.newEtcdClient()
+	if err != nil {
+		return err
+	}
+
+	scanner := objectcount.NewScanner(
+		etcdClient,
+		s.Options.GenericControlPlane.Etcd.StorageConfig.Prefix,
+		s.Options.Extra.LogicalClusterObjectCountScanInterval,
+		s.ObjectCountRegistry,
+		s.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters().Lister(),
+		s.Options.Extra.ShardName,
+	)
+
+	return s.registerControllerWithoutLeaderElection(&controllerWrapper{
+		Name: "kcp-logicalcluster-objectcount-scanner",
+		Wait: func(ctx context.Context, s *Server) error {
+			return wait.PollUntilContextCancel(ctx, waitPollInterval, true, func(ctx context.Context) (bool, error) {
+				return s.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters().Informer().HasSynced(), nil
+			})
+		},
+		Runner: func(ctx context.Context) {
+			defer etcdClient.Close()
+			scanner.Start(ctx)
 		},
 	})
 }

--- a/pkg/server/metrics/metrics.go
+++ b/pkg/server/metrics/metrics.go
@@ -88,6 +88,27 @@ var (
 		},
 		[]string{"shard"},
 	)
+
+	// logicalClusterObjectCount and logicalClusterObjectLimit are only
+	// published for logical clusters at or above 90% of their total object
+	// count limit to keep the label cardinality bounded.
+	logicalClusterObjectCount = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Name:           "kcp_logicalcluster_object_count",
+			Help:           "Total number of objects in a logical cluster. Only published for logical clusters at or above 90% of their total object count limit.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"shard", "cluster"},
+	)
+
+	logicalClusterObjectLimit = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Name:           "kcp_logicalcluster_object_limit",
+			Help:           "Effective total object count limit of a logical cluster. Only published for logical clusters at or above 90% of their total object count limit.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"shard", "cluster"},
+	)
 )
 
 func init() {
@@ -98,6 +119,22 @@ func init() {
 	legacyregistry.MustRegister(apiBindingReadyDurationMs)
 	legacyregistry.MustRegister(apiExportConditionStatus)
 	legacyregistry.MustRegister(apiExportReadyDurationMs)
+	legacyregistry.MustRegister(logicalClusterObjectCount)
+	legacyregistry.MustRegister(logicalClusterObjectLimit)
+}
+
+// SetLogicalClusterObjectCount publishes the total object count and effective
+// limit for the given logical cluster.
+func SetLogicalClusterObjectCount(shardName, cluster string, count, limit int64) {
+	logicalClusterObjectCount.WithLabelValues(shardName, cluster).Set(float64(count))
+	logicalClusterObjectLimit.WithLabelValues(shardName, cluster).Set(float64(limit))
+}
+
+// DeleteLogicalClusterObjectCount stops publishing object count metrics for
+// the given logical cluster.
+func DeleteLogicalClusterObjectCount(shardName, cluster string) {
+	logicalClusterObjectCount.DeleteLabelValues(shardName, cluster)
+	logicalClusterObjectLimit.DeleteLabelValues(shardName, cluster)
 }
 
 // IncrementLogicalClusterCount increments the count for the given shard and phase.

--- a/pkg/server/options/options.go
+++ b/pkg/server/options/options.go
@@ -74,6 +74,8 @@ type ExtraOptions struct {
 	MountProxyClientKeyFile               string
 	DiscoveryPollInterval                 time.Duration
 	ExperimentalBindFreePort              bool
+	LogicalClusterTotalObjectLimit        int64
+	LogicalClusterObjectCountScanInterval time.Duration
 	LogicalClusterAdminKubeconfig         string
 	ExternalLogicalClusterAdminKubeconfig string
 	ConversionCELTransformationTimeout    time.Duration
@@ -128,6 +130,9 @@ func NewOptions(rootDir string) *Options {
 			DiscoveryPollInterval:              60 * time.Second,
 			ExperimentalBindFreePort:           false,
 			ConversionCELTransformationTimeout: time.Second,
+
+			LogicalClusterTotalObjectLimit:        0,
+			LogicalClusterObjectCountScanInterval: 60 * time.Second,
 
 			BatteriesIncluded:   sets.List[string](batteries.Defaults),
 			ServiceAccountCache: saCache,
@@ -195,6 +200,9 @@ func (o *Options) AddFlags(fss *cliflag.NamedFlagSets) {
 	fs.MarkHidden("external-hostname") //nolint:errcheck
 
 	fs.DurationVar(&o.Extra.ConversionCELTransformationTimeout, "conversion-cel-transformation-timeout", o.Extra.ConversionCELTransformationTimeout, "Maximum amount of time that CEL transformations may take per object conversion.")
+
+	fs.Int64Var(&o.Extra.LogicalClusterTotalObjectLimit, "logical-cluster-total-object-limit", o.Extra.LogicalClusterTotalObjectLimit, "Maximum total number of objects allowed in a logical cluster on this shard. 0 disables the default limit. The "+corev1alpha1.LogicalClusterMaxTotalObjectsAnnotationKey+" annotation on a LogicalCluster overrides this value for that logical cluster.")
+	fs.DurationVar(&o.Extra.LogicalClusterObjectCountScanInterval, "logical-cluster-object-count-scan-interval", o.Extra.LogicalClusterObjectCountScanInterval, "Interval at which etcd is scanned to count objects per logical cluster for total object count limit enforcement.")
 
 	fs.StringSliceVar(&o.Extra.BatteriesIncluded, "batteries-included", o.Extra.BatteriesIncluded, fmt.Sprintf(
 		`A list of batteries included (= default objects that might be unwanted in production, but are very helpful in trying out kcp or for development). These are the possible values: %s.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -745,6 +745,13 @@ func (s *Server) Run(ctx context.Context) error {
 			return err
 		}
 	}
+	// Registered outside of installControllers so that it is registered exactly
+	// once per process: it runs on every replica, independent of leader election,
+	// because it feeds per-process, in-memory state used by the local admission chain.
+	if err := s.installObjectCountScanner(ctx); err != nil {
+		return err
+	}
+
 	if err := s.AddPostStartHook("kcp-start-controllers", func(hookContext genericapiserver.PostStartHookContext) error {
 		logger := klog.FromContext(ctx).WithValues("postStartHook", "kcp-start-controllers")
 		controllerCtx := klog.NewContext(hookContext, logger)

--- a/staging/src/github.com/kcp-dev/sdk/apis/core/v1alpha1/logicalcluster_types.go
+++ b/staging/src/github.com/kcp-dev/sdk/apis/core/v1alpha1/logicalcluster_types.go
@@ -74,6 +74,12 @@ const (
 	// LogicalClusterShardAnnotationKey is the shard name the LogicalCluster is scheduled on.
 	// This annotation is set on both the LogicalCluster and its owner, if the owner is set.
 	LogicalClusterShardAnnotationKey = "core.kcp.io/shard"
+
+	// LogicalClusterMaxTotalObjectsAnnotationKey overrides the shard-wide default
+	// limit on the total number of objects in this logical cluster. A value <= 0
+	// disables the limit for this logical cluster. The annotation is protected by
+	// the ReservedMetadata admission plugin, i.e. only system users may set it.
+	LogicalClusterMaxTotalObjectsAnnotationKey = "core.kcp.io/max-total-objects"
 )
 
 // LogicalClusterPhaseType is the type of the current phase of the logical cluster.

--- a/test/e2e/quota/objectcount_test.go
+++ b/test/e2e/quota/objectcount_test.go
@@ -1,0 +1,234 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package quota
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
+	"github.com/kcp-dev/logicalcluster/v3"
+	"github.com/kcp-dev/sdk/apis/core"
+	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
+	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
+	kcptesting "github.com/kcp-dev/sdk/testing"
+	kcptestinghelpers "github.com/kcp-dev/sdk/testing/helpers"
+	kcptestingserver "github.com/kcp-dev/sdk/testing/server"
+
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+)
+
+// TestLogicalClusterTotalObjectCountLimit exercises the poor man's quota: a
+// hard limit on the total number of objects in a logical cluster, configured
+// via the core.kcp.io/max-total-objects annotation on the LogicalCluster.
+func TestLogicalClusterTotalObjectCountLimit(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "control-plane")
+
+	// A private server is used because the object count scanner needs a fast
+	// scan interval for the test to be quick. No shard-wide default limit is
+	// set (it would also apply to the root workspace); enforcement is enabled
+	// per logical cluster via the annotation.
+	server := kcptesting.PrivateKcpServer(t,
+		kcptestingserver.WithCustomArguments("--logical-cluster-object-count-scan-interval=1s"),
+	)
+	cfg := server.BaseConfig(t)
+
+	kcpClusterClient, err := kcpclientset.NewForConfig(cfg)
+	require.NoError(t, err, "error creating kcp cluster client")
+	kubeClusterClient, err := kcpkubernetesclientset.NewForConfig(cfg)
+	require.NoError(t, err, "error creating kube cluster client")
+
+	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
+	wsPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)
+
+	const limit = 40
+
+	t.Logf("Setting the max total objects annotation to %d on the LogicalCluster of %q", limit, wsPath)
+	setMaxTotalObjectsAnnotation(t, kcpClusterClient, wsPath, fmt.Sprintf("%d", limit))
+
+	t.Logf("Creating ConfigMaps in %q until the total object count limit is reached", wsPath)
+	created := make([]string, 0, limit)
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		name := fmt.Sprintf("quota-test-%d", len(created))
+		_, err := kubeClusterClient.Cluster(wsPath).CoreV1().ConfigMaps("default").Create(t.Context(), &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+		}, metav1.CreateOptions{})
+		switch {
+		case err == nil:
+			created = append(created, name)
+			if len(created) > 2*limit {
+				t.Fatalf("created %d ConfigMaps without hitting the limit of %d", len(created), limit)
+			}
+			return false, fmt.Sprintf("created %d ConfigMaps so far, limit not reached yet", len(created))
+		case apierrors.IsForbidden(err):
+			require.Contains(t, err.Error(), "total object count limit", "unexpected forbidden error")
+			return true, ""
+		default:
+			return false, err.Error()
+		}
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "expected creates to eventually be forbidden")
+	require.NotEmpty(t, created, "expected at least one ConfigMap to be created before hitting the limit")
+
+	t.Logf("Deleting one ConfigMap to free up capacity")
+	err = kubeClusterClient.Cluster(wsPath).CoreV1().ConfigMaps("default").Delete(t.Context(), created[0], metav1.DeleteOptions{})
+	require.NoError(t, err, "deletes must always be allowed")
+
+	t.Logf("Verifying that one create slot is free again")
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		_, err := kubeClusterClient.Cluster(wsPath).CoreV1().ConfigMaps("default").Create(t.Context(), &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "quota-test-refill"},
+		}, metav1.CreateOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+		return true, ""
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "expected create to succeed after delete freed capacity")
+
+	t.Logf("Verifying that creates are rejected again once the limit is reached")
+	rejected := 0
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		_, err := kubeClusterClient.Cluster(wsPath).CoreV1().ConfigMaps("default").Create(t.Context(), &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("quota-test-again-%d", rejected)},
+		}, metav1.CreateOptions{})
+		switch {
+		case err == nil:
+			rejected++
+			return false, "create still succeeding"
+		case apierrors.IsForbidden(err):
+			return true, ""
+		default:
+			return false, err.Error()
+		}
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "expected creates to eventually be forbidden again")
+
+	t.Logf("Opting the logical cluster out via annotation value 0")
+	setMaxTotalObjectsAnnotation(t, kcpClusterClient, wsPath, "0")
+
+	t.Logf("Verifying that creates succeed again")
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		_, err := kubeClusterClient.Cluster(wsPath).CoreV1().ConfigMaps("default").Create(t.Context(), &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "quota-test-unlimited"},
+		}, metav1.CreateOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+		return true, ""
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "expected creates to succeed after opting out")
+
+	t.Logf("Verifying that other logical clusters are not affected")
+	otherPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)
+	_, err = kubeClusterClient.Cluster(otherPath).CoreV1().ConfigMaps("default").Create(t.Context(), &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "quota-test-other"},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err, "expected create in another workspace to succeed")
+}
+
+// TestLogicalClusterTotalObjectCountLimitShardDefault exercises the shard-wide
+// default limit set via the --logical-cluster-total-object-limit flag: a fresh
+// workspace without any annotation must inherit the default, while the root
+// logical cluster is exempted from the default by design (the shard writes
+// bootstrap content there, and a default limit must never break that).
+func TestLogicalClusterTotalObjectCountLimitShardDefault(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "control-plane")
+
+	const limit = 60
+
+	// The server starting up at all already proves the root exemption: root
+	// contains far more bootstrap objects than the test limit.
+	server := kcptesting.PrivateKcpServer(t,
+		kcptestingserver.WithCustomArguments(
+			fmt.Sprintf("--logical-cluster-total-object-limit=%d", limit),
+			"--logical-cluster-object-count-scan-interval=1s",
+		),
+	)
+	cfg := server.BaseConfig(t)
+
+	kcpClusterClient, err := kcpclientset.NewForConfig(cfg)
+	require.NoError(t, err, "error creating kcp cluster client")
+	kubeClusterClient, err := kcpkubernetesclientset.NewForConfig(cfg)
+	require.NoError(t, err, "error creating kube cluster client")
+
+	wsPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path())
+
+	t.Logf("Creating ConfigMaps in %q (no annotation) until the shard-wide default limit is reached", wsPath)
+	created := 0
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		_, err := kubeClusterClient.Cluster(wsPath).CoreV1().ConfigMaps("default").Create(t.Context(), &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("quota-default-test-%d", created)},
+		}, metav1.CreateOptions{})
+		switch {
+		case err == nil:
+			created++
+			if created > 2*limit {
+				t.Fatalf("created %d ConfigMaps without hitting the shard-wide default limit of %d", created, limit)
+			}
+			return false, fmt.Sprintf("created %d ConfigMaps so far, limit not reached yet", created)
+		case apierrors.IsForbidden(err):
+			require.Contains(t, err.Error(), "total object count limit", "unexpected forbidden error")
+			return true, ""
+		default:
+			return false, err.Error()
+		}
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "expected creates to eventually be forbidden by the shard-wide default limit")
+	require.NotZero(t, created, "expected at least one ConfigMap to be created before hitting the limit")
+
+	t.Logf("Verifying that root is exempted: creates into root must still succeed")
+	_, err = kubeClusterClient.Cluster(core.RootCluster.Path()).CoreV1().ConfigMaps("default").Create(t.Context(), &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "quota-default-test-root"},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err, "expected create in exempted root workspace to succeed")
+
+	t.Logf("Verifying that a per-workspace annotation overrides the shard-wide default")
+	setMaxTotalObjectsAnnotation(t, kcpClusterClient, wsPath, fmt.Sprintf("%d", 2*limit))
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		_, err := kubeClusterClient.Cluster(wsPath).CoreV1().ConfigMaps("default").Create(t.Context(), &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "quota-default-test-raised"},
+		}, metav1.CreateOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+		return true, ""
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "expected create to succeed after raising the limit via annotation")
+}
+
+func setMaxTotalObjectsAnnotation(t *testing.T, kcpClusterClient kcpclientset.ClusterInterface, path logicalcluster.Path, value string) {
+	t.Helper()
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		lc, err := kcpClusterClient.Cluster(path).CoreV1alpha1().LogicalClusters().Get(t.Context(), corev1alpha1.LogicalClusterName, metav1.GetOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+		if lc.Annotations == nil {
+			lc.Annotations = map[string]string{}
+		}
+		lc.Annotations[corev1alpha1.LogicalClusterMaxTotalObjectsAnnotationKey] = value
+		if _, err := kcpClusterClient.Cluster(path).CoreV1alpha1().LogicalClusters().Update(t.Context(), lc, metav1.UpdateOptions{}); err != nil {
+			return false, err.Error()
+		}
+		return true, ""
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "failed to set %s=%s", corev1alpha1.LogicalClusterMaxTotalObjectsAnnotationKey, value)
+}


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Implements #4235: a hard limit on the total number of objects in a logical cluster (across all resource types) — something ResourceQuota cannot express. Protects a shard from a single workspace, creating unbounded objects.

### How?

- A per-shard scanner periodically counts objects per logical cluster via a single keys-only etcd scan (`--logical-cluster-object-count-scan-interval`, default 60s). A new validating admission plugin (`core.kcp.io/LogicalClusterObjectCountLimit`) tracks deltas between scans (+1 create / −1 delete) and rejects creates with `403 Forbidden` once the limit is reached.
- Limit resolution: `core.kcp.io/max-total-objects` annotation on the LogicalCluster (admin-only, protected by `ReservedMetadata`) takes precedence; otherwise the shard-wide `--logical-cluster-total-object-limit` flag applies (default 0 = disabled). Annotation <= 0 opts a logical cluster out. The default never applies to r`oot/system:*` clusters so shard bootstrap can't be blocked.
- Deletes, updates, subresources, and events are never blocked; enforcement only starts once the logical cluster is Ready. Counts are eventually consistent by design ("poor man's quota") — drift self-corrects each scan.
- Metrics `kcp_logicalcluster_object_count{shard,cluster}` / `kcp_logicalcluster_object_limit` are published only for clusters at ≥90% of their limit to keep cardinality bounded.

## What Type of PR Is This?
/kind feature

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Add LogicalCluster quota limited --logical-cluster-object-count-scan-interval
```
