### PR TITLE
[1/2] APIBinding resource adoption on binding deletion

### DIFF
--- a/pkg/reconciler/apis/apibindingdeletion/apibinding_adoption.go
+++ b/pkg/reconciler/apis/apibindingdeletion/apibinding_adoption.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apibindingdeletion
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
+)
+
+// adoptedResources returns, per bound group/resource of the deleting
+// APIBinding, the name of another APIBinding in the same workspace that will
+// take the instances over. Instances of an adopted resource must not be
+// deleted when this APIBinding is deleted: the successor serves them
+// unchanged.
+//
+// A binding is a successor for a bound resource only if its referenced
+// APIExport serves the same group/resource through the same APIResourceSchema
+// (by UID) with the same identity hash. That guarantees identical storage
+// (same etcd prefix) and identical served API (same bound CRD), so the
+// handover moves no data.
+//
+// Lookups go through (possibly lagging) informers. A just-created successor
+// can be missed on one pass; the deleting binding is requeued and re-evaluated
+// while its instances remain, so a transient miss only delays the handover.
+func (c *Controller) adoptedResources(clusterName logicalcluster.Name, apibinding *apisv1alpha2.APIBinding) (map[schema.GroupResource]string, error) {
+	bindings, err := c.listAPIBindings(clusterName)
+	if err != nil {
+		return nil, err
+	}
+	candidates := make([]*apisv1alpha2.APIBinding, 0, len(bindings))
+	for _, b := range bindings {
+		if b.Name == apibinding.Name || !b.DeletionTimestamp.IsZero() {
+			continue
+		}
+		candidates = append(candidates, b)
+	}
+
+	adopted := map[schema.GroupResource]string{}
+	for _, br := range apibinding.Status.BoundResources {
+		if successor, ok := c.successorFor(clusterName, candidates, br); ok {
+			adopted[schema.GroupResource{Group: br.Group, Resource: br.Resource}] = successor
+		}
+	}
+
+	return adopted, nil
+}
+
+// successorFor returns the name of an APIBinding among candidates whose
+// referenced APIExport serves the given bound resource through the same
+// APIResourceSchema (by UID) with the same identity hash.
+func (c *Controller) successorFor(clusterName logicalcluster.Name, candidates []*apisv1alpha2.APIBinding, br apisv1alpha2.BoundAPIResource) (string, bool) {
+	for _, b := range candidates {
+		if b.Spec.Reference.Export == nil {
+			continue
+		}
+		path := logicalcluster.NewPath(b.Spec.Reference.Export.Path)
+		if path.Empty() {
+			path = clusterName.Path()
+		}
+		export, err := c.getAPIExportByPath(path, b.Spec.Reference.Export.Name)
+		if err != nil {
+			// A candidate whose export cannot be resolved cannot be verified as
+			// same-storage; skip it rather than block deletion on a dangling
+			// reference.
+			continue
+		}
+		if export.Status.IdentityHash != br.Schema.IdentityHash {
+			continue
+		}
+		for _, res := range export.Spec.Resources {
+			if res.Group != br.Group || res.Name != br.Resource {
+				continue
+			}
+			sch, err := c.getAPIResourceSchema(logicalcluster.From(export), res.Schema)
+			if err != nil {
+				continue
+			}
+			if string(sch.UID) == br.Schema.UID {
+				return b.Name, true
+			}
+		}
+	}
+
+	return "", false
+}

