### PR TITLE
load-test: option to run with external cache-server

### DIFF
--- a/test/load/setup/manifests/cache-server.yaml
+++ b/test/load/setup/manifests/cache-server.yaml
@@ -4,6 +4,8 @@ metadata:
   name: cache
   namespace: kcp
 spec:
+  image:
+    tag: v0.32.3
   certificates:
     issuerRef:
       group: cert-manager.io

--- a/test/load/setup/manifests/cache-server.yaml
+++ b/test/load/setup/manifests/cache-server.yaml
@@ -1,0 +1,24 @@
+apiVersion: operator.kcp.io/v1alpha1
+kind: CacheServer
+metadata:
+  name: cache
+  namespace: kcp
+spec:
+  certificates:
+    issuerRef:
+      group: cert-manager.io
+      kind: Issuer
+      name: selfsigned
+  deploymentTemplate:
+    spec:
+      template:
+        spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: $NODEPOOL_SELECTOR
+                        operator: In
+                        values:
+                          - "kcp-server"

--- a/test/load/setup/manifests/kcp.yaml
+++ b/test/load/setup/manifests/kcp.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kcp
 spec:
   image:
-    tag: v0.32.3
+    tag: 4a47e3b43 # latest working version on release 0.32 branch
   external:
     hostname: frontproxy.$GATEWAY_BASE_URL
     port: 443
@@ -67,7 +67,7 @@ metadata:
   namespace: kcp
 spec:
   image:
-    tag: v0.32.3
+    tag: 4a47e3b43 # latest working version on release 0.32 branch
   certificateTemplates:
     server:
       spec:
@@ -108,7 +108,7 @@ metadata:
   namespace: kcp
 spec:
   image:
-    tag: v0.32.3
+    tag: 4a47e3b43 # latest working version on release 0.32 branch
   shardBaseURL: "https://shard2.$GATEWAY_BASE_URL:443"
   certificateTemplates:
     server:
@@ -163,7 +163,7 @@ metadata:
   namespace: kcp
 spec:
   image:
-    tag: v0.32.3
+    tag: 4a47e3b43 # latest working version on release 0.32 branch
   shardBaseURL: "https://shard3.$GATEWAY_BASE_URL:443"
   certificateTemplates:
     server:

--- a/test/load/setup/manifests/kcp.yaml
+++ b/test/load/setup/manifests/kcp.yaml
@@ -33,7 +33,7 @@ spec:
       cpu: "2"
       memory: 3Gi
     limits:
-      cpu: "12"
+      cpu: "14"
       memory: 115Gi
   etcd:
     endpoints:
@@ -132,7 +132,7 @@ spec:
       cpu: "2"
       memory: 3Gi
     limits:
-      cpu: "12"
+      cpu: "14"
       memory: 115Gi
   deploymentTemplate:
     spec:
@@ -187,7 +187,7 @@ spec:
       cpu: "2"
       memory: 3Gi
     limits:
-      cpu: "12"
+      cpu: "14"
       memory: 115Gi
   deploymentTemplate:
     spec:

--- a/test/load/setup/manifests/kcp.yaml
+++ b/test/load/setup/manifests/kcp.yaml
@@ -4,6 +4,8 @@ metadata:
   name: root
   namespace: kcp
 spec:
+  image:
+    tag: v0.32.3
   external:
     hostname: frontproxy.$GATEWAY_BASE_URL
     port: 443
@@ -32,7 +34,7 @@ spec:
       memory: 3Gi
     limits:
       cpu: "12"
-      memory: 48Gi
+      memory: 115Gi
   etcd:
     endpoints:
       - http://kcp-etcd-shard-1-client.etcd-system.svc.cluster.local:2379
@@ -64,6 +66,8 @@ metadata:
   name: frontproxy
   namespace: kcp
 spec:
+  image:
+    tag: v0.32.3
   certificateTemplates:
     server:
       spec:
@@ -103,6 +107,8 @@ metadata:
   name: shard2
   namespace: kcp
 spec:
+  image:
+    tag: v0.32.3
   shardBaseURL: "https://shard2.$GATEWAY_BASE_URL:443"
   certificateTemplates:
     server:
@@ -127,7 +133,7 @@ spec:
       memory: 3Gi
     limits:
       cpu: "12"
-      memory: 48Gi
+      memory: 115Gi
   deploymentTemplate:
     spec:
       template:
