### PR TITLE
cli/pkg/base/options.go: don't disable any CLI options

### DIFF
--- a/staging/src/github.com/kcp-dev/cli/pkg/base/options.go
+++ b/staging/src/github.com/kcp-dev/cli/pkg/base/options.go
@@ -68,16 +68,7 @@ func (o *Options) BindFlags(cmd *cobra.Command) {
 		)
 	}
 
-	// We add only a subset of kubeconfig-related flags to the plugin.
-	// All those with LongName == "" will be ignored.
 	kubectlConfigOverrideFlags := clientcmd.RecommendedConfigOverrideFlags("")
-	kubectlConfigOverrideFlags.AuthOverrideFlags.ClientCertificate.LongName = ""
-	kubectlConfigOverrideFlags.AuthOverrideFlags.ClientKey.LongName = ""
-	kubectlConfigOverrideFlags.AuthOverrideFlags.Impersonate.LongName = ""
-	kubectlConfigOverrideFlags.AuthOverrideFlags.ImpersonateGroups.LongName = ""
-	kubectlConfigOverrideFlags.ContextOverrideFlags.ClusterName.LongName = ""
-	kubectlConfigOverrideFlags.Timeout.LongName = ""
-
 	clientcmd.BindOverrideFlags(o.KubectlOverrides, cmd.PersistentFlags(), kubectlConfigOverrideFlags)
 }
 


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

This allows passing the additional flags:

--as
--as-group
--client-certificate
--client-key
--cluster
--request-timeout

The only conflating one might be --cluster in the context of kcp, but there is already a --workspace flag.

e.g.

```
k ws tree --as alice
```

## What Type of PR Is This?


/kind feature

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #4312

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Enable the following flags for all CLI commands similarly to how kubectl supports them: --as, --as-group, --client-certificate, --client-key, --cluster, --request-timeout.
```