--- a/pkg/reconciler/apis/apibindingdeletion/apibinding_adoption_test.go
+++ b/pkg/reconciler/apis/apibindingdeletion/apibinding_adoption_test.go
@@ -1,0 +1,249 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apibindingdeletion
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+	apisv1alpha1 "github.com/kcp-dev/sdk/apis/apis/v1alpha1"
+	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
+)
+
+const (
+	testCluster      = "root:consumer"
+	providerPath     = "root:provider"
+	cowboySchemaName = "v1.cowboys.wildwest.dev"
+	cowboySchemaUID  = "cowboy-schema-uid"
+	identity         = "abc123"
+)
+
+func deletingBinding() *apisv1alpha2.APIBinding {
+	now := metav1.Now()
+	return &apisv1alpha2.APIBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "wildwest",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{APIBindingFinalizer},
+			Annotations:       map[string]string{logicalcluster.AnnotationKey: testCluster},
+		},
+		Status: apisv1alpha2.APIBindingStatus{
+			BoundResources: []apisv1alpha2.BoundAPIResource{
+				{
+					Group:           "wildwest.dev",
+					Resource:        "cowboys",
+					StorageVersions: []string{"v1alpha1"},
+					Schema: apisv1alpha2.BoundAPIResourceSchema{
+						Name:         cowboySchemaName,
+						UID:          cowboySchemaUID,
+						IdentityHash: identity,
+					},
+				},
+			},
+		},
+	}
+}
+
+func candidateBinding(name, exportName string) *apisv1alpha2.APIBinding {
+	return &apisv1alpha2.APIBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Annotations: map[string]string{logicalcluster.AnnotationKey: testCluster},
+		},
+		Spec: apisv1alpha2.APIBindingSpec{
+			Reference: apisv1alpha2.BindingReference{
+				Export: &apisv1alpha2.ExportBindingReference{
+					Path: providerPath,
+					Name: exportName,
+				},
+			},
+		},
+	}
+}
+
+func cowboysExport(name, identityHash, schemaName string) *apisv1alpha2.APIExport {
+	return &apisv1alpha2.APIExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Annotations: map[string]string{logicalcluster.AnnotationKey: providerPath},
+		},
+		Spec: apisv1alpha2.APIExportSpec{
+			Resources: []apisv1alpha2.ResourceSchema{
+				{
+					Group:  "wildwest.dev",
+					Name:   "cowboys",
+					Schema: schemaName,
+				},
+			},
+		},
+		Status: apisv1alpha2.APIExportStatus{
+			IdentityHash: identityHash,
+		},
+	}
+}
+
+func TestAdoptedResources(t *testing.T) {
+	t.Parallel()
+
+	cowboysGR := schema.GroupResource{Group: "wildwest.dev", Resource: "cowboys"}
+
+	tests := []struct {
+		name     string
+		bindings []*apisv1alpha2.APIBinding
+		exports  map[string]*apisv1alpha2.APIExport
+		schemas  map[string]*apisv1alpha1.APIResourceSchema
+
+		expectSuccessor string // "" means not adopted
+	}{
+		{
+			name: "no candidates: not adopted",
+		},
+		{
+			name:     "successor with same schema UID and identity: adopted",
+			bindings: []*apisv1alpha2.APIBinding{candidateBinding("cowboys", "cowboys")},
+			exports: map[string]*apisv1alpha2.APIExport{
+				"cowboys": cowboysExport("cowboys", identity, cowboySchemaName),
+			},
+			schemas: map[string]*apisv1alpha1.APIResourceSchema{
+				cowboySchemaName: {ObjectMeta: metav1.ObjectMeta{Name: cowboySchemaName, UID: types.UID(cowboySchemaUID)}},
+			},
+			expectSuccessor: "cowboys",
+		},
+		{
+			name:     "successor export has different identity: not adopted",
+			bindings: []*apisv1alpha2.APIBinding{candidateBinding("cowboys", "cowboys")},
+			exports: map[string]*apisv1alpha2.APIExport{
+				"cowboys": cowboysExport("cowboys", "other-identity", cowboySchemaName),
+			},
+			schemas: map[string]*apisv1alpha1.APIResourceSchema{
+				cowboySchemaName: {ObjectMeta: metav1.ObjectMeta{Name: cowboySchemaName, UID: types.UID(cowboySchemaUID)}},
+			},
+		},
+		{
+			name:     "successor schema has different UID: not adopted",
+			bindings: []*apisv1alpha2.APIBinding{candidateBinding("cowboys", "cowboys")},
+			exports: map[string]*apisv1alpha2.APIExport{
+				"cowboys": cowboysExport("cowboys", identity, cowboySchemaName),
+			},
+			schemas: map[string]*apisv1alpha1.APIResourceSchema{
+				cowboySchemaName: {ObjectMeta: metav1.ObjectMeta{Name: cowboySchemaName, UID: types.UID("other-uid")}},
+			},
+		},
+		{
+			name: "successor being deleted itself: ignored",
+			bindings: func() []*apisv1alpha2.APIBinding {
+				b := candidateBinding("cowboys", "cowboys")
+				now := metav1.Now()
+				b.DeletionTimestamp = &now
+				return []*apisv1alpha2.APIBinding{b}
+			}(),
+			exports: map[string]*apisv1alpha2.APIExport{
+				"cowboys": cowboysExport("cowboys", identity, cowboySchemaName),
+			},
+			schemas: map[string]*apisv1alpha1.APIResourceSchema{
+				cowboySchemaName: {ObjectMeta: metav1.ObjectMeta{Name: cowboySchemaName, UID: types.UID(cowboySchemaUID)}},
+			},
+		},
+		{
+			name:     "successor export unresolvable: not adopted",
+			bindings: []*apisv1alpha2.APIBinding{candidateBinding("cowboys", "cowboys")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			deleting := deletingBinding()
+			c := &Controller{
+				listAPIBindings: func(cluster logicalcluster.Name) ([]*apisv1alpha2.APIBinding, error) {
+					return append([]*apisv1alpha2.APIBinding{deleting}, tt.bindings...), nil
+				},
+				getAPIExportByPath: func(path logicalcluster.Path, name string) (*apisv1alpha2.APIExport, error) {
+					if export, ok := tt.exports[name]; ok {
+						return export, nil
+					}
+					return nil, fmt.Errorf("APIExport %s|%s not found", path, name)
+				},
+				getAPIResourceSchema: func(cluster logicalcluster.Name, name string) (*apisv1alpha1.APIResourceSchema, error) {
+					if sch, ok := tt.schemas[name]; ok {
+						return sch, nil
+					}
+					return nil, fmt.Errorf("APIResourceSchema %s|%s not found", cluster, name)
+				},
+			}
+
+			adopted, err := c.adoptedResources(logicalcluster.Name(testCluster), deleting)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			successor, ok := adopted[cowboysGR]
+			if (tt.expectSuccessor != "") != ok {
+				t.Fatalf("expected adopted=%v, got %v (%v)", tt.expectSuccessor != "", ok, adopted)
+			}
+			if successor != tt.expectSuccessor {
+				t.Errorf("expected successor %q, got %q", tt.expectSuccessor, successor)
+			}
+		})
+	}
+}
+
+func TestDeleteAllCRsSkipsAdopted(t *testing.T) {
+	t.Parallel()
+
+	deleting := deletingBinding()
+
+	deleted := map[schema.GroupVersionResource]bool{}
+	c := &Controller{
+		listAPIBindings: func(cluster logicalcluster.Name) ([]*apisv1alpha2.APIBinding, error) {
+			return []*apisv1alpha2.APIBinding{deleting, candidateBinding("cowboys", "cowboys")}, nil
+		},
+		getAPIExportByPath: func(path logicalcluster.Path, name string) (*apisv1alpha2.APIExport, error) {
+			return cowboysExport("cowboys", identity, cowboySchemaName), nil
+		},
+		getAPIResourceSchema: func(cluster logicalcluster.Name, name string) (*apisv1alpha1.APIResourceSchema, error) {
+			return &apisv1alpha1.APIResourceSchema{ObjectMeta: metav1.ObjectMeta{Name: cowboySchemaName, UID: types.UID(cowboySchemaUID)}}, nil
+		},
+		listResources: func(ctx context.Context, cluster logicalcluster.Path, gvr schema.GroupVersionResource) (*metav1.PartialObjectMetadataList, error) {
+			return &metav1.PartialObjectMetadataList{Items: []metav1.PartialObjectMetadata{
+				*newPartialObject("wildwest.dev/v1alpha1", "Cowboy", "luke", "saloon", nil),
+			}}, nil
+		},
+		deleteResources: func(ctx context.Context, cluster logicalcluster.Path, gvr schema.GroupVersionResource, namespace string) error {
+			deleted[gvr] = true
+			return nil
+		},
+	}
+
+	remaining, err := c.deleteAllCRs(context.Background(), deleting)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(deleted) != 0 {
+		t.Errorf("expected no deletions for adopted resources, got %v", deleted)
+	}
+	if len(remaining.gvrToNumRemaining) != 0 {
+		t.Errorf("adopted resources must not count as remaining (would block finalization), got %v", remaining.gvrToNumRemaining)
+	}
+}