@@ -156,6 +162,8 @@ metadata:
   name: shard3
   namespace: kcp
 spec:
+  image:
+    tag: v0.32.3
   shardBaseURL: "https://shard3.$GATEWAY_BASE_URL:443"
   certificateTemplates:
     server:
@@ -180,7 +188,7 @@ spec:
       memory: 3Gi
     limits:
       cpu: "12"
-      memory: 48Gi
+      memory: 115Gi
   deploymentTemplate:
     spec:
       template:

--- a/test/load/setup/reset-kcp.sh
+++ b/test/load/setup/reset-kcp.sh
@@ -28,12 +28,18 @@ cd "$(dirname "$0")"
 : "${NODEPOOL_SELECTOR:? must be set to indicate which label is used for pooling nodes (e.g. worker.gardener.cloud/pool). This depends on your infrastructure setup. Please refer to the architecture document to see which pools should exist}"
 : "${GATEWAY_BASE_URL:? must be set to indicate the base domain for the gateway. Needed to setup kcp correctly.}"
 
+# Must match the value used by setup.sh so we know whether an external
+# cache-server needs to be torn down and re-created alongside the shards.
+USE_EXTERNAL_CACHE="${USE_EXTERNAL_CACHE:-true}"
+
 echo "=== Resetting kcp and etcd data ==="
 
-echo "Deleting kcp shards and front-proxy"
+echo "Deleting kcp shards and front-proxy and external cache-server (if exists)"
 kubectl delete shard --all -n kcp --ignore-not-found
 kubectl delete frontproxy --all -n kcp --ignore-not-found
 kubectl delete rootshard --all -n kcp --ignore-not-found
+kubectl delete cacheserver --all -n kcp --ignore-not-found
+
 
 echo "Waiting for kcp pods to terminate"
 kubectl wait --for=delete pod -l app.kubernetes.io/managed-by=kcp-operator -n kcp --timeout=120s 2>/dev/null || true
@@ -61,8 +67,23 @@ kubectl wait --for=condition=Ready etcds/kcp-etcd-shard-1 --namespace etcd-syste
 kubectl wait --for=condition=Ready etcds/kcp-etcd-shard-2 --namespace etcd-system --timeout=200s
 kubectl wait --for=condition=Ready etcds/kcp-etcd-shard-3 --namespace etcd-system --timeout=200s
 
+if [ "$USE_EXTERNAL_CACHE" = "true" ]; then
+  echo "=== Re-creating external cache-server ==="
+  kubectl apply -f <(envsubst < manifests/cache-server.yaml)
+
+  echo "Waiting for cache-server deployment to become ready"
+  kubectl wait --for=create deployment/cache-cache-server -n kcp --timeout=120s
+  kubectl wait --for=condition=available deployment/cache-cache-server -n kcp --timeout=200s
+fi
+
 echo "=== Re-creating kcp shards ==="
-kubectl apply -f <(envsubst < manifests/kcp.yaml)
+if [ "$USE_EXTERNAL_CACHE" = "true" ]; then
+  envsubst < manifests/kcp.yaml \
+    | yq '(select(.kind == "RootShard" or .kind == "Shard") | .spec.cache) = {"ref": {"name": "cache"}}' \
+    | kubectl apply -f -
+else
+  kubectl apply -f <(envsubst < manifests/kcp.yaml)
+fi
 
 echo "Waiting for kcp shards to become ready"
 kubectl wait --for=jsonpath='{.status.phase}'=Running rootshard/root -n kcp --timeout=300s

--- a/test/load/setup/setup.sh
+++ b/test/load/setup/setup.sh
@@ -24,7 +24,7 @@ set -o pipefail
 cd "$(dirname "$0")"
 
 # optional variables
-KCP_OPERATOR_VERSION="${KCP_OPERATOR_VERSION:-0.6.0}"
+KCP_OPERATOR_VERSION="${KCP_OPERATOR_VERSION:-0.7.6}"
 ETCD_DRUID_VERSION="${ETCD_DRUID_VERSION:-v0.35.0}"
 CERT_MANAGER_VERSION="${CERT_MANAGER_VERSION:-v1.19.3}"
 ENVOY_GATEWAY_VERSION="${ENVOY_GATEWAY_VERSION:-v1.7.0}"
