### PR TITLE
display a warning banner for old versions

### DIFF
--- a/docs/overrides/scripts/version_banner.js
+++ b/docs/overrides/scripts/version_banner.js
@@ -1,72 +1,40 @@
 (function () {
   "use strict";
 
-  const UNRELEASED_VERSION = "main";
+  const path = window.location.pathname;
+  const match = path.match(/^(.*?\/)(main|v\d+\.\d+[^\/]*)(\/|$)/);
+  if (!match) return;
 
-  function getCurrentVersion() {
-    const path = window.location.pathname;
-    const versionMatch = path.match(/\/(main|v\d+\.\d+[^\/]*)/);
-    return versionMatch ? versionMatch[1] : null;
-  }
+  const root = match[1];
+  const currentVersion = match[2];
 
-  function getAvailableVersions() {
-    const versionList = document.querySelector("ul.md-version__list");
-    if (!versionList) return [];
+  fetch(root + "versions.json")
+    .then((response) => response.json())
+    .then((versions) => {
+      const latest =
+        versions.find((v) => (v.aliases || []).includes("latest")) || versions[0];
+      if (!latest) return;
 
-    const links = Array.from(
-      versionList.querySelectorAll("a.md-version__link")
-    );
+      let message;
+      if (currentVersion === "main") {
+        message = "You are viewing the docs for an unreleased version.";
+      } else if (currentVersion !== latest.version) {
+        message = "You are viewing the docs for an old version.";
+      }
+      if (!message) return;
 
-    return links
-      .map((link) => {
-        const href = link.href || link.getAttribute("href");
-        const match = href.match(/\/(v\d+\.\d+[^\/]*)\//);
-        return match ? match[1] : null;
-      })
-      .filter((v) => v && /^v\d+\.\d+/.test(v))
-      .filter((v, i, arr) => arr.indexOf(v) === i);
-  }
+      const rest = path.slice(root.length + currentVersion.length);
+      createBanner(message, root + latest.version + rest);
+    })
+    .catch(() => {});
 
-  function getLatestVersionPath() {
-    const versions = getAvailableVersions();
-    const latestVersion = versions[0];
-
-    if (!latestVersion) {
-      return null;
-    }
-
-    const currentPath = window.location.pathname;
-
-    return (
-      currentPath.replace(/\/main(\/|$)/, `/${latestVersion}$1`) ||
-      `/${latestVersion}/`
-    );
-  }
-
-  function createBanner() {
+  function createBanner(message, latestPath) {
     const banner = document.createElement("div");
     banner.id = "version-banner";
     banner.innerHTML = `
-    <strong>You are viewing the docs for an unreleased version.</strong>
-    <a href="#" id="latest-version-link">Click here to go to the latest stable version.</a>
+    <strong>${message}</strong>
+    <a href="${latestPath}" id="latest-version-link">Click here to go to the latest stable version.</a>
   `;
-
-    banner.querySelector("#latest-version-link").addEventListener("click", function (e) {
-      const path = getLatestVersionPath();
-      if (path) {
-        e.preventDefault();
-        window.location.href = path;
-      }
-    });
-
     document.body.insertBefore(banner, document.body.firstChild);
-
-    return banner;
   }
-
-  if (getCurrentVersion() !== UNRELEASED_VERSION) {
-    return;
-  }
-
-  createBanner();
 })();


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

This change displays a banner on old releases to warn users that they are viewing an old release. Motivation was that we received community feedback, where a user searched for "kcp cluster management" on Google, which led to an old version back when we had this functionality, leading to some confusion.

## What it looks like now

unreleased (aka main)
<img width="2400" height="174" alt="grafik" src="https://github.com/user-attachments/assets/48286c25-a10d-4103-8525-918a94e06dac" />

latest release
<img width="2384" height="110" alt="grafik" src="https://github.com/user-attachments/assets/161e17c4-cc79-43f2-9bd6-3e40a837db5d" />

old version
<img width="2400" height="172" alt="grafik" src="https://github.com/user-attachments/assets/c33a1087-08b5-4739-b5a3-88d9ad7702f4" />


## Implementation Hints

I know this looks a little bit like much code to just display another message. However the revamp makes sense. Unlike previously with main, which can be directly obtained from url path, we now need to have the whole list of available versions, to figure out if we are the latest one. With this approach we now just go ahead and fetch it directly from mike's versions.json. This is much better than the alternative, where we would need to async wait for the version dropdown menue to render and then parse it out of the DOM.

## Next steps

I will need to cherrypick this to all release branches once, so it gets deployed to those versions. Good news is for future versions this is not necessary anymore and will work out of the box, since versions.json is global.

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->
/kind documentation

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Display out of date banner on old documentation versions
```
