### PR TITLE
Add names selection to ClusterCachedResource

### DIFF
--- a/config/crds/cache.kcp.io_clustercachedresources.yaml
+++ b/config/crds/cache.kcp.io_clustercachedresources.yaml
@@ -130,6 +130,21 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              names:
+                description: |-
+                  names narrows publishing to resources called exactly these.
+
+                  Leaving it empty publishes every resource the label selector allows,
+                  which is the usual case: a ClusterCachedResource normally stands for a
+                  whole kind. Naming resources is for the case where something points at
+                  one object in particular and only that object is worth caching.
+
+                  Names and labelSelector both apply -- a resource has to satisfy each of
+                  the ones that is set.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
               resource:
                 description: |-
                   resource is the name of the resource.

--- a/config/root-phase0/apiexport-cache.kcp.io.yaml
+++ b/config/root-phase0/apiexport-cache.kcp.io.yaml
@@ -11,7 +11,7 @@ spec:
       crd: {}
   - group: cache.kcp.io
     name: clustercachedresources
-    schema: v250920-de0c8484d.clustercachedresources.cache.kcp.io
+    schema: v260814-239feb181.clustercachedresources.cache.kcp.io
     storage:
       crd: {}
 status: {}

--- a/config/root-phase0/apiresourceschema-clustercachedresources.cache.kcp.io.yaml
+++ b/config/root-phase0/apiresourceschema-clustercachedresources.cache.kcp.io.yaml
@@ -1,7 +1,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v250920-de0c8484d.clustercachedresources.cache.kcp.io
+  name: v260814-239feb181.clustercachedresources.cache.kcp.io
 spec:
   group: cache.kcp.io
   names:
@@ -126,6 +126,21 @@ spec:
                   type: object
               type: object
               x-kubernetes-map-type: atomic
+            names:
+              description: |-
+                names narrows publishing to resources called exactly these.
+
+                Leaving it empty publishes every resource the label selector allows,
+                which is the usual case: a ClusterCachedResource normally stands for a
+                whole kind. Naming resources is for the case where something points at
+                one object in particular and only that object is worth caching.
+
+                Names and labelSelector both apply -- a resource has to satisfy each of
+                the ones that is set.
+              items:
+                type: string
+              type: array
+              x-kubernetes-list-type: set
             resource:
               description: |-
                 resource is the name of the resource.

--- a/pkg/indexers/apiexport.go
+++ b/pkg/indexers/apiexport.go
@@ -19,7 +19,6 @@ package indexers
 import (
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
@@ -124,14 +123,11 @@ func IndexAPIExportEndpointSliceByAPIExport(obj interface{}) ([]string, error) {
 }
 
 // IndexAPIExportByVirtualResourceFingerprint indexes an APIExport by the fingerprint of each
-// virtual storage resource (identity hash + endpoint slice reference).
+// virtual storage resource (owning APIExport + endpoint slice reference).
 func IndexAPIExportByVirtualResourceFingerprint(obj interface{}) ([]string, error) {
 	apiExport, ok := obj.(*apisv1alpha2.APIExport)
 	if !ok {
 		return []string{}, fmt.Errorf("obj %T is not an APIExport", obj)
-	}
-	if apiExport.Status.IdentityHash == "" {
-		return []string{}, nil
 	}
 
 	keys := sets.New[string]()
@@ -141,9 +137,5 @@ func IndexAPIExportByVirtualResourceFingerprint(obj interface{}) ([]string, erro
 		}
 	}
 
-	return sets.List[string](keys), nil
-}
-
-func VirtualResourceIdentityAndGRKey(identityHash string, gr schema.GroupResource) string {
-	return fmt.Sprintf("%s:%s", gr.String(), identityHash)
+	return sets.List(keys), nil
 }

--- a/pkg/reconciler/cache/clustercachedresources/clustercachedresources_reconcile.go
+++ b/pkg/reconciler/cache/clustercachedresources/clustercachedresources_reconcile.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
@@ -38,6 +37,7 @@ import (
 	cacheclient "github.com/kcp-dev/kcp/pkg/cache/client"
 	"github.com/kcp-dev/kcp/pkg/cache/client/shard"
 	"github.com/kcp-dev/kcp/pkg/logging"
+	replicationcontroller "github.com/kcp-dev/kcp/pkg/reconciler/cache/clustercachedresources/replication"
 )
 
 type reconcileStatus int
