### PR TITLE
Add global cluster-aware validating admission webhook

### DIFF
--- a/cmd/kcp/options/flags.go
+++ b/cmd/kcp/options/flags.go
@@ -18,6 +18,7 @@ package options
 
 var (
 	namedFlagSetOrder = []string{
+		"admission",
 		"auditing",
 		"authentication",
 		"etcd",

--- a/config/examples/global-admission-webhook/README.md
+++ b/config/examples/global-admission-webhook/README.md
@@ -1,0 +1,47 @@
+# Global cluster-aware validating admission webhook
+
+kcp admission webhooks are normally registered *per logical cluster* (a
+`ValidatingWebhookConfiguration` object lives in, and fires only for, one
+workspace) — or, for APIExport-bound resources, once in the provider workspace
+for that export's resources. There was no way to register **one** webhook that
+fires for **every** workspace, the way `--authorization-webhook-config-file`
+wires a single global authorization webhook.
+
+The `apis.kcp.io/GlobalValidatingWebhook` admission plugin fills that gap: a
+single `ValidatingWebhookConfiguration`, supplied to the shard at **startup**,
+applied to **all** logical clusters. Unlike the authorization webhook it is an
+**admission** webhook — the callout carries the full object body + operation and
+can **deny**. Because it is wired into the shard (not an in-workspace object), a
+workspace admin cannot see or remove it.
+
+## How the webhook learns the cluster
+
+The reviewed object carries the request's logical cluster on its
+`kcp.io/cluster` annotation, stamped for the duration of the callout (create/update
+on the new object, delete on the old object) and reverted afterwards — so a single
+endpoint is cluster-aware on every operation.
+
+## Use
+
+```sh
+kcp start \
+  --admission-control-config-file=config/examples/global-admission-webhook/admission-config.yaml
+```
+
+- `admission-config.yaml` — an `AdmissionConfiguration` pointing the plugin at the
+  webhook config.
+- `global-validatingwebhookconfiguration.yaml` — a normal
+  `ValidatingWebhookConfiguration` (URL clientConfig + caBundle). Serve
+  AdmissionReview `v1`.
+
+The plugin is default-on but **inert** unless this config is supplied.
+
+## Notes / guardrails
+
+- It is on the write path of every matching request across every workspace —
+  keep `failurePolicy` and `timeoutSeconds` tight, and narrow `rules` /
+  `matchConditions` (CEL) so you are only called for objects you care about.
+- Only **URL** clientConfig is exercised (service resolution is not wired for the
+  static source). Provide the `caBundle`.
+- This is the validating (deny) variant; a mutating sibling can be added the same
+  way if needed.

--- a/config/examples/global-admission-webhook/admission-config.yaml
+++ b/config/examples/global-admission-webhook/admission-config.yaml
@@ -1,0 +1,9 @@
+# Pass this to the shard: --admission-control-config-file=admission-config.yaml
+# It points the global validating-webhook admission plugin at a
+# ValidatingWebhookConfiguration that is applied to EVERY logical cluster.
+apiVersion: apiserver.config.k8s.io/v1
+kind: AdmissionConfiguration
+plugins:
+- name: apis.kcp.io/GlobalValidatingWebhook
+  # Inline the config, or use `path: global-validatingwebhookconfiguration.yaml`.
+  path: global-validatingwebhookconfiguration.yaml

--- a/config/examples/global-admission-webhook/global-validatingwebhookconfiguration.yaml
+++ b/config/examples/global-admission-webhook/global-validatingwebhookconfiguration.yaml
@@ -1,0 +1,31 @@
+# A normal ValidatingWebhookConfiguration - but supplied to the shard at startup
+# (via admission-config.yaml) rather than created as an object in a workspace. It
+# therefore fires for matching requests in ALL logical clusters, with no per-
+# workspace registration, and a workspace admin cannot see or remove it.
+#
+# The request's logical cluster is delivered to the endpoint on the reviewed
+# object's `kcp.io/cluster` annotation (stamped for the duration of the callout).
+# Use URL clientConfig + caBundle; the webhook must serve AdmissionReview v1 and
+# can DENY. Keep failurePolicy/timeout tight - this is on the write path of every
+# matching request across every workspace.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: metering-global
+webhooks:
+- name: enforce.metering.contrib.kcp.io
+  clientConfig:
+    url: https://metering-webhook.metering.svc:443/validate
+    caBundle: REPLACE_WITH_BASE64_CA
+  rules:
+  - apiGroups: ["*"]
+    apiVersions: ["*"]
+    operations: ["CREATE", "DELETE"]
+    resources: ["*"]
+    scope: "*"
+  # Narrow with matchConditions (CEL) so you are not called for every request -
+  # e.g. only objects a MeteringConfig meters.
+  failurePolicy: Ignore
+  timeoutSeconds: 2
+  sideEffects: None
+  admissionReviewVersions: ["v1"]

--- a/pkg/admission/globalwebhook/plugin.go
+++ b/pkg/admission/globalwebhook/plugin.go
@@ -1,0 +1,217 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package globalwebhook implements a GLOBAL, cluster-aware validating admission
+// webhook: a single ValidatingWebhookConfiguration, supplied to the shard at
+// startup (via --admission-control-config-file, this plugin's config section),
+// that fires for requests in EVERY logical cluster - without a per-workspace
+// WebhookConfiguration object, and tamper-proof against workspace admins.
+//
+// This is to admission what --authorization-webhook-config-file is to
+// authorization: one endpoint, wired at bootstrap, applied globally. Unlike the
+// authorization webhook it is an ADMISSION webhook, so the callout carries the
+// full object body + operation and can DENY. The request's logical cluster is
+// conveyed on the object via the kcp.io/cluster annotation (like kcp's per-
+// cluster webhook plugin), stamped here for create/update (object) and delete
+// (oldObject) so the external webhook is cluster-aware on every operation.
+//
+// Configure it by putting a normal ValidatingWebhookConfiguration in this
+// plugin's admission-config section (see docs/content/...); leave it unset and
+// the plugin is inert. Only URL clientConfig with a caBundle is required - no
+// per-cluster objects, no APIBindings.
+package globalwebhook
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"sigs.k8s.io/yaml"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/admission/plugin/webhook"
+	"k8s.io/apiserver/pkg/admission/plugin/webhook/generic"
+	"k8s.io/apiserver/pkg/admission/plugin/webhook/validating"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	admissionregistrationapiv1 "k8s.io/kubernetes/pkg/apis/admissionregistration/v1"
+
+	kcpkubernetesinformers "github.com/kcp-dev/client-go/informers"
+	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
+
+	kcpinitializers "github.com/kcp-dev/kcp/pkg/admission/initializers"
+	"github.com/kcp-dev/kcp/pkg/admission/validatingwebhook"
+)
+
+const (
+	// PluginName is the admission plugin name.
+	PluginName = "apis.kcp.io/GlobalValidatingWebhook"
+)
+
+// Plugin is a global, cluster-aware validating admission webhook. It holds a
+// static webhook source parsed once from its admission config; when that config
+// is absent it is inert.
+type Plugin struct {
+	*admission.Handler
+
+	// source is the static, cluster-independent set of webhooks parsed from the
+	// plugin config. nil => not configured => the plugin is a no-op.
+	source generic.Source
+
+	// Injected via initializers; needed by the inner validating webhook for
+	// namespaceSelector matching and (service) endpoint resolution.
+	kubeClusterClient              kcpkubernetesclientset.ClusterInterface
+	localKubeSharedInformerFactory kcpkubernetesinformers.SharedInformerFactory
+}
+
+var (
+	_ = admission.ValidationInterface(&Plugin{})
+	_ = admission.InitializationValidator(&Plugin{})
+	_ = kcpinitializers.WantsKubeClusterClient(&Plugin{})
+	_ = kcpinitializers.WantsKubeInformers(&Plugin{})
+)
+
+// staticSource is a generic.Source backed by a fixed webhook list - the same for
+// every logical cluster (that is what makes the webhook "global").
+type staticSource struct {
+	hooks []webhook.WebhookAccessor
+}
+
+func (s *staticSource) Webhooks() []webhook.WebhookAccessor { return s.hooks }
+func (s *staticSource) HasSynced() bool                     { return true }
+
+// NewGlobalValidatingWebhook parses the plugin config (a
+// ValidatingWebhookConfiguration) into a static source. An empty config yields
+// an inert plugin.
+func NewGlobalValidatingWebhook(configFile io.Reader) (*Plugin, error) {
+	p := &Plugin{
+		Handler: admission.NewHandler(admission.Connect, admission.Create, admission.Delete, admission.Update),
+	}
+	if configFile == nil {
+		return p, nil
+	}
+	raw, err := io.ReadAll(configFile)
+	if err != nil {
+		return nil, err
+	}
+	if len(raw) == 0 {
+		return p, nil
+	}
+
+	var cfg admissionregistrationv1.ValidatingWebhookConfiguration
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		return nil, fmt.Errorf("globalwebhook: parse config as ValidatingWebhookConfiguration: %w", err)
+	}
+	// Apply API defaulting the same way object creation would: a parsed config
+	// otherwise leaves namespaceSelector/objectSelector nil, and
+	// LabelSelectorAsSelector(nil) matches NOTHING - so the webhook would silently
+	// never fire. Defaulting sets empty (match-all) selectors, matchPolicy, scope,
+	// failurePolicy and timeout.
+	admissionregistrationapiv1.SetObjectDefaults_ValidatingWebhookConfiguration(&cfg)
+	if len(cfg.Webhooks) == 0 {
+		return p, nil
+	}
+
+	name := cfg.Name
+	if name == "" {
+		name = "global"
+	}
+	hooks := make([]webhook.WebhookAccessor, 0, len(cfg.Webhooks))
+	for i := range cfg.Webhooks {
+		h := &cfg.Webhooks[i]
+		uid := fmt.Sprintf("%s/%s/%d", name, h.Name, i)
+		hooks = append(hooks, webhook.NewValidatingWebhookAccessor(uid, name, h))
+	}
+	p.source = &staticSource{hooks: hooks}
+	return p, nil
+}
+
+// Register registers the plugin.
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(configFile io.Reader) (admission.Interface, error) {
+		return NewGlobalValidatingWebhook(configFile)
+	})
+}
+
+// Validate dispatches the admission request to the globally-configured webhook,
+// with the request's logical cluster stamped on the object so the external
+// webhook is cluster-aware.
+func (p *Plugin) Validate(ctx context.Context, attr admission.Attributes, o admission.ObjectInterfaces) error {
+	if p.source == nil {
+		return nil // not configured
+	}
+
+	cluster, err := genericapirequest.ValidClusterFrom(ctx)
+	if err != nil {
+		return err
+	}
+	clusterName := cluster.Name
+
+	plugin, err := validating.NewValidatingAdmissionWebhook(nil)
+	if err != nil {
+		return fmt.Errorf("globalwebhook: create validating admission webhook: %w", err)
+	}
+	plugin.SetExternalKubeClientSet(p.kubeClusterClient.Cluster(clusterName.Path()))
+	plugin.SetNamespaceInformer(p.localKubeSharedInformerFactory.Core().V1().Namespaces().Cluster(clusterName))
+	plugin.SetAPISource(p.source)
+	if err := plugin.ValidateInitialization(); err != nil {
+		return fmt.Errorf("globalwebhook: validate initialization: %w", err)
+	}
+
+	// Convey the logical cluster to the external webhook via the kcp.io/cluster
+	// annotation, on whichever object the operation carries: the new object for
+	// create/update, the old object for delete. Reverted right after dispatch so
+	// it is never persisted.
+	if obj, ok := attr.GetObject().(metav1.Object); ok && obj != nil {
+		if undo := validatingwebhook.SetClusterAnnotation(obj, clusterName); undo != nil {
+			defer undo()
+		}
+	}
+	if old, ok := attr.GetOldObject().(metav1.Object); ok && old != nil {
+		if undo := validatingwebhook.SetClusterAnnotation(old, clusterName); undo != nil {
+			defer undo()
+		}
+	}
+
+	return plugin.Validate(ctx, attr, o)
+}
+
+// ValidateInitialization ensures required dependencies were injected.
+func (p *Plugin) ValidateInitialization() error {
+	if p.source == nil {
+		return nil // inert; no dependencies needed
+	}
+	if p.kubeClusterClient == nil {
+		return errors.New("missing kubeClusterClient")
+	}
+	if p.localKubeSharedInformerFactory == nil {
+		return errors.New("missing localKubeSharedInformerFactory")
+	}
+	return nil
+}
+
+// SetKubeClusterClient implements WantsKubeClusterClient.
+func (p *Plugin) SetKubeClusterClient(client kcpkubernetesclientset.ClusterInterface) {
+	p.kubeClusterClient = client
+}
+
+// SetKubeInformers implements WantsKubeInformers. Only the local factory is used
+// (namespace informer); the source is static, so no global config informer.
+func (p *Plugin) SetKubeInformers(local, global kcpkubernetesinformers.SharedInformerFactory) {
+	p.localKubeSharedInformerFactory = local
+}

