### PR TITLE
Add refence controller for APIExports

### DIFF
--- a/pkg/reconciler/cache/apiexportreference/apiexportreference_controller.go
+++ b/pkg/reconciler/cache/apiexportreference/apiexportreference_controller.go
@@ -108,8 +108,6 @@ func NewController(
 			}
 			return out, nil
 		},
-		apiExportsSynced:             apiExportInformer.Informer().HasSynced,
-		clusterCachedResourcesSynced: clusterCachedResourceInformer.Informer().HasSynced,
 	}
 
 	_, _ = apiExportInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -139,9 +137,6 @@ type controller struct {
 	listOwnedResources func(cluster logicalcluster.Name, export string) ([]*cachev1alpha1.ClusterCachedResource, error)
 	applyResource      func(ctx context.Context, cluster logicalcluster.Name, ccr *cachev1alpha1apply.ClusterCachedResourceApplyConfiguration) error
 	deleteResource     func(ctx context.Context, cluster logicalcluster.Name, name string) error
-
-	apiExportsSynced             cache.InformerSynced
-	clusterCachedResourcesSynced cache.InformerSynced
 }
 
 // reference is one object an APIExport points at. It names a kind, because

--- a/pkg/reconciler/cache/apiexportreference/apiexportreference_controller.go
+++ b/pkg/reconciler/cache/apiexportreference/apiexportreference_controller.go
@@ -1,0 +1,393 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package apiexportreference keeps a ClusterCachedResource for every object an
+// APIExport points at.
+//
+// An APIExport can name an object through spec.resources[].storage.virtual.
+// reference, and the shard resolves that reference through the cache server --
+// so an object that is not in the cache cannot be referenced at all.
+//
+// Getting it there is what ClusterCachedResources already do: they replicate,
+// they make the cache server serve the kind, they clean up after themselves,
+// and they keep each provider in its own part of the cache. So this controller
+// does not replicate anything itself. It writes down what the APIExport asked
+// for, as a ClusterCachedResource that the APIExport owns, and lets that
+// machinery do the rest.
+package apiexportreference
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base32"
+	"fmt"
+	"strings"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+
+	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
+	"github.com/kcp-dev/logicalcluster/v3"
+	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
+	cachev1alpha1 "github.com/kcp-dev/sdk/apis/cache/v1alpha1"
+	cachev1alpha1apply "github.com/kcp-dev/sdk/client/applyconfiguration/cache/v1alpha1"
+	metav1apply "github.com/kcp-dev/sdk/client/applyconfiguration/meta/v1"
+	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
+	apisv1alpha2informers "github.com/kcp-dev/sdk/client/informers/externalversions/apis/v1alpha2"
+	cachev1alpha1informers "github.com/kcp-dev/sdk/client/informers/externalversions/cache/v1alpha1"
+
+	"github.com/kcp-dev/kcp/pkg/logging"
+)
+
+const (
+	// ControllerName holds this controller's name.
+	ControllerName = "kcp-apiexport-reference-controller"
+)
+
+// NewController returns a controller that keeps a ClusterCachedResource for
+// every object an APIExport references.
+func NewController(
+	kcpClusterClient kcpclientset.ClusterInterface,
+	apiExportInformer apisv1alpha2informers.APIExportClusterInformer,
+	clusterCachedResourceInformer cachev1alpha1informers.ClusterCachedResourceClusterInformer,
+	restMappingFor func(cluster logicalcluster.Name, gk schema.GroupKind) (*meta.RESTMapping, error),
+) (*controller, error) {
+	c := &controller{
+		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{Name: ControllerName},
+		),
+		restMappingFor: restMappingFor,
+		applyResource: func(ctx context.Context, cluster logicalcluster.Name, ccr *cachev1alpha1apply.ClusterCachedResourceApplyConfiguration) error {
+			_, err := kcpClusterClient.Cluster(cluster.Path()).CacheV1alpha1().ClusterCachedResources().Apply(ctx, ccr, metav1.ApplyOptions{
+				FieldManager: ControllerName,
+				Force:        true,
+			})
+			return err
+		},
+		deleteResource: func(ctx context.Context, cluster logicalcluster.Name, name string) error {
+			return kcpClusterClient.Cluster(cluster.Path()).CacheV1alpha1().ClusterCachedResources().Delete(ctx, name, metav1.DeleteOptions{})
+		},
+		getAPIExport: func(cluster logicalcluster.Name, name string) (*apisv1alpha2.APIExport, error) {
+			return apiExportInformer.Lister().Cluster(cluster).Get(name)
+		},
+		listOwnedResources: func(cluster logicalcluster.Name, export string) ([]*cachev1alpha1.ClusterCachedResource, error) {
+			all, err := clusterCachedResourceInformer.Lister().Cluster(cluster).List(labels.Everything())
+			if err != nil {
+				return nil, err
+			}
+			var out []*cachev1alpha1.ClusterCachedResource
+			for _, ccr := range all {
+				if ownedBy(ccr, export) {
+					out = append(out, ccr)
+				}
+			}
+			return out, nil
+		},
+		apiExportsSynced:             apiExportInformer.Informer().HasSynced,
+		clusterCachedResourcesSynced: clusterCachedResourceInformer.Informer().HasSynced,
+	}
+
+	_, _ = apiExportInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { c.enqueueAPIExport(obj) },
+		UpdateFunc: func(_, obj interface{}) { c.enqueueAPIExport(obj) },
+		DeleteFunc: func(obj interface{}) { c.enqueueAPIExport(obj) },
+	})
+
+	// A ClusterCachedResource that somebody deleted or edited by hand has to
+	// come back while its APIExport still wants it. Reconciling applies only
+	// the fields this controller owns, so reacting to every update is safe:
+	// a write by someone else (the clustercachedresources controller
+	// defaulting spec.identity, say) resolves to a no-op apply, not a fight.
+	_, _ = clusterCachedResourceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		DeleteFunc: func(obj interface{}) { c.enqueueOwningAPIExport(obj) },
+		UpdateFunc: func(_, obj interface{}) { c.enqueueOwningAPIExport(obj) },
+	})
+
+	return c, nil
+}
+
+type controller struct {
+	queue workqueue.TypedRateLimitingInterface[string]
+
+	restMappingFor     func(cluster logicalcluster.Name, gk schema.GroupKind) (*meta.RESTMapping, error)
+	getAPIExport       func(cluster logicalcluster.Name, name string) (*apisv1alpha2.APIExport, error)
+	listOwnedResources func(cluster logicalcluster.Name, export string) ([]*cachev1alpha1.ClusterCachedResource, error)
+	applyResource      func(ctx context.Context, cluster logicalcluster.Name, ccr *cachev1alpha1apply.ClusterCachedResourceApplyConfiguration) error
+	deleteResource     func(ctx context.Context, cluster logicalcluster.Name, name string) error
+
+	apiExportsSynced             cache.InformerSynced
+	clusterCachedResourcesSynced cache.InformerSynced
+}
+
+// reference is one object an APIExport points at. It names a kind, because
+// that is what the APIExport carries; resolving it to a resource needs a
+// RESTMapper.
+type reference struct {
+	group string
+	kind  string
+	name  string
+}
+
+// resolved is a reference once its kind has been turned into a resource.
+type resolved struct {
+	gvr  schema.GroupVersionResource
+	name string
+}
+
+// referencesFrom collects what an APIExport points at. A reference names a kind
+// rather than a resource, and the object is always in the APIExport's own
+// logical cluster: a provider can only publish endpoints for itself.
+func referencesFrom(export *apisv1alpha2.APIExport) []reference {
+	var refs []reference
+	for _, resource := range export.Spec.Resources {
+		if resource.Storage.Virtual == nil {
+			continue
+		}
+		ref := resource.Storage.Virtual.Reference
+		if ref.Kind == "" || ref.Name == "" {
+			continue
+		}
+		refs = append(refs, reference{
+			group: ptr.Deref(ref.APIGroup, ""),
+			kind:  ref.Kind,
+			name:  ref.Name,
+		})
+	}
+	return refs
+}
+
+func ownedBy(ccr *cachev1alpha1.ClusterCachedResource, export string) bool {
+	for _, ref := range ccr.OwnerReferences {
+		if ref.Kind == "APIExport" && ref.Name == export &&
+			ref.APIVersion == apisv1alpha2.SchemeGroupVersion.String() {
+			return true
+		}
+	}
+	return false
+}
+
+// nameFor builds a stable name for the ClusterCachedResource standing in for
+// one reference. It has to be a legal object name whatever the reference looks
+// like, and it has to be the same every time so that reconciling twice does not
+// make two of them.
+func nameFor(export string, ref resolved) string {
+	h := sha256.Sum256([]byte(export + "|" + ref.gvr.String() + "|" + ref.name))
+	suffix := strings.ToLower(base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(h[:5]))
+
+	// Keep something human-readable in front, but leave room for the hash.
+	prefix := ref.gvr.Resource
+	if len(prefix) > 40 {
+		prefix = prefix[:40]
+	}
+	return fmt.Sprintf("apiexport-%s-%s", prefix, suffix)
+}
+
+// desired builds the apply configuration that stands for a reference. It
+// carries only the fields this controller owns; applying it with a field
+// manager leaves everything else -- spec.identity, most notably, which the
+// clustercachedresources controller defaults in place -- to its owners.
+func desired(export *apisv1alpha2.APIExport, ref resolved) *cachev1alpha1apply.ClusterCachedResourceApplyConfiguration {
+	return cachev1alpha1apply.ClusterCachedResource(nameFor(export.Name, ref)).
+		// Owned by the APIExport, so that the whole thing goes away with it
+		// -- and its finalizer drains the cache on the way out.
+		WithOwnerReferences(metav1apply.OwnerReference().
+			WithAPIVersion(apisv1alpha2.SchemeGroupVersion.String()).
+			WithKind("APIExport").
+			WithName(export.Name).
+			WithUID(export.UID)).
+		WithAnnotations(map[string]string{
+			"cache.kcp.io/referenced-by": export.Name,
+		}).
+		WithSpec(cachev1alpha1apply.ClusterCachedResourceSpec().
+			WithGroup(ref.gvr.Group).
+			WithVersion(ref.gvr.Version).
+			WithResource(ref.gvr.Resource).
+			// Only the object that was referenced. A ClusterCachedResource
+			// usually stands for a whole kind; here it stands for one object.
+			WithNames(ref.name))
+}
+
+func (c *controller) enqueueAPIExport(obj interface{}) {
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
+	export, ok := obj.(*apisv1alpha2.APIExport)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("object is %T, not an APIExport", obj))
+		return
+	}
+	c.queue.Add(kcpcache.ToClusterAwareKey(logicalcluster.From(export).String(), "", export.Name))
+}
+
+func (c *controller) enqueueOwningAPIExport(obj interface{}) {
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
+	ccr, ok := obj.(*cachev1alpha1.ClusterCachedResource)
+	if !ok {
+		return
+	}
+	for _, ref := range ccr.OwnerReferences {
+		if ref.Kind != "APIExport" {
+			continue
+		}
+		c.queue.Add(kcpcache.ToClusterAwareKey(logicalcluster.From(ccr).String(), "", ref.Name))
+	}
+}
+
+func (c *controller) Start(ctx context.Context, workers int) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	logger := logging.WithReconciler(klog.FromContext(ctx), ControllerName)
+	ctx = klog.NewContext(ctx, logger)
+	logger.Info("Starting controller")
+	defer logger.Info("Shutting down controller")
+
+	for range workers {
+		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
+	}
+
+	<-ctx.Done()
+}
+
+func (c *controller) startWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *controller) processNextWorkItem(ctx context.Context) bool {
+	key, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(key)
+
+	logger := klog.FromContext(ctx).WithValues("apiExport", key)
+	ctx = klog.NewContext(ctx, logger)
+
+	if err := c.reconcile(ctx, key); err != nil {
+		utilruntime.HandleError(fmt.Errorf("%q controller failed to sync %q: %w", ControllerName, key, err))
+		c.queue.AddRateLimited(key)
+		return true
+	}
+	c.queue.Forget(key)
+	return true
+}
+
+func (c *controller) reconcile(ctx context.Context, rawKey string) error {
+	cluster, _, name, err := kcpcache.SplitMetaClusterNamespaceKey(rawKey)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return nil
+	}
+
+	export, err := c.getAPIExport(cluster, name)
+	if apierrors.IsNotFound(err) {
+		// Gone. Its ClusterCachedResources are owned by it, so the garbage
+		// collector takes them, and each one drains the cache on its way out.
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	wanted, err := c.wantedFor(export)
+	if err != nil {
+		return err
+	}
+
+	existing, err := c.listOwnedResources(cluster, export.Name)
+	if err != nil {
+		return err
+	}
+
+	// Anything this APIExport owns but no longer asks for goes. Deleting the
+	// ClusterCachedResource is what removes the copies: its finalizer drains
+	// them while the kind is still served.
+	for _, ccr := range existing {
+		if _, keep := wanted[ccr.Name]; keep {
+			continue
+		}
+		if !ccr.DeletionTimestamp.IsZero() {
+			continue
+		}
+		klog.FromContext(ctx).V(2).Info("dropping a ClusterCachedResource nothing references anymore",
+			"clusterCachedResource", ccr.Name)
+		if err := c.deleteResource(ctx, cluster, ccr.Name); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+
+	// Server-side apply what is wanted. The apply configuration names only the
+	// fields this controller owns, so an existing ClusterCachedResource keeps
+	// whatever others put on it -- the clustercachedresources controller
+	// defaults spec.identity in place, and that must survive this write.
+	for _, want := range wanted {
+		if err := c.applyResource(ctx, cluster, want); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// wantedFor resolves an APIExport's references to the ClusterCachedResources
+// that should exist for them, as apply configurations keyed by name.
+func (c *controller) wantedFor(export *apisv1alpha2.APIExport) (map[string]*cachev1alpha1apply.ClusterCachedResourceApplyConfiguration, error) {
+	if !export.DeletionTimestamp.IsZero() {
+		// On its way out. The garbage collector handles what it owns.
+		return nil, nil
+	}
+
+	cluster := logicalcluster.From(export)
+	wanted := map[string]*cachev1alpha1apply.ClusterCachedResourceApplyConfiguration{}
+	seen := sets.New[resolved]()
+
+	for _, ref := range referencesFrom(export) {
+		mapping, err := c.restMappingFor(cluster, schema.GroupKind{Group: ref.group, Kind: ref.kind})
+		if err != nil {
+			if meta.IsNoMatchError(err) {
+				// The kind is not served in that workspace. Nothing to cache,
+				// and nothing this controller can do about it: the APIExport is
+				// pointing at something that does not exist.
+				continue
+			}
+			return nil, err
+		}
+
+		r := resolved{gvr: mapping.Resource, name: ref.name}
+		if seen.Has(r) {
+			continue
+		}
+		seen.Insert(r)
+
+		wanted[nameFor(export.Name, r)] = desired(export, r)
+	}
+
+	return wanted, nil
+}

--- a/pkg/reconciler/cache/apiexportreference/apiexportreference_controller_test.go
+++ b/pkg/reconciler/cache/apiexportreference/apiexportreference_controller_test.go
@@ -1,0 +1,320 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiexportreference
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+
+	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
+	"github.com/kcp-dev/logicalcluster/v3"
+	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
+	cachev1alpha1 "github.com/kcp-dev/sdk/apis/cache/v1alpha1"
+	cachev1alpha1apply "github.com/kcp-dev/sdk/client/applyconfiguration/cache/v1alpha1"
+)
+
+const testCluster = "root:org:provider"
+
+func export(name string, refs ...corev1.TypedLocalObjectReference) *apisv1alpha2.APIExport {
+	e := &apisv1alpha2.APIExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			UID:         "export-uid",
+			Annotations: map[string]string{logicalcluster.AnnotationKey: testCluster},
+		},
+	}
+	for _, ref := range refs {
+		e.Spec.Resources = append(e.Spec.Resources, apisv1alpha2.ResourceSchema{
+			Group:  ptr.Deref(ref.APIGroup, ""),
+			Name:   "cowboys",
+			Schema: "today.cowboys.wildwest.dev",
+			Storage: apisv1alpha2.ResourceSchemaStorage{
+				Virtual: &apisv1alpha2.ResourceSchemaStorageVirtual{Reference: ref},
+			},
+		})
+	}
+	return e
+}
+
+func sheriffRef(name string) corev1.TypedLocalObjectReference {
+	return corev1.TypedLocalObjectReference{
+		APIGroup: ptr.To("wildwest.dev"),
+		Kind:     "Sheriff",
+		Name:     name,
+	}
+}
+
+func sheriffMapper(t *testing.T) func(cluster logicalcluster.Name, gk schema.GroupKind) (*meta.RESTMapping, error) {
+	return func(cluster logicalcluster.Name, gk schema.GroupKind) (*meta.RESTMapping, error) {
+		require.Equal(t, logicalcluster.Name(testCluster), cluster, "references must resolve in the APIExport's own cluster")
+		if gk.Group == "wildwest.dev" && gk.Kind == "Sheriff" {
+			return &meta.RESTMapping{
+				Resource:         schema.GroupVersionResource{Group: "wildwest.dev", Version: "v1alpha1", Resource: "sheriffs"},
+				GroupVersionKind: schema.GroupVersionKind{Group: "wildwest.dev", Version: "v1alpha1", Kind: "Sheriff"},
+				Scope:            meta.RESTScopeRoot,
+			}, nil
+		}
+		return nil, &meta.NoKindMatchError{GroupKind: gk}
+	}
+}
+
+func TestReferencesFrom(t *testing.T) {
+	e := export("wildwest-provider", sheriffRef("one"))
+	e.Spec.Resources = append(e.Spec.Resources,
+		// Regular storage: not a reference.
+		apisv1alpha2.ResourceSchema{Group: "wildwest.dev", Name: "cowboys", Schema: "today.cowboys.wildwest.dev"},
+		// Virtual storage without kind or name: not a usable reference.
+		apisv1alpha2.ResourceSchema{
+			Group:   "wildwest.dev",
+			Name:    "cowboys",
+			Schema:  "today.cowboys.wildwest.dev",
+			Storage: apisv1alpha2.ResourceSchemaStorage{Virtual: &apisv1alpha2.ResourceSchemaStorageVirtual{}},
+		},
+	)
+
+	require.Equal(t,
+		[]reference{{group: "wildwest.dev", kind: "Sheriff", name: "one"}},
+		referencesFrom(e))
+}
+
+func TestNameFor(t *testing.T) {
+	ref := resolved{
+		gvr:  schema.GroupVersionResource{Group: "wildwest.dev", Version: "v1alpha1", Resource: "sheriffs"},
+		name: "one",
+	}
+
+	name := nameFor("wildwest-provider", ref)
+	require.Equal(t, name, nameFor("wildwest-provider", ref), "the name has to be stable")
+	require.Regexp(t, regexp.MustCompile(`^apiexport-sheriffs-[a-z0-9]+$`), name)
+
+	require.NotEqual(t, name, nameFor("other-export", ref), "a different export must yield a different name")
+	require.NotEqual(t, name, nameFor("wildwest-provider", resolved{gvr: ref.gvr, name: "two"}),
+		"a different object must yield a different name")
+
+	long := resolved{
+		gvr:  schema.GroupVersionResource{Group: "example.org", Version: "v1", Resource: "someveryveryverylongresourcenamethatjustkeepsongoing"},
+		name: "one",
+	}
+	require.LessOrEqual(t, len(nameFor("export", long)), 63, "the name has to stay a legal object name")
+}
+
+func TestOwnedBy(t *testing.T) {
+	ccr := &cachev1alpha1.ClusterCachedResource{
+		ObjectMeta: metav1.ObjectMeta{
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: apisv1alpha2.SchemeGroupVersion.String(),
+				Kind:       "APIExport",
+				Name:       "wildwest-provider",
+			}},
+		},
+	}
+	require.True(t, ownedBy(ccr, "wildwest-provider"))
+	require.False(t, ownedBy(ccr, "other-export"))
+	require.False(t, ownedBy(&cachev1alpha1.ClusterCachedResource{}, "wildwest-provider"))
+
+	wrongKind := ccr.DeepCopy()
+	wrongKind.OwnerReferences[0].Kind = "Workspace"
+	require.False(t, ownedBy(wrongKind, "wildwest-provider"))
+}
+
+func TestDesired(t *testing.T) {
+	e := export("wildwest-provider")
+	ref := resolved{
+		gvr:  schema.GroupVersionResource{Group: "wildwest.dev", Version: "v1alpha1", Resource: "sheriffs"},
+		name: "one",
+	}
+
+	got := desired(e, ref)
+
+	require.Equal(t, nameFor("wildwest-provider", ref), *got.Name)
+	require.Len(t, got.OwnerReferences, 1)
+	require.Equal(t, "APIExport", *got.OwnerReferences[0].Kind)
+	require.Equal(t, "wildwest-provider", *got.OwnerReferences[0].Name)
+	require.Equal(t, e.UID, *got.OwnerReferences[0].UID)
+	require.Equal(t, "wildwest.dev", *got.Spec.Group)
+	require.Equal(t, "v1alpha1", *got.Spec.Version)
+	require.Equal(t, "sheriffs", *got.Spec.Resource)
+	require.Equal(t, []string{"one"}, got.Spec.Names)
+	require.Nil(t, got.Spec.Identity, "identity is not this controller's to manage")
+}
+
+func TestWantedFor(t *testing.T) {
+	t.Run("a deleting export wants nothing", func(t *testing.T) {
+		c := &controller{restMappingFor: sheriffMapper(t)}
+		e := export("wildwest-provider", sheriffRef("one"))
+		e.DeletionTimestamp = ptr.To(metav1.Now())
+
+		wanted, err := c.wantedFor(e)
+		require.NoError(t, err)
+		require.Empty(t, wanted)
+	})
+
+	t.Run("no references, nothing wanted", func(t *testing.T) {
+		c := &controller{restMappingFor: sheriffMapper(t)}
+
+		wanted, err := c.wantedFor(export("wildwest-provider"))
+		require.NoError(t, err)
+		require.Empty(t, wanted)
+	})
+
+	t.Run("a reference resolves to one ClusterCachedResource", func(t *testing.T) {
+		c := &controller{restMappingFor: sheriffMapper(t)}
+
+		wanted, err := c.wantedFor(export("wildwest-provider", sheriffRef("one")))
+		require.NoError(t, err)
+		require.Len(t, wanted, 1)
+		want := wanted[nameFor("wildwest-provider", resolved{
+			gvr:  schema.GroupVersionResource{Group: "wildwest.dev", Version: "v1alpha1", Resource: "sheriffs"},
+			name: "one",
+		})]
+		require.NotNil(t, want)
+		require.Equal(t, []string{"one"}, want.Spec.Names)
+	})
+
+	t.Run("duplicate references collapse", func(t *testing.T) {
+		c := &controller{restMappingFor: sheriffMapper(t)}
+
+		wanted, err := c.wantedFor(export("wildwest-provider", sheriffRef("one"), sheriffRef("one")))
+		require.NoError(t, err)
+		require.Len(t, wanted, 1)
+	})
+
+	t.Run("a kind that is not served is skipped", func(t *testing.T) {
+		c := &controller{restMappingFor: sheriffMapper(t)}
+
+		wanted, err := c.wantedFor(export("wildwest-provider", corev1.TypedLocalObjectReference{
+			APIGroup: ptr.To("nowhere.dev"),
+			Kind:     "Ghost",
+			Name:     "one",
+		}))
+		require.NoError(t, err)
+		require.Empty(t, wanted)
+	})
+
+	t.Run("other mapper errors propagate", func(t *testing.T) {
+		boom := errors.New("boom")
+		c := &controller{restMappingFor: func(logicalcluster.Name, schema.GroupKind) (*meta.RESTMapping, error) {
+			return nil, boom
+		}}
+
+		_, err := c.wantedFor(export("wildwest-provider", sheriffRef("one")))
+		require.ErrorIs(t, err, boom)
+	})
+}
+
+func TestReconcile(t *testing.T) {
+	key := kcpcache.ToClusterAwareKey(testCluster, "", "wildwest-provider")
+
+	owned := func(name string) *cachev1alpha1.ClusterCachedResource {
+		return &cachev1alpha1.ClusterCachedResource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        name,
+				Annotations: map[string]string{logicalcluster.AnnotationKey: testCluster},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: apisv1alpha2.SchemeGroupVersion.String(),
+					Kind:       "APIExport",
+					Name:       "wildwest-provider",
+				}},
+			},
+		}
+	}
+
+	newController := func(e *apisv1alpha2.APIExport, existing []*cachev1alpha1.ClusterCachedResource, applied *[]string, deleted *[]string) *controller {
+		return &controller{
+			restMappingFor: sheriffMapper(t),
+			getAPIExport: func(cluster logicalcluster.Name, name string) (*apisv1alpha2.APIExport, error) {
+				if e == nil {
+					return nil, apierrors.NewNotFound(schema.GroupResource{Group: "apis.kcp.io", Resource: "apiexports"}, name)
+				}
+				return e, nil
+			},
+			listOwnedResources: func(cluster logicalcluster.Name, export string) ([]*cachev1alpha1.ClusterCachedResource, error) {
+				return existing, nil
+			},
+			applyResource: func(_ context.Context, _ logicalcluster.Name, ccr *cachev1alpha1apply.ClusterCachedResourceApplyConfiguration) error {
+				*applied = append(*applied, *ccr.Name)
+				return nil
+			},
+			deleteResource: func(_ context.Context, _ logicalcluster.Name, name string) error {
+				*deleted = append(*deleted, name)
+				return nil
+			},
+		}
+	}
+
+	wantedName := nameFor("wildwest-provider", resolved{
+		gvr:  schema.GroupVersionResource{Group: "wildwest.dev", Version: "v1alpha1", Resource: "sheriffs"},
+		name: "one",
+	})
+
+	t.Run("a gone export leaves everything to the garbage collector", func(t *testing.T) {
+		var applied, deleted []string
+		c := newController(nil, []*cachev1alpha1.ClusterCachedResource{owned("stale")}, &applied, &deleted)
+
+		require.NoError(t, c.reconcile(context.Background(), key))
+		require.Empty(t, applied)
+		require.Empty(t, deleted)
+	})
+
+	t.Run("what is referenced is applied, what is not goes", func(t *testing.T) {
+		var applied, deleted []string
+		c := newController(
+			export("wildwest-provider", sheriffRef("one")),
+			[]*cachev1alpha1.ClusterCachedResource{owned("stale")},
+			&applied, &deleted)
+
+		require.NoError(t, c.reconcile(context.Background(), key))
+		require.Equal(t, []string{wantedName}, applied)
+		require.Equal(t, []string{"stale"}, deleted)
+	})
+
+	t.Run("a wanted resource that already exists is still applied, not skipped", func(t *testing.T) {
+		var applied, deleted []string
+		c := newController(
+			export("wildwest-provider", sheriffRef("one")),
+			[]*cachev1alpha1.ClusterCachedResource{owned(wantedName)},
+			&applied, &deleted)
+
+		require.NoError(t, c.reconcile(context.Background(), key))
+		require.Equal(t, []string{wantedName}, applied, "apply is how drift on owned fields is healed")
+		require.Empty(t, deleted)
+	})
+
+	t.Run("a resource already on its way out is not deleted again", func(t *testing.T) {
+		var applied, deleted []string
+		stale := owned("stale")
+		stale.DeletionTimestamp = ptr.To(metav1.Now())
+		c := newController(
+			export("wildwest-provider", sheriffRef("one")),
+			[]*cachev1alpha1.ClusterCachedResource{stale},
+			&applied, &deleted)
+
+		require.NoError(t, c.reconcile(context.Background(), key))
+		require.Empty(t, deleted)
+	})
+}

