### PR TITLE
Forward the caller's identity to virtual workspaces

### DIFF
--- a/pkg/proxy/authheaders/authheaders.go
+++ b/pkg/proxy/authheaders/authheaders.go
@@ -30,6 +30,16 @@ import (
 	userinfo "k8s.io/apiserver/pkg/authentication/user"
 )
 
+// The header names a backend is conventionally configured to trust, matching
+// the --requestheader-username-headers, --requestheader-group-headers and
+// --requestheader-extra-headers-prefix that kcp starts its shards and virtual
+// workspace servers with.
+const (
+	DefaultUserHeader        = "X-Remote-User"
+	DefaultGroupHeader       = "X-Remote-Group"
+	DefaultExtraHeaderPrefix = "X-Remote-Extra-"
+)
+
 // ClearAuthHeaders deletes any inbound copies of the request-header identity
 // headers.
 func ClearAuthHeaders(header http.Header, userHeader, groupHeader, extraHeaderPrefix string) {

--- a/pkg/server/virtualresources/server.go
+++ b/pkg/server/virtualresources/server.go
@@ -47,6 +47,7 @@ import (
 	"github.com/kcp-dev/kcp/pkg/cache/client/shard"
 	"github.com/kcp-dev/kcp/pkg/endpointslice"
 	"github.com/kcp-dev/kcp/pkg/indexers"
+	"github.com/kcp-dev/kcp/pkg/proxy/authheaders"
 	"github.com/kcp-dev/kcp/pkg/reconciler/dynamicrestmapper"
 	kcpfilters "github.com/kcp-dev/kcp/pkg/server/filters"
 )
@@ -404,13 +405,26 @@ func newVirtualResourceHandler(cfg *rest.Config, vwURL, clusterNameOrWildcard st
 		Transport: tr,
 		Rewrite: func(r *httputil.ProxyRequest) {
 			r.SetURL(scopedURL)
-			r.SetXForwarded()
-			// SetURL clears the outbound Host along with pointing the request at
-			// the virtual workspace; keep the host the caller asked for, which is
-			// what a single-host reverse proxy forwards.
-			r.Out.Host = r.In.Host
-
 			hops.SetHeader(r.Out.Header, inboundHops+1)
+			// Say who asked.
+			//
+			// The connection to the virtual workspace authenticates as this shard,
+			// so without this the virtual workspace sees the shard and authorizes
+			// that instead of the caller -- and a provider's backend is told the
+			// shard's identity rather than the user's. The virtual workspace
+			// believes these headers only over a connection whose client
+			// certificate its --requestheader-client-ca-file trusts, which is the
+			// same arrangement the front proxy already uses to reach shards.
+			//
+			// Stamping strips any inbound copies first, so a client cannot assert
+			// an identity by setting the headers itself.
+			if user, ok := genericapirequest.UserFrom(r.Out.Context()); ok {
+				authheaders.SetAuthHeaders(r.Out.Header, user,
+					authheaders.DefaultUserHeader, authheaders.DefaultGroupHeader, authheaders.DefaultExtraHeaderPrefix)
+			} else {
+				authheaders.ClearAuthHeaders(r.Out.Header,
+					authheaders.DefaultUserHeader, authheaders.DefaultGroupHeader, authheaders.DefaultExtraHeaderPrefix)
+			}
 		},
 	}
 

--- a/pkg/server/virtualresources/server_test.go
+++ b/pkg/server/virtualresources/server_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package virtualresources
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apiserver/pkg/authentication/user"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/client-go/rest"
+
+	"github.com/kcp-dev/kcp/pkg/proxy/authheaders"
+)
+
+// forward runs a request through the proxy's rewrite and returns the headers
+// the virtual workspace would see.
+func forward(t *testing.T, req *http.Request) http.Header {
+	t.Helper()
+
+	handler, err := newVirtualResourceHandler(&rest.Config{Host: "https://vw.example.com"},
+		"https://vw.example.com/services/ephemeral/cluster/export", "cluster")
+	require.NoError(t, err)
+
+	proxy, ok := handler.(*httputil.ReverseProxy)
+	require.True(t, ok, "the handler is expected to be a reverse proxy")
+
+	// The outbound request starts as a copy of the inbound one, as it does in
+	// ReverseProxy.ServeHTTP, so anything the client sent is there to be stripped.
+	outbound := req.Clone(req.Context())
+	proxy.Rewrite(&httputil.ProxyRequest{In: req, Out: outbound})
+
+	return outbound.Header
+}
+
+// The virtual workspace authorizes whoever these headers name, and asking a
+// provider's webhook "who is this for" is the point of the feature. Without
+// them the connection's own identity -- this shard -- is what arrives.
+func TestForwardsTheCallersIdentity(t *testing.T) {
+	t.Parallel()
+
+	ctx := genericapirequest.WithUser(t.Context(), &user.DefaultInfo{
+		Name:   "alice",
+		Groups: []string{"team-a", "system:authenticated"},
+		Extra:  map[string][]string{"authentication.kcp.io/scopes": {"cluster:root"}},
+	})
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "https://shard.example.com/apis/s3.dev/v1alpha1/bucketinfos", http.NoBody)
+
+	header := forward(t, req)
+
+	require.Equal(t, "alice", header.Get(authheaders.DefaultUserHeader))
+	require.Equal(t, []string{"team-a", "system:authenticated"}, header.Values(authheaders.DefaultGroupHeader))
+	require.Equal(t, []string{"cluster:root"},
+		header.Values(authheaders.DefaultExtraHeaderPrefix+"authentication.kcp.io%2Fscopes"),
+		"extras carry warrants and scopes, which the far end needs to authorize as this user")
+}
+
+// A client that sets the headers itself must not be believed: the far end
+// trusts them because of the connection they arrive on, so anything a client
+// sent has to be replaced, not merged.
+func TestStripsClientSuppliedIdentity(t *testing.T) {
+	t.Parallel()
+
+	ctx := genericapirequest.WithUser(t.Context(), &user.DefaultInfo{Name: "alice"})
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "https://shard.example.com/apis/s3.dev/v1alpha1/bucketinfos", http.NoBody)
+	req.Header.Set(authheaders.DefaultUserHeader, "system:masters-please")
+	req.Header.Add(authheaders.DefaultGroupHeader, "system:masters")
+	req.Header.Set(authheaders.DefaultExtraHeaderPrefix+"smuggled", "yes")
+
+	header := forward(t, req)
+
+	require.Equal(t, "alice", header.Get(authheaders.DefaultUserHeader))
+	require.Empty(t, header.Values(authheaders.DefaultGroupHeader),
+		"a group the client asked for must not survive")
+	require.Empty(t, header.Values(authheaders.DefaultExtraHeaderPrefix+"smuggled"))
+}
+
+// An unauthenticated request should not reach here, but if one does the headers
+// must be cleared rather than passed through.
+func TestStripsIdentityWhenThereIsNone(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://shard.example.com/apis/s3.dev/v1alpha1/bucketinfos", http.NoBody)
+	req.Header.Set(authheaders.DefaultUserHeader, "nobody")
+
+	header := forward(t, req)
+
+	require.Empty(t, header.Values(authheaders.DefaultUserHeader))
+}

--- a/pkg/server/virtualresources/server_test.go
+++ b/pkg/server/virtualresources/server_test.go
@@ -37,7 +37,7 @@ func forward(t *testing.T, req *http.Request) http.Header {
 	t.Helper()
 
 	handler, err := newVirtualResourceHandler(&rest.Config{Host: "https://vw.example.com"},
-		"https://vw.example.com/services/ephemeral/cluster/export", "cluster")
+		"https://vw.example.com/services/ephemeral/cluster/export", "cluster", 0)
 	require.NoError(t, err)
 
 	proxy, ok := handler.(*httputil.ReverseProxy)


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

The shard proxies virtual resources to the virtual workspace over a connection that authenticates as the shard, so the VW authorized the shard rather than the user. Stamp the request-header identity on the forwarded request instead, clearing any inbound copies first.

## What Type of PR Is This?
/kind documentation
/kind feature

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Add identity forward to virtual workspaces
```