--- a/pkg/admission/globalwebhook/plugin_test.go
+++ b/pkg/admission/globalwebhook/plugin_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package globalwebhook
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"k8s.io/apiserver/pkg/admission"
+)
+
+const twoWebhookConfig = `
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: metering
+webhooks:
+- name: enforce.metering.contrib.kcp.io
+  clientConfig:
+    url: https://metering-webhook.metering.svc/validate
+    caBundle: dGVzdA==
+  rules:
+  - apiGroups: ["*"]
+    apiVersions: ["*"]
+    operations: ["CREATE","DELETE"]
+    resources: ["*"]
+  failurePolicy: Ignore
+  sideEffects: None
+  admissionReviewVersions: ["v1"]
+- name: second.metering.contrib.kcp.io
+  clientConfig:
+    url: https://metering-webhook.metering.svc/validate2
+    caBundle: dGVzdA==
+  sideEffects: None
+  admissionReviewVersions: ["v1"]
+`
+
+func TestInertWhenUnconfigured(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name   string
+		config string
+		nilCfg bool
+	}{
+		{name: "nil config", nilCfg: true},
+		{name: "empty config", config: ""},
+		{name: "zero webhooks", config: "apiVersion: admissionregistration.k8s.io/v1\nkind: ValidatingWebhookConfiguration\nmetadata:\n  name: x\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var r *strings.Reader
+			if !tc.nilCfg {
+				r = strings.NewReader(tc.config)
+			}
+			var p *Plugin
+			var err error
+			if r == nil {
+				p, err = NewGlobalValidatingWebhook(nil)
+			} else {
+				p, err = NewGlobalValidatingWebhook(r)
+			}
+			if err != nil {
+				t.Fatalf("construct: %v", err)
+			}
+			if p.source != nil {
+				t.Fatalf("expected inert plugin (nil source), got a source")
+			}
+			// Inert plugin admits everything without touching injected deps.
+			if err := p.Validate(context.Background(), nil, nil); err != nil {
+				t.Fatalf("inert Validate should no-op, got %v", err)
+			}
+			if err := p.ValidateInitialization(); err != nil {
+				t.Fatalf("inert ValidateInitialization should pass, got %v", err)
+			}
+		})
+	}
+}
+
+func TestBuildsStaticSourceFromConfig(t *testing.T) {
+	t.Parallel()
+	p, err := NewGlobalValidatingWebhook(strings.NewReader(twoWebhookConfig))
+	if err != nil {
+		t.Fatalf("construct: %v", err)
+	}
+	if p.source == nil {
+		t.Fatal("expected a static source, got nil")
+	}
+	hooks := p.source.Webhooks()
+	if len(hooks) != 2 {
+		t.Fatalf("expected 2 webhooks, got %d", len(hooks))
+	}
+	if !p.source.HasSynced() {
+		t.Fatal("static source should always report HasSynced=true")
+	}
+}
+
+func TestHandlesAllOperations(t *testing.T) {
+	t.Parallel()
+	p, _ := NewGlobalValidatingWebhook(nil)
+	for _, op := range []admission.Operation{admission.Create, admission.Update, admission.Delete, admission.Connect} {
+		if !p.Handles(op) {
+			t.Errorf("expected plugin to handle %v", op)
+		}
+	}
+}
+
+func TestBadConfigErrors(t *testing.T) {
+	t.Parallel()
+	if _, err := NewGlobalValidatingWebhook(strings.NewReader("webhooks: [ this: is: not: valid")); err == nil {
+		t.Fatal("expected an error for malformed config")
+	}
+}

