### PR TITLE
pkg/virtual: use system identity for system initializers

### DIFF
--- a/pkg/virtual/initializingworkspaces/builder/build.go
+++ b/pkg/virtual/initializingworkspaces/builder/build.go
@@ -20,13 +20,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/url"
 	"path"
 	"strings"
 	"time"
 
-	authenticationv1 "k8s.io/api/authentication/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
@@ -291,67 +291,9 @@ func BuildVirtualWorkspace(
 					return
 				}
 
-				if wst != nil && len(wst.Spec.InitializerPermissions) > 0 {
-					caller := authorization.RequestUserInfo(request)
-					if caller == nil {
-						http.Error(writer, "no user information in request context", http.StatusInternalServerError)
-						return
-					}
-					// Evaluate the initializer's permissions. If not allowed, reject the request. If
-					// allowed, forward with the initializer's identity plus a synthetic group that signals.
-					if allowed, reason := authorization.EvaluateLifecyclePermissions(request, caller, wst.Spec.InitializerPermissions); !allowed {
-						http.Error(writer, fmt.Sprintf("initializer %q denied by initializerPermissions: %s", initializer, reason), http.StatusForbidden)
-						return
-					}
-
-					thisCfg := rest.CopyConfig(cfg)
-					extra := map[string][]string{}
-					for k, v := range caller.GetExtra() {
-						extra[k] = v
-					}
-					thisCfg.Impersonate = rest.ImpersonationConfig{
-						UserName: caller.GetName(),
-						UID:      caller.GetUID(),
-						// Inject the synthetic group so the workspace content authorizer
-						// trusts this request as pre-authorized by the VW. This will be used for auditing.
-						Groups: append([]string{authorization.InitializerGroup(initializer)}, caller.GetGroups()...),
-						Extra:  extra,
-					}
-					authenticatingTransport, err := rest.TransportFor(thisCfg)
-					if err != nil {
-						http.Error(writer, fmt.Sprintf("could not create round-tripper: %v", err), http.StatusInternalServerError)
-						return
-					}
-					virtualshared.ServeProxy(writer, request, forwardedHost, authenticatingTransport)
-					return
-				}
-
-				// Owner-impersonation fallback (mode 2).
-				if logicalCluster.Spec.CreatedBy == nil {
-					http.Error(writer, fmt.Sprintf("LogicalCluster %s|%s had no createdBy recorded", cluster, corev1alpha1.LogicalClusterName), http.StatusInternalServerError)
-					return
-				}
-				info := authenticationv1.UserInfo{
-					Username: logicalCluster.Spec.CreatedBy.Username,
-					UID:      logicalCluster.Spec.CreatedBy.UID,
-					Groups:   logicalCluster.Spec.CreatedBy.Groups,
-					Extra:    logicalCluster.Spec.CreatedBy.Extra,
-				}
-				extra := map[string][]string{}
-				for k, v := range info.Extra {
-					extra[k] = v
-				}
-
-				thisCfg := rest.CopyConfig(cfg)
-				thisCfg.Impersonate = rest.ImpersonationConfig{
-					UserName: info.Username,
-					UID:      info.UID,
-					Groups:   info.Groups,
-					Extra:    extra,
-				}
-				authenticatingTransport, err := rest.TransportFor(thisCfg)
+				authenticatingTransport, status, err := transportForInitializer(request, cfg, initializer, wst, logicalCluster.Spec.CreatedBy)
 				if err != nil {
-					http.Error(writer, fmt.Sprintf("could not create round-tripper: %v", err), http.StatusInternalServerError)
+					http.Error(writer, err.Error(), status)
 					return
 				}
 				virtualshared.ServeProxy(writer, request, forwardedHost, authenticatingTransport)
@@ -455,6 +397,71 @@ func resolveInitializerWorkspaceType(
 		func() (logicalcluster.Name, string, error) { return initialization.TypeFrom(initializer) },
 		localWSTIndexer, cachedWSTIndexer,
 	)