@@ -149,15 +149,14 @@ func (c *Controller) listSelectedLocalResources(ctx context.Context, cluster log
 		Resource: clusterCachedResource.Spec.Resource,
 	}
 
-	listOpts := metav1.ListOptions{}
-	if clusterCachedResource.Spec.LabelSelector != nil {
-		listOpts.LabelSelector = labels.SelectorFromSet(clusterCachedResource.Spec.LabelSelector.MatchLabels).String()
-	}
+	selection := replicationcontroller.SelectionFor(clusterCachedResource)
 
-	resources, err := c.localDynamicClient.Cluster(cluster.Path()).Resource(gvr).List(ctx, listOpts)
+	resources, err := c.localDynamicClient.Cluster(cluster.Path()).Resource(gvr).List(ctx, selection.ListOptions())
 	if err != nil {
 		return nil, err
 	}
+	// Names cannot go into the list options, so they are applied here.
+	resources.Items = selection.Filter(resources.Items)
 
 	return resources, nil
 }

--- a/pkg/reconciler/cache/clustercachedresources/clustercachedresources_reconcile_replication.go
+++ b/pkg/reconciler/cache/clustercachedresources/clustercachedresources_reconcile_replication.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -63,10 +62,7 @@ func (r *replication) reconcile(ctx context.Context, clusterCachedResource *cach
 	}
 	cluster := logicalcluster.From(clusterCachedResource)
 
-	var resourceLabelSelector labels.Selector
-	if clusterCachedResource.Spec.LabelSelector != nil {
-		resourceLabelSelector = labels.SelectorFromSet(clusterCachedResource.Spec.LabelSelector.MatchLabels)
-	}
+	selection := replicationcontroller.SelectionFor(clusterCachedResource)
 
 	clusterName := logicalcluster.From(clusterCachedResource)
 	controllerName := fmt.Sprintf("%s.%s.%s.%s.%s", clusterName, gvr.Version, gvr.Resource, gvr.Group, clusterCachedResource.Name)
