### PR TITLE
e2e: fix second EventuallyWithT loop in TestShardMetricsEndpoint to retry properly

### DIFF
--- a/test/e2e/authorizer/shardmetrics_test.go
+++ b/test/e2e/authorizer/shardmetrics_test.go
@@ -95,7 +95,7 @@ func TestShardMetricsEndpoint(t *testing.T) {
 				Name:     "user-1",
 			}},
 		}, metav1.CreateOptions{})
-		require.NoError(t, err)
+		require.NoError(c, err)
 	}, wait.ForeverTestTimeout, 200*time.Millisecond, "waiting to create ClusterRoleBinding for user-1")
 
 	workspaceMetricsPath := fmt.Sprintf("/clusters/%s/metrics", wsPath.String())


### PR DESCRIPTION
## Summary

Fixes the second `require.EventuallyWithT` polling loop in `TestShardMetricsEndpoint` (ClusterRoleBinding creation retry), which still asserted against the outer `*testing.T` instead of the tick-local `*assert.CollectT`. This caused the loop to abort after a single failed attempt instead of retrying, mirroring a bug already fixed in the first loop in the same test.

## What Type of PR Is This?

/kind flake

## Related Issue(s)

Fixes #3933

## Release Notes

```release-note
NONE
```

---
AI assistance: this change was drafted with Claude Code.