@@ -34,6 +34,7 @@ PROMTAIL_VERSION="${PROMTAIL_VERSION:-6.17.1}"
 PYROSCOPE_VERSION="${PYROSCOPE_VERSION:-1.20.3}"
 USE_DEFAULT_ENVOY_GATEWAY="${USE_DEFAULT_ENVOY_GATEWAY:-true}"
 USE_PYROSCOPE="${USE_PYROSCOPE:-false}"
+USE_EXTERNAL_CACHE="${USE_EXTERNAL_CACHE:-true}"
 
 # required variables
 : "${NODEPOOL_SELECTOR:? must be set to indicate which label is used for pooling nodes (e.g. worker.gardener.cloud/pool). This depends on your infrastructure setup. Please refer to the architecture document to see which pools should exist}"
@@ -46,6 +47,10 @@ fi
 
 if [ "$USE_PYROSCOPE" = "true" ]; then
   echo "Pyroscope will be deployed for continuous profiling. This can adversely impact performance. Only use it for debugging. Set USE_PYROSCOPE to false to disable it."
+fi
+
+if [ "$USE_EXTERNAL_CACHE" = "true" ]; then
+  echo "kcp will be deployed with an external cache-server. Set USE_EXTERNAL_CACHE to false to use the embedded cache-server on the root shard instead."
 fi
 
 echo "Configuring helm repositories"
@@ -94,8 +99,25 @@ kubectl wait --for=condition=Ready etcds/kcp-etcd-shard-1 --namespace etcd-syste
 kubectl wait --for=condition=Ready etcds/kcp-etcd-shard-2 --namespace etcd-system --timeout=200s
 kubectl wait --for=condition=Ready etcds/kcp-etcd-shard-3 --namespace etcd-system --timeout=200s
 
+if [ "$USE_EXTERNAL_CACHE" = "true" ]; then
+  echo "Deploying external cache-server"
+  kubectl apply -f <(envsubst < manifests/cache-server.yaml)
+
+  echo "Waiting for cache-server deployment to become ready"
+  kubectl wait --for=create deployment/cache-cache-server -n kcp --timeout=120s
+  kubectl wait --for=condition=available deployment/cache-cache-server -n kcp --timeout=200s
+fi
+
 echo "Creating kcp shards"
-kubectl apply -f <(envsubst < manifests/kcp.yaml)
+if [ "$USE_EXTERNAL_CACHE" = "true" ]; then
+  # Point the RootShard and Shards at the standalone CacheServer, replacing the
+  # embedded cache config baked into kcp.yaml.
+  envsubst < manifests/kcp.yaml \
+    | yq '(select(.kind == "RootShard" or .kind == "Shard") | .spec.cache) = {"ref": {"name": "cache"}}' \
+    | kubectl apply -f -
+else
+  kubectl apply -f <(envsubst < manifests/kcp.yaml)
+fi
 
 echo "Waiting for kcp shards to become ready"
 kubectl wait --for=jsonpath='{.status.phase}'=Running rootshard/root -n kcp --timeout=300s

--- a/test/load/suite.sh
+++ b/test/load/suite.sh
@@ -42,7 +42,7 @@ if [[ -z "$testname" ]]; then
 fi
 
 # build go test args
-go_test_args=(-timeout 2h -test.fullpath=true -run "^${testname}$" -count=1 -v github.com/kcp-dev/kcp/test/load/testing)
+go_test_args=(-timeout 3h -test.fullpath=true -run "^${testname}$" -count=1 -v github.com/kcp-dev/kcp/test/load/testing)
 if [[ -n "$configfile" ]]; then
   go_test_args+=(-args --config="$configfile")
 fi
@@ -52,7 +52,7 @@ logfile="$logdir/${testname}_$(date '+%Y-%m-%d-%H:%M:%S').log"
 echo "Executing test: $testname"
 echo "Logs will be saved to: $logfile"
 
-go test "${go_test_args[@]}" &> "$logfile" &
+setsid go test "${go_test_args[@]}" &> "$logfile" &
 test_pid=$!
 
 # on Ctrl+C: stop tailing but keep the test running

--- a/test/load/testing/config.go
+++ b/test/load/testing/config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package testing
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -31,6 +32,9 @@ var testConfig Config
 // Config is the top-level configuration structure unmarshalled from the
 // JSON config file passed via --config.
 type Config struct {
+	// add as field here so our example passes stric decoding
+	Comment string `json:"_comment,omitempty"`
+
 	Params Params `json:"params"`
 }
 
@@ -136,7 +140,9 @@ func parseConfig(configFile string) error {
 		return fmt.Errorf("failed to read config file %q: %w", configFile, err)
 	}
 
