### PR TITLE
Wire in reference controller

### DIFF
--- a/config/crds/cache.kcp.io_clustercachedresources.yaml
+++ b/config/crds/cache.kcp.io_clustercachedresources.yaml
@@ -130,6 +130,21 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              names:
+                description: |-
+                  names narrows publishing to resources called exactly these.
+
+                  Leaving it empty publishes every resource the label selector allows,
+                  which is the usual case: a ClusterCachedResource normally stands for a
+                  whole kind. Naming resources is for the case where something points at
+                  one object in particular and only that object is worth caching.
+
+                  Names and labelSelector both apply -- a resource has to satisfy each of
+                  the ones that is set.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
               resource:
                 description: |-
                   resource is the name of the resource.

--- a/config/root-phase0/apiexport-cache.kcp.io.yaml
+++ b/config/root-phase0/apiexport-cache.kcp.io.yaml
@@ -11,7 +11,7 @@ spec:
       crd: {}
   - group: cache.kcp.io
     name: clustercachedresources
-    schema: v250920-de0c8484d.clustercachedresources.cache.kcp.io
+    schema: v260814-239feb181.clustercachedresources.cache.kcp.io
     storage:
       crd: {}
 status: {}

--- a/config/root-phase0/apiresourceschema-clustercachedresources.cache.kcp.io.yaml
+++ b/config/root-phase0/apiresourceschema-clustercachedresources.cache.kcp.io.yaml
@@ -1,7 +1,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v250920-de0c8484d.clustercachedresources.cache.kcp.io
+  name: v260814-239feb181.clustercachedresources.cache.kcp.io
 spec:
   group: cache.kcp.io
   names:
@@ -126,6 +126,21 @@ spec:
                   type: object
               type: object
               x-kubernetes-map-type: atomic
+            names:
+              description: |-
+                names narrows publishing to resources called exactly these.
+
+                Leaving it empty publishes every resource the label selector allows,
+                which is the usual case: a ClusterCachedResource normally stands for a
+                whole kind. Naming resources is for the case where something points at
+                one object in particular and only that object is worth caching.
+
+                Names and labelSelector both apply -- a resource has to satisfy each of
+                the ones that is set.
+              items:
+                type: string
+              type: array
+              x-kubernetes-list-type: set
             resource:
               description: |-
                 resource is the name of the resource.

--- a/pkg/indexers/apiexport.go
+++ b/pkg/indexers/apiexport.go
@@ -19,7 +19,6 @@ package indexers
 import (
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
@@ -124,14 +123,11 @@ func IndexAPIExportEndpointSliceByAPIExport(obj interface{}) ([]string, error) {
 }
 
 // IndexAPIExportByVirtualResourceFingerprint indexes an APIExport by the fingerprint of each
-// virtual storage resource (identity hash + endpoint slice reference).
+// virtual storage resource (owning APIExport + endpoint slice reference).
 func IndexAPIExportByVirtualResourceFingerprint(obj interface{}) ([]string, error) {
 	apiExport, ok := obj.(*apisv1alpha2.APIExport)
 	if !ok {
 		return []string{}, fmt.Errorf("obj %T is not an APIExport", obj)
-	}
-	if apiExport.Status.IdentityHash == "" {
-		return []string{}, nil
 	}
 
 	keys := sets.New[string]()
@@ -141,9 +137,5 @@ func IndexAPIExportByVirtualResourceFingerprint(obj interface{}) ([]string, erro
 		}
 	}
 
-	return sets.List[string](keys), nil
-}
-
-func VirtualResourceIdentityAndGRKey(identityHash string, gr schema.GroupResource) string {
-	return fmt.Sprintf("%s:%s", gr.String(), identityHash)
+	return sets.List(keys), nil
 }

