### PR TITLE
Share and refcount origin migration client across concurrent migrations

### DIFF
--- a/pkg/reconciler/migration/logicalclustermigration/controller.go
+++ b/pkg/reconciler/migration/logicalclustermigration/controller.go
@@ -43,7 +43,6 @@ import (
 	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
 	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 	migrationv1alpha1 "github.com/kcp-dev/sdk/apis/migration/v1alpha1"
-	kcpsdkclient "github.com/kcp-dev/sdk/client/clientset/versioned"
 	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
 	migrationv1alpha1client "github.com/kcp-dev/sdk/client/clientset/versioned/typed/migration/v1alpha1"
 	apisv1alpha1informers "github.com/kcp-dev/sdk/client/informers/externalversions/apis/v1alpha1"
@@ -111,7 +110,7 @@ func NewController(
 		getCRD: func(clusterName logicalcluster.Name, name string) (*apiextensionsv1.CustomResourceDefinition, error) {
 			return crdInformer.Lister().Cluster(clusterName).Get(name)
 		},
-		originClients: make(map[originClientKey]kcpsdkclient.Interface),
+		originClients: make(map[string]*originClientEntry),
 	}
 	c.copyPageFromOrigin = c.copyPageFromOriginViaHTTP
 
@@ -164,18 +163,21 @@ type Controller struct {
 
 	// originClientsMu guards originClients.
 	originClientsMu sync.Mutex
-	// originClients caches one client per (origin shard, logical cluster)
-	// pair so a paginated copy reuses the same underlying HTTP transport
-	// and connection pool across pages, instead of building a new one
-	// per page.
-	originClients map[originClientKey]kcpsdkclient.Interface
+	// originClients caches one client per origin shard, shared by every
+	// concurrent migration copying data from that shard, so they reuse
+	// the same underlying HTTP transport and connection pool instead of
+	// each building their own. Entries are refcounted (see
+	// originClientEntry) and only torn down once no migration is using
+	// them anymore.
+	originClients map[string]*originClientEntry
 }
 
-// originClientKey identifies a cached origin client for one migration's
-// data copy.
-type originClientKey struct {
-	originShardName string
-	lcName          logicalcluster.Name
+// originClientEntry is a refcounted, shared client for one origin shard.
+// refs tracks which logical clusters currently have a migration actively
+// copying data from this shard; the entry is dropped once refs is empty.
+type originClientEntry struct {
+	client kcpclientset.ClusterInterface
+	refs   map[logicalcluster.Name]struct{}
 }
 
 func (c *Controller) enqueue(obj interface{}) {

--- a/pkg/reconciler/migration/logicalclustermigration/datacopy.go
+++ b/pkg/reconciler/migration/logicalclustermigration/datacopy.go
@@ -28,7 +28,7 @@ import (
 	"github.com/kcp-dev/logicalcluster/v3"
 	"github.com/kcp-dev/sdk/apis/core"
 	migrationv1alpha1 "github.com/kcp-dev/sdk/apis/migration/v1alpha1"
-	kcpsdkclient "github.com/kcp-dev/sdk/client/clientset/versioned"
+	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
 
 	"github.com/kcp-dev/kcp/pkg/virtual/migratingworkspaces"
 )
@@ -47,10 +47,11 @@ import (
 func (c *Controller) copyPageFromOriginViaHTTP(ctx context.Context, lcName logicalcluster.Name, originShardName, continueToken string) (int64, string, error) {
 	logger := klog.FromContext(ctx)
 
-	client, err := c.originClient(lcName, originShardName)
+	shardClient, err := c.acquireOriginClient(lcName, originShardName)
 	if err != nil {
 		return 0, "", err
 	}
+	client := shardClient.Cluster(lcName.Path())
 
 	logger.V(2).Info("requesting logical cluster dump page from origin", "logicalCluster", lcName, "originShard", originShardName, "continue", continueToken)
 
@@ -83,45 +84,62 @@ func (c *Controller) copyPageFromOriginViaHTTP(ctx context.Context, lcName logic
 	return int64(len(dump.Status.Entries)), dump.Status.Continue, nil
 }
 
-// originClient returns the cached client for requesting LogicalClusterDump
-// pages of lcName from originShardName, creating and caching one if none
-// exists yet. Reusing the client across pages of the same copy avoids
-// building a new HTTP transport and connection pool per page.
-func (c *Controller) originClient(lcName logicalcluster.Name, originShardName string) (kcpsdkclient.Interface, error) {
-	key := originClientKey{originShardName: originShardName, lcName: lcName}
-
+// acquireOriginClient returns the shared, cluster-aware client for
+// originShardName, creating it if none exists yet, and records lcName as a
+// user of it. The underlying client is scoped to the origin shard's
+// migrating virtual workspace as a whole (not to any one logical cluster),
+// so every concurrent migration copying data from the same origin shard
+// reuses the same HTTP transport and connection pool - callers scope it to
+// their own logical cluster per request via shardClient.Cluster(path).
+//
+// Safe to call repeatedly for the same (originShardName, lcName) pair, e.g.
+// once per page of the same copy: recording lcName as a user is idempotent,
+// so it doesn't inflate a refcount.
+func (c *Controller) acquireOriginClient(lcName logicalcluster.Name, originShardName string) (kcpclientset.ClusterInterface, error) {
 	c.originClientsMu.Lock()
 	defer c.originClientsMu.Unlock()
 
-	if client, ok := c.originClients[key]; ok {
-		return client, nil
+	entry, ok := c.originClients[originShardName]
+	if !ok {
+		originShard, err := c.shardLister.Cluster(core.RootCluster).Get(originShardName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get origin shard %q: %w", originShardName, err)
+		}
+		if originShard.Spec.VirtualWorkspaceURL == "" {
+			return nil, fmt.Errorf("origin shard %q has no VirtualWorkspaceURL", originShardName)
+		}
+
+		cfg := rest.CopyConfig(c.externalLogicalClusterAdminConfig)
+		cfg.Host = originShard.Spec.VirtualWorkspaceURL + migratingworkspaces.URLFor()
+
+		client, err := kcpclientset.NewForConfig(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create origin migrating client: %w", err)
+		}
+
+		entry = &originClientEntry{client: client, refs: map[logicalcluster.Name]struct{}{}}
+		c.originClients[originShardName] = entry
 	}
 
-	originShard, err := c.shardLister.Cluster(core.RootCluster).Get(originShardName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get origin shard %q: %w", originShardName, err)
-	}
-	if originShard.Spec.VirtualWorkspaceURL == "" {
-		return nil, fmt.Errorf("origin shard %q has no VirtualWorkspaceURL", originShardName)
-	}
-
-	cfg := rest.CopyConfig(c.externalLogicalClusterAdminConfig)
-	cfg.Host = originShard.Spec.VirtualWorkspaceURL + migratingworkspaces.URLFor() + "/clusters/" + string(lcName)
-
-	client, err := kcpsdkclient.NewForConfig(cfg)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create origin migrating client: %w", err)
-	}
-
-	c.originClients[key] = client
-	return client, nil
+	entry.refs[lcName] = struct{}{}
+	return entry.client, nil
 }
 
-// evictOriginClient drops the cached client for lcName/originShardName once
-// its data copy is done, so the migration's HTTP transport doesn't linger
-// forever in the cache.
-func (c *Controller) evictOriginClient(lcName logicalcluster.Name, originShardName string) {
+// releaseOriginClient marks lcName as done with originShardName's client.
+// Once no logical cluster is using it anymore, the shared client is
+// dropped from the cache instead of lingering indefinitely. Safe to call
+// even if lcName never acquired the client (e.g. the migration failed
+// before ever reaching copyPageFromOriginViaHTTP).
+func (c *Controller) releaseOriginClient(lcName logicalcluster.Name, originShardName string) {
 	c.originClientsMu.Lock()
 	defer c.originClientsMu.Unlock()
-	delete(c.originClients, originClientKey{originShardName: originShardName, lcName: lcName})
+
+	entry, ok := c.originClients[originShardName]
+	if !ok {
+		return
+	}
+	delete(entry.refs, lcName)
+	if len(entry.refs) == 0 {
+		delete(c.originClients, originShardName)
+	}
 }

--- a/pkg/reconciler/migration/logicalclustermigration/datacopy_test.go
+++ b/pkg/reconciler/migration/logicalclustermigration/datacopy_test.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logicalclustermigration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+
+	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
+	"github.com/kcp-dev/logicalcluster/v3"
+	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
+	corev1alpha1listers "github.com/kcp-dev/sdk/client/listers/core/v1alpha1"
+)
+
+// newTestController returns a Controller with just enough wired up to
+// exercise acquireOriginClient/releaseOriginClient: a shardLister backed by
+// the given fixture shards (all in the root cluster, matching how
+// c.shardLister.Cluster(core.RootCluster).Get(name) is called), and a
+// harmless rest.Config. No network calls are made by these tests -
+// kcpclientset.NewForConfig only builds a client struct, it doesn't dial.
+func newTestController(t *testing.T, shards ...*corev1alpha1.Shard) *Controller {
+	t.Helper()
+
+	indexer := cache.NewIndexer(kcpcache.MetaClusterNamespaceKeyFunc, cache.Indexers{})
+	for _, shard := range shards {
+		require.NoError(t, indexer.Add(shard))
+	}
+
+	return &Controller{
+		shardLister:                       corev1alpha1listers.NewShardClusterLister(indexer),
+		externalLogicalClusterAdminConfig: &rest.Config{Host: "https://unused.invalid"},
+		originClients:                     make(map[string]*originClientEntry),
+	}
+}
+
+func newTestShard(name, virtualWorkspaceURL string) *corev1alpha1.Shard {
+	return &corev1alpha1.Shard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Annotations: map[string]string{logicalcluster.AnnotationKey: "root"},
+		},
+		Spec: corev1alpha1.ShardSpec{
+			VirtualWorkspaceURL: virtualWorkspaceURL,
+		},
+	}
+}
+
+func TestAcquireOriginClient_sharesOneClientAcrossLogicalClustersOnSameShard(t *testing.T) {
+	t.Parallel()
+
+	c := newTestController(t, newTestShard("shard-a", "https://shard-a.invalid"))
+
+	client1, err := c.acquireOriginClient(logicalcluster.Name("lc-1"), "shard-a")
+	require.NoError(t, err)
+
+	client2, err := c.acquireOriginClient(logicalcluster.Name("lc-2"), "shard-a")
+	require.NoError(t, err)
+
+	require.Same(t, client1, client2, "two logical clusters migrating from the same origin shard must share one client")
+}
+
+func TestAcquireOriginClient_separateShardsGetSeparateClients(t *testing.T) {
+	t.Parallel()
+
+	c := newTestController(t,
+		newTestShard("shard-a", "https://shard-a.invalid"),
+		newTestShard("shard-b", "https://shard-b.invalid"),
+	)
+
+	clientA, err := c.acquireOriginClient(logicalcluster.Name("lc-1"), "shard-a")
+	require.NoError(t, err)
+
+	clientB, err := c.acquireOriginClient(logicalcluster.Name("lc-1"), "shard-b")
+	require.NoError(t, err)
+
+	require.NotSame(t, clientA, clientB, "different origin shards must not share a client")
+}
+
+func TestAcquireOriginClient_repeatedAcquireForSameLogicalClusterIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	c := newTestController(t, newTestShard("shard-a", "https://shard-a.invalid"))
+	lc := logicalcluster.Name("lc-1")
+
+	client1, err := c.acquireOriginClient(lc, "shard-a")
+	require.NoError(t, err)
+
+	// Simulate copying several pages of the same migration: acquiring
+	// again for the same (shard, lc) pair must not create additional refs.
+	for range 3 {
+		client, err := c.acquireOriginClient(lc, "shard-a")
+		require.NoError(t, err)
+		require.Same(t, client1, client)
+	}
+
+	c.originClientsMu.Lock()
+	refCount := len(c.originClients["shard-a"].refs)
+	c.originClientsMu.Unlock()
+	require.Equal(t, 1, refCount, "repeated acquires for the same logical cluster must not inflate the refcount")
+
+	// A single release must be enough to fully drop it.
+	c.releaseOriginClient(lc, "shard-a")
+	c.originClientsMu.Lock()
+	_, stillCached := c.originClients["shard-a"]
+	c.originClientsMu.Unlock()
+	require.False(t, stillCached, "one release should fully drop an entry that was only ever acquired by one logical cluster")
+}
+
+func TestReleaseOriginClient_keepsSharedClientAliveUntilLastUserReleases(t *testing.T) {
+	t.Parallel()
+
+	c := newTestController(t, newTestShard("shard-a", "https://shard-a.invalid"))
+
+	client1, err := c.acquireOriginClient(logicalcluster.Name("lc-1"), "shard-a")
+	require.NoError(t, err)
+	_, err = c.acquireOriginClient(logicalcluster.Name("lc-2"), "shard-a")
+	require.NoError(t, err)
+
+	// lc-1 finishes first: the shared client must survive because lc-2 is
+	// still using it.
+	c.releaseOriginClient(logicalcluster.Name("lc-1"), "shard-a")
+
+	c.originClientsMu.Lock()
+	entry, stillCached := c.originClients["shard-a"]
+	c.originClientsMu.Unlock()
+	require.True(t, stillCached, "client must stay cached while lc-2 is still using it")
+	require.Same(t, client1, entry.client)
+
+	// lc-2 finishes: now it's the last user, the entry must be dropped.
+	c.releaseOriginClient(logicalcluster.Name("lc-2"), "shard-a")
+
+	c.originClientsMu.Lock()
+	_, stillCached = c.originClients["shard-a"]
+	c.originClientsMu.Unlock()
+	require.False(t, stillCached, "client must be dropped once the last user releases it")
+}
+
+func TestReleaseOriginClient_neverAcquiredIsANoop(t *testing.T) {
+	t.Parallel()
+
+	c := newTestController(t, newTestShard("shard-a", "https://shard-a.invalid"))
+
+	require.NotPanics(t, func() {
+		c.releaseOriginClient(logicalcluster.Name("never-acquired"), "shard-a")
+	})
+	require.NotPanics(t, func() {
+		c.releaseOriginClient(logicalcluster.Name("lc-1"), "shard-that-does-not-exist")
+	})
+}

--- a/pkg/reconciler/migration/logicalclustermigration/reconciler.go
+++ b/pkg/reconciler/migration/logicalclustermigration/reconciler.go
@@ -193,9 +193,11 @@ func (c *Controller) reconcileMigrating(ctx context.Context, migration *migratio
 	if requeue {
 		logger.V(2).Info("copied data page, more remaining", "logicalCluster", lcName, "entriesCopied", migration.Status.EntriesCopied)
 	} else {
-		// Copy is done, drop the cached origin client for this migration
-		// rather than keeping its HTTP transport around indefinitely.
-		c.evictOriginClient(lcName, migration.Status.OriginShard)
+		// Copy is done, release this migration's hold on the origin
+		// shard's shared client. It's only actually torn down once no
+		// other concurrent migration from the same origin shard is still
+		// using it.
+		c.releaseOriginClient(lcName, migration.Status.OriginShard)
 		logger.V(2).Info("data copied, transitioning to OriginCleanup", "logicalCluster", lcName, "entriesCopied", migration.Status.EntriesCopied)
 	}
 	return requeue, nil

--- a/test/e2e/logicalclustermigration/migration_test.go
+++ b/test/e2e/logicalclustermigration/migration_test.go
@@ -289,6 +289,160 @@ func TestFullMigration(t *testing.T) {
 	})
 }
 
+// TestConcurrentMigrationsFromSameOriginShard runs several migrations from
+// the same origin shard to the same destination shard at the same time.
+// The destination shard's controller shares one client per origin shard
+// across concurrent migrations (refcounted, torn down once the last user
+// releases it) instead of building one per migration - this exercises that
+// sharing isn't observable as internal state from a black-box e2e test, so
+// what's actually being checked is the thing that WOULD break if the
+// sharing/refcounting had a bug: every migration completes with the right
+// data, and none of them interfere with each other's copy.
+func TestConcurrentMigrationsFromSameOriginShard(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "control-plane")
+
+	server := kcptesting.SharedKcpServer(t)
+
+	if len(server.ShardNames()) < 2 {
+		t.Skip("requires multi-shard setup")
+	}
+
+	cfg := server.BaseConfig(t)
+	kcpClusterClient, err := kcpclientset.NewForConfig(cfg)
+	require.NoError(t, err)
+	kubeClusterClient, err := kcpkubernetesclientset.NewForConfig(cfg)
+	require.NoError(t, err)
+
+	shardNames := server.ShardNames()
+	originShard := shardNames[0]
+	destinationShard := shardNames[1]
+
+	const numMigrations = 3
+
+	t.Logf("Using origin shard %q and destination shard %q for %d concurrent migrations", originShard, destinationShard, numMigrations)
+
+	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path())
+
+	t.Logf("Creating APIBinding for migration.kcp.io in %s", orgPath)
+	_, err = kcpClusterClient.Cluster(orgPath).ApisV1alpha2().APIBindings().Create(
+		t.Context(),
+		&apisv1alpha2.APIBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "migration",
+			},
+			Spec: apisv1alpha2.APIBindingSpec{
+				Reference: apisv1alpha2.BindingReference{
+					Export: &apisv1alpha2.ExportBindingReference{
+						Path: core.RootCluster.Path().String(),
+						Name: "migration.kcp.io",
+					},
+				},
+			},
+		},
+		metav1.CreateOptions{},
+	)
+	require.NoError(t, err)
+
+	t.Logf("Waiting for migration APIBinding to be bound in %s", orgPath)
+	require.Eventually(t, func() bool {
+		binding, err := kcpClusterClient.Cluster(orgPath).ApisV1alpha2().APIBindings().Get(t.Context(), "migration", metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return binding.Status.Phase == apisv1alpha2.APIBindingPhaseBound
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "migration APIBinding never reached Bound phase")
+
+	// Set up all workspaces + their own distinct test data up front, all
+	// pinned to the same origin shard, so their migrations can genuinely
+	// overlap once kicked off below.
+	type target struct {
+		wsPath logicalcluster.Path
+		lcName logicalcluster.Name
+		cmName string
+	}
+	targets := make([]target, numMigrations)
+	for i := range numMigrations {
+		wsPath, ws := kcptesting.NewWorkspaceFixture(t, server, orgPath, kcptesting.WithShard(originShard))
+		lcName := logicalcluster.Name(ws.Spec.Cluster)
+		cmName := fmt.Sprintf("concurrent-migration-marker-%d", i)
+
+		t.Logf("Workspace %d: %s (logical cluster %s) created on shard %s", i, wsPath, lcName, originShard)
+
+		_, err := kubeClusterClient.Cluster(wsPath).CoreV1().ConfigMaps("default").Create(
+			t.Context(),
+			&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: cmName},
+				Data:       map[string]string{"workspace-index": fmt.Sprintf("%d", i)},
+			},
+			metav1.CreateOptions{},
+		)
+		require.NoError(t, err)
+
+		targets[i] = target{wsPath: wsPath, lcName: lcName, cmName: cmName}
+	}
+
+	// Kick off all migrations before waiting on any of them, to maximize
+	// the chance their copies genuinely overlap in time.
+	migrationNames := make([]string, numMigrations)
+	for i, tgt := range targets {
+		migrationName := fmt.Sprintf("concurrent-migration-%d", i)
+		migrationNames[i] = migrationName
+
+		t.Logf("Creating LogicalClusterMigration %q for %s from %s to %s", migrationName, tgt.lcName, originShard, destinationShard)
+		require.Eventually(t, func() bool {
+			_, err := kcpClusterClient.Cluster(orgPath).MigrationV1alpha1().LogicalClusterMigrations().Create(
+				t.Context(),
+				&migrationv1alpha1.LogicalClusterMigration{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: migrationName,
+					},
+					Spec: migrationv1alpha1.LogicalClusterMigrationSpec{
+						LogicalCluster:   tgt.lcName.String(),
+						DestinationShard: destinationShard,
+					},
+				},
+				metav1.CreateOptions{},
+			)
+			if err != nil {
+				t.Logf("failed to create LogicalClusterMigration %q: %v", migrationName, err)
+			}
+			return err == nil
+		}, wait.ForeverTestTimeout, 100*time.Millisecond, "failed to create LogicalClusterMigration %q", migrationName)
+	}
+
+	// Wait for + verify each migration in parallel: t.Parallel() subtests
+	// all pause here until every sibling has reached this point, then run
+	// concurrently, so the "wait for completion" below happens for all
+	// numMigrations migrations at once.
+	for i, tgt := range targets {
+		t.Run(migrationNames[i], func(t *testing.T) {
+			t.Parallel()
+
+			migrationName := migrationNames[i]
+
+			var completedMigration *migrationv1alpha1.LogicalClusterMigration
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				migration, err := kcpClusterClient.Cluster(orgPath).MigrationV1alpha1().LogicalClusterMigrations().Get(t.Context(), migrationName, metav1.GetOptions{})
+				require.NoError(c, err)
+				require.Equal(c, migrationv1alpha1.LogicalClusterMigrationPhaseCompleted, migration.Status.Phase)
+				completedMigration = migration
+			}, wait.ForeverTestTimeout, 500*time.Millisecond, "waiting for migration %q to complete", migrationName)
+
+			assert.Positive(t, completedMigration.Status.EntriesCopied, "status.entriesCopied should reflect the copied etcd entries for %q", migrationName)
+			assert.Empty(t, completedMigration.Status.DumpContinue, "status.dumpContinue should be cleared once %q is complete", migrationName)
+
+			// Data integrity: this workspace must have exactly its own
+			// marker ConfigMap - not missing (dropped by a racing copy)
+			// and not some other workspace's data (cross-contamination
+			// from an incorrectly-shared client/request).
+			cm, err := kubeClusterClient.Cluster(tgt.wsPath).CoreV1().ConfigMaps("default").Get(t.Context(), tgt.cmName, metav1.GetOptions{})
+			require.NoError(t, err, "marker ConfigMap %q missing after migration", tgt.cmName)
+			assert.Equal(t, fmt.Sprintf("%d", i), cm.Data["workspace-index"], "marker ConfigMap %q has wrong data - possible cross-contamination between concurrent migrations", tgt.cmName)
+		})
+	}
+}
+
 // TestMigrationAPIBindingUnprivileged verifies that the migration API
 // can't be bound even by cluster-admin users in other workspaces.
 func TestMigrationAPIBindingUnprivileged(t *testing.T) {


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary
- Key the destination shard's cached origin migration client by origin shard only (was `(originShard, logicalCluster)`), so concurrent migrations from the same origin shard share one client/HTTP transport instead of each building their own.
- Refcount each shard's cached client (`acquireOriginClient`/`releaseOriginClient`) so it's only torn down once the last concurrent migration using it finishes, instead of evicting per-migration.
- Follow-up from review on #4244.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/reconciler/migration/... ./pkg/server/migrationdump/... ./pkg/etcd/...`
- [x] New unit tests (datacopy_test.go) that directly check the sharing/refcount logic: logical clusters on the same shard share one client, different shards get different clients, calling acquire again for the same logical cluster doesn't double-count it, the shared client stays alive as long as at least one migration is still using it, and releasing something that was never acquired just does nothing instead of breaking.
- [x] New e2e test `TestConcurrentMigrationsFromSameOriginShard` - runs 3 migrations from the same origin shard at once and checks they all finish correctly with no data mixing between them. Passed locally on a real 2-shard cluster.
- [x] Also tested it live by hand: ran 3 migrations concurrently on a local cluster with a temporary delay added to make sure they would actually overlap, and checked the logs - only one client got created and one got torn down for all 3, not one each. Removed the temporary delay after.

## What Type of PR Is This?
/kind feature
<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #4267

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
No user-facing behavior changes here — this only affects internal HTTP client reuse during migrations.
```