@@ -124,7 +120,7 @@ func (r *replication) reconcile(ctx context.Context, clusterCachedResource *cach
 			gvr,
 			replicated,
 			requeueSelf,
-			resourceLabelSelector,
+			selection,
 		)
 		if err != nil {
 			cancel()
@@ -155,7 +151,7 @@ func (r *replication) reconcile(ctx context.Context, clusterCachedResource *cach
 
 		return reconcileStatusStopAndRequeue, nil // Once controller is started, we requeue to check if we need to delete it.
 	}
-	controller.SetLabelSelector(resourceLabelSelector)
+	controller.SetSelection(selection)
 
 	// Check if we need to wait for cleaning. This can be few cases:
 	// 1. We are in deleting phase, but nothing to delete - we are good.

--- a/pkg/reconciler/cache/clustercachedresources/replication/replication_controller.go
+++ b/pkg/reconciler/cache/clustercachedresources/replication/replication_controller.go
@@ -23,7 +23,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -80,7 +79,7 @@ func NewController(
 	gvr schema.GroupVersionResource,
 	replicated *ReplicatedGVR,
 	requeueSelf func(),
-	localLabelSelector labels.Selector,
+	selection Selection,
 ) (*Controller, error) {
 	c := &Controller{
 		shardName: shardName,
@@ -96,7 +95,7 @@ func NewController(
 		replicated:                      replicated,
 		requeueSelf:                     requeueSelf,
 		onShutdownFuncs:                 make([]func(), 0),
-		localLabelSelector:              localLabelSelector,
+		selection:                       selection,
 	}
 
 	localHandler, err := c.replicated.Local.AddEventHandler(cache.FilteringResourceEventHandler{
@@ -177,8 +176,8 @@ func (c *Controller) Started() bool {
 	return c.started
 }
 
-func (c *Controller) SetLabelSelector(localLabelSelector labels.Selector) {
-	c.localLabelSelector = localLabelSelector
+func (c *Controller) SetSelection(selection Selection) {
+	c.selection = selection
 }
 
 func (c *Controller) startWorker(ctx context.Context) {
@@ -232,9 +231,9 @@ type Controller struct {
 	// onShutdownFuncs are cleanup functions that are called when the controller is stopped.
 	onShutdownFuncs []func()
 
-	// localLabelSelector is the label selector that we use to filter the objects that we want to replicate.
-	// It is set when the controller is created and can be changed by the parent controller.
-	localLabelSelector labels.Selector
+	// selection is which objects of the kind we replicate. It is set when the
+	// controller is created and can be changed by the parent controller.
+	selection Selection
 
 	started bool
 	deleted bool

--- a/pkg/reconciler/cache/clustercachedresources/replication/replication_reconcile.go
+++ b/pkg/reconciler/cache/clustercachedresources/replication/replication_reconcile.go
@@ -24,7 +24,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/klog/v2"
@@ -59,8 +58,8 @@ func (c *Controller) reconcile(ctx context.Context, gvrKey string) error {
 	key := keyParts[1]
 
 	r := &replicationReconciler{
-		shardName:          c.shardName,
-		localLabelSelector: c.localLabelSelector,
+		shardName: c.shardName,
+		selection: c.selection,
 		getLocalPartialObjectMetadata: func(cluster logicalcluster.Name, namespace, name string) (*unstructured.Unstructured, error) {
 			gvr := gvrFromKey
 			key := kcpcache.ToClusterAwareKey(cluster.String(), namespace, name)
@@ -159,9 +158,9 @@ func (c *Controller) reconcile(ctx context.Context, gvrKey string) error {
 }
 
 type replicationReconciler struct {
-	shardName          string
-	deleted            bool
-	localLabelSelector labels.Selector
+	shardName string
+	deleted   bool
+	selection Selection
 
 	getLocalPartialObjectMetadata func(cluster logicalcluster.Name, namespace, name string) (*unstructured.Unstructured, error)
 	getLocalCopy                  func(ctx context.Context, cluster logicalcluster.Name, namespace, name string) (*unstructured.Unstructured, error)
@@ -199,9 +198,9 @@ func (r *replicationReconciler) reconcile(ctx context.Context, key string) error
 	}
 	localExists := !apierrors.IsNotFound(err)
 
-	if localExists && r.localLabelSelector != nil && !r.localLabelSelector.Matches(labels.Set(localPartialObjMeta.GetLabels())) {
-		// Exit early: the label selector doesn't match.
-		logger.V(2).WithValues("cluster", clusterName, "namespace", ns, "name", name).Info("Object does not match label selector, skipping")
+	if localExists && !r.selection.Matches(localPartialObjMeta) {
+		// Exit early: this is not one of the objects being published.
+		logger.V(2).WithValues("cluster", clusterName, "namespace", ns, "name", name).Info("Object is not selected, skipping")
 		return nil
 	}
 

--- a/pkg/reconciler/cache/clustercachedresources/replication/selection.go
+++ b/pkg/reconciler/cache/clustercachedresources/replication/selection.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package replication
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	cachev1alpha1 "github.com/kcp-dev/sdk/apis/cache/v1alpha1"
+)
+
+// Selection is what a ClusterCachedResource says it publishes: everything of
+// its kind, or some subset picked out by labels, by name, or by both.
+type Selection struct {
+	Labels labels.Selector
+	Names  sets.Set[string]
+}
+
+// SelectionFor reads the selection off a ClusterCachedResource. A resource that
+// sets neither publishes its whole kind.
+func SelectionFor(clusterCachedResource *cachev1alpha1.ClusterCachedResource) Selection {
+	var s Selection
+	if clusterCachedResource.Spec.LabelSelector != nil {
+		s.Labels = labels.SelectorFromSet(clusterCachedResource.Spec.LabelSelector.MatchLabels)
+	}
+	if len(clusterCachedResource.Spec.Names) > 0 {
+		s.Names = sets.New(clusterCachedResource.Spec.Names...)
+	}
+	return s
+}
+
+// Matches reports whether an object is one of the ones being published. Both
+// halves apply: an object has to satisfy every part of the selection that is
+// set.
+func (s Selection) Matches(obj metav1.Object) bool {
+	if s.Labels != nil && !s.Labels.Matches(labels.Set(obj.GetLabels())) {
+		return false
+	}
+	if s.Names.Len() > 0 && !s.Names.Has(obj.GetName()) {
+		return false
+	}
+	return true
+}
+
+// ListOptions returns the part of the selection the API server can apply for
+// us. Names are left out on purpose -- a field selector only compares one value
+// and a selection may name several -- so a caller that lists still has to run
+// the results through Matches.
+func (s Selection) ListOptions() metav1.ListOptions {
+	opts := metav1.ListOptions{}
+	if s.Labels != nil {
+		opts.LabelSelector = s.Labels.String()
+	}
+	return opts
+}
+
+// Filter drops the objects a selection does not publish.
+func (s Selection) Filter(items []unstructured.Unstructured) []unstructured.Unstructured {
+	if s.Names.Len() == 0 {
+		return items
+	}
+	out := items[:0]
+	for _, item := range items {
+		if s.Names.Has(item.GetName()) {
+			out = append(out, item)
+		}
+	}
+	return out
+}

--- a/pkg/reconciler/cache/clustercachedresources/replication/selection.go
+++ b/pkg/reconciler/cache/clustercachedresources/replication/selection.go
@@ -72,12 +72,9 @@ func (s Selection) ListOptions() metav1.ListOptions {
 
 // Filter drops the objects a selection does not publish.
 func (s Selection) Filter(items []unstructured.Unstructured) []unstructured.Unstructured {
-	if s.Names.Len() == 0 {
-		return items
-	}
-	out := items[:0]
+	out := make([]unstructured.Unstructured, 0, len(items))
 	for _, item := range items {
-		if s.Names.Has(item.GetName()) {
+		if s.Matches(&item) {
 			out = append(out, item)
 		}
 	}

--- a/pkg/reconciler/cache/clustercachedresources/replication/selection_test.go
+++ b/pkg/reconciler/cache/clustercachedresources/replication/selection_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package replication
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	cachev1alpha1 "github.com/kcp-dev/sdk/apis/cache/v1alpha1"
+)
+
+func obj(name string, objLabels map[string]string) unstructured.Unstructured {
+	u := unstructured.Unstructured{Object: map[string]interface{}{}}
+	u.SetName(name)
+	if objLabels != nil {
+		u.SetLabels(objLabels)
+	}
+	return u
+}
+
+func names(items []unstructured.Unstructured) []string {
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		out = append(out, item.GetName())
+	}
+	return out
+}
+
+func TestSelectionMatches(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name      string
+		spec      cachev1alpha1.ClusterCachedResourceSpec
+		object    unstructured.Unstructured
+		wantMatch bool
+	}{
+		{
+			name:      "empty selection publishes the whole kind",
+			spec:      cachev1alpha1.ClusterCachedResourceSpec{},
+			object:    obj("anything", nil),
+			wantMatch: true,
+		},
+		{
+			name: "label selector matches",
+			spec: cachev1alpha1.ClusterCachedResourceSpec{
+				LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "sheriff"}},
+			},
+			object:    obj("one", map[string]string{"app": "sheriff", "extra": "fine"}),
+			wantMatch: true,
+		},
+		{
+			name: "label selector rejects",
+			spec: cachev1alpha1.ClusterCachedResourceSpec{
+				LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "sheriff"}},
+			},
+			object:    obj("one", map[string]string{"app": "outlaw"}),
+			wantMatch: false,
+		},
+		{
+			name: "names match",
+			spec: cachev1alpha1.ClusterCachedResourceSpec{
+				Names: []string{"one", "two"},
+			},
+			object:    obj("two", nil),
+			wantMatch: true,
+		},
+		{
+			name: "names reject",
+			spec: cachev1alpha1.ClusterCachedResourceSpec{
+				Names: []string{"one", "two"},
+			},
+			object:    obj("three", nil),
+			wantMatch: false,
+		},
+		{
+			name: "both halves have to hold, name alone is not enough",
+			spec: cachev1alpha1.ClusterCachedResourceSpec{
+				LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "sheriff"}},
+				Names:         []string{"one"},
+			},
+			object:    obj("one", map[string]string{"app": "outlaw"}),
+			wantMatch: false,
+		},
+		{
+			name: "both halves have to hold, labels alone are not enough",
+			spec: cachev1alpha1.ClusterCachedResourceSpec{
+				LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "sheriff"}},
+				Names:         []string{"one"},
+			},
+			object:    obj("two", map[string]string{"app": "sheriff"}),
+			wantMatch: false,
+		},
+		{
+			name: "both halves hold",
+			spec: cachev1alpha1.ClusterCachedResourceSpec{
+				LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "sheriff"}},
+				Names:         []string{"one"},
+			},
+			object:    obj("one", map[string]string{"app": "sheriff"}),
+			wantMatch: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := SelectionFor(&cachev1alpha1.ClusterCachedResource{Spec: tc.spec})
+			require.Equal(t, tc.wantMatch, s.Matches(&tc.object))
+		})
+	}
+}
+
+func TestSelectionListOptions(t *testing.T) {
+	t.Parallel()
+	empty := SelectionFor(&cachev1alpha1.ClusterCachedResource{})
+	require.Empty(t, empty.ListOptions().LabelSelector)
+
+	withLabels := SelectionFor(&cachev1alpha1.ClusterCachedResource{
+		Spec: cachev1alpha1.ClusterCachedResourceSpec{
+			LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "sheriff"}},
+			// Names deliberately have no ListOptions equivalent: a field
+			// selector compares one value and a selection may name several.
+			Names: []string{"one"},
+		},
+	})
+	require.Equal(t, "app=sheriff", withLabels.ListOptions().LabelSelector)
+}
+
+func TestSelectionFilter(t *testing.T) {
+	t.Parallel()
+	items := []unstructured.Unstructured{
+		obj("one", map[string]string{"app": "sheriff"}),
+		obj("two", map[string]string{"app": "outlaw"}),
+		obj("three", nil),
+	}
+
+	empty := SelectionFor(&cachev1alpha1.ClusterCachedResource{})
+	require.Equal(t, []string{"one", "two", "three"}, names(empty.Filter(items)))
+
+	s := SelectionFor(&cachev1alpha1.ClusterCachedResource{
+		Spec: cachev1alpha1.ClusterCachedResourceSpec{
+			LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "sheriff"}},
+			Names:         []string{"one", "three"},
+		},
+	})
+	require.Equal(t, []string{"one"}, names(s.Filter(items)))
+
+	// Filtering must not disturb the list it was given.
+	require.Equal(t, []string{"one", "two", "three"}, names(items))
+}