--- a/pkg/reconciler/cache/apiexportreference/apiexportreference_controller.go
+++ b/pkg/reconciler/cache/apiexportreference/apiexportreference_controller.go
@@ -1,0 +1,409 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package apiexportreference keeps a ClusterCachedResource for every object an
+// APIExport points at.
+//
+// An APIExport can name an object through spec.resources[].storage.virtual.
+// reference, and the shard resolves that reference through the cache server --
+// so an object that is not in the cache cannot be referenced at all.
+//
+// Getting it there is what ClusterCachedResources already do: they replicate,
+// they make the cache server serve the kind, they clean up after themselves,
+// and they keep each provider in its own part of the cache. So this controller
+// does not replicate anything itself. It writes down what the APIExport asked
+// for, as a ClusterCachedResource that the APIExport owns, and lets that
+// machinery do the rest.
+package apiexportreference
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base32"
+	"fmt"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+
+	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
+	"github.com/kcp-dev/logicalcluster/v3"
+	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
+	cachev1alpha1 "github.com/kcp-dev/sdk/apis/cache/v1alpha1"
+	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
+	apisv1alpha2informers "github.com/kcp-dev/sdk/client/informers/externalversions/apis/v1alpha2"
+	cachev1alpha1informers "github.com/kcp-dev/sdk/client/informers/externalversions/cache/v1alpha1"
+
+	"github.com/kcp-dev/kcp/pkg/logging"
+)
+
+const (
+	// ControllerName holds this controller's name.
+	ControllerName = "kcp-apiexport-reference-controller"
+)
+
+// NewController returns a controller that keeps a ClusterCachedResource for
+// every object an APIExport references.
+func NewController(
+	kcpClusterClient kcpclientset.ClusterInterface,
+	apiExportInformer apisv1alpha2informers.APIExportClusterInformer,
+	clusterCachedResourceInformer cachev1alpha1informers.ClusterCachedResourceClusterInformer,
+	restMappingFor func(cluster logicalcluster.Name, gk schema.GroupKind) (*meta.RESTMapping, error),
+) (*controller, error) {
+	c := &controller{
+		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{Name: ControllerName},
+		),
+		restMappingFor: restMappingFor,
+		createResource: func(ctx context.Context, cluster logicalcluster.Name, ccr *cachev1alpha1.ClusterCachedResource) error {
+			_, err := kcpClusterClient.Cluster(cluster.Path()).CacheV1alpha1().ClusterCachedResources().Create(ctx, ccr, metav1.CreateOptions{})
+			return err
+		},
+		updateResource: func(ctx context.Context, cluster logicalcluster.Name, ccr *cachev1alpha1.ClusterCachedResource) error {
+			_, err := kcpClusterClient.Cluster(cluster.Path()).CacheV1alpha1().ClusterCachedResources().Update(ctx, ccr, metav1.UpdateOptions{})
+			return err
+		},
+		deleteResource: func(ctx context.Context, cluster logicalcluster.Name, name string) error {
+			return kcpClusterClient.Cluster(cluster.Path()).CacheV1alpha1().ClusterCachedResources().Delete(ctx, name, metav1.DeleteOptions{})
+		},
+		getAPIExport: func(cluster logicalcluster.Name, name string) (*apisv1alpha2.APIExport, error) {
+			return apiExportInformer.Lister().Cluster(cluster).Get(name)
+		},
+		listOwnedResources: func(cluster logicalcluster.Name, export string) ([]*cachev1alpha1.ClusterCachedResource, error) {
+			all, err := clusterCachedResourceInformer.Lister().Cluster(cluster).List(labels.Everything())
+			if err != nil {
+				return nil, err
+			}
+			var out []*cachev1alpha1.ClusterCachedResource
+			for _, ccr := range all {
+				if ownedBy(ccr, export) {
+					out = append(out, ccr)
+				}
+			}
+			return out, nil
+		},
+		apiExportsSynced:             apiExportInformer.Informer().HasSynced,
+		clusterCachedResourcesSynced: clusterCachedResourceInformer.Informer().HasSynced,
+	}
+
+	_, _ = apiExportInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { c.enqueueAPIExport(obj) },
+		UpdateFunc: func(_, obj interface{}) { c.enqueueAPIExport(obj) },
+		DeleteFunc: func(obj interface{}) { c.enqueueAPIExport(obj) },
+	})
+
+	// A ClusterCachedResource that somebody deleted by hand has to come back
+	// while its APIExport still wants it.
+	_, _ = clusterCachedResourceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		DeleteFunc: func(obj interface{}) { c.enqueueOwningAPIExport(obj) },
+		UpdateFunc: func(_, obj interface{}) { c.enqueueOwningAPIExport(obj) },
+	})
+
+	return c, nil
+}
+
+type controller struct {
+	queue workqueue.TypedRateLimitingInterface[string]
+
+	restMappingFor     func(cluster logicalcluster.Name, gk schema.GroupKind) (*meta.RESTMapping, error)
+	getAPIExport       func(cluster logicalcluster.Name, name string) (*apisv1alpha2.APIExport, error)
+	listOwnedResources func(cluster logicalcluster.Name, export string) ([]*cachev1alpha1.ClusterCachedResource, error)
+	createResource     func(ctx context.Context, cluster logicalcluster.Name, ccr *cachev1alpha1.ClusterCachedResource) error
+	updateResource     func(ctx context.Context, cluster logicalcluster.Name, ccr *cachev1alpha1.ClusterCachedResource) error
+	deleteResource     func(ctx context.Context, cluster logicalcluster.Name, name string) error
+
+	apiExportsSynced             cache.InformerSynced
+	clusterCachedResourcesSynced cache.InformerSynced
+}
+
+// reference is one object an APIExport points at. It names a kind, because
+// that is what the APIExport carries; resolving it to a resource needs a
+// RESTMapper.
+type reference struct {
+	group string
+	kind  string
+	name  string
+}
+
+// resolved is a reference once its kind has been turned into a resource.
+type resolved struct {
+	gvr  schema.GroupVersionResource
+	name string
+}
+
+// referencesFrom collects what an APIExport points at. A reference names a kind
+// rather than a resource, and the object is always in the APIExport's own
+// logical cluster: a provider can only publish endpoints for itself.
+func referencesFrom(export *apisv1alpha2.APIExport) []reference {
+	var refs []reference
+	for _, resource := range export.Spec.Resources {
+		if resource.Storage.Virtual == nil {
+			continue
+		}
+		ref := resource.Storage.Virtual.Reference
+		if ref.Kind == "" || ref.Name == "" {
+			continue
+		}
+		refs = append(refs, reference{
+			group: ptr.Deref(ref.APIGroup, ""),
+			kind:  ref.Kind,
+			name:  ref.Name,
+		})
+	}
+	return refs
+}
+
+func ownedBy(ccr *cachev1alpha1.ClusterCachedResource, export string) bool {
+	for _, ref := range ccr.OwnerReferences {
+		if ref.Kind == "APIExport" && ref.Name == export &&
+			ref.APIVersion == apisv1alpha2.SchemeGroupVersion.String() {
+			return true
+		}
+	}
+	return false
+}
+
+// nameFor builds a stable name for the ClusterCachedResource standing in for
+// one reference. It has to be a legal object name whatever the reference looks
+// like, and it has to be the same every time so that reconciling twice does not
+// make two of them.
+func nameFor(export string, ref resolved) string {
+	h := sha256.Sum256([]byte(export + "|" + ref.gvr.String() + "|" + ref.name))
+	suffix := strings.ToLower(base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(h[:5]))
+
+	// Keep something human-readable in front, but leave room for the hash.
+	prefix := ref.gvr.Resource
+	if len(prefix) > 40 {
+		prefix = prefix[:40]
+	}
+	return fmt.Sprintf("apiexport-%s-%s", prefix, suffix)
+}
+
+// desired builds the ClusterCachedResource that stands for a reference.
+func desired(export *apisv1alpha2.APIExport, ref resolved) *cachev1alpha1.ClusterCachedResource {
+	return &cachev1alpha1.ClusterCachedResource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nameFor(export.Name, ref),
+			// Owned by the APIExport, so that the whole thing goes away with it
+			// -- and its finalizer drains the cache on the way out.
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: apisv1alpha2.SchemeGroupVersion.String(),
+				Kind:       "APIExport",
+				Name:       export.Name,
+				UID:        export.UID,
+			}},
+			Annotations: map[string]string{
+				"cache.kcp.io/referenced-by": export.Name,
+			},
+		},
+		Spec: cachev1alpha1.ClusterCachedResourceSpec{
+			GroupVersionResource: cachev1alpha1.GroupVersionResource{
+				Group:    ref.gvr.Group,
+				Version:  ref.gvr.Version,
+				Resource: ref.gvr.Resource,
+			},
+			// Only the object that was referenced. A ClusterCachedResource
+			// usually stands for a whole kind; here it stands for one object.
+			Names: []string{ref.name},
+		},
+	}
+}
+
+func (c *controller) enqueueAPIExport(obj interface{}) {
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
+	export, ok := obj.(*apisv1alpha2.APIExport)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("object is %T, not an APIExport", obj))
+		return
+	}
+	c.queue.Add(kcpcache.ToClusterAwareKey(logicalcluster.From(export).String(), "", export.Name))
+}
+
+func (c *controller) enqueueOwningAPIExport(obj interface{}) {
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
+	ccr, ok := obj.(*cachev1alpha1.ClusterCachedResource)
+	if !ok {
+		return
+	}
+	for _, ref := range ccr.OwnerReferences {
+		if ref.Kind != "APIExport" {
+			continue
+		}
+		c.queue.Add(kcpcache.ToClusterAwareKey(logicalcluster.From(ccr).String(), "", ref.Name))
+	}
+}
+
+func (c *controller) Start(ctx context.Context, workers int) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	logger := logging.WithReconciler(klog.FromContext(ctx), ControllerName)
+	ctx = klog.NewContext(ctx, logger)
+	logger.Info("Starting controller")
+	defer logger.Info("Shutting down controller")
+
+	for range workers {
+		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
+	}
+
+	<-ctx.Done()
+}
+
+func (c *controller) startWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *controller) processNextWorkItem(ctx context.Context) bool {
+	key, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(key)
+
+	logger := klog.FromContext(ctx).WithValues("apiExport", key)
+	ctx = klog.NewContext(ctx, logger)
+
+	if err := c.reconcile(ctx, key); err != nil {
+		utilruntime.HandleError(fmt.Errorf("%q controller failed to sync %q: %w", ControllerName, key, err))
+		c.queue.AddRateLimited(key)
+		return true
+	}
+	c.queue.Forget(key)
+	return true
+}
+
+func (c *controller) reconcile(ctx context.Context, rawKey string) error {
+	cluster, _, name, err := kcpcache.SplitMetaClusterNamespaceKey(rawKey)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return nil
+	}
+
+	export, err := c.getAPIExport(cluster, name)
+	if apierrors.IsNotFound(err) {
+		// Gone. Its ClusterCachedResources are owned by it, so the garbage
+		// collector takes them, and each one drains the cache on its way out.
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	wanted, err := c.wantedFor(export)
+	if err != nil {
+		return err
+	}
+
+	existing, err := c.listOwnedResources(cluster, export.Name)
+	if err != nil {
+		return err
+	}
+
+	// Anything this APIExport owns but no longer asks for goes. Deleting the
+	// ClusterCachedResource is what removes the copies: its finalizer drains
+	// them while the kind is still served.
+	byName := map[string]*cachev1alpha1.ClusterCachedResource{}
+	for _, ccr := range existing {
+		byName[ccr.Name] = ccr
+	}
+	for _, ccr := range existing {
+		if _, keep := wanted[ccr.Name]; keep {
+			continue
+		}
+		if !ccr.DeletionTimestamp.IsZero() {
+			continue
+		}
+		klog.FromContext(ctx).V(2).Info("dropping a ClusterCachedResource nothing references anymore",
+			"clusterCachedResource", ccr.Name)
+		if err := c.deleteResource(ctx, cluster, ccr.Name); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+
+	for name, want := range wanted {
+		have, ok := byName[name]
+		if !ok {
+			if err := c.createResource(ctx, cluster, want); err != nil && !apierrors.IsAlreadyExists(err) {
+				return err
+			}
+			continue
+		}
+		if equality.Semantic.DeepEqual(have.Spec, want.Spec) {
+			continue
+		}
+		updated := have.DeepCopy()
+		updated.Spec = want.Spec
+		if err := c.updateResource(ctx, cluster, updated); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// wantedFor resolves an APIExport's references to the ClusterCachedResources
+// that should exist for them, keyed by name.
+func (c *controller) wantedFor(export *apisv1alpha2.APIExport) (map[string]*cachev1alpha1.ClusterCachedResource, error) {
+	if !export.DeletionTimestamp.IsZero() {
+		// On its way out. The garbage collector handles what it owns.
+		return nil, nil
+	}
+
+	cluster := logicalcluster.From(export)
+	wanted := map[string]*cachev1alpha1.ClusterCachedResource{}
+	seen := sets.New[resolved]()
+
+	for _, ref := range referencesFrom(export) {
+		mapping, err := c.restMappingFor(cluster, schema.GroupKind{Group: ref.group, Kind: ref.kind})
+		if err != nil {
+			if meta.IsNoMatchError(err) {
+				// The kind is not served in that workspace. Nothing to cache,
+				// and nothing this controller can do about it: the APIExport is
+				// pointing at something that does not exist.
+				continue
+			}
+			return nil, err
+		}
+
+		r := resolved{gvr: mapping.Resource, name: ref.name}
+		if seen.Has(r) {
+			continue
+		}
+		seen.Insert(r)
+
+		ccr := desired(export, r)
+		wanted[ccr.Name] = ccr
+	}
+
+	return wanted, nil
+}

--- a/pkg/reconciler/cache/apiexportreference/apiexportreference_controller.go
+++ b/pkg/reconciler/cache/apiexportreference/apiexportreference_controller.go
@@ -37,7 +37,6 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,6 +54,8 @@ import (
 	"github.com/kcp-dev/logicalcluster/v3"
 	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
 	cachev1alpha1 "github.com/kcp-dev/sdk/apis/cache/v1alpha1"
+	cachev1alpha1apply "github.com/kcp-dev/sdk/client/applyconfiguration/cache/v1alpha1"
+	metav1apply "github.com/kcp-dev/sdk/client/applyconfiguration/meta/v1"
 	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
 	apisv1alpha2informers "github.com/kcp-dev/sdk/client/informers/externalversions/apis/v1alpha2"
 	cachev1alpha1informers "github.com/kcp-dev/sdk/client/informers/externalversions/cache/v1alpha1"
@@ -81,12 +82,11 @@ func NewController(
 			workqueue.TypedRateLimitingQueueConfig[string]{Name: ControllerName},
 		),
 		restMappingFor: restMappingFor,
-		createResource: func(ctx context.Context, cluster logicalcluster.Name, ccr *cachev1alpha1.ClusterCachedResource) error {
-			_, err := kcpClusterClient.Cluster(cluster.Path()).CacheV1alpha1().ClusterCachedResources().Create(ctx, ccr, metav1.CreateOptions{})
-			return err
-		},
-		updateResource: func(ctx context.Context, cluster logicalcluster.Name, ccr *cachev1alpha1.ClusterCachedResource) error {
-			_, err := kcpClusterClient.Cluster(cluster.Path()).CacheV1alpha1().ClusterCachedResources().Update(ctx, ccr, metav1.UpdateOptions{})
+		applyResource: func(ctx context.Context, cluster logicalcluster.Name, ccr *cachev1alpha1apply.ClusterCachedResourceApplyConfiguration) error {
+			_, err := kcpClusterClient.Cluster(cluster.Path()).CacheV1alpha1().ClusterCachedResources().Apply(ctx, ccr, metav1.ApplyOptions{
+				FieldManager: ControllerName,
+				Force:        true,
+			})
 			return err
 		},
 		deleteResource: func(ctx context.Context, cluster logicalcluster.Name, name string) error {
@@ -118,8 +118,11 @@ func NewController(
 		DeleteFunc: func(obj interface{}) { c.enqueueAPIExport(obj) },
 	})
 
-	// A ClusterCachedResource that somebody deleted by hand has to come back
-	// while its APIExport still wants it.
+	// A ClusterCachedResource that somebody deleted or edited by hand has to
+	// come back while its APIExport still wants it. Reconciling applies only
+	// the fields this controller owns, so reacting to every update is safe:
+	// a write by someone else (the clustercachedresources controller
+	// defaulting spec.identity, say) resolves to a no-op apply, not a fight.
 	_, _ = clusterCachedResourceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		DeleteFunc: func(obj interface{}) { c.enqueueOwningAPIExport(obj) },
 		UpdateFunc: func(_, obj interface{}) { c.enqueueOwningAPIExport(obj) },
@@ -134,8 +137,7 @@ type controller struct {
 	restMappingFor     func(cluster logicalcluster.Name, gk schema.GroupKind) (*meta.RESTMapping, error)
 	getAPIExport       func(cluster logicalcluster.Name, name string) (*apisv1alpha2.APIExport, error)
 	listOwnedResources func(cluster logicalcluster.Name, export string) ([]*cachev1alpha1.ClusterCachedResource, error)
-	createResource     func(ctx context.Context, cluster logicalcluster.Name, ccr *cachev1alpha1.ClusterCachedResource) error
-	updateResource     func(ctx context.Context, cluster logicalcluster.Name, ccr *cachev1alpha1.ClusterCachedResource) error
+	applyResource      func(ctx context.Context, cluster logicalcluster.Name, ccr *cachev1alpha1apply.ClusterCachedResourceApplyConfiguration) error
 	deleteResource     func(ctx context.Context, cluster logicalcluster.Name, name string) error
 
 	apiExportsSynced             cache.InformerSynced
@@ -205,34 +207,29 @@ func nameFor(export string, ref resolved) string {
 	return fmt.Sprintf("apiexport-%s-%s", prefix, suffix)
 }
 
-// desired builds the ClusterCachedResource that stands for a reference.
-func desired(export *apisv1alpha2.APIExport, ref resolved) *cachev1alpha1.ClusterCachedResource {
-	return &cachev1alpha1.ClusterCachedResource{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: nameFor(export.Name, ref),
-			// Owned by the APIExport, so that the whole thing goes away with it
-			// -- and its finalizer drains the cache on the way out.
-			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: apisv1alpha2.SchemeGroupVersion.String(),
-				Kind:       "APIExport",
-				Name:       export.Name,
-				UID:        export.UID,
-			}},
-			Annotations: map[string]string{
-				"cache.kcp.io/referenced-by": export.Name,
-			},
-		},
-		Spec: cachev1alpha1.ClusterCachedResourceSpec{
-			GroupVersionResource: cachev1alpha1.GroupVersionResource{
-				Group:    ref.gvr.Group,
-				Version:  ref.gvr.Version,
-				Resource: ref.gvr.Resource,
-			},
+// desired builds the apply configuration that stands for a reference. It
+// carries only the fields this controller owns; applying it with a field
+// manager leaves everything else -- spec.identity, most notably, which the
+// clustercachedresources controller defaults in place -- to its owners.
+func desired(export *apisv1alpha2.APIExport, ref resolved) *cachev1alpha1apply.ClusterCachedResourceApplyConfiguration {
+	return cachev1alpha1apply.ClusterCachedResource(nameFor(export.Name, ref)).
+		// Owned by the APIExport, so that the whole thing goes away with it
+		// -- and its finalizer drains the cache on the way out.
+		WithOwnerReferences(metav1apply.OwnerReference().
+			WithAPIVersion(apisv1alpha2.SchemeGroupVersion.String()).
+			WithKind("APIExport").
+			WithName(export.Name).
+			WithUID(export.UID)).
+		WithAnnotations(map[string]string{
+			"cache.kcp.io/referenced-by": export.Name,
+		}).
+		WithSpec(cachev1alpha1apply.ClusterCachedResourceSpec().
+			WithGroup(ref.gvr.Group).
+			WithVersion(ref.gvr.Version).
+			WithResource(ref.gvr.Resource).
 			// Only the object that was referenced. A ClusterCachedResource
 			// usually stands for a whole kind; here it stands for one object.
-			Names: []string{ref.name},
-		},
-	}
+			WithNames(ref.name))
 }
 
 func (c *controller) enqueueAPIExport(obj interface{}) {
@@ -332,10 +329,6 @@ func (c *controller) reconcile(ctx context.Context, rawKey string) error {
 	// Anything this APIExport owns but no longer asks for goes. Deleting the
 	// ClusterCachedResource is what removes the copies: its finalizer drains
 	// them while the kind is still served.
-	byName := map[string]*cachev1alpha1.ClusterCachedResource{}
-	for _, ccr := range existing {
-		byName[ccr.Name] = ccr
-	}
 	for _, ccr := range existing {
 		if _, keep := wanted[ccr.Name]; keep {
 			continue
@@ -350,20 +343,12 @@ func (c *controller) reconcile(ctx context.Context, rawKey string) error {
 		}
 	}
 
-	for name, want := range wanted {
-		have, ok := byName[name]
-		if !ok {
-			if err := c.createResource(ctx, cluster, want); err != nil && !apierrors.IsAlreadyExists(err) {
-				return err
-			}
-			continue
-		}
-		if equality.Semantic.DeepEqual(have.Spec, want.Spec) {
-			continue
-		}
-		updated := have.DeepCopy()
-		updated.Spec = want.Spec
-		if err := c.updateResource(ctx, cluster, updated); err != nil {
+	// Server-side apply what is wanted. The apply configuration names only the
+	// fields this controller owns, so an existing ClusterCachedResource keeps
+	// whatever others put on it -- the clustercachedresources controller
+	// defaults spec.identity in place, and that must survive this write.
+	for _, want := range wanted {
+		if err := c.applyResource(ctx, cluster, want); err != nil {
 			return err
 		}
 	}
@@ -372,15 +357,15 @@ func (c *controller) reconcile(ctx context.Context, rawKey string) error {
 }
 
 // wantedFor resolves an APIExport's references to the ClusterCachedResources
-// that should exist for them, keyed by name.
-func (c *controller) wantedFor(export *apisv1alpha2.APIExport) (map[string]*cachev1alpha1.ClusterCachedResource, error) {
+// that should exist for them, as apply configurations keyed by name.
+func (c *controller) wantedFor(export *apisv1alpha2.APIExport) (map[string]*cachev1alpha1apply.ClusterCachedResourceApplyConfiguration, error) {
 	if !export.DeletionTimestamp.IsZero() {
 		// On its way out. The garbage collector handles what it owns.
 		return nil, nil
 	}
 
 	cluster := logicalcluster.From(export)
-	wanted := map[string]*cachev1alpha1.ClusterCachedResource{}
+	wanted := map[string]*cachev1alpha1apply.ClusterCachedResourceApplyConfiguration{}
 	seen := sets.New[resolved]()
 
 	for _, ref := range referencesFrom(export) {
@@ -401,8 +386,7 @@ func (c *controller) wantedFor(export *apisv1alpha2.APIExport) (map[string]*cach
 		}
 		seen.Insert(r)
 
-		ccr := desired(export, r)
-		wanted[ccr.Name] = ccr
+		wanted[nameFor(export.Name, r)] = desired(export, r)
 	}
 
 	return wanted, nil

--- a/pkg/reconciler/cache/clustercachedresources/clustercachedresources_reconcile.go
+++ b/pkg/reconciler/cache/clustercachedresources/clustercachedresources_reconcile.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
@@ -38,6 +37,7 @@ import (
 	cacheclient "github.com/kcp-dev/kcp/pkg/cache/client"
 	"github.com/kcp-dev/kcp/pkg/cache/client/shard"
 	"github.com/kcp-dev/kcp/pkg/logging"
+	replicationcontroller "github.com/kcp-dev/kcp/pkg/reconciler/cache/clustercachedresources/replication"
 )
 
 type reconcileStatus int
@@ -149,15 +149,14 @@ func (c *Controller) listSelectedLocalResources(ctx context.Context, cluster log
 		Resource: clusterCachedResource.Spec.Resource,
 	}
 
-	listOpts := metav1.ListOptions{}
-	if clusterCachedResource.Spec.LabelSelector != nil {
-		listOpts.LabelSelector = labels.SelectorFromSet(clusterCachedResource.Spec.LabelSelector.MatchLabels).String()
-	}
+	selection := replicationcontroller.SelectionFor(clusterCachedResource)
 
-	resources, err := c.localDynamicClient.Cluster(cluster.Path()).Resource(gvr).List(ctx, listOpts)
+	resources, err := c.localDynamicClient.Cluster(cluster.Path()).Resource(gvr).List(ctx, selection.ListOptions())
 	if err != nil {
 		return nil, err
 	}
+	// Names cannot go into the list options, so they are applied here.
+	resources.Items = selection.Filter(resources.Items)
 
 	return resources, nil
 }

--- a/pkg/reconciler/cache/clustercachedresources/clustercachedresources_reconcile_replication.go
+++ b/pkg/reconciler/cache/clustercachedresources/clustercachedresources_reconcile_replication.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -63,10 +62,7 @@ func (r *replication) reconcile(ctx context.Context, clusterCachedResource *cach
 	}
 	cluster := logicalcluster.From(clusterCachedResource)
 
-	var resourceLabelSelector labels.Selector
-	if clusterCachedResource.Spec.LabelSelector != nil {
-		resourceLabelSelector = labels.SelectorFromSet(clusterCachedResource.Spec.LabelSelector.MatchLabels)
-	}
+	selection := replicationcontroller.SelectionFor(clusterCachedResource)
 
 	clusterName := logicalcluster.From(clusterCachedResource)
 	controllerName := fmt.Sprintf("%s.%s.%s.%s.%s", clusterName, gvr.Version, gvr.Resource, gvr.Group, clusterCachedResource.Name)
@@ -124,7 +120,7 @@ func (r *replication) reconcile(ctx context.Context, clusterCachedResource *cach
 			gvr,
 			replicated,
 			requeueSelf,
-			resourceLabelSelector,
+			selection,
 		)
 		if err != nil {
 			cancel()
@@ -155,7 +151,7 @@ func (r *replication) reconcile(ctx context.Context, clusterCachedResource *cach
 
 		return reconcileStatusStopAndRequeue, nil // Once controller is started, we requeue to check if we need to delete it.
 	}
-	controller.SetLabelSelector(resourceLabelSelector)
+	controller.SetSelection(selection)
 
 	// Check if we need to wait for cleaning. This can be few cases:
 	// 1. We are in deleting phase, but nothing to delete - we are good.

--- a/pkg/reconciler/cache/clustercachedresources/replication/replication_controller.go
+++ b/pkg/reconciler/cache/clustercachedresources/replication/replication_controller.go
@@ -23,7 +23,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -80,7 +79,7 @@ func NewController(
 	gvr schema.GroupVersionResource,
 	replicated *ReplicatedGVR,
 	requeueSelf func(),
-	localLabelSelector labels.Selector,
+	selection Selection,
 ) (*Controller, error) {
 	c := &Controller{
 		shardName: shardName,
@@ -96,7 +95,7 @@ func NewController(
 		replicated:                      replicated,
 		requeueSelf:                     requeueSelf,
 		onShutdownFuncs:                 make([]func(), 0),
-		localLabelSelector:              localLabelSelector,
+		selection:                       selection,
 	}
 
 	localHandler, err := c.replicated.Local.AddEventHandler(cache.FilteringResourceEventHandler{
@@ -177,8 +176,8 @@ func (c *Controller) Started() bool {
 	return c.started
 }
 
-func (c *Controller) SetLabelSelector(localLabelSelector labels.Selector) {
-	c.localLabelSelector = localLabelSelector
+func (c *Controller) SetSelection(selection Selection) {
+	c.selection = selection
 }
 
 func (c *Controller) startWorker(ctx context.Context) {
@@ -232,9 +231,9 @@ type Controller struct {
 	// onShutdownFuncs are cleanup functions that are called when the controller is stopped.
 	onShutdownFuncs []func()
 
-	// localLabelSelector is the label selector that we use to filter the objects that we want to replicate.
-	// It is set when the controller is created and can be changed by the parent controller.
-	localLabelSelector labels.Selector
+	// selection is which objects of the kind we replicate. It is set when the
+	// controller is created and can be changed by the parent controller.
+	selection Selection
 
 	started bool
 	deleted bool

--- a/pkg/reconciler/cache/clustercachedresources/replication/replication_reconcile.go
+++ b/pkg/reconciler/cache/clustercachedresources/replication/replication_reconcile.go
@@ -24,7 +24,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/klog/v2"
@@ -59,8 +58,8 @@ func (c *Controller) reconcile(ctx context.Context, gvrKey string) error {
 	key := keyParts[1]
 
 	r := &replicationReconciler{
-		shardName:          c.shardName,
-		localLabelSelector: c.localLabelSelector,
+		shardName: c.shardName,
+		selection: c.selection,
 		getLocalPartialObjectMetadata: func(cluster logicalcluster.Name, namespace, name string) (*unstructured.Unstructured, error) {
 			gvr := gvrFromKey
 			key := kcpcache.ToClusterAwareKey(cluster.String(), namespace, name)
@@ -159,9 +158,9 @@ func (c *Controller) reconcile(ctx context.Context, gvrKey string) error {
 }
 
 type replicationReconciler struct {
-	shardName          string
-	deleted            bool
-	localLabelSelector labels.Selector
+	shardName string
+	deleted   bool
+	selection Selection
 
 	getLocalPartialObjectMetadata func(cluster logicalcluster.Name, namespace, name string) (*unstructured.Unstructured, error)
 	getLocalCopy                  func(ctx context.Context, cluster logicalcluster.Name, namespace, name string) (*unstructured.Unstructured, error)
@@ -199,9 +198,9 @@ func (r *replicationReconciler) reconcile(ctx context.Context, key string) error
 	}
 	localExists := !apierrors.IsNotFound(err)
 
-	if localExists && r.localLabelSelector != nil && !r.localLabelSelector.Matches(labels.Set(localPartialObjMeta.GetLabels())) {
-		// Exit early: the label selector doesn't match.
-		logger.V(2).WithValues("cluster", clusterName, "namespace", ns, "name", name).Info("Object does not match label selector, skipping")
+	if localExists && !r.selection.Matches(localPartialObjMeta) {
+		// Exit early: this is not one of the objects being published.
+		logger.V(2).WithValues("cluster", clusterName, "namespace", ns, "name", name).Info("Object is not selected, skipping")
 		return nil
 	}
 

--- a/pkg/reconciler/cache/clustercachedresources/replication/selection.go
+++ b/pkg/reconciler/cache/clustercachedresources/replication/selection.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package replication
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	cachev1alpha1 "github.com/kcp-dev/sdk/apis/cache/v1alpha1"
+)
+
+// Selection is what a ClusterCachedResource says it publishes: everything of
+// its kind, or some subset picked out by labels, by name, or by both.
+type Selection struct {
+	Labels labels.Selector
+	Names  sets.Set[string]
+}
+
+// SelectionFor reads the selection off a ClusterCachedResource. A resource that
+// sets neither publishes its whole kind.
+func SelectionFor(clusterCachedResource *cachev1alpha1.ClusterCachedResource) Selection {
+	var s Selection
+	if clusterCachedResource.Spec.LabelSelector != nil {
+		s.Labels = labels.SelectorFromSet(clusterCachedResource.Spec.LabelSelector.MatchLabels)
+	}
+	if len(clusterCachedResource.Spec.Names) > 0 {
+		s.Names = sets.New(clusterCachedResource.Spec.Names...)
+	}
+	return s
+}
+
+// Matches reports whether an object is one of the ones being published. Both
+// halves apply: an object has to satisfy every part of the selection that is
+// set.
+func (s Selection) Matches(obj metav1.Object) bool {
+	if s.Labels != nil && !s.Labels.Matches(labels.Set(obj.GetLabels())) {
+		return false
+	}
+	if s.Names.Len() > 0 && !s.Names.Has(obj.GetName()) {
+		return false
+	}
+	return true
+}
+
+// ListOptions returns the part of the selection the API server can apply for
+// us. Names are left out on purpose -- a field selector only compares one value
+// and a selection may name several -- so a caller that lists still has to run
+// the results through Matches.
+func (s Selection) ListOptions() metav1.ListOptions {
+	opts := metav1.ListOptions{}
+	if s.Labels != nil {
+		opts.LabelSelector = s.Labels.String()
+	}
+	return opts
+}
+
+// Filter drops the objects a selection does not publish.
+func (s Selection) Filter(items []unstructured.Unstructured) []unstructured.Unstructured {
+	if s.Names.Len() == 0 {
+		return items
+	}
+	out := items[:0]
+	for _, item := range items {
+		if s.Names.Has(item.GetName()) {
+			out = append(out, item)
+		}
+	}
+	return out
+}

--- a/pkg/server/aggregatingcrdversiondiscovery/verbs_provider.go
+++ b/pkg/server/aggregatingcrdversiondiscovery/verbs_provider.go
@@ -17,10 +17,8 @@ limitations under the License.
 package aggregatingcrdversiondiscovery
 
 import (
-	"cmp"
 	"context"
 	"fmt"
-	"slices"
 	"strings"
 
 	apiextensionshelpers "k8s.io/apiextensions-apiserver/pkg/apihelpers"
@@ -71,14 +69,13 @@ func (f *storageAwareResourceVerbsProviderFactory) newResourceVerbsProvider(ctx 
 		if len(apiExports) == 0 {
 			return nil, fmt.Errorf("no matching APIExport for virtual resource fingerprint %q", fingerprint)
 		}
-		// Pick a deterministic export. Multiple exports in different logical clusters
-		// may share the same fingerprint; sort for stable selection.
-		slices.SortFunc(apiExports, func(a, b *apisv1alpha2.APIExport) int {
-			return cmp.Or(
-				cmp.Compare(logicalcluster.From(a), logicalcluster.From(b)),
-				cmp.Compare(a.Name, b.Name),
-			)
-		})
+		// A fingerprint carries the owning APIExport's logical cluster and name, so it
+		// identifies exactly one APIExport. More than one match means the index is
+		// keyed by something weaker than we think, and picking either one would serve
+		// another workspace's virtual workspace URL under this one's discovery.
+		if len(apiExports) > 1 {
+			return nil, fmt.Errorf("virtual resource fingerprint %q matches %d APIExports, expected exactly one", fingerprint, len(apiExports))
+		}
 
 		return newVirtualStorageVerbsProvider(ctx, schema.GroupVersionResource{
 			Group:    crd.Spec.Group,

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -30,6 +30,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsscheme "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -83,6 +84,7 @@ import (
 	apisreplicateclusterrole "github.com/kcp-dev/kcp/pkg/reconciler/apis/replicateclusterrole"
 	apisreplicateclusterrolebinding "github.com/kcp-dev/kcp/pkg/reconciler/apis/replicateclusterrolebinding"
 	apisreplicatelogicalcluster "github.com/kcp-dev/kcp/pkg/reconciler/apis/replicatelogicalcluster"
+	"github.com/kcp-dev/kcp/pkg/reconciler/cache/apiexportreference"
 	"github.com/kcp-dev/kcp/pkg/reconciler/cache/clustercachedresourceendpointslice"
 	"github.com/kcp-dev/kcp/pkg/reconciler/cache/clustercachedresourceendpointsliceurls"
 	"github.com/kcp-dev/kcp/pkg/reconciler/cache/clustercachedresources"
@@ -1794,6 +1796,50 @@ func (s *Server) installReplicationController(ctx context.Context, config *rest.
 					}
 				}
 				return true, nil
+			})
+		},
+		Runner: func(ctx context.Context) {
+			controller.Start(ctx, 2)
+		},
+	})
+}
+
+// installAPIExportReferenceController keeps a ClusterCachedResource for every
+// object an APIExport points at, so that the shard can resolve the reference
+// through the cache server.
+//
+// Only relevant with CacheAPIs: virtual storage, which is what a reference
+// describes, is not served without it.
+func (s *Server) installAPIExportReferenceController(ctx context.Context, config *rest.Config) error {
+	if !kcpfeatures.DefaultFeatureGate.Enabled(kcpfeatures.CacheAPIs) {
+		return nil
+	}
+
+	config = rest.CopyConfig(config)
+	config = rest.AddUserAgent(config, apiexportreference.ControllerName)
+	kcpClusterClient, err := kcpclientset.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+
+	controller, err := apiexportreference.NewController(
+		kcpClusterClient,
+		s.KcpSharedInformerFactory.Apis().V1alpha2().APIExports(),
+		s.KcpSharedInformerFactory.Cache().V1alpha1().ClusterCachedResources(),
+		func(cluster logicalcluster.Name, gk schema.GroupKind) (*meta.RESTMapping, error) {
+			return s.DynamicRESTMapper.ForCluster(cluster).RESTMapping(gk)
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	return s.registerController(&controllerWrapper{
+		Name: apiexportreference.ControllerName,
+		Wait: func(ctx context.Context, s *Server) error {
+			return wait.PollUntilContextCancel(ctx, waitPollInterval, true, func(ctx context.Context) (bool, error) {
+				return s.KcpSharedInformerFactory.Apis().V1alpha2().APIExports().Informer().HasSynced() &&
+					s.KcpSharedInformerFactory.Cache().V1alpha1().ClusterCachedResources().Informer().HasSynced(), nil
 			})
 		},
 		Runner: func(ctx context.Context) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -288,6 +288,9 @@ func (s *Server) installControllers(ctx context.Context, controllerConfig *rest.
 	if err := s.installReplicationController(ctx, controllerConfig, gvrs); err != nil {
 		return err
 	}
+	if err := s.installAPIExportReferenceController(ctx, controllerConfig); err != nil {
+		return err
+	}
 
 	enabled := sets.New[string](s.Options.Controllers.IndividuallyEnabled...)
 	if len(enabled) > 0 {

--- a/staging/src/github.com/kcp-dev/sdk/apis/cache/v1alpha1/types_clustercachedresource.go
+++ b/staging/src/github.com/kcp-dev/sdk/apis/cache/v1alpha1/types_clustercachedresource.go
@@ -65,6 +65,20 @@ type ClusterCachedResourceSpec struct {
 	// LabelSelector is used to filter which resources should be published
 	// +optional
 	LabelSelector *metav1.LabelSelector `json:"labelSelector,omitempty"`
+
+	// names narrows publishing to resources called exactly these.
+	//
+	// Leaving it empty publishes every resource the label selector allows,
+	// which is the usual case: a ClusterCachedResource normally stands for a
+	// whole kind. Naming resources is for the case where something points at
+	// one object in particular and only that object is worth caching.
+	//
+	// Names and labelSelector both apply -- a resource has to satisfy each of
+	// the ones that is set.
+	//
+	// +optional
+	// +listType=set
+	Names []string `json:"names,omitempty"`
 }
 
 // Identity defines the identity of a ClusterCachedResource, i.e. determines the cached resource access

--- a/staging/src/github.com/kcp-dev/sdk/apis/cache/v1alpha1/zz_generated.deepcopy.go
+++ b/staging/src/github.com/kcp-dev/sdk/apis/cache/v1alpha1/zz_generated.deepcopy.go
@@ -230,6 +230,11 @@ func (in *ClusterCachedResourceSpec) DeepCopyInto(out *ClusterCachedResourceSpec
 		*out = new(v1.LabelSelector)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Names != nil {
+		in, out := &in.Names, &out.Names
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/staging/src/github.com/kcp-dev/sdk/client/applyconfiguration/cache/v1alpha1/clustercachedresourcespec.go
+++ b/staging/src/github.com/kcp-dev/sdk/client/applyconfiguration/cache/v1alpha1/clustercachedresourcespec.go
@@ -41,6 +41,16 @@ type ClusterCachedResourceSpecApplyConfiguration struct {
 	Identity *IdentityApplyConfiguration `json:"identity,omitempty"`
 	// LabelSelector is used to filter which resources should be published
 	LabelSelector *v1.LabelSelectorApplyConfiguration `json:"labelSelector,omitempty"`
+	// names narrows publishing to resources called exactly these.
+	//
+	// Leaving it empty publishes every resource the label selector allows,
+	// which is the usual case: a ClusterCachedResource normally stands for a
+	// whole kind. Naming resources is for the case where something points at
+	// one object in particular and only that object is worth caching.
+	//
+	// Names and labelSelector both apply -- a resource has to satisfy each of
+	// the ones that is set.
+	Names []string `json:"names,omitempty"`
 }
 
 // ClusterCachedResourceSpecApplyConfiguration constructs a declarative configuration of the ClusterCachedResourceSpec type for use with
@@ -86,5 +96,15 @@ func (b *ClusterCachedResourceSpecApplyConfiguration) WithIdentity(value *Identi
 // If called multiple times, the LabelSelector field is set to the value of the last call.
 func (b *ClusterCachedResourceSpecApplyConfiguration) WithLabelSelector(value *v1.LabelSelectorApplyConfiguration) *ClusterCachedResourceSpecApplyConfiguration {
 	b.LabelSelector = value
+	return b
+}
+
+// WithNames adds the given value to the Names field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the Names field.
+func (b *ClusterCachedResourceSpecApplyConfiguration) WithNames(values ...string) *ClusterCachedResourceSpecApplyConfiguration {
+	for i := range values {
+		b.Names = append(b.Names, values[i])
+	}
 	return b
 }

--- a/staging/src/github.com/kcp-dev/sdk/openapi/zz_generated.openapi.go
+++ b/staging/src/github.com/kcp-dev/sdk/openapi/zz_generated.openapi.go
@@ -3359,6 +3359,26 @@ func schema_sdk_apis_cache_v1alpha1_ClusterCachedResourceSpec(ref common.Referen
 							Ref:         ref(v1.LabelSelector{}.OpenAPIModelName()),
 						},
 					},
+					"names": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "set",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "names narrows publishing to resources called exactly these.\n\nLeaving it empty publishes every resource the label selector allows, which is the usual case: a ClusterCachedResource normally stands for a whole kind. Naming resources is for the case where something points at one object in particular and only that object is worth caching.\n\nNames and labelSelector both apply -- a resource has to satisfy each of the ones that is set.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
 				},
 				Required: []string{"resource"},
 			},

--- a/test/e2e/cache/reference_replication_test.go
+++ b/test/e2e/cache/reference_replication_test.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/ptr"
+
+	kcpapiextensionsclientset "github.com/kcp-dev/client-go/apiextensions/client"
+	kcpdynamic "github.com/kcp-dev/client-go/dynamic"
+	"github.com/kcp-dev/logicalcluster/v3"
+	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
+	"github.com/kcp-dev/sdk/apis/core"
+	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
+	kcptesting "github.com/kcp-dev/sdk/testing"
+	kcptestinghelpers "github.com/kcp-dev/sdk/testing/helpers"
+
+	"github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest"
+	wildwestv1alpha1 "github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/apis/wildwest/v1alpha1"
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+	cache2e "github.com/kcp-dev/kcp/test/e2e/reconciler/cache"
+)
+
+// TestReferenceReplication covers an object reaching the cache because an
+// APIExport points at it through spec.resources[].storage.virtual.reference,
+// and leaving again when nothing does.
+//
+// The kind matters. Sheriffs are not something the replication controller
+// copies on its own, so whether a sheriff is in the cache is decided entirely
+// by whether an APIExport references it -- which is the whole point of the
+// feature. Pick a kind that is replicated unconditionally (an endpoint slice,
+// say) and this test would pass without the reference machinery doing anything.
+func TestReferenceReplication(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "control-plane")
+
+	server := kcptesting.SharedKcpServer(t)
+	cfg := server.BaseConfig(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	kcpClusterClient, err := kcpclientset.NewForConfig(cfg)
+	require.NoError(t, err, "error creating kcp cluster client")
+
+	dynamicClusterClient, err := kcpdynamic.NewForConfig(cfg)
+	require.NoError(t, err, "error creating dynamic cluster client")
+
+	apiExtensionsClient, err := kcpapiextensionsclientset.NewForConfig(cfg)
+	require.NoError(t, err, "error creating apiextensions cluster client")
+
+	cacheClientCfg := createCacheClientConfigForEnvironment(ctx, t, server.RootShardSystemMasterBaseConfig(t))
+	cacheDynClient, err := kcpdynamic.NewForConfig(cache2e.ClientRoundTrippersFor(cacheClientCfg))
+	require.NoError(t, err, "error creating cache dynamic client")
+
+	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path())
+	providerPath, providerWS := kcptesting.NewWorkspaceFixture(t, server, orgPath)
+
+	// The cache server keys by logical cluster name and knows nothing of the
+	// workspace hierarchy, so reads against it cannot go through the path.
+	providerCluster := logicalcluster.Name(providerWS.Spec.Cluster)
+
+	gr := metav1.GroupResource{Group: "wildwest.dev", Resource: "sheriffs"}
+	sheriffsGVR := wildwestv1alpha1.SchemeGroupVersion.WithResource("sheriffs")
+
+	t.Logf("Creating the sheriffs CRD in %q", providerPath)
+	wildwest.Create(t, providerPath, apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions(), gr)
+	kcptesting.WaitForAPIReady(t, kcpClusterClient.Cluster(providerPath).Discovery(), wildwestv1alpha1.SchemeGroupVersion)
+
+	const (
+		referenced   = "referenced-sheriff"
+		unreferenced = "unreferenced-sheriff"
+		exportName   = "wildwest-provider"
+	)
+
+	for _, name := range []string{referenced, unreferenced} {
+		t.Logf("Creating Sheriff %q in %q", name, providerPath)
+		_, err = dynamicClusterClient.Cluster(providerPath).Resource(sheriffsGVR).Create(ctx, &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": wildwestv1alpha1.SchemeGroupVersion.String(),
+				"kind":       "Sheriff",
+				"metadata":   map[string]interface{}{"name": name},
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err, "error creating Sheriff %s", name)
+	}
+
+	exports := kcpClusterClient.Cluster(providerPath).ApisV1alpha2().APIExports()
+
+	t.Logf("Creating APIExport %q referencing Sheriff %q", exportName, referenced)
+	_, err = exports.Create(ctx, &apisv1alpha2.APIExport{
+		ObjectMeta: metav1.ObjectMeta{Name: exportName},
+		Spec: apisv1alpha2.APIExportSpec{
+			Resources: []apisv1alpha2.ResourceSchema{{
+				Group:  "wildwest.dev",
+				Name:   "cowboys",
+				Schema: "today.cowboys.wildwest.dev",
+				Storage: apisv1alpha2.ResourceSchemaStorage{
+					Virtual: &apisv1alpha2.ResourceSchemaStorageVirtual{
+						Reference: corev1.TypedLocalObjectReference{
+							APIGroup: ptr.To("wildwest.dev"),
+							Kind:     "Sheriff",
+							Name:     referenced,
+						},
+					},
+				},
+			}},
+		},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err, "error creating APIExport")
+
+	cachedSheriffs := func() ([]string, error) {
+		list, err := cacheDynClient.Cluster(providerCluster.Path()).Resource(sheriffsGVR).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return nil, err
+		}
+		names := make([]string, 0, len(list.Items))
+		for _, item := range list.Items {
+			names = append(names, item.GetName())
+		}
+		return names, nil
+	}
+
+	t.Logf("Waiting for the referenced Sheriff to reach the cache server")
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		names, err := cachedSheriffs()
+		if err != nil {
+			return false, fmt.Sprintf("error listing sheriffs in the cache: %v", err)
+		}
+		return slices.Contains(names, referenced), fmt.Sprintf("cache holds %v", names)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "the referenced Sheriff never reached the cache")
+
+	// Replicating what is referenced rather than what exists is the difference
+	// between this and the replication controller, so it is worth asserting
+	// that the sheriff nobody named stayed out.
+	names, err := cachedSheriffs()
+	require.NoError(t, err)
+	require.NotContains(t, names, unreferenced,
+		"a Sheriff no APIExport references must not be replicated")
+
+	t.Logf("Deleting APIExport %q", exportName)
+	require.NoError(t, exports.Delete(ctx, exportName, metav1.DeleteOptions{}), "error deleting APIExport")
+
+	t.Logf("Waiting for the cached copy to be removed")
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		names, err := cachedSheriffs()
+		if err != nil {
+			return false, fmt.Sprintf("error listing sheriffs in the cache: %v", err)
+		}
+		return !slices.Contains(names, referenced), fmt.Sprintf("cache holds %v", names)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "the cached copy outlived the last reference to it")
+
+	// The local object is untouched: only the copy was ever this controller's
+	// to remove.
+	_, err = dynamicClusterClient.Cluster(providerPath).Resource(sheriffsGVR).Get(ctx, referenced, metav1.GetOptions{})
+	require.NoError(t, err, "replication must not delete the object it was copying")
+}

--- a/test/e2e/cache/reference_replication_test.go
+++ b/test/e2e/cache/reference_replication_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -169,6 +170,12 @@ func TestReferenceReplication(t *testing.T) {
 	t.Logf("Waiting for the cached copy to be removed")
 	kcptestinghelpers.Eventually(t, func() (bool, string) {
 		names, err := cachedSheriffs()
+		if apierrors.IsNotFound(err) {
+			// The kind is served out of a synthetic CRD that exists only as
+			// long as some ClusterCachedResource wants it. With the last one
+			// gone the whole kind goes, which removes the copy and then some.
+			return true, ""
+		}
 		if err != nil {
 			return false, fmt.Sprintf("error listing sheriffs in the cache: %v", err)
 		}


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Wire in the reference replication controller.
The controller replicates custom objects referenced by APIExports, like custom xEndpointSlices, so they can be referenced via the cache server.

/kind feature 

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