+}
+
+// transportForInitializer picks the identity the initializing-workspaces VW forwards an initializer
+// request with. System initializers use the VW's own system identity and not impersonate
+// the creating user.
+func transportForInitializer(
+	request *http.Request,
+	cfg *rest.Config,
+	initializer corev1alpha1.LogicalClusterInitializer,
+	wst *tenancyv1alpha1.WorkspaceType,
+	createdBy *corev1alpha1.OwnerUserInfo,
+) (http.RoundTripper, int, error) {
+	thisCfg := cfg
+
+	switch {
+	case wst == nil:
+		// System initializer. Forward as the VW's own system identity and do not impersonate
+		// the creator. Impersonating would require the creator to hold permissions
+		// on the defaultAPIBindings references.
+
+	case len(wst.Spec.InitializerPermissions) > 0:
+		caller := authorization.RequestUserInfo(request)
+		if caller == nil {
+			return nil, http.StatusInternalServerError, fmt.Errorf("initializer %q: no user information in request context", initializer)
+		}
+		if allowed, reason := authorization.EvaluateLifecyclePermissions(request, caller, wst.Spec.InitializerPermissions); !allowed {
+			return nil, http.StatusForbidden, fmt.Errorf("initializer %q denied by initializerPermissions: %s", initializer, reason)
+		}
+		thisCfg = rest.CopyConfig(cfg)
+		thisCfg.Impersonate = rest.ImpersonationConfig{
+			UserName: caller.GetName(),
+			UID:      caller.GetUID(),
+			Groups:   append([]string{authorization.InitializerGroup(initializer)}, caller.GetGroups()...),
+			Extra:    copyExtra(caller.GetExtra()),
+		}
+
+	default:
+		// Impersonate the user.
+		if createdBy == nil {
+			return nil, http.StatusInternalServerError, fmt.Errorf("initializer %q: no createdBy recorded for owner impersonation", initializer)
+		}
+		extra := make(map[string][]string, len(createdBy.Extra))
+		for k, v := range createdBy.Extra {
+			extra[k] = []string(v)
+		}
+		thisCfg = rest.CopyConfig(cfg)
+		thisCfg.Impersonate = rest.ImpersonationConfig{
+			UserName: createdBy.Username,
+			UID:      createdBy.UID,
+			Groups:   createdBy.Groups,
+			Extra:    extra,
+		}
+	}
+
+	rt, err := rest.TransportFor(thisCfg)
+	if err != nil {
+		return nil, http.StatusInternalServerError, fmt.Errorf("could not create round-tripper: %w", err)
+	}
+	return rt, http.StatusOK, nil
+}
+
+func copyExtra(in map[string][]string) map[string][]string {
+	out := make(map[string][]string, len(in))
+	maps.Copy(out, in)
+	return out
 }
 
 // URLFor returns the absolute path for the specified initializer.

--- a/pkg/virtual/initializingworkspaces/builder/build_test.go
+++ b/pkg/virtual/initializingworkspaces/builder/build_test.go
@@ -17,13 +17,18 @@ limitations under the License.
 package builder
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	authenticationv1 "k8s.io/api/authentication/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/client-go/rest"
@@ -38,6 +43,7 @@ import (
 	"github.com/kcp-dev/virtual-workspace-framework/framework"
 	"github.com/kcp-dev/virtual-workspace-framework/pkg/dynamic/context"
 
+	"github.com/kcp-dev/kcp/pkg/authorization"
 	"github.com/kcp-dev/kcp/pkg/indexers"
 )
 