--- a/pkg/server/aggregatingcrdversiondiscovery/verbs_provider.go
+++ b/pkg/server/aggregatingcrdversiondiscovery/verbs_provider.go
@@ -17,10 +17,8 @@ limitations under the License.
 package aggregatingcrdversiondiscovery
 
 import (
-	"cmp"
 	"context"
 	"fmt"
-	"slices"
 	"strings"
 
 	apiextensionshelpers "k8s.io/apiextensions-apiserver/pkg/apihelpers"
@@ -71,14 +69,13 @@ func (f *storageAwareResourceVerbsProviderFactory) newResourceVerbsProvider(ctx 
 		if len(apiExports) == 0 {
 			return nil, fmt.Errorf("no matching APIExport for virtual resource fingerprint %q", fingerprint)
 		}
-		// Pick a deterministic export. Multiple exports in different logical clusters
-		// may share the same fingerprint; sort for stable selection.
-		slices.SortFunc(apiExports, func(a, b *apisv1alpha2.APIExport) int {
-			return cmp.Or(
-				cmp.Compare(logicalcluster.From(a), logicalcluster.From(b)),
-				cmp.Compare(a.Name, b.Name),
-			)
-		})
+		// A fingerprint carries the owning APIExport's logical cluster and name, so it
+		// identifies exactly one APIExport. More than one match means the index is
+		// keyed by something weaker than we think, and picking either one would serve
+		// another workspace's virtual workspace URL under this one's discovery.
+		if len(apiExports) > 1 {
+			return nil, fmt.Errorf("virtual resource fingerprint %q matches %d APIExports, expected exactly one", fingerprint, len(apiExports))
+		}
 
 		return newVirtualStorageVerbsProvider(ctx, schema.GroupVersionResource{
 			Group:    crd.Spec.Group,

--- a/staging/src/github.com/kcp-dev/sdk/apis/cache/v1alpha1/types_clustercachedresource.go
+++ b/staging/src/github.com/kcp-dev/sdk/apis/cache/v1alpha1/types_clustercachedresource.go
@@ -65,6 +65,20 @@ type ClusterCachedResourceSpec struct {
 	// LabelSelector is used to filter which resources should be published
 	// +optional
 	LabelSelector *metav1.LabelSelector `json:"labelSelector,omitempty"`
+
+	// names narrows publishing to resources called exactly these.
+	//
+	// Leaving it empty publishes every resource the label selector allows,
+	// which is the usual case: a ClusterCachedResource normally stands for a
+	// whole kind. Naming resources is for the case where something points at
+	// one object in particular and only that object is worth caching.
+	//
+	// Names and labelSelector both apply -- a resource has to satisfy each of
+	// the ones that is set.
+	//
+	// +optional
+	// +listType=set
+	Names []string `json:"names,omitempty"`
 }
 
 // Identity defines the identity of a ClusterCachedResource, i.e. determines the cached resource access

--- a/staging/src/github.com/kcp-dev/sdk/apis/cache/v1alpha1/zz_generated.deepcopy.go
+++ b/staging/src/github.com/kcp-dev/sdk/apis/cache/v1alpha1/zz_generated.deepcopy.go
@@ -230,6 +230,11 @@ func (in *ClusterCachedResourceSpec) DeepCopyInto(out *ClusterCachedResourceSpec
 		*out = new(v1.LabelSelector)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Names != nil {
+		in, out := &in.Names, &out.Names
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/staging/src/github.com/kcp-dev/sdk/client/applyconfiguration/cache/v1alpha1/clustercachedresourcespec.go
+++ b/staging/src/github.com/kcp-dev/sdk/client/applyconfiguration/cache/v1alpha1/clustercachedresourcespec.go
@@ -41,6 +41,16 @@ type ClusterCachedResourceSpecApplyConfiguration struct {
 	Identity *IdentityApplyConfiguration `json:"identity,omitempty"`
 	// LabelSelector is used to filter which resources should be published
 	LabelSelector *v1.LabelSelectorApplyConfiguration `json:"labelSelector,omitempty"`
+	// names narrows publishing to resources called exactly these.
+	//
+	// Leaving it empty publishes every resource the label selector allows,
+	// which is the usual case: a ClusterCachedResource normally stands for a
+	// whole kind. Naming resources is for the case where something points at
+	// one object in particular and only that object is worth caching.
+	//
+	// Names and labelSelector both apply -- a resource has to satisfy each of
+	// the ones that is set.
+	Names []string `json:"names,omitempty"`
 }
 
 // ClusterCachedResourceSpecApplyConfiguration constructs a declarative configuration of the ClusterCachedResourceSpec type for use with
@@ -86,5 +96,15 @@ func (b *ClusterCachedResourceSpecApplyConfiguration) WithIdentity(value *Identi
 // If called multiple times, the LabelSelector field is set to the value of the last call.
 func (b *ClusterCachedResourceSpecApplyConfiguration) WithLabelSelector(value *v1.LabelSelectorApplyConfiguration) *ClusterCachedResourceSpecApplyConfiguration {
 	b.LabelSelector = value
+	return b
+}
+
+// WithNames adds the given value to the Names field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the Names field.
+func (b *ClusterCachedResourceSpecApplyConfiguration) WithNames(values ...string) *ClusterCachedResourceSpecApplyConfiguration {
+	for i := range values {
+		b.Names = append(b.Names, values[i])
+	}
 	return b
 }

--- a/staging/src/github.com/kcp-dev/sdk/openapi/zz_generated.openapi.go
+++ b/staging/src/github.com/kcp-dev/sdk/openapi/zz_generated.openapi.go
@@ -3359,6 +3359,26 @@ func schema_sdk_apis_cache_v1alpha1_ClusterCachedResourceSpec(ref common.Referen
 							Ref:         ref(v1.LabelSelector{}.OpenAPIModelName()),
 						},
 					},
+					"names": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "set",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "names narrows publishing to resources called exactly these.\n\nLeaving it empty publishes every resource the label selector allows, which is the usual case: a ClusterCachedResource normally stands for a whole kind. Naming resources is for the case where something points at one object in particular and only that object is worth caching.\n\nNames and labelSelector both apply -- a resource has to satisfy each of the ones that is set.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
 				},
 				Required: []string{"resource"},
 			},


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

A `ClusterCachedResource` can now narrow publishing to resources called exactly the names in `spec.names`, on top of the existing label selector. This is for callers that want one object in particular cached rather than a whole kind.

Also tighten virtual resource fingerprint handling: the fingerprint carries the owning APIExport, so the index no longer gates on the identity hash and discovery errors out on ambiguous matches instead of sorting for a deterministic pick.


## What Type of PR Is This?
/kind api-change

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Add names selector into ClusterCachedResource
```
