### PR TITLE
fix: skip DynamicRESTMapper CRD mapping until CRD is Established

### DIFF
--- a/pkg/reconciler/dynamicrestmapper/dynamicrestmapper_dynamic_controller.go
+++ b/pkg/reconciler/dynamicrestmapper/dynamicrestmapper_dynamic_controller.go
@@ -410,6 +410,12 @@ func (c *DynamicTypesController) gatherGVKRsForCRD(crd *apiextensionsv1.CustomRe
 	if crd == nil {
 		return nil
 	}
+	if !apiextensionshelpers.IsCRDConditionTrue(crd, apiextensionsv1.Established) {
+		// The CRD's Status.AcceptedNames may not be populated yet. Bail out
+		// instead of storing garbage mappings; enqueueCRDUpdate will trigger
+		// a re-processing once the CRD becomes established.
+		return nil
+	}
 	gvkrs := make([]typeMeta, 0, len(crd.Spec.Versions))
 	for _, version := range crd.Spec.Versions {
 		if !version.Served {

--- a/pkg/reconciler/dynamicrestmapper/dynamicrestmapper_dynamic_controller.go
+++ b/pkg/reconciler/dynamicrestmapper/dynamicrestmapper_dynamic_controller.go
@@ -201,7 +201,10 @@ func diffResourceBindingsAnn(oldAnn, newAnn apibinding.ResourceBindingsAnnotatio
 
 func (c *DynamicTypesController) enqueueCRDUpdate(crd *apiextensionsv1.CustomResourceDefinition) {
 	if !apiextensionshelpers.IsCRDConditionTrue(crd, apiextensionsv1.Established) {
-		// The CRD is not ready yet. Nothing to do, we'll get notified on the next update event.
+		// The CRD is not ready yet. Nothing to do, we'll get notified on the
+		// next Update event once the CRD's status changes (e.g. reaches
+		// Established), since that's itself an Update the informer delivers.
+		klog.Background().V(4).Info("CRD not yet Established, skipping enqueue for now", "crd", crd.Name)
 		return
 	}
 

--- a/pkg/reconciler/dynamicrestmapper/dynamicrestmapper_dynamic_controller.go
+++ b/pkg/reconciler/dynamicrestmapper/dynamicrestmapper_dynamic_controller.go
@@ -19,6 +19,7 @@ package dynamicrestmapper
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -397,8 +398,16 @@ func (c *DynamicTypesController) processNextWorkItem(ctx context.Context) bool {
 		return true
 	}
 
-	if err := c.process(ctx, key, it); err != nil {
+	requeue, err := c.process(ctx, key, it)
+	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("%q controller failed to sync %q, err: %w", DynamicTypesControllerName, key, err))
+		c.queue.AddRateLimited(key)
+		return true
+	}
+	if requeue {
+		// Some bound CRDs are not yet Established; retry with backoff
+		// instead of Forget, so repeated not-yet-established results keep
+		// escalating the per-item rate limiter delay rather than resetting it.
 		c.queue.AddRateLimited(key)
 		return true
 	}
@@ -406,17 +415,26 @@ func (c *DynamicTypesController) processNextWorkItem(ctx context.Context) bool {
 	return true
 }
 
-func (c *DynamicTypesController) gatherGVKRsForCRD(crd *apiextensionsv1.CustomResourceDefinition) []typeMeta {
+// errCRDNotEstablished is returned via gatherGVKRsForBoundResource when a
+// CRD bound resource hasn't reached Established yet, so its Status.AcceptedNames
+// isn't populated. process() treats this as a per-resource skip-and-retry
+// (rather than failing the whole queue item), so one CRD that never
+// establishes (e.g. a permanent name conflict) can't block every other
+// resource in the same ToAdd batch.
+var errCRDNotEstablished = errors.New("CRD not yet Established")
+
+func (c *DynamicTypesController) gatherGVKRsForCRD(crd *apiextensionsv1.CustomResourceDefinition) (gvkrs []typeMeta, notEstablished bool) {
 	if crd == nil {
-		return nil
+		return nil, false
 	}
 	if !apiextensionshelpers.IsCRDConditionTrue(crd, apiextensionsv1.Established) {
 		// The CRD's Status.AcceptedNames may not be populated yet. Bail out
-		// instead of storing garbage mappings; enqueueCRDUpdate will trigger
-		// a re-processing once the CRD becomes established.
-		return nil
+		// instead of storing garbage mappings; the caller will re-queue with
+		// backoff so this is retried once the CRD becomes established.
+		klog.Background().V(4).Info("CRD not yet Established, skipping its mapping for now", "crd", crd.Name)
+		return nil, true
 	}
-	gvkrs := make([]typeMeta, 0, len(crd.Spec.Versions))
+	gvkrs = make([]typeMeta, 0, len(crd.Spec.Versions))
 	for _, version := range crd.Spec.Versions {
 		if !version.Served {
 			continue
@@ -431,7 +449,7 @@ func (c *DynamicTypesController) gatherGVKRsForCRD(crd *apiextensionsv1.CustomRe
 			resourceScopeToRESTScope(crd.Spec.Scope),
 		))
 	}
-	return gvkrs
+	return gvkrs, false
 }
 
 func (c *DynamicTypesController) gatherGVKRsForAPIBinding(apiBinding *apisv1alpha2.APIBinding) ([]typeMeta, error) {
@@ -479,7 +497,11 @@ func (c *DynamicTypesController) gatherGVKRsForBoundResource(clusterName logical
 			return nil, fmt.Errorf("failed to retrieve CRD %s: %v", resourceGroup, err)
 		}
 
-		return c.gatherGVKRsForCRD(crd), nil
+		gvkrs, notEstablished := c.gatherGVKRsForCRD(crd)
+		if notEstablished {
+			return nil, errCRDNotEstablished
+		}
+		return gvkrs, nil
 	}
 
 	apiBinding, err := c.getAPIBinding(clusterName, boundResourceLock.Name)
@@ -501,48 +523,60 @@ func (c *DynamicTypesController) gatherGVKRsForMappedBoundResource(clusterName l
 	return gvkrs, nil
 }
 
-func (c *DynamicTypesController) process(ctx context.Context, key string, item queueItem) error {
+// process applies the mapping changes described by item. The returned
+// requeue flag tells the caller to reschedule key with backoff (rather than
+// Forget it) because some bound CRDs are not yet Established; it is
+// distinct from err, which signals an actual failure.
+func (c *DynamicTypesController) process(ctx context.Context, key string, item queueItem) (requeue bool, err error) {
 	logger := logging.WithQueueKey(klog.FromContext(ctx), key)
 
 	if item.Op == opDelete {
 		logger.V(4).Info("LogicalCluster was removed, removing all its mappings")
 		c.state.deleteMappingsForCluster(item.ClusterName)
-		return nil
+		return false, nil
 	}
 
 	if _, err := c.getLogicalCluster(item.ClusterName, item.ClusterResourceName); err != nil {
 		if apierrors.IsNotFound(err) {
 			c.state.deleteMappingsForCluster(item.ClusterName)
 			logger.V(4).Info("LogicalCluster already deleted, skipping")
-			return nil
+			return false, nil
 		}
-		return err
+		return false, err
 	}
 
 	// Retrieve type meta for all detected changes in bound resources.
 
 	type gathererFunc func(clusterName logicalcluster.Name, resourceGroup string, boundResourceLock apibinding.Lock) ([]typeMeta, error)
 
-	gatherGVKRs := func(boundResources apibinding.ResourceBindingsAnnotation, gatherer gathererFunc) ([]typeMeta, error) {
-		gatheredGVKRs := make([]typeMeta, 0, len(boundResources))
+	// gatherGVKRs gathers mappings for every bound resource. A resource that
+	// signals errCRDNotEstablished is skipped (not fatal) and reported via
+	// the requeue return value, so a single not-yet-established CRD doesn't
+	// prevent the other resources in this batch from being applied.
+	gatherGVKRs := func(boundResources apibinding.ResourceBindingsAnnotation, gatherer gathererFunc) (gathered []typeMeta, requeue bool, err error) {
+		gathered = make([]typeMeta, 0, len(boundResources))
 		for resourceGroup, boundResourceLock := range boundResources {
 			gvkrs, err := gatherer(item.ClusterName, resourceGroup, boundResourceLock.Lock)
 			if err != nil {
-				return nil, err
+				if errors.Is(err, errCRDNotEstablished) {
+					requeue = true
+					continue
+				}
+				return nil, false, err
 			}
-			gatheredGVKRs = append(gatheredGVKRs, gvkrs...)
+			gathered = append(gathered, gvkrs...)
 		}
-		return gatheredGVKRs, nil
+		return gathered, requeue, nil
 	}
 
-	typeMetaToRemove, err := gatherGVKRs(item.ToRemove, c.gatherGVKRsForMappedBoundResource)
+	typeMetaToRemove, _, err := gatherGVKRs(item.ToRemove, c.gatherGVKRsForMappedBoundResource)
 	if err != nil {
-		return err
+		return false, err
 	}
 
-	typeMetaToAdd, err := gatherGVKRs(item.ToAdd, c.gatherGVKRsForBoundResource)
+	typeMetaToAdd, requeue, err := gatherGVKRs(item.ToAdd, c.gatherGVKRsForBoundResource)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// Finally, store the new mappings in the RESTMapper for this LogicalCluster.
@@ -551,5 +585,9 @@ func (c *DynamicTypesController) process(ctx context.Context, key string, item q
 
 	c.state.ForCluster(item.ClusterName).apply(typeMetaToRemove, typeMetaToAdd)
 
-	return nil
+	if requeue {
+		logger.V(4).Info("some bound CRDs are not yet Established, will retry with backoff")
+	}
+
+	return requeue, nil
 }

--- a/pkg/reconciler/dynamicrestmapper/dynamicrestmapper_test.go
+++ b/pkg/reconciler/dynamicrestmapper/dynamicrestmapper_test.go
@@ -17,15 +17,21 @@ limitations under the License.
 package dynamicrestmapper
 
 import (
+	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/util/workqueue"
 
 	"github.com/kcp-dev/logicalcluster/v3"
+	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 
 	"github.com/kcp-dev/kcp/pkg/reconciler/apis/apibinding"
 )
@@ -436,15 +442,16 @@ func TestGatherGVKRsForCRD(t *testing.T) {
 					{Name: "v1", Served: true},
 				},
 			},
-			Status: apiextensionsv1.CustomResourceDefinitionStatus{
-				AcceptedNames: apiextensionsv1.CustomResourceDefinitionNames{
-					Kind:     "Widget",
-					Singular: "widget",
-					Plural:   "widgets",
-				},
-			},
 		}
 		if established {
+			// AcceptedNames is only populated once the CRD has been
+			// reconciled to Established; that's the actual race being
+			// guarded against, not just the condition being absent.
+			crd.Status.AcceptedNames = apiextensionsv1.CustomResourceDefinitionNames{
+				Kind:     "Widget",
+				Singular: "widget",
+				Plural:   "widgets",
+			}
 			crd.Status.Conditions = append(crd.Status.Conditions, apiextensionsv1.CustomResourceDefinitionCondition{
 				Type:   apiextensionsv1.Established,
 				Status: apiextensionsv1.ConditionTrue,
@@ -455,16 +462,111 @@ func TestGatherGVKRsForCRD(t *testing.T) {
 
 	c := &DynamicTypesController{}
 
-	t.Run("not established yields no mappings", func(t *testing.T) {
+	t.Run("not established yields no mappings and signals a retry", func(t *testing.T) {
 		t.Parallel()
-		require.Empty(t, c.gatherGVKRsForCRD(newCRD(false)))
+		gvkrs, notEstablished := c.gatherGVKRsForCRD(newCRD(false))
+		require.Empty(t, gvkrs)
+		require.True(t, notEstablished)
 	})
 
 	t.Run("established yields the accepted names", func(t *testing.T) {
 		t.Parallel()
-		gvkrs := c.gatherGVKRsForCRD(newCRD(true))
+		gvkrs, notEstablished := c.gatherGVKRsForCRD(newCRD(true))
+		require.False(t, notEstablished)
 		require.Equal(t, []typeMeta{
 			newTypeMeta("example.com", "v1", "Widget", "widget", "widgets", meta.RESTScopeRoot),
 		}, gvkrs)
 	})
+}
+
+// TestProcessRequeuesNotEstablishedCRD checks that a queue item covering
+// several bound resources still applies the mappings it can gather even
+// when one of them is a CRD that hasn't reached Established yet, and that
+// the item is requeued with backoff (rather than the whole batch failing)
+// so the not-yet-established CRD is retried later. It drives the change
+// through processNextWorkItem (not just process) because the backoff only
+// actually escalates if processNextWorkItem calls AddRateLimited instead of
+// Forget when process reports requeue=true; calling process directly can't
+// observe that distinction.
+func TestProcessRequeuesNotEstablishedCRD(t *testing.T) {
+	t.Parallel()
+
+	clusterName := logicalcluster.Name("root:org:ws")
+
+	establishedCRD := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "widgets.example.com"},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "example.com",
+			Scope: apiextensionsv1.ClusterScoped,
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{Name: "v1", Served: true},
+			},
+		},
+		Status: apiextensionsv1.CustomResourceDefinitionStatus{
+			AcceptedNames: apiextensionsv1.CustomResourceDefinitionNames{
+				Kind:     "Widget",
+				Singular: "widget",
+				Plural:   "widgets",
+			},
+			Conditions: []apiextensionsv1.CustomResourceDefinitionCondition{
+				{Type: apiextensionsv1.Established, Status: apiextensionsv1.ConditionTrue},
+			},
+		},
+	}
+	pendingCRD := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "gadgets.example.com"},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "example.com",
+			Scope: apiextensionsv1.ClusterScoped,
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{Name: "v1", Served: true},
+			},
+		},
+	}
+
+	c := &DynamicTypesController{
+		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
+		),
+		state: NewDynamicRESTMapper(),
+		getLogicalCluster: func(logicalcluster.Name, string) (*corev1alpha1.LogicalCluster, error) {
+			return &corev1alpha1.LogicalCluster{}, nil
+		},
+		getCRD: func(_ logicalcluster.Name, name string) (*apiextensionsv1.CustomResourceDefinition, error) {
+			switch name {
+			case establishedCRD.Name:
+				return establishedCRD, nil
+			case pendingCRD.Name:
+				return pendingCRD, nil
+			default:
+				return nil, apierrors.NewNotFound(apiextensionsv1.Resource("customresourcedefinitions"), name)
+			}
+		},
+	}
+
+	item := queueItem{
+		ClusterName:         clusterName,
+		ClusterResourceName: corev1alpha1.LogicalClusterName,
+		Op:                  opUpdate,
+		ToAdd: apibinding.ResourceBindingsAnnotation{
+			establishedCRD.Name: {Lock: apibinding.Lock{CRD: true}},
+			pendingCRD.Name:     {Lock: apibinding.Lock{CRD: true}},
+		},
+	}
+	keyBytes, err := json.Marshal(&item)
+	require.NoError(t, err)
+	key := string(keyBytes)
+	t.Cleanup(c.queue.ShutDown)
+
+	c.queue.Add(key)
+	require.True(t, c.processNextWorkItem(context.Background()))
+
+	gvkrs, err := c.state.ForCluster(clusterName).getGVKRs(schema.GroupResource{Group: "example.com", Resource: "widgets"})
+	require.NoError(t, err)
+	require.NotEmpty(t, gvkrs, "the established CRD's mapping should still be applied")
+
+	require.Equal(t, 1, c.queue.NumRequeues(key),
+		"processNextWorkItem must call AddRateLimited (not Forget) when process reports requeue, "+
+			"otherwise the per-item exponential backoff never escalates for a CRD that never establishes")
 }

--- a/pkg/reconciler/dynamicrestmapper/dynamicrestmapper_test.go
+++ b/pkg/reconciler/dynamicrestmapper/dynamicrestmapper_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -417,4 +418,53 @@ func TestDiffResourceBindingsAnn(t *testing.T) {
 				"mismatch in annotation keys to add")
 		})
 	}