@@ -209,6 +215,158 @@ func TestResolveInitializerWorkspaceType(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTransportForInitializer(t *testing.T) {
+	t.Parallel()
+
+	const initializer = corev1alpha1.LogicalClusterInitializer("root:org:custom")
+	syntheticGroup := authorization.InitializerGroup(initializer)
+
+	wstAllowingCreate := &tenancyv1alpha1.WorkspaceType{
+		Spec: tenancyv1alpha1.WorkspaceTypeSpec{
+			InitializerPermissions: []rbacv1.PolicyRule{{
+				APIGroups: []string{"apis.kcp.io"},
+				Resources: []string{"apibindings"},
+				Verbs:     []string{"create"},
+			}},
+		},
+	}
+	wstAllowingGetOnly := &tenancyv1alpha1.WorkspaceType{
+		Spec: tenancyv1alpha1.WorkspaceTypeSpec{
+			InitializerPermissions: []rbacv1.PolicyRule{{
+				APIGroups: []string{"apis.kcp.io"},
+				Resources: []string{"apibindings"},
+				Verbs:     []string{"get"},
+			}},
+		},
+	}
+	wstNoPermissions := &tenancyv1alpha1.WorkspaceType{}
+
+	caller := &user.DefaultInfo{
+		Name:   "alice",
+		UID:    "uid-alice",
+		Groups: []string{"g1"},
+		Extra:  map[string][]string{"scope": {"cluster:root"}},
+	}
+	owner := &corev1alpha1.OwnerUserInfo{
+		Username: "bob",
+		UID:      "uid-bob",
+		Groups:   []string{"o1"},
+		Extra:    map[string]authenticationv1.ExtraValue{"scope": {"cluster:root"}},
+	}
+
+	// A create request against apibindings, optionally carrying an authenticated user.
+	newRequest := func(u user.Info) *http.Request {
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost,
+			"/clusters/some-cluster/apis/apis.kcp.io/v1alpha2/apibindings", http.NoBody)
+		if u != nil {
+			req = req.WithContext(request.WithUser(req.Context(), u))
+		}
+		return req
+	}
+
+	tests := []struct {
+		name       string
+		request    *http.Request
+		wst        *tenancyv1alpha1.WorkspaceType
+		createdBy  *corev1alpha1.OwnerUserInfo
+		wantErr    bool
+		wantStatus int
+		// wantUser == "" means no impersonation, i.e. the VW's own system identity.
+		wantUser   string
+		wantGroups []string
+		wantExtra  map[string][]string
+	}{
+		{
+			name:     "system initializer uses the VW system identity",
+			request:  newRequest(nil),
+			wst:      nil,
+			wantUser: "",
+		},
+		{
+			name:       "caller allowed, impersonates caller plus synthetic group",
+			request:    newRequest(caller),
+			wst:        wstAllowingCreate,
+			wantUser:   "alice",
+			wantGroups: []string{syntheticGroup, "g1"},
+			wantExtra:  map[string][]string{"scope": {"cluster:root"}},
+		},
+		{
+			name:       "owner impersonation fallback",
+			request:    newRequest(nil),
+			wst:        wstNoPermissions,
+			createdBy:  owner,
+			wantUser:   "bob",
+			wantGroups: []string{"o1"},
+			wantExtra:  map[string][]string{"scope": {"cluster:root"}},
+		},
+		{
+			name:       "caller denied by initializerPermissions",
+			request:    newRequest(caller),
+			wst:        wstAllowingGetOnly,
+			wantErr:    true,
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "no user in context",
+			request:    newRequest(nil),
+			wst:        wstAllowingCreate,
+			wantErr:    true,
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:       "no createdBy recorded",
+			request:    newRequest(nil),
+			wst:        wstNoPermissions,
+			wantErr:    true,
+			wantStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			captured := &capturingRoundTripper{}
+			rt, status, err := transportForInitializer(tc.request, &rest.Config{Transport: captured}, initializer, tc.wst, tc.createdBy)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Equal(t, tc.wantStatus, status)
+				require.Nil(t, rt)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, status)
+			require.NotNil(t, rt)
+
+			outReq, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://kcp.test/", http.NoBody)
+			require.NoError(t, err)
+			resp, err := rt.RoundTrip(outReq)
+			require.NoError(t, err)
+			resp.Body.Close()
+
+			got := captured.header
+			if tc.wantUser == "" {
+				assert.Empty(t, got.Get("Impersonate-User"))
+				return
+			}
+			assert.Equal(t, tc.wantUser, got.Get("Impersonate-User"))
+			assert.ElementsMatch(t, tc.wantGroups, got.Values("Impersonate-Group"))
+			for k, vals := range tc.wantExtra {
+				assert.Equal(t, vals, got.Values("Impersonate-Extra-"+k))
+			}
+		})
+	}
+}
+
+type capturingRoundTripper struct {
+	header http.Header
+}
+
+func (c *capturingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	c.header = req.Header.Clone()
+	return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: http.NoBody}, nil
 }
 
 func newWSTIndexer(t *testing.T, objs ...*tenancyv1alpha1.WorkspaceType) cache.Indexer {


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Do not impersonate the user when creating a `defaultAPIBindings` from a custom WST, with a system initializer. The user might not have `bind` verb permissions to `bind` to those `APIExports`.

Extract common code in a new function and unit test the various cases.

also to fold it in the TTL cache for impersonating requesting PR:
- https://github.com/kcp-dev/kcp/pull/4285

## What Type of PR Is This?

/kind bug

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #4299

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Fixed a bug where the creation of a `Workspace` defined by a custom `WorkspaceType` without custom initializers can be stalled if the creating user has no `bind` permission of the `defaultAPIBindings` defined on the `WorkspaceType`.
```
