### PR TITLE
Add VirtualWorkspace hop limit

### DIFF
--- a/pkg/server/virtualresources/server.go
+++ b/pkg/server/virtualresources/server.go
@@ -41,6 +41,7 @@ import (
 
 	"github.com/kcp-dev/logicalcluster/v3"
 	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
+	"github.com/kcp-dev/virtual-workspace-framework/pkg/hops"
 
 	cacheclient "github.com/kcp-dev/kcp/pkg/cache/client"
 	"github.com/kcp-dev/kcp/pkg/cache/client/shard"
@@ -268,7 +269,26 @@ func (s *Server) handleResource(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// We have a virtual resource. Get the endpoint URL, create a proxy handler and serve from that endpoint.
+	// We have a virtual resource. Before forwarding, check how far this request
+	// has already travelled: the virtual workspace it is on its way to may
+	// serve it by delegating back here, and only the count says whether that is
+	// one leg of a legitimate chain or a lap of a cycle.
+	inboundHops := hops.FromHeader(r.Header)
+	if hops.Exceeded(inboundHops) {
+		err := fmt.Errorf("request for %s has been forwarded %d times without being served: "+
+			"the virtual workspace advertised for it delegates it back to this shard. "+
+			"Check that the endpoint slice referenced by the APIExport points at a virtual workspace "+
+			"that serves %s, and that --shard-virtual-workspace-url does not point back at this shard",
+			gr, inboundHops, gr)
+		utilruntime.HandleError(err)
+		responsewriters.ErrorNegotiated(
+			apierrors.NewInternalError(err),
+			errorCodecs, schema.GroupVersion{Group: requestInfo.APIGroup, Version: requestInfo.APIVersion}, w, r,
+		)
+		return
+	}
+
+	// Get the endpoint URL, create a proxy handler and serve from that endpoint.
 
 	apiExportShard := shard.Name(apiExport.Annotations[shard.AnnotationKey])
 	if apiExportShard.Empty() {
@@ -293,7 +313,7 @@ func (s *Server) handleResource(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	vrHandler, err := newVirtualResourceHandler(s.Extra.VWClientConfig, vrEndpointURL, clusterNameOrWildcard.String())
+	vrHandler, err := newVirtualResourceHandler(s.Extra.VWClientConfig, vrEndpointURL, clusterNameOrWildcard.String(), inboundHops)
 	if err != nil {
 		utilruntime.HandleError(err)
 		responsewriters.ErrorNegotiated(
@@ -369,7 +389,7 @@ func (s *Server) getAPIBindingForRequest(
 	return nil, nil
 }
 
-func newVirtualResourceHandler(cfg *rest.Config, vwURL, clusterNameOrWildcard string) (http.Handler, error) {
+func newVirtualResourceHandler(cfg *rest.Config, vwURL, clusterNameOrWildcard string, inboundHops int) (http.Handler, error) {
 	scopedURL, err := url.Parse(virtualResourceURLWithCluster(vwURL, clusterNameOrWildcard))
 	if err != nil {
 		return nil, err
@@ -380,8 +400,19 @@ func newVirtualResourceHandler(cfg *rest.Config, vwURL, clusterNameOrWildcard st
 		return nil, err
 	}
 
-	proxy := httputil.NewSingleHostReverseProxy(scopedURL)
-	proxy.Transport = tr
+	proxy := &httputil.ReverseProxy{
+		Transport: tr,
+		Rewrite: func(r *httputil.ProxyRequest) {
+			r.SetURL(scopedURL)
+			r.SetXForwarded()
+			// SetURL clears the outbound Host along with pointing the request at
+			// the virtual workspace; keep the host the caller asked for, which is
+			// what a single-host reverse proxy forwards.
+			r.Out.Host = r.In.Host
+
+			hops.SetHeader(r.Out.Header, inboundHops+1)
+		},
+	}
 
 	return proxy, nil
 }

--- a/pkg/virtual/apiexport/builder/build.go
+++ b/pkg/virtual/apiexport/builder/build.go
@@ -47,6 +47,7 @@ import (
 	"github.com/kcp-dev/virtual-workspace-framework/pkg/dynamic/apiserver"
 	dynamiccontext "github.com/kcp-dev/virtual-workspace-framework/pkg/dynamic/context"
 	"github.com/kcp-dev/virtual-workspace-framework/pkg/forwardingregistry"
+	"github.com/kcp-dev/virtual-workspace-framework/pkg/hops"
 	"github.com/kcp-dev/virtual-workspace-framework/pkg/rootapiserver"
 
 	"github.com/kcp-dev/kcp/pkg/authorization"
@@ -105,6 +106,12 @@ func BuildVirtualWorkspace(
 		}),
 
 		BootstrapAPISetManagement: func(mainConfig genericapiserver.CompletedConfig) (apidefinition.APIDefinitionSetGetter, error) {
+			// This virtual workspace serves resources by delegating to the
+			// shard, and the shard may forward some of them straight back here.
+			// Carrying the hop count on those calls is what lets that cycle be
+			// cut off instead of spinning.
+			cfg := hops.WrapConfig(cfg)
+
 			dynamicClient, err := kcpdynamic.NewForConfig(cfg)
 			if err != nil {
 				return nil, fmt.Errorf("error creating privileged dynamic kcp client: %w", err)

--- a/staging/src/github.com/kcp-dev/virtual-workspace-framework/pkg/hops/hops.go
+++ b/staging/src/github.com/kcp-dev/virtual-workspace-framework/pkg/hops/hops.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package hops bounds how far a request may travel between a shard and the
+// virtual workspaces serving its virtual resources.
+//
+// A shard serves a virtual resource by forwarding to the virtual workspace
+// advertised for it, and a virtual workspace may serve a resource by delegating
+// back to the shard. Both are legitimate, and chaining them is legitimate too:
+//
+//	APIExport VW -> shard -> Replication VW -> cache server        terminates
+//
+// But the same two moves also compose into a cycle, when the virtual workspace
+// a request is forwarded to is the one that delegated it in the first place:
+//
+//	APIExport VW -> shard -> APIExport VW -> shard -> ...           spins
+//
+// Nothing static distinguishes the two. The export, the storage type and the
+// endpoint URL are identical in both; only what the far end does with the
+// request differs, and that is not knowable before sending it. So instead of
+// trying to detect the cycle, this counts how deep a request has gone and
+// refuses to go deeper than a legitimate chain ever needs.
+//
+// Counting only works if every leg carries the count. An HTTP proxy forwards
+// headers on its own, but a virtual workspace that delegates through a
+// client-go client starts a fresh request, so the count has to survive as
+// context: WithRequestHops puts an inbound header into the context, and
+// WrapConfig puts the context value back onto outbound requests.
+package hops
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+
+	"k8s.io/client-go/rest"
+)
+
+// Header carries how many times a request has been forwarded.
+//
+// A client may set it, but only against itself: an inflated value fails that
+// one request, which is why it is not stripped at the edge.
+const Header = "X-Kcp-Virtual-Resource-Hops"
+
+// Max is how deep forwarding may go before a request is refused.
+//
+// The longest legitimate chain observed is two hops -- a client reaching an
+// APIExport virtual workspace, which delegates to the shard, which forwards to
+// the replication virtual workspace. The limit leaves room above that; a cycle
+// exceeds any finite limit.
+const Max = 4
+
+type contextKey int
+
+const hopsKey contextKey = iota
+
+// FromHeader reports how many times the request carrying these headers has
+// been forwarded. Anything unparsable counts as Max, so that a malformed header
+// cannot buy more hops than a well-formed one.
+func FromHeader(h http.Header) int {
+	raw := h.Get(Header)
+	if raw == "" {
+		return 0
+	}
+	hops, err := strconv.Atoi(raw)
+	if err != nil || hops < 0 {
+		return Max
+	}
+	return hops
+}
+
+// SetHeader records a hop count on an outgoing request.
+func SetHeader(h http.Header, hops int) {
+	h.Set(Header, strconv.Itoa(hops))
+}
+
+// WithHops returns a context carrying a hop count.
+func WithHops(ctx context.Context, hops int) context.Context {
+	return context.WithValue(ctx, hopsKey, hops)
+}
+
+// FromContext reports the hop count carried by a context, zero if none is.
+func FromContext(ctx context.Context) int {
+	hops, ok := ctx.Value(hopsKey).(int)
+	if !ok {
+		return 0
+	}
+	return hops
+}
+
+// Exceeded reports whether a request that has been forwarded this many times
+// has reached the limit and must not be forwarded again.
+func Exceeded(hops int) bool {
+	return hops >= Max
+}
+
+// WithRequestHops records the inbound hop count in the request context, so that
+// work done on behalf of this request can carry it onwards.
+func WithRequestHops(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		hops := FromHeader(req.Header)
+		if hops > 0 {
+			req = req.WithContext(WithHops(req.Context(), hops))
+		}
+		handler.ServeHTTP(w, req)
+	})
+}
+
+// WrapConfig makes clients built from cfg carry the hop count of the request
+// they are serving. Without it a virtual workspace that answers by delegating
+// through a client-go client would restart the count at zero on every lap of a
+// cycle, and the count would never reach its limit.
+func WrapConfig(cfg *rest.Config) *rest.Config {
+	cfg = rest.CopyConfig(cfg)
+	cfg.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+		return roundTripper{delegate: rt}
+	})
+	return cfg
+}
+
+type roundTripper struct {
+	delegate http.RoundTripper
+}
+
+func (r roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if hops := FromContext(req.Context()); hops > 0 {
+		req = req.Clone(req.Context())
+		SetHeader(req.Header, hops)
+	}
+	return r.delegate.RoundTrip(req)
+}

--- a/staging/src/github.com/kcp-dev/virtual-workspace-framework/pkg/hops/hops_test.go
+++ b/staging/src/github.com/kcp-dev/virtual-workspace-framework/pkg/hops/hops_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hops
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFromHeader(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		value string
+		want  int
+	}{
+		{"absent", "", 0},
+		{"first hop", "1", 1},
+		{"not a number", "lots", Max},
+		{"negative", "-1", Max},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			h := http.Header{}
+			if tc.value != "" {
+				h.Set(Header, tc.value)
+			}
+			require.Equal(t, tc.want, FromHeader(h),
+				"a header a client can forge must never yield fewer hops than it claims")
+		})
+	}
+}
+
+// The count has to survive a virtual workspace that answers by starting a fresh
+// client request: header in, context, header out. Without the middle step a
+// cycle restarts the count every lap and never reaches the limit.
+func TestCountSurvivesReOrigination(t *testing.T) {
+	t.Parallel()
+
+	var forwarded http.Header
+	var delegateErr error
+	inbound := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/apis/s3.dev/v1alpha1/bucketinfos", http.NoBody)
+	SetHeader(inbound.Header, 2)
+
+	WithRequestHops(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+		// What a virtual workspace's client-go delegation looks like: a new
+		// request that inherits only the context.
+		outbound := httptest.NewRequestWithContext(req.Context(), http.MethodGet, "/clusters/x/apis/s3.dev/v1alpha1/bucketinfos", http.NoBody)
+
+		rt := roundTripper{delegate: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			forwarded = r.Header
+			return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+		})}
+		resp, err := rt.RoundTrip(outbound)
+		delegateErr = err
+		if resp != nil {
+			resp.Body.Close()
+		}
+	})).ServeHTTP(httptest.NewRecorder(), inbound)
+
+	require.NoError(t, delegateErr)
+	require.Equal(t, 2, FromHeader(forwarded),
+		"the delegated request must carry the count of the request it serves")
+}
+
+// A cycle must terminate. Each lap is: the shard forwards (+1), the virtual
+// workspace delegates back carrying the same count.
+func TestCycleTerminates(t *testing.T) {
+	t.Parallel()
+
+	h := http.Header{}
+	laps := 0
+	for !Exceeded(FromHeader(h)) {
+		SetHeader(h, FromHeader(h)+1)
+		laps++
+		require.Less(t, laps, 100, "forwarding did not terminate")
+	}
+	require.Equal(t, Max, laps, "a cycle should be cut off after Max laps")
+}
+
+// The chain a cached resource takes must still fit: a client reaches the
+// APIExport virtual workspace, which delegates to the shard, which forwards to
+// the replication virtual workspace.
+func TestLegitimateChainFits(t *testing.T) {
+	t.Parallel()
+
+	clientToVW := 0                     // client -> APIExport VW, no header
+	vwToShard := clientToVW             // delegated, carries the same count
+	shardToReplication := vwToShard + 1 // forwarded, counts a hop
+
+	require.False(t, Exceeded(vwToShard), "the shard must accept the delegated request")
+	require.False(t, Exceeded(shardToReplication), "the replication VW must be reachable")
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }

