### PR TITLE
pkg/virtual: use a TTLCache for impersonating roundtrippers

### DIFF
--- a/pkg/virtual/initializingworkspaces/builder/build.go
+++ b/pkg/virtual/initializingworkspaces/builder/build.go
@@ -225,6 +225,8 @@ func BuildVirtualWorkspace(
 			}
 		}),
 		HandlerFactory: handler.HandlerFactory(func(rootAPIServerConfig genericapiserver.CompletedConfig) (http.Handler, error) {
+			transportCache := virtualshared.NewTransportCache(cfg)
+
 			if err := rootAPIServerConfig.AddPostStartHook(workspaceContentName, func(hookContext genericapiserver.PostStartHookContext) error {
 				defer close(workspaceContentReadyCh)
 
@@ -238,6 +240,8 @@ func BuildVirtualWorkspace(
 						return nil
 					}
 				}
+
+				transportCache.StartWithContext(hookContext)
 
 				return nil
 			}); err != nil {
@@ -304,20 +308,18 @@ func BuildVirtualWorkspace(
 						return
 					}
 
-					thisCfg := rest.CopyConfig(cfg)
 					extra := map[string][]string{}
 					for k, v := range caller.GetExtra() {
 						extra[k] = v
 					}
-					thisCfg.Impersonate = rest.ImpersonationConfig{
+					authenticatingTransport, err := transportCache.TransportFor(rest.ImpersonationConfig{
 						UserName: caller.GetName(),
 						UID:      caller.GetUID(),
 						// Inject the synthetic group so the workspace content authorizer
 						// trusts this request as pre-authorized by the VW. This will be used for auditing.
 						Groups: append([]string{authorization.InitializerGroup(initializer)}, caller.GetGroups()...),
 						Extra:  extra,
-					}
-					authenticatingTransport, err := rest.TransportFor(thisCfg)
+					})
 					if err != nil {
 						http.Error(writer, fmt.Sprintf("could not create round-tripper: %v", err), http.StatusInternalServerError)
 						return
@@ -342,14 +344,12 @@ func BuildVirtualWorkspace(
 					extra[k] = v
 				}
 
-				thisCfg := rest.CopyConfig(cfg)
-				thisCfg.Impersonate = rest.ImpersonationConfig{
+				authenticatingTransport, err := transportCache.TransportFor(rest.ImpersonationConfig{
 					UserName: info.Username,
 					UID:      info.UID,
 					Groups:   info.Groups,
 					Extra:    extra,
-				}
-				authenticatingTransport, err := rest.TransportFor(thisCfg)
+				})
 				if err != nil {
 					http.Error(writer, fmt.Sprintf("could not create round-tripper: %v", err), http.StatusInternalServerError)
 					return

--- a/pkg/virtual/shared/proxy.go
+++ b/pkg/virtual/shared/proxy.go
@@ -21,12 +21,18 @@ limitations under the License.
 package shared
 
 import (
+	"context"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"sort"
 	"strings"
 
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/transport"
+
+	"github.com/kcp-dev/kcp/pkg/shardlookup"
 )
 
 // ServeProxy strips any client-supplied auth/impersonation headers from the
@@ -56,4 +62,107 @@ func ServeProxy(writer http.ResponseWriter, request *http.Request, forwardedHost
 		Transport: rt,
 	}
 	proxy.ServeHTTP(writer, request)
+}
+
+type idleConnectionsCloser interface {
+	CloseIdleConnections()
+}
+
+// closeIdleConnections closes the idle connections held by rt's underlying
+// http.Transport and reports whether it found one. The round-trippers built by
+// rest.TransportFor do not implement the function, so unwrap them until
+// an http.Transport is found.
+func closeIdleConnections(rt http.RoundTripper) bool {
+	for {
+		if closer, ok := rt.(idleConnectionsCloser); ok {
+			closer.CloseIdleConnections()
+			return true
+		}
+		wrapper, ok := rt.(utilnet.RoundTripperWrapper)
+		if !ok {
+			return false
+		}
+		rt = wrapper.WrappedRoundTripper()
+		if rt == nil {
+			return false
+		}
+	}
+}
+
+// TransportCache caches impersonating round-trippers so that long-lived
+// initializing and terminating workspaces do not rebuild an http.Transport
+// on every request. TTLCache allows for concurrent requests on the same
+// key to be enqueued. Idle connections are closed once an entry expires.
+type TransportCache struct {
+	cfg   *rest.Config
+	cache *shardlookup.TTLCache[http.RoundTripper]
+}
+
+// NewTransportCache creates a TransportCache that derives transports from cfg.
+func NewTransportCache(cfg *rest.Config) *TransportCache {
+	c := &TransportCache{
+		cfg:   cfg,
+		cache: shardlookup.NewTTLCache[http.RoundTripper](),
+	}
+	c.cache.OnEviction(func(rt http.RoundTripper) {
+		_ = closeIdleConnections(rt)
+	})
+	return c
+}
+
+// StartWithContext starts the background eviction goroutine and stops it when
+// ctx is cancelled.
+func (c *TransportCache) StartWithContext(ctx context.Context) {
+	c.cache.StartWithContext(ctx)
+}
+
+// TransportFor returns a cached or new round-tripper for the given impersonation config.
+func (c *TransportCache) TransportFor(imp rest.ImpersonationConfig) (http.RoundTripper, error) {
+	return c.cache.Get(impersonationKey(imp), func() (http.RoundTripper, error) {
+		cfg := rest.CopyConfig(c.cfg)
+		cfg.Impersonate = imp
+		return rest.TransportFor(cfg)
+	})
+}
+
+const impersonationKeySeparator = "\x00"
+
+// impersonationKey returns a string that uniquely identifies the given
+// impersonation config. \x00 (NUL) separator is used as it cannot be in
+// any of the values. This is faster and less memory than doing something
+// like: sorting, marshaling to JSON, and hashing.
+func impersonationKey(imp rest.ImpersonationConfig) string {
+	var b strings.Builder
+	b.WriteString("u=")
+	b.WriteString(imp.UserName)
+	b.WriteString(impersonationKeySeparator)
+	b.WriteString("uid=")
+	b.WriteString(imp.UID)
+
+	groups := append([]string(nil), imp.Groups...)
+	sort.Strings(groups)
+	for _, g := range groups {
+		b.WriteString(impersonationKeySeparator)
+		b.WriteString("g=")
+		b.WriteString(g)
+	}
+
+	keys := make([]string, 0, len(imp.Extra))
+	for k := range imp.Extra {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		vals := append([]string(nil), imp.Extra[k]...)
+		sort.Strings(vals)
+		for _, v := range vals {
+			b.WriteString(impersonationKeySeparator)
+			b.WriteString("e=")
+			b.WriteString(k)
+			b.WriteString("=")
+			b.WriteString(v)
+		}
+	}
+
+	return b.String()
 }

--- a/pkg/virtual/shared/proxy_test.go
+++ b/pkg/virtual/shared/proxy_test.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shared
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"k8s.io/client-go/rest"
+)
+
+func TestImpersonationKey(t *testing.T) {
+	t.Parallel()
+
+	base := rest.ImpersonationConfig{
+		UserName: "alice",
+		UID:      "uid-1",
+		Groups:   []string{"g1", "g2"},
+		Extra:    map[string][]string{"scopes": {"a", "b"}},
+	}
+
+	t.Run("ensure output is stable", func(t *testing.T) {
+		t.Parallel()
+
+		got := impersonationKey(base)
+		var b strings.Builder
+		b.WriteString("u=alice")
+		b.WriteString(impersonationKeySeparator)
+		b.WriteString("uid=uid-1")
+		b.WriteString(impersonationKeySeparator)
+		b.WriteString("g=g1")
+		b.WriteString(impersonationKeySeparator)
+		b.WriteString("g=g2")
+		b.WriteString(impersonationKeySeparator)
+		b.WriteString("e=scopes=a")
+		b.WriteString(impersonationKeySeparator)
+		b.WriteString("e=scopes=b")
+		want := b.String()
+		if got != want {
+			t.Errorf("impersonationKey = %q, want %q", got, want)
+		}
+	})
+
+	tests := []struct {
+		name  string
+		a, b  rest.ImpersonationConfig
+		equal bool
+	}{
+		{
+			name:  "identical",
+			a:     base,
+			b:     base,
+			equal: true,
+		},
+		{
+			name:  "group order does not matter",
+			a:     base,
+			b:     rest.ImpersonationConfig{UserName: "alice", UID: "uid-1", Groups: []string{"g2", "g1"}, Extra: map[string][]string{"scopes": {"a", "b"}}},
+			equal: true,
+		},
+		{
+			name:  "extra value order does not matter",
+			a:     base,
+			b:     rest.ImpersonationConfig{UserName: "alice", UID: "uid-1", Groups: []string{"g1", "g2"}, Extra: map[string][]string{"scopes": {"b", "a"}}},
+			equal: true,
+		},
+		{
+			name:  "different UID",
+			a:     base,
+			b:     rest.ImpersonationConfig{UserName: "alice", UID: "uid-2", Groups: []string{"g1", "g2"}, Extra: map[string][]string{"scopes": {"a", "b"}}},
+			equal: false,
+		},
+		{
+			name:  "different user",
+			a:     base,
+			b:     rest.ImpersonationConfig{UserName: "bob", UID: "uid-1", Groups: []string{"g1", "g2"}, Extra: map[string][]string{"scopes": {"a", "b"}}},
+			equal: false,
+		},
+		{
+			name:  "different group",
+			a:     base,
+			b:     rest.ImpersonationConfig{UserName: "alice", UID: "uid-1", Groups: []string{"g1", "g3"}, Extra: map[string][]string{"scopes": {"a", "b"}}},
+			equal: false,
+		},
+		{
+			name:  "extra key vs value cannot collide",
+			a:     rest.ImpersonationConfig{UserName: "alice", Extra: map[string][]string{"a": {"b"}}},
+			b:     rest.ImpersonationConfig{UserName: "alice", Extra: map[string][]string{"a=b": nil}},
+			equal: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ka, kb := impersonationKey(tc.a), impersonationKey(tc.b)
+			if (ka == kb) != tc.equal {
+				t.Errorf("impersonationKey equality = %v, want %v\n a=%q\n b=%q", ka == kb, tc.equal, ka, kb)
+			}
+		})
+	}
+}
+
+func TestTransportCacheReusesTransport(t *testing.T) {
+	t.Parallel()
+
+	c := NewTransportCache(&rest.Config{Host: "https://example.com"})
+
+	imp := rest.ImpersonationConfig{UserName: "alice", UID: "uid-1"}
+	rt1, err := c.TransportFor(imp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rt2, err := c.TransportFor(imp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rt1 != rt2 {
+		t.Errorf("expected the same round-tripper for identical impersonation, got distinct instances")
+	}
+
+	other, err := c.TransportFor(rest.ImpersonationConfig{UserName: "bob", UID: "uid-2"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rt1 == other {
+		t.Errorf("expected distinct round-trippers for different impersonation identities")
+	}
+}
+
+type roundTripperWithoutClose struct{}
+
+func (roundTripperWithoutClose) RoundTrip(*http.Request) (*http.Response, error) { return nil, nil }
+
+func TestCloseIdleConnections(t *testing.T) {
+	t.Parallel()
+
+	config := &rest.Config{Host: "https://example.com"}
+	cache := NewTransportCache(config)
+	impersonated, err := cache.TransportFor(rest.ImpersonationConfig{
+		UserName: "alice",
+		UID:      "uid-1",
+		Groups:   []string{"g1"},
+		Extra:    map[string][]string{"scopes": {"a"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		rt   http.RoundTripper
+		want bool
+	}{
+		{name: "bare http.Transport", rt: &http.Transport{}, want: true},
+		{name: "impersonating transport from TransportFor", rt: impersonated, want: true},
+		{name: "round-tripper without CloseIdleConnections", rt: roundTripperWithoutClose{}, want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := closeIdleConnections(tc.rt); got != tc.want {
+				t.Errorf("closeIdleConnections() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/virtual/terminatingworkspaces/builder/build.go
+++ b/pkg/virtual/terminatingworkspaces/builder/build.go
@@ -218,6 +218,8 @@ func BuildVirtualWorkspace(
 			}
 		}),
 		HandlerFactory: handler.HandlerFactory(func(rootAPIServerConfig genericapiserver.CompletedConfig) (http.Handler, error) {
+			transportCache := virtualshared.NewTransportCache(cfg)
+
 			if err := rootAPIServerConfig.AddPostStartHook(workspaceContentName, func(hookContext genericapiserver.PostStartHookContext) error {
 				defer close(workspaceContentReadyCh)
 
@@ -231,6 +233,8 @@ func BuildVirtualWorkspace(
 						return nil
 					}
 				}
+
+				transportCache.StartWithContext(hookContext)
 
 				return nil
 			}); err != nil {
@@ -292,18 +296,16 @@ func BuildVirtualWorkspace(
 						return
 					}
 
-					thisCfg := rest.CopyConfig(cfg)
 					extra := map[string][]string{}
 					for k, v := range caller.GetExtra() {
 						extra[k] = v
 					}
-					thisCfg.Impersonate = rest.ImpersonationConfig{
+					authenticatingTransport, err := transportCache.TransportFor(rest.ImpersonationConfig{
 						UserName: caller.GetName(),
 						UID:      caller.GetUID(),
 						Groups:   append([]string{authorization.TerminatorGroup(terminator)}, caller.GetGroups()...),
 						Extra:    extra,
-					}
-					authenticatingTransport, err := rest.TransportFor(thisCfg)
+					})
 					if err != nil {
 						http.Error(writer, fmt.Sprintf("could not create round-tripper: %v", err), http.StatusInternalServerError)
 						return
@@ -328,14 +330,12 @@ func BuildVirtualWorkspace(
 					extra[k] = v
 				}
 
-				thisCfg := rest.CopyConfig(cfg)
-				thisCfg.Impersonate = rest.ImpersonationConfig{
+				authenticatingTransport, err := transportCache.TransportFor(rest.ImpersonationConfig{
 					UserName: info.Username,
 					UID:      info.UID,
 					Groups:   info.Groups,
 					Extra:    extra,
-				}
-				authenticatingTransport, err := rest.TransportFor(thisCfg)
+				})
 				if err != nil {
 					http.Error(writer, fmt.Sprintf("could not create round-tripper: %v", err), http.StatusInternalServerError)
 					return


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

```
Initializing and terminating VWs construct a new http.Transport
for every rest.ImpersonationConfig for a given request.
This is taxing on both the CPU and memory, so adding some
caching is desired.

The TTLCache is perfect for this since it supports both
eviction callbacks and concurrent enqueueing.

- Implement TransportCache in proxy.go.
- Add unit tests.

Benchmarks are omitted but as a short summary, for a 100
identical rest.ImpersonationConfig, the new approach is 5% faster
and 3x less memory to obtain an http.Transport.
```

## What Type of PR Is This?


/kind feature

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes https://github.com/kcp-dev/kcp/issues/4084

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
feature: cache impersonating HTTP transports in the initializing and terminating virtual workspaces as a performance improvement.
```