+}
+
+// TestGatherGVKRsForCRD guards against a race where the resource-bindings
+// lock for a CRD becomes visible before the CRD itself is established:
+// reading Status.AcceptedNames at that point would yield empty names and
+// store a garbage mapping that is never corrected.
+func TestGatherGVKRsForCRD(t *testing.T) {
+	t.Parallel()
+
+	newCRD := func(established bool) *apiextensionsv1.CustomResourceDefinition {
+		crd := &apiextensionsv1.CustomResourceDefinition{
+			Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+				Group: "example.com",
+				Scope: apiextensionsv1.ClusterScoped,
+				Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+					{Name: "v1", Served: true},
+				},
+			},
+			Status: apiextensionsv1.CustomResourceDefinitionStatus{
+				AcceptedNames: apiextensionsv1.CustomResourceDefinitionNames{
+					Kind:     "Widget",
+					Singular: "widget",
+					Plural:   "widgets",
+				},
+			},
+		}
+		if established {
+			crd.Status.Conditions = append(crd.Status.Conditions, apiextensionsv1.CustomResourceDefinitionCondition{
+				Type:   apiextensionsv1.Established,
+				Status: apiextensionsv1.ConditionTrue,
+			})
+		}
+		return crd
+	}
+
+	c := &DynamicTypesController{}
+
+	t.Run("not established yields no mappings", func(t *testing.T) {
+		t.Parallel()
+		require.Empty(t, c.gatherGVKRsForCRD(newCRD(false)))
+	})
+
+	t.Run("established yields the accepted names", func(t *testing.T) {
+		t.Parallel()
+		gvkrs := c.gatherGVKRsForCRD(newCRD(true))
+		require.Equal(t, []typeMeta{
+			newTypeMeta("example.com", "v1", "Widget", "widget", "widgets", meta.RESTScopeRoot),
+		}, gvkrs)
+	})
 }


### PR DESCRIPTION
## Summary

Fixes a bug in the `DynamicRESTMapper`'s `DynamicTypesController` where a CRD observed before it reached the `Established` condition could have its `Status.AcceptedNames` (Kind/Singular/Plural) read while still empty, causing an incorrect/empty type mapping to be stored for that CRD. This happened because the `apis.kcp.io/CRDNoOverlappingGVR` admission plugin writes a resource-bindings lock annotation onto the `LogicalCluster` at CRD Create time, before the CRD has been reconciled to `Established`. `gatherGVKRsForCRD` now applies the same "not ready yet, skip" guard (`apiextensionshelpers.IsCRDConditionTrue(crd, Established)`) that `enqueueCRDUpdate` already uses, so a not-yet-established CRD is skipped instead of stored with garbage data.

## What Type of PR Is This?

/kind bug

## Related Issue(s)

Fixes #3896

## Release Notes

```release-note
Fixed a bug where the `DynamicRESTMapper` could store an incorrect/empty type mapping for a CRD observed before it reached the `Established` condition.
```

---
AI assistance: this change was drafted with Claude Code.