--- a/pkg/reconciler/cache/apiexportreference/apiexportreference_controller_test.go
+++ b/pkg/reconciler/cache/apiexportreference/apiexportreference_controller_test.go
@@ -19,7 +19,6 @@ package apiexportreference
 import (
 	"context"
 	"errors"
-	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -84,6 +83,8 @@ func sheriffMapper(t *testing.T) func(cluster logicalcluster.Name, gk schema.Gro
 }
 
 func TestReferencesFrom(t *testing.T) {
+	t.Parallel()
+
 	e := export("wildwest-provider", sheriffRef("one"))
 	e.Spec.Resources = append(e.Spec.Resources,
 		// Regular storage: not a reference.
@@ -103,6 +104,8 @@ func TestReferencesFrom(t *testing.T) {
 }
 
 func TestNameFor(t *testing.T) {
+	t.Parallel()
+
 	ref := resolved{
 		gvr:  schema.GroupVersionResource{Group: "wildwest.dev", Version: "v1alpha1", Resource: "sheriffs"},
 		name: "one",
@@ -110,7 +113,7 @@ func TestNameFor(t *testing.T) {
 
 	name := nameFor("wildwest-provider", ref)
 	require.Equal(t, name, nameFor("wildwest-provider", ref), "the name has to be stable")
-	require.Regexp(t, regexp.MustCompile(`^apiexport-sheriffs-[a-z0-9]+$`), name)
+	require.Regexp(t, `^apiexport-sheriffs-[a-z0-9]+$`, name)
 
 	require.NotEqual(t, name, nameFor("other-export", ref), "a different export must yield a different name")
 	require.NotEqual(t, name, nameFor("wildwest-provider", resolved{gvr: ref.gvr, name: "two"}),
@@ -124,6 +127,8 @@ func TestNameFor(t *testing.T) {
 }
 
 func TestOwnedBy(t *testing.T) {
+	t.Parallel()
+
 	ccr := &cachev1alpha1.ClusterCachedResource{
 		ObjectMeta: metav1.ObjectMeta{
 			OwnerReferences: []metav1.OwnerReference{{
@@ -143,6 +148,8 @@ func TestOwnedBy(t *testing.T) {
 }
 
 func TestDesired(t *testing.T) {
+	t.Parallel()
+
 	e := export("wildwest-provider")
 	ref := resolved{
 		gvr:  schema.GroupVersionResource{Group: "wildwest.dev", Version: "v1alpha1", Resource: "sheriffs"},
@@ -164,7 +171,11 @@ func TestDesired(t *testing.T) {
 }
 
 func TestWantedFor(t *testing.T) {
+	t.Parallel()
+
 	t.Run("a deleting export wants nothing", func(t *testing.T) {
+		t.Parallel()
+
 		c := &controller{restMappingFor: sheriffMapper(t)}
 		e := export("wildwest-provider", sheriffRef("one"))
 		e.DeletionTimestamp = ptr.To(metav1.Now())
@@ -175,6 +186,8 @@ func TestWantedFor(t *testing.T) {
 	})
 
 	t.Run("no references, nothing wanted", func(t *testing.T) {
+		t.Parallel()
+
 		c := &controller{restMappingFor: sheriffMapper(t)}
 
 		wanted, err := c.wantedFor(export("wildwest-provider"))
@@ -183,6 +196,8 @@ func TestWantedFor(t *testing.T) {
 	})
 
 	t.Run("a reference resolves to one ClusterCachedResource", func(t *testing.T) {
+		t.Parallel()
+
 		c := &controller{restMappingFor: sheriffMapper(t)}
 
 		wanted, err := c.wantedFor(export("wildwest-provider", sheriffRef("one")))
@@ -197,6 +212,8 @@ func TestWantedFor(t *testing.T) {
 	})
 
 	t.Run("duplicate references collapse", func(t *testing.T) {
+		t.Parallel()
+
 		c := &controller{restMappingFor: sheriffMapper(t)}
 
 		wanted, err := c.wantedFor(export("wildwest-provider", sheriffRef("one"), sheriffRef("one")))
@@ -205,6 +222,8 @@ func TestWantedFor(t *testing.T) {
 	})
 
 	t.Run("a kind that is not served is skipped", func(t *testing.T) {
+		t.Parallel()
+
 		c := &controller{restMappingFor: sheriffMapper(t)}
 
 		wanted, err := c.wantedFor(export("wildwest-provider", corev1.TypedLocalObjectReference{
@@ -217,6 +236,8 @@ func TestWantedFor(t *testing.T) {
 	})
 
 	t.Run("other mapper errors propagate", func(t *testing.T) {
+		t.Parallel()
+
 		boom := errors.New("boom")
 		c := &controller{restMappingFor: func(logicalcluster.Name, schema.GroupKind) (*meta.RESTMapping, error) {
 			return nil, boom
@@ -228,6 +249,8 @@ func TestWantedFor(t *testing.T) {
 }
 
 func TestReconcile(t *testing.T) {
+	t.Parallel()
+
 	key := kcpcache.ToClusterAwareKey(testCluster, "", "wildwest-provider")
 
 	owned := func(name string) *cachev1alpha1.ClusterCachedResource {
@@ -273,6 +296,8 @@ func TestReconcile(t *testing.T) {
 	})
 
 	t.Run("a gone export leaves everything to the garbage collector", func(t *testing.T) {
+		t.Parallel()
+
 		var applied, deleted []string
 		c := newController(nil, []*cachev1alpha1.ClusterCachedResource{owned("stale")}, &applied, &deleted)
 
@@ -282,6 +307,8 @@ func TestReconcile(t *testing.T) {
 	})
 
 	t.Run("what is referenced is applied, what is not goes", func(t *testing.T) {
+		t.Parallel()
+
 		var applied, deleted []string
 		c := newController(
 			export("wildwest-provider", sheriffRef("one")),
@@ -294,6 +321,8 @@ func TestReconcile(t *testing.T) {
 	})
 
 	t.Run("a wanted resource that already exists is still applied, not skipped", func(t *testing.T) {
+		t.Parallel()
+
 		var applied, deleted []string
 		c := newController(
 			export("wildwest-provider", sheriffRef("one")),
@@ -306,6 +335,8 @@ func TestReconcile(t *testing.T) {
 	})
 
 	t.Run("a resource already on its way out is not deleted again", func(t *testing.T) {
+		t.Parallel()
+
 		var applied, deleted []string
 		stale := owned("stale")
 		stale.DeletionTimestamp = ptr.To(metav1.Now())

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -30,6 +30,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsscheme "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -83,6 +84,7 @@ import (
 	apisreplicateclusterrole "github.com/kcp-dev/kcp/pkg/reconciler/apis/replicateclusterrole"
 	apisreplicateclusterrolebinding "github.com/kcp-dev/kcp/pkg/reconciler/apis/replicateclusterrolebinding"
 	apisreplicatelogicalcluster "github.com/kcp-dev/kcp/pkg/reconciler/apis/replicatelogicalcluster"
+	"github.com/kcp-dev/kcp/pkg/reconciler/cache/apiexportreference"
 	"github.com/kcp-dev/kcp/pkg/reconciler/cache/clustercachedresourceendpointslice"
 	"github.com/kcp-dev/kcp/pkg/reconciler/cache/clustercachedresourceendpointsliceurls"
 	"github.com/kcp-dev/kcp/pkg/reconciler/cache/clustercachedresources"
@@ -1794,6 +1796,50 @@ func (s *Server) installReplicationController(ctx context.Context, config *rest.
 					}
 				}
 				return true, nil
+			})
+		},
+		Runner: func(ctx context.Context) {
+			controller.Start(ctx, 2)
+		},
+	})
+}
+
+// installAPIExportReferenceController keeps a ClusterCachedResource for every
+// object an APIExport points at, so that the shard can resolve the reference
+// through the cache server.
+//
+// Only relevant with CacheAPIs: virtual storage, which is what a reference
+// describes, is not served without it.
+func (s *Server) installAPIExportReferenceController(ctx context.Context, config *rest.Config) error {
+	if !kcpfeatures.DefaultFeatureGate.Enabled(kcpfeatures.CacheAPIs) {
+		return nil
+	}
+
+	config = rest.CopyConfig(config)
+	config = rest.AddUserAgent(config, apiexportreference.ControllerName)
+	kcpClusterClient, err := kcpclientset.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+
+	controller, err := apiexportreference.NewController(
+		kcpClusterClient,
+		s.KcpSharedInformerFactory.Apis().V1alpha2().APIExports(),
+		s.KcpSharedInformerFactory.Cache().V1alpha1().ClusterCachedResources(),
+		func(cluster logicalcluster.Name, gk schema.GroupKind) (*meta.RESTMapping, error) {
+			return s.DynamicRESTMapper.ForCluster(cluster).RESTMapping(gk)
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	return s.registerController(&controllerWrapper{
+		Name: apiexportreference.ControllerName,
+		Wait: func(ctx context.Context, s *Server) error {
+			return wait.PollUntilContextCancel(ctx, waitPollInterval, true, func(ctx context.Context) (bool, error) {
+				return s.KcpSharedInformerFactory.Apis().V1alpha2().APIExports().Informer().HasSynced() &&
+					s.KcpSharedInformerFactory.Cache().V1alpha1().ClusterCachedResources().Informer().HasSynced(), nil
 			})
 		},
 		Runner: func(ctx context.Context) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -288,6 +288,9 @@ func (s *Server) installControllers(ctx context.Context, controllerConfig *rest.
 	if err := s.installReplicationController(ctx, controllerConfig, gvrs); err != nil {
 		return err
 	}
+	if err := s.installAPIExportReferenceController(ctx, controllerConfig); err != nil {
+		return err
+	}
 
 	enabled := sets.New[string](s.Options.Controllers.IndividuallyEnabled...)
 	if len(enabled) > 0 {

--- a/test/e2e/cache/reference_replication_test.go
+++ b/test/e2e/cache/reference_replication_test.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/ptr"
+
+	kcpapiextensionsclientset "github.com/kcp-dev/client-go/apiextensions/client"
+	kcpdynamic "github.com/kcp-dev/client-go/dynamic"
+	"github.com/kcp-dev/logicalcluster/v3"
+	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
+	"github.com/kcp-dev/sdk/apis/core"
+	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned/cluster"
+	kcptesting "github.com/kcp-dev/sdk/testing"
+	kcptestinghelpers "github.com/kcp-dev/sdk/testing/helpers"
+
+	"github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest"
+	wildwestv1alpha1 "github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/apis/wildwest/v1alpha1"
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+	cache2e "github.com/kcp-dev/kcp/test/e2e/reconciler/cache"
+)
+
+// TestReferenceReplication covers an object reaching the cache because an
+// APIExport points at it through spec.resources[].storage.virtual.reference,
+// and leaving again when nothing does.
+//
+// The kind matters. Sheriffs are not something the replication controller
+// copies on its own, so whether a sheriff is in the cache is decided entirely
+// by whether an APIExport references it -- which is the whole point of the
+// feature. Pick a kind that is replicated unconditionally (an endpoint slice,
+// say) and this test would pass without the reference machinery doing anything.
+func TestReferenceReplication(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "control-plane")
+
+	server := kcptesting.SharedKcpServer(t)
+	cfg := server.BaseConfig(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	kcpClusterClient, err := kcpclientset.NewForConfig(cfg)
+	require.NoError(t, err, "error creating kcp cluster client")
+
+	dynamicClusterClient, err := kcpdynamic.NewForConfig(cfg)
+	require.NoError(t, err, "error creating dynamic cluster client")
+
+	apiExtensionsClient, err := kcpapiextensionsclientset.NewForConfig(cfg)
+	require.NoError(t, err, "error creating apiextensions cluster client")
+
+	cacheClientCfg := createCacheClientConfigForEnvironment(ctx, t, server.RootShardSystemMasterBaseConfig(t))
+	cacheDynClient, err := kcpdynamic.NewForConfig(cache2e.ClientRoundTrippersFor(cacheClientCfg))
+	require.NoError(t, err, "error creating cache dynamic client")
+
+	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path())
+	providerPath, providerWS := kcptesting.NewWorkspaceFixture(t, server, orgPath)
+
+	// The cache server keys by logical cluster name and knows nothing of the
+	// workspace hierarchy, so reads against it cannot go through the path.
+	providerCluster := logicalcluster.Name(providerWS.Spec.Cluster)
+
+	gr := metav1.GroupResource{Group: "wildwest.dev", Resource: "sheriffs"}
+	sheriffsGVR := wildwestv1alpha1.SchemeGroupVersion.WithResource("sheriffs")
+
+	t.Logf("Creating the sheriffs CRD in %q", providerPath)
+	wildwest.Create(t, providerPath, apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions(), gr)
+	kcptesting.WaitForAPIReady(t, kcpClusterClient.Cluster(providerPath).Discovery(), wildwestv1alpha1.SchemeGroupVersion)
+
+	const (
+		referenced   = "referenced-sheriff"
+		unreferenced = "unreferenced-sheriff"
+		exportName   = "wildwest-provider"
+	)
+
+	for _, name := range []string{referenced, unreferenced} {
+		t.Logf("Creating Sheriff %q in %q", name, providerPath)
+		_, err = dynamicClusterClient.Cluster(providerPath).Resource(sheriffsGVR).Create(ctx, &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": wildwestv1alpha1.SchemeGroupVersion.String(),
+				"kind":       "Sheriff",
+				"metadata":   map[string]interface{}{"name": name},
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err, "error creating Sheriff %s", name)
+	}
+
+	exports := kcpClusterClient.Cluster(providerPath).ApisV1alpha2().APIExports()
+
+	t.Logf("Creating APIExport %q referencing Sheriff %q", exportName, referenced)
+	_, err = exports.Create(ctx, &apisv1alpha2.APIExport{
+		ObjectMeta: metav1.ObjectMeta{Name: exportName},
+		Spec: apisv1alpha2.APIExportSpec{
+			Resources: []apisv1alpha2.ResourceSchema{{
+				Group:  "wildwest.dev",
+				Name:   "cowboys",
+				Schema: "today.cowboys.wildwest.dev",
+				Storage: apisv1alpha2.ResourceSchemaStorage{
+					Virtual: &apisv1alpha2.ResourceSchemaStorageVirtual{
+						Reference: corev1.TypedLocalObjectReference{
+							APIGroup: ptr.To("wildwest.dev"),
+							Kind:     "Sheriff",
+							Name:     referenced,
+						},
+					},
+				},
+			}},
+		},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err, "error creating APIExport")
+
+	cachedSheriffs := func() ([]string, error) {
+		list, err := cacheDynClient.Cluster(providerCluster.Path()).Resource(sheriffsGVR).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return nil, err
+		}
+		names := make([]string, 0, len(list.Items))
+		for _, item := range list.Items {
+			names = append(names, item.GetName())
+		}
+		return names, nil
+	}
+
+	t.Logf("Waiting for the referenced Sheriff to reach the cache server")
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		names, err := cachedSheriffs()
+		if err != nil {
+			return false, fmt.Sprintf("error listing sheriffs in the cache: %v", err)
+		}
+		return slices.Contains(names, referenced), fmt.Sprintf("cache holds %v", names)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "the referenced Sheriff never reached the cache")
+
+	// Replicating what is referenced rather than what exists is the difference
+	// between this and the replication controller, so it is worth asserting
+	// that the sheriff nobody named stayed out.
+	names, err := cachedSheriffs()
+	require.NoError(t, err)
+	require.NotContains(t, names, unreferenced,
+		"a Sheriff no APIExport references must not be replicated")
+
+	t.Logf("Deleting APIExport %q", exportName)
+	require.NoError(t, exports.Delete(ctx, exportName, metav1.DeleteOptions{}), "error deleting APIExport")
+
+	t.Logf("Waiting for the cached copy to be removed")
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		names, err := cachedSheriffs()
+		if apierrors.IsNotFound(err) {
+			// The kind is served out of a synthetic CRD that exists only as
+			// long as some ClusterCachedResource wants it. With the last one
+			// gone the whole kind goes, which removes the copy and then some.
+			return true, ""
+		}
+		if err != nil {
+			return false, fmt.Sprintf("error listing sheriffs in the cache: %v", err)
+		}
+		return !slices.Contains(names, referenced), fmt.Sprintf("cache holds %v", names)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "the cached copy outlived the last reference to it")
+
+	// The local object is untouched: only the copy was ever this controller's
+	// to remove.
+	_, err = dynamicClusterClient.Cluster(providerPath).Resource(sheriffsGVR).Get(ctx, referenced, metav1.GetOptions{})
+	require.NoError(t, err, "replication must not delete the object it was copying")
+}


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Add apiexport reference controller. It watches apiexports and created ClusterCachedResource so we can replicate endpointslice object to cache server

## What Type of PR Is This?
/kind feature


<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