--- a/pkg/reconciler/apis/apibindingdeletion/apibinding_deletion_controller.go
+++ b/pkg/reconciler/apis/apibindingdeletion/apibinding_deletion_controller.go
@@ -26,6 +26,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -36,13 +37,18 @@ import (
 	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
 	kcpmetadata "github.com/kcp-dev/client-go/metadata"
 	"github.com/kcp-dev/logicalcluster/v3"
+	apisv1alpha1 "github.com/kcp-dev/sdk/apis/apis/v1alpha1"
 	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
 	conditionsv1alpha1 "github.com/kcp-dev/sdk/apis/third_party/conditions/apis/conditions/v1alpha1"
 	"github.com/kcp-dev/sdk/apis/third_party/conditions/util/conditions"
 	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
 	apisv1alpha2client "github.com/kcp-dev/sdk/client/clientset/versioned/typed/apis/v1alpha2"
+	apisv1alpha1informers "github.com/kcp-dev/sdk/client/informers/externalversions/apis/v1alpha1"
 	apisv1alpha2informers "github.com/kcp-dev/sdk/client/informers/externalversions/apis/v1alpha2"
+	apisv1alpha1listers "github.com/kcp-dev/sdk/client/listers/apis/v1alpha1"
 
+	"github.com/kcp-dev/kcp/pkg/indexers"
+	"github.com/kcp-dev/kcp/pkg/informer"
 	"github.com/kcp-dev/kcp/pkg/logging"
 	"github.com/kcp-dev/kcp/pkg/reconciler/committer"
 	"github.com/kcp-dev/kcp/pkg/reconciler/core/logicalclusterdeletion/deletion"
@@ -72,6 +78,8 @@ func NewController(
 	metadataClient kcpmetadata.ClusterInterface,
 	kcpClusterClient kcpclientset.ClusterInterface,
 	apiBindingInformer apisv1alpha2informers.APIBindingClusterInformer,
+	apiExportInformer, globalAPIExportInformer apisv1alpha2informers.APIExportClusterInformer,
+	apiResourceSchemaInformer, globalAPIResourceSchemaInformer apisv1alpha1informers.APIResourceSchemaClusterInformer,
 ) *Controller {
 	c := &Controller{
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
@@ -91,8 +99,24 @@ func NewController(
 		getAPIBinding: func(cluster logicalcluster.Name, name string) (*apisv1alpha2.APIBinding, error) {
 			return apiBindingInformer.Lister().Cluster(cluster).Get(name)
 		},
-		commit: committer.NewCommitter[*APIBinding, Patcher, *APIBindingSpec, *APIBindingStatus](kcpClusterClient.ApisV1alpha2().APIBindings()),
+		listAPIBindings: func(cluster logicalcluster.Name) ([]*apisv1alpha2.APIBinding, error) {
+			return apiBindingInformer.Lister().Cluster(cluster).List(labels.Everything())
+		},
+		getAPIExportByPath: func(path logicalcluster.Path, name string) (*apisv1alpha2.APIExport, error) {
+			return indexers.ByPathAndNameWithFallback[*apisv1alpha2.APIExport](apisv1alpha2.Resource("apiexports"), apiExportInformer.Informer().GetIndexer(), globalAPIExportInformer.Informer().GetIndexer(), path, name)
+		},
+		getAPIResourceSchema: informer.NewScopedGetterWithFallback[*apisv1alpha1.APIResourceSchema, apisv1alpha1listers.APIResourceSchemaLister](apiResourceSchemaInformer.Lister(), globalAPIResourceSchemaInformer.Lister()),
+		commit:               committer.NewCommitter[*APIBinding, Patcher, *APIBindingSpec, *APIBindingStatus](kcpClusterClient.ApisV1alpha2().APIBindings()),
 	}
+
+	// Ensure the index used by getAPIExportByPath exists. AddIfNotPresentOrDie is
+	// idempotent across the controllers sharing these informer instances.
+	indexers.AddIfNotPresentOrDie(apiExportInformer.Informer().GetIndexer(), cache.Indexers{
+		indexers.ByLogicalClusterPathAndName: indexers.IndexByLogicalClusterPathAndName,
+	})
+	indexers.AddIfNotPresentOrDie(globalAPIExportInformer.Informer().GetIndexer(), cache.Indexers{
+		indexers.ByLogicalClusterPathAndName: indexers.IndexByLogicalClusterPathAndName,
+	})
 
 	_, _ = apiBindingInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: func(obj interface{}) bool {
@@ -125,8 +149,12 @@ type Controller struct {
 	listResources   func(ctx context.Context, cluster logicalcluster.Path, gvr schema.GroupVersionResource) (*metav1.PartialObjectMetadataList, error)
 	deleteResources func(ctx context.Context, cluster logicalcluster.Path, gvr schema.GroupVersionResource, namespace string) error
 
-	getAPIBinding func(cluster logicalcluster.Name, name string) (*apisv1alpha2.APIBinding, error)
-	commit        CommitFunc
+	getAPIBinding        func(cluster logicalcluster.Name, name string) (*apisv1alpha2.APIBinding, error)
+	listAPIBindings      func(cluster logicalcluster.Name) ([]*apisv1alpha2.APIBinding, error)
+	getAPIExportByPath   func(path logicalcluster.Path, name string) (*apisv1alpha2.APIExport, error)
+	getAPIResourceSchema func(cluster logicalcluster.Name, name string) (*apisv1alpha1.APIResourceSchema, error)
+
+	commit CommitFunc
 }
 
 func (c *Controller) enqueue(obj interface{}) {

--- a/pkg/reconciler/apis/apibindingdeletion/apibinding_deletor.go
+++ b/pkg/reconciler/apis/apibindingdeletion/apibinding_deletor.go
@@ -50,8 +50,21 @@ func (c *Controller) deleteAllCRs(ctx context.Context, apibinding *apisv1alpha2.
 		finalizersToNumRemaining: map[string]int{},
 	}
 
+	// Resources that another APIBinding in this workspace will adopt (same
+	// schema UID and identity) are handed over, not deleted.
+	adopted, err := c.adoptedResources(logicalcluster.From(apibinding), apibinding)
+	if err != nil {
+		return totalResourceRemaining, err
+	}
+
 	deleteContentErrs := []error{}
 	for _, resource := range apibinding.Status.BoundResources {
+		if successor, ok := adopted[schema.GroupResource{Group: resource.Group, Resource: resource.Resource}]; ok {
+			logger.V(2).Info("not deleting instances of bound resource, adopted by another APIBinding",
+				"group", resource.Group, "resource", resource.Resource, "successor", successor)
+			continue
+		}
+
 		for _, version := range resource.StorageVersions {
 			gvr := schema.GroupVersionResource{
 				Group:    resource.Group,

--- a/pkg/reconciler/apis/apibindingdeletion/apibinding_deletor_test.go
+++ b/pkg/reconciler/apis/apibindingdeletion/apibinding_deletor_test.go
@@ -204,6 +204,9 @@ func TestAPIBindingTerminating(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			controller := &Controller{
+				listAPIBindings: func(cluster logicalcluster.Name) ([]*apisv1alpha2.APIBinding, error) {
+					return nil, nil
+				},
 				listResources: func(ctx context.Context, cluster logicalcluster.Path, gvr schema.GroupVersionResource) (*metav1.PartialObjectMetadataList, error) {
 					if tt.existingObjects == nil {
 						return &metav1.PartialObjectMetadataList{Items: []metav1.PartialObjectMetadata{}}, nil

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -926,13 +926,21 @@ func (s *Server) installAPIBindingController(ctx context.Context, config *rest.C
 		metadataClient,
 		kcpClusterClient,
 		s.KcpSharedInformerFactory.Apis().V1alpha2().APIBindings(),
+		s.KcpSharedInformerFactory.Apis().V1alpha2().APIExports(),
+		s.CacheKcpSharedInformerFactory.Apis().V1alpha2().APIExports(),
+		s.KcpSharedInformerFactory.Apis().V1alpha1().APIResourceSchemas(),
+		s.CacheKcpSharedInformerFactory.Apis().V1alpha1().APIResourceSchemas(),
 	)
 
 	return s.registerController(&controllerWrapper{
 		Name: apibindingdeletion.ControllerName,
 		Wait: func(ctx context.Context, s *Server) error {
 			return wait.PollUntilContextCancel(ctx, waitPollInterval, true, func(ctx context.Context) (bool, error) {
-				return s.KcpSharedInformerFactory.Apis().V1alpha2().APIBindings().Informer().HasSynced(), nil
+				return s.KcpSharedInformerFactory.Apis().V1alpha2().APIBindings().Informer().HasSynced() &&
+					s.KcpSharedInformerFactory.Apis().V1alpha2().APIExports().Informer().HasSynced() &&
+					s.CacheKcpSharedInformerFactory.Apis().V1alpha2().APIExports().Informer().HasSynced() &&
+					s.KcpSharedInformerFactory.Apis().V1alpha1().APIResourceSchemas().Informer().HasSynced() &&
+					s.CacheKcpSharedInformerFactory.Apis().V1alpha1().APIResourceSchemas().Informer().HasSynced(), nil
 			})
 		},
 		Runner: func(ctx context.Context) {

--- a/test/e2e/apibinding/apibinding_adoption_test.go
+++ b/test/e2e/apibinding/apibinding_adoption_test.go
@@ -1,0 +1,206 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apibinding
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/restmapper"
+
+	kcpdynamic "github.com/kcp-dev/client-go/dynamic"
+	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
+	"github.com/kcp-dev/sdk/apis/core"
+	"github.com/kcp-dev/sdk/apis/third_party/conditions/util/conditions"
+	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
+	kcptesting "github.com/kcp-dev/sdk/testing"
+	kcptestinghelpers "github.com/kcp-dev/sdk/testing/helpers"
+
+	"github.com/kcp-dev/kcp/config/helpers"
+	wildwestv1alpha1 "github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/apis/wildwest/v1alpha1"
+	wildwestclientset "github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/client/clientset/versioned/cluster"
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+)
+
+// TestAPIBindingAdoption models replacing an APIBinding with a successor bound
+// to a different APIExport that serves the same resource through the same
+// APIResourceSchema and identity: instances must survive the swap untouched.
+func TestAPIBindingAdoption(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "control-plane")
+
+	server := kcptesting.SharedKcpServer(t)
+
+	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
+	providerPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)
+	consumerPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath)
+
+	cfg := server.BaseConfig(t)
+
+	kcpClusterClient, err := kcpclientset.NewForConfig(cfg)
+	require.NoError(t, err, "failed to construct kcp cluster client for server")
+	dynamicClusterClient, err := kcpdynamic.NewForConfig(cfg)
+	require.NoError(t, err, "failed to construct dynamic cluster client for server")
+	wildwestClusterClient, err := wildwestclientset.NewForConfig(cfg)
+	require.NoError(t, err)
+
+	t.Logf("Install cowboys APIResourceSchema into provider workspace %q", providerPath)
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(kcpClusterClient.Cluster(providerPath).Discovery()))
+	err = helpers.CreateResourceFromFS(t.Context(), dynamicClusterClient.Cluster(providerPath), mapper, nil, "apiresourceschema_cowboys.yaml", testFiles)
+	require.NoError(t, err)
+
+	t.Logf("Create the predecessor APIExport %q", "wildwest")
+	wildwestExport := &apisv1alpha2.APIExport{
+		ObjectMeta: metav1.ObjectMeta{Name: "wildwest"},
+		Spec: apisv1alpha2.APIExportSpec{
+			Resources: []apisv1alpha2.ResourceSchema{
+				{
+					Name:    "cowboys",
+					Group:   "wildwest.dev",
+					Schema:  "today.cowboys.wildwest.dev",
+					Storage: apisv1alpha2.ResourceSchemaStorage{CRD: &apisv1alpha2.ResourceSchemaStorageCRD{}},
+				},
+			},
+		},
+	}
+	_, err = kcpClusterClient.Cluster(providerPath).ApisV1alpha2().APIExports().Create(t.Context(), wildwestExport, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("Wait for the wildwest APIExport identity")
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		export, err := kcpClusterClient.Cluster(providerPath).ApisV1alpha2().APIExports().Get(t.Context(), "wildwest", metav1.GetOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+		return export.Status.IdentityHash != "", "identity hash not set yet"
+	}, wait.ForeverTestTimeout, time.Millisecond*100)
+
+	t.Logf("Bind %q in consumer workspace %q", "wildwest", consumerPath)
+	wildwestBinding := &apisv1alpha2.APIBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "wildwest"},
+		Spec: apisv1alpha2.APIBindingSpec{
+			Reference: apisv1alpha2.BindingReference{
+				Export: &apisv1alpha2.ExportBindingReference{Path: providerPath.String(), Name: "wildwest"},
+			},
+		},
+	}
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		_, err := kcpClusterClient.Cluster(consumerPath).ApisV1alpha2().APIBindings().Create(t.Context(), wildwestBinding, metav1.CreateOptions{})
+		return err == nil, fmt.Sprintf("Error creating APIBinding: %v", err)
+	}, wait.ForeverTestTimeout, time.Millisecond*100)
+	kcptestinghelpers.EventuallyCondition(t, func() (conditions.Getter, error) {
+		return kcpClusterClient.Cluster(consumerPath).ApisV1alpha2().APIBindings().Get(t.Context(), "wildwest", metav1.GetOptions{})
+	}, kcptestinghelpers.Is(apisv1alpha2.InitialBindingCompleted))
+
+	t.Logf("Create a cowboy in consumer workspace %q", consumerPath)
+	cowboyClient := wildwestClusterClient.WildwestV1alpha1().Cluster(consumerPath).Cowboys("default")
+	var cowboyUID types.UID
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		cowboy, err := cowboyClient.Create(t.Context(), &wildwestv1alpha1.Cowboy{
+			ObjectMeta: metav1.ObjectMeta{Name: "luke", Namespace: "default"},
+		}, metav1.CreateOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+		cowboyUID = cowboy.UID
+		return true, ""
+	}, wait.ForeverTestTimeout, time.Millisecond*100)
+
+	t.Logf("Create the successor APIExport %q reusing the %q identity and schema", "cowboys", "wildwest")
+	cowboysExport := &apisv1alpha2.APIExport{
+		ObjectMeta: metav1.ObjectMeta{Name: "cowboys"},
+		Spec: apisv1alpha2.APIExportSpec{
+			Identity: &apisv1alpha2.Identity{
+				SecretRef: &corev1.SecretReference{Namespace: "kcp-system", Name: "wildwest"},
+			},
+			Resources: []apisv1alpha2.ResourceSchema{
+				{
+					Name:    "cowboys",
+					Group:   "wildwest.dev",
+					Schema:  "today.cowboys.wildwest.dev",
+					Storage: apisv1alpha2.ResourceSchemaStorage{CRD: &apisv1alpha2.ResourceSchemaStorageCRD{}},
+				},
+			},
+		},
+	}
+	_, err = kcpClusterClient.Cluster(providerPath).ApisV1alpha2().APIExports().Create(t.Context(), cowboysExport, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("Both exports must share one identity hash")
+	var identity string
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		oldExport, err := kcpClusterClient.Cluster(providerPath).ApisV1alpha2().APIExports().Get(t.Context(), "wildwest", metav1.GetOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+		newExport, err := kcpClusterClient.Cluster(providerPath).ApisV1alpha2().APIExports().Get(t.Context(), "cowboys", metav1.GetOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+		identity = newExport.Status.IdentityHash
+		return identity != "" && identity == oldExport.Status.IdentityHash,
+			fmt.Sprintf("identities differ or unset: old=%q new=%q", oldExport.Status.IdentityHash, newExport.Status.IdentityHash)
+	}, wait.ForeverTestTimeout, time.Millisecond*100)
+
+	t.Logf("Pre-create the successor APIBinding %q; it must sit in NamingConflicts", "cowboys")
+	cowboysBinding := &apisv1alpha2.APIBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "cowboys"},
+		Spec: apisv1alpha2.APIBindingSpec{
+			Reference: apisv1alpha2.BindingReference{
+				Export: &apisv1alpha2.ExportBindingReference{Path: providerPath.String(), Name: "cowboys"},
+			},
+		},
+	}
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		_, err := kcpClusterClient.Cluster(consumerPath).ApisV1alpha2().APIBindings().Create(t.Context(), cowboysBinding, metav1.CreateOptions{})
+		return err == nil, fmt.Sprintf("Error creating APIBinding: %v", err)
+	}, wait.ForeverTestTimeout, time.Millisecond*100)
+	kcptestinghelpers.EventuallyCondition(t, func() (conditions.Getter, error) {
+		return kcpClusterClient.Cluster(consumerPath).ApisV1alpha2().APIBindings().Get(t.Context(), "cowboys", metav1.GetOptions{})
+	}, kcptestinghelpers.IsNot(apisv1alpha2.BindingUpToDate).WithReason(apisv1alpha2.NamingConflictsReason))
+
+	t.Logf("Delete the predecessor binding %q; instances must be adopted, not deleted", "wildwest")
+	err = kcpClusterClient.Cluster(consumerPath).ApisV1alpha2().APIBindings().Delete(t.Context(), "wildwest", metav1.DeleteOptions{})
+	require.NoError(t, err)
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		_, err := kcpClusterClient.Cluster(consumerPath).ApisV1alpha2().APIBindings().Get(t.Context(), "wildwest", metav1.GetOptions{})
+		return apierrors.IsNotFound(err), fmt.Sprintf("wildwest binding still present: %v", err)
+	}, wait.ForeverTestTimeout, time.Millisecond*100)
+
+	t.Logf("The successor binding must become ready")
+	kcptestinghelpers.EventuallyCondition(t, func() (conditions.Getter, error) {
+		return kcpClusterClient.Cluster(consumerPath).ApisV1alpha2().APIBindings().Get(t.Context(), "cowboys", metav1.GetOptions{})
+	}, kcptestinghelpers.Is(apisv1alpha2.InitialBindingCompleted))
+
+	t.Logf("The cowboy must have survived the swap with the same UID")
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		cowboy, err := cowboyClient.Get(t.Context(), "luke", metav1.GetOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+		return cowboy.UID == cowboyUID, fmt.Sprintf("UID changed: was %q, now %q", cowboyUID, cowboy.UID)
+	}, wait.ForeverTestTimeout, time.Millisecond*100)
+}


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Allows migrating apiexport without deleting. 

## What Type of PR Is This?
/kind feature

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Allow migrating apiexports without deleting the resource 
```