-	if err := json.Unmarshal(data, &testConfig); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&testConfig); err != nil {
 		return fmt.Errorf("failed to parse config file %q: %w", configFile, err)
 	}
 

--- a/test/load/testing/report.go
+++ b/test/load/testing/report.go
@@ -19,6 +19,9 @@ package testing
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -56,5 +59,53 @@ func NewKCPReport(ctx context.Context, t *testing.T, title string, cfg *rest.Con
 
 	report.Metadata = append(report.Metadata, measurement.Parameter{Key: "kcp Shards", Value: fmt.Sprintf("%d", len(shards.Items))})
 
+	// running on first shard name is fine, we just want to detect if cache server is used and not verify that it is correct for all shards
+	firstShard := shards.Items[0].Name
+	report.Metadata = append(report.Metadata, measurement.Parameter{Key: "kcp Cache Server", Value: detectCacheServer(ctx, t, cfg, firstShard)})
+
 	return report
+}
+
+// In our two setups, we can use a little trick to determine if the cache server is embedded or external:
+// 200 -> we reached embedded cache handler
+// 404 -> can't reach cache via external VW, also embedded
+// 403 + "not resolved to valid virtual workspace" -> external cache server
+// anything else, can't tell.
+// This might become a bit brittle, but since its just to report metadata, we should be fine.
+// Any alternative would involve sharing setup data or giving access to the underlying Kubernetes cluster.
+func detectCacheServer(ctx context.Context, t *testing.T, cfg *rest.Config, shardName string) string {
+	// strip out any clusters
+	host := cfg.Host
+	if i := strings.Index(host, "/clusters/"); i != -1 {
+		host = host[:i]
+	}
+	httpClient, err := rest.HTTPClientFor(cfg)
+	if err != nil {
+		t.Logf("Could not build HTTP client for cache-server probe: %v", err)
+		return "unknown"
+	}
+	url := host + "/services/cache/shards/" + shardName + "/healthz"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		t.Logf("Could not build request for cache-server probe: %v", err)
+		return "unknown"
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		t.Logf("Could not probe cache-server endpoint: %v", err)
+		return "unknown"
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNotFound {
+		return "embedded"
+	}
+
+	if resp.StatusCode == http.StatusForbidden {
+		body, _ := io.ReadAll(resp.Body)
+		if strings.Contains(string(body), "Path not resolved to a valid virtual workspace") {
+			return "external"
+		}
+	}
+	return "unknown"
 }

--- a/test/load/testing/workspace_apisharing_test.go
+++ b/test/load/testing/workspace_apisharing_test.go
@@ -80,6 +80,11 @@ func TestAPISharing(t *testing.T) {
 
 	t.Logf("Running custom resource CRUD operations")
 	crudSection := crudCustomResources(t, dynamicClusterClient, wt, params.CRUDSharedAPIQPS, params.ProviderWorkspacesCount, params.ConsumerWorkspacesCount, params.BindingsPerConsumer, dummy)
+	crudSection.Parameters = append(crudSection.Parameters,
+		measurement.Parameter{Key: "CRLeafFields", Value: fmt.Sprintf("%d", params.CRLeafFields)},
+		measurement.Parameter{Key: "CRListItems", Value: fmt.Sprintf("%d", params.CRListItems)},
+		measurement.Parameter{Key: "CRTargetSizeBytes", Value: fmt.Sprintf("%d", params.CRTargetSizeBytes)},
+	)
 	sections = append(sections, crudSection)
 
 	report := NewKCPReport(t.Context(), t, "API Sharing", cfg.FrontProxyKubeconfig)

--- a/test/load/testing/workspace_apisharing_test.go
+++ b/test/load/testing/workspace_apisharing_test.go
@@ -198,7 +198,7 @@ func createAPIBindings(t *testing.T, client kcpclientset.ClusterInterface, wt tr
 
 		// Wait for the binding to become bound.
 		opStart = time.Now()
-		err = wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 4*time.Minute, true, func(ctx context.Context) (bool, error) {
 			got, err := client.Cluster(consumerPath).ApisV1alpha2().APIBindings().Get(ctx, binding.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, nil //nolint:nilerr


### PR DESCRIPTION
## Summary

Adds option to run the kcp loadtest with an external cache-server.

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->
/kind feature

## Related Issue(s)

Fixes https://github.com/platform-mesh/backlog/issues/235

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