--- a/pkg/admission/plugins.go
+++ b/pkg/admission/plugins.go
@@ -55,6 +55,7 @@ import (
 	"github.com/kcp-dev/kcp/pkg/admission/apiresourceschema"
 	"github.com/kcp-dev/kcp/pkg/admission/cachedresource"
 	"github.com/kcp-dev/kcp/pkg/admission/crdnooverlappinggvr"
+	"github.com/kcp-dev/kcp/pkg/admission/globalwebhook"
 	"github.com/kcp-dev/kcp/pkg/admission/kubequota"
 	"github.com/kcp-dev/kcp/pkg/admission/logicalcluster"
 	"github.com/kcp-dev/kcp/pkg/admission/logicalclusterfinalizer"
@@ -94,6 +95,7 @@ var AllOrderedPlugins = beforeWebhooks(
 	kcpmutatingadmissionpolicy.PluginName,
 	kcpvalidatingadmissionpolicy.PluginName,
 	kcpvalidatingwebhook.PluginName,
+	globalwebhook.PluginName,
 	reservedcrdannotations.PluginName,
 	reservedcrdgroups.PluginName,
 	reservednames.PluginName,
@@ -136,6 +138,7 @@ func RegisterAllKcpAdmissionPlugins(plugins *admission.Plugins) {
 	kcpmutatingadmissionpolicy.Register(plugins)
 	kcpvalidatingadmissionpolicy.Register(plugins)
 	kcpvalidatingwebhook.Register(plugins)
+	globalwebhook.Register(plugins)
 	reservedcrdannotations.Register(plugins)
 	reservedcrdgroups.Register(plugins)
 	reservednames.Register(plugins)
@@ -169,6 +172,7 @@ var defaultOnPluginsInKcp = sets.New[string](
 	kcpmutatingadmissionpolicy.PluginName,
 	kcpvalidatingadmissionpolicy.PluginName,
 	kcpvalidatingwebhook.PluginName,
+	globalwebhook.PluginName,
 	reservedcrdannotations.PluginName,
 	reservedcrdgroups.PluginName,
 	reservednames.PluginName,

--- a/pkg/server/options/flags.go
+++ b/pkg/server/options/flags.go
@@ -158,6 +158,9 @@ var (
 		"disabled-metrics",                // This flag provides an escape hatch for misbehaving metrics. You must provide the fully qualified metric name in order to disable it. Disclaimer: disabling metrics is higher in precedence than showing hidden metrics.
 		"show-hidden-metrics-for-version", // The previous version for which you want to show hidden metrics. Only the previous minor version is meaningful, other values will not be allowed. The format is <major>.<minor>, e.g.: '1.16'. The purpose of this format is make sure you have the opportunity to notice if the next release hides additional metrics, rather than being surprised when they are permanently removed in the release after that.
 
+		// admission flags
+		"admission-control-config-file", // File with admission control configuration (per-plugin admission config; notably for the apis.kcp.io/GlobalValidatingWebhook plugin - a global, cluster-aware validating webhook wired at shard startup).
+
 		// misc flags
 		"enable-logs-handler",                   // If true, install a /logs handler for the apiserver logs.
 		"event-ttl",                             // Amount of time to retain events.
@@ -189,10 +192,14 @@ var (
 		// admission flags
 		"default-not-ready-toleration-seconds",   // Indicates the tolerationSeconds of the toleration for notReady:NoExecute that is added by default to every pod that does not already have such a toleration.
 		"default-unreachable-toleration-seconds", // Indicates the tolerationSeconds of the toleration for unreachable:NoExecute that is added by default to every pod that does not already have such a toleration.
-		"admission-control-config-file",          // File with admission control configuration.
-		"disable-admission-plugins",              // admission plugins that should be disabled although they are in the default enabled plugins list (NamespaceLifecycle). Comma-delimited list of admission plugins: MutatingAdmissionWebhook, NamespaceLifecycle, ValidatingAdmissionWebhook. The order of plugins in this flag does not matter.
-		"enable-admission-plugins",               // admission plugins that should be enabled in addition to default enabled ones (NamespaceLifecycle). Comma-delimited list of admission plugins: MutatingAdmissionWebhook, NamespaceLifecycle, ValidatingAdmissionWebhook. The order of plugins in this flag does not matter.
-		"admission-control",                      // Deprecated: Use --enable-admission-plugins or --disable-admission-plugins instead. Will be removed in a future version.
+		// admission-control-config-file is intentionally EXPOSED (not disallowed):
+		// it delivers per-plugin admission config, notably for the
+		// apis.kcp.io/GlobalValidatingWebhook plugin (a global, cluster-aware
+		// validating webhook wired at startup). enable/disable-admission-plugins
+		// remain disallowed - the plugin set stays curated.
+		"disable-admission-plugins", // admission plugins that should be disabled although they are in the default enabled plugins list (NamespaceLifecycle). Comma-delimited list of admission plugins: MutatingAdmissionWebhook, NamespaceLifecycle, ValidatingAdmissionWebhook. The order of plugins in this flag does not matter.
+		"enable-admission-plugins",  // admission plugins that should be enabled in addition to default enabled ones (NamespaceLifecycle). Comma-delimited list of admission plugins: MutatingAdmissionWebhook, NamespaceLifecycle, ValidatingAdmissionWebhook. The order of plugins in this flag does not matter.
+		"admission-control",         // Deprecated: Use --enable-admission-plugins or --disable-admission-plugins instead. Will be removed in a future version.
 
 		// egress selector flags
 		"egress-selector-config-file", // File with apiserver egress selector configuration.

--- a/test/e2e/admissionwebhook/globalwebhook_test.go
+++ b/test/e2e/admissionwebhook/globalwebhook_test.go
@@ -1,0 +1,194 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admissionwebhook
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+
+	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
+	"github.com/kcp-dev/logicalcluster/v3"
+	"github.com/kcp-dev/sdk/apis/core"
+	kcptesting "github.com/kcp-dev/sdk/testing"
+	kcptestingserver "github.com/kcp-dev/sdk/testing/server"
+
+	webhookserver "github.com/kcp-dev/kcp/test/e2e/fixtures/webhook"
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+	"github.com/kcp-dev/kcp/test/server/pki"
+)
+
+// TestGlobalValidatingWebhook exercises the apis.kcp.io/GlobalValidatingWebhook
+// admission plugin: a SINGLE ValidatingWebhookConfiguration supplied to the shard
+// at startup (--admission-control-config-file) that fires for requests in EVERY
+// logical cluster - here on ConfigMaps, a NATIVE resource that is part of no
+// APIExport (the case a per-workspace/per-export webhook can't cover globally).
+//
+// It asserts the three properties that make this webhook distinct:
+//   - GLOBAL: one startup config fires in two independent workspaces.
+//   - CLUSTER-AWARE: the reviewed object carries each request's own
+//     kcp.io/cluster annotation.
+//   - DENY + CONTENT: it decodes the full object body and can reject the request.
+func TestGlobalValidatingWebhook(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "control-plane")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	// Decoder for AdmissionReview + ConfigMap (the fixture decodes both).
+	scheme := runtime.NewScheme()
+	require.NoError(t, admissionv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	deserializer := serializer.NewCodecFactory(scheme).UniversalDeserializer()
+
+	var (
+		seen sync.Map    // cluster name -> struct{}: which clusters the webhook saw
+		deny atomic.Bool // flip to make the webhook reject
+	)
+	testWebhook := &webhookserver.AdmissionWebhookServer{
+		ObjectGVK:    schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"},
+		Deserializer: deserializer,
+		ResponseFn: func(obj runtime.Object, review *admissionv1.AdmissionReview) (*admissionv1.AdmissionResponse, error) {
+			cm := obj.(*corev1.ConfigMap)
+			seen.Store(logicalcluster.From(cm).String(), struct{}{})
+			if deny.Load() {
+				return &admissionv1.AdmissionResponse{
+					Allowed: false,
+					Result:  &metav1.Status{Message: "denied by e2e global webhook"},
+				}, nil
+			}
+			return &admissionv1.AdmissionResponse{Allowed: true}, nil
+		},
+	}
+
+	// Serving cert for localhost, generated BEFORE kcp so its CA can be baked into
+	// the startup admission config.
+	certDir := t.TempDir()
+	certFile := filepath.Join(certDir, "webhook.crt")
+	keyFile := filepath.Join(certDir, "webhook.key")
+	caFile := filepath.Join(certDir, "webhook-ca.crt")
+	require.NoError(t, pki.GenerateSelfSignedCert(certFile, keyFile, caFile, []string{"localhost", "127.0.0.1"}))
+
+	port, err := kcptestingserver.GetFreePort(t)
+	require.NoError(t, err)
+	testWebhook.StartTLS(t, certFile, keyFile, "https://localhost:"+port, port)
+
+	caPEM, err := os.ReadFile(caFile)
+	require.NoError(t, err)
+
+	// The global ValidatingWebhookConfiguration + the AdmissionConfiguration that
+	// points our plugin at it. objectSelector keeps the blast radius to this
+	// test's ConfigMaps only (so kcp's own ConfigMaps are never intercepted).
+	vwcPath := filepath.Join(certDir, "global-vwc.yaml")
+	vwc := fmt.Sprintf(`apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: e2e-global
+webhooks:
+- name: e2e.globalwebhook.kcp.io
+  clientConfig:
+    url: %q
+    caBundle: %q
+  rules:
+  - apiGroups: [""]
+    apiVersions: ["v1"]
+    operations: ["CREATE"]
+    resources: ["configmaps"]
+    scope: "*"
+  objectSelector:
+    matchLabels:
+      e2e-globalwebhook: "true"
+  failurePolicy: Fail
+  timeoutSeconds: 5
+  sideEffects: None
+  admissionReviewVersions: ["v1"]
+`, testWebhook.GetURL(), base64.StdEncoding.EncodeToString(caPEM))
+	require.NoError(t, os.WriteFile(vwcPath, []byte(vwc), 0o644))
+
+	admissionCfgPath := filepath.Join(certDir, "admission-config.yaml")
+	admissionCfg := fmt.Sprintf(`apiVersion: apiserver.config.k8s.io/v1
+kind: AdmissionConfiguration
+plugins:
+- name: apis.kcp.io/GlobalValidatingWebhook
+  path: %q
+`, vwcPath)
+	require.NoError(t, os.WriteFile(admissionCfgPath, []byte(admissionCfg), 0o644))
+
+	// A dedicated shard started with the global webhook wired in.
+	server := kcptesting.PrivateKcpServer(t,
+		kcptestingserver.WithCustomArguments("--admission-control-config-file", admissionCfgPath))
+	// Avoid the known early-shutdown race (see authorizer e2e).
+	time.Sleep(3 * time.Second)
+
+	cfg := server.BaseConfig(t)
+	kubeClusterClient, err := kcpkubernetesclientset.NewForConfig(cfg)
+	require.NoError(t, err)
+
+	// Two independent workspaces; one startup webhook must fire in both.
+	ws1Path, ws1 := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path())
+	ws2Path, ws2 := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path())
+
+	newCM := func(name string) *corev1.ConfigMap {
+		return &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Labels: map[string]string{"e2e-globalwebhook": "true"}},
+		}
+	}
+
+	t.Log("Create a labeled ConfigMap in each workspace; the single global webhook fires in both.")
+	for i, wsPath := range []logicalcluster.Path{ws1Path, ws2Path} {
+		name := fmt.Sprintf("allowed-%d", i)
+		var lastErr error
+		ok := func() bool {
+			for start := time.Now(); time.Since(start) < 30*time.Second; time.Sleep(200 * time.Millisecond) {
+				_, lastErr = kubeClusterClient.Cluster(wsPath).CoreV1().ConfigMaps("default").Create(ctx, newCM(name), metav1.CreateOptions{})
+				if lastErr == nil {
+					return true
+				}
+			}
+			return false
+		}()
+		require.True(t, ok, "creating ConfigMap in %s failed; last error: %v", wsPath, lastErr)
+	}
+
+	// Cluster-aware: the webhook saw each workspace's own kcp.io/cluster.
+	_, saw1 := seen.Load(ws1.Spec.Cluster)
+	_, saw2 := seen.Load(ws2.Spec.Cluster)
+	require.True(t, saw1, "webhook should have seen ws1 cluster %q (stamped kcp.io/cluster)", ws1.Spec.Cluster)
+	require.True(t, saw2, "webhook should have seen ws2 cluster %q (stamped kcp.io/cluster)", ws2.Spec.Cluster)
+
+	t.Log("Flip the webhook to deny; a matching ConfigMap create is now rejected.")
+	deny.Store(true)
+	_, err = kubeClusterClient.Cluster(ws1Path).CoreV1().ConfigMaps("default").Create(ctx, newCM("denied"), metav1.CreateOptions{})
+	require.Error(t, err, "create should be denied by the global webhook")
+	require.Contains(t, err.Error(), "denied by e2e global webhook")
+}


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Introduce a compiled-in admission plugin, `apis.kcp.io/GlobalValidatingWebhook`, that applies a single `ValidatingWebhookConfiguration` - supplied to the shard at startup via `--admission-control-config-file` - to requests in EVERY logical cluster, without a per-workspace WebhookConfiguration object.

This is to admission what `--authorization-webhook-config-file` is to authorization: one endpoint, wired at bootstrap, applied globally. Unlike the authorization webhook it is an admission webhook, so the callout carries the full object body + operation and **can deny**. The request's logical cluster is conveyed to the endpoint on the object's `kcp.io/cluster` annotation (`create/update` on the object, delete on the old object). Parsed config is run through API defaulting so nil namespace/object selectors do not silently match nothing.

This allows to start setting global policies on all instance. 

## What Type of PR Is This?

/kind feature

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Add global/system-wide ValidatingWebhookConfiguration
```