--- a/staging/src/github.com/kcp-dev/virtual-workspace-framework/pkg/rootapiserver/server.go
+++ b/staging/src/github.com/kcp-dev/virtual-workspace-framework/pkg/rootapiserver/server.go
@@ -38,6 +38,7 @@ import (
 	"github.com/kcp-dev/sdk/apis/core"
 	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 	virtualcontext "github.com/kcp-dev/virtual-workspace-framework/pkg/context"
+	"github.com/kcp-dev/virtual-workspace-framework/pkg/hops"
 )
 
 type auditClusterKeyType int
@@ -116,7 +117,10 @@ func getRootHandlerChain(c CompletedConfig, delegateAPIServer genericapiserver.D
 			apiHandler.ServeHTTP(w, req)
 		})
 
-		delegateAfterDefaultHandlerChain := genericapiserver.DefaultBuildHandlerChain(auditAnnotationWrapper, c.Generic.Config)
+		// Record how far this request has already travelled, so that anything
+		// this virtual workspace does on its behalf carries the count onwards.
+		delegateAfterDefaultHandlerChain := genericapiserver.DefaultBuildHandlerChain(
+			hops.WithRequestHops(auditAnnotationWrapper), c.Generic.Config)
 
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			requestContext := req.Context()


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

A shard forwards virtual resources to a virtual workspace, and a virtual workspace may serve them by delegating back to the shard. Chained that way the two can also form a cycle, which nothing static distinguishes from a legitimate chain. Carry a hop count on each leg and refuse to go deeper than a real chain needs.

Ran into a case where, if misconfigured, one can take down all shard by creating funky traffic patterns


## What Type of PR Is This?
/kind bug

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Add hop limit for Virtual workspaces
```
