### PR TITLE
Retry APIExport references that are not resolvable yet

### DIFF
--- a/pkg/reconciler/cache/apiexportreference/apiexportreference_controller.go
+++ b/pkg/reconciler/cache/apiexportreference/apiexportreference_controller.go
@@ -329,12 +329,6 @@ func (c *controller) reconcile(ctx context.Context, rawKey string) error {
 	// Anything this APIExport owns but no longer asks for goes. Deleting the
 	// ClusterCachedResource is what removes the copies: its finalizer drains
 	// them while the kind is still served.
-	//
-	// Only when every reference resolved, though. With one still unresolved the
-	// wanted set is a partial answer, and pruning against it would delete a
-	// ClusterCachedResource the APIExport does in fact still ask for -- then
-	// recreate it on the next pass, draining and refilling the cache for a kind
-	// that never stopped being referenced.
 	if len(unresolved) == 0 {
 		for _, ccr := range existing {
 			if _, keep := wanted[ccr.Name]; keep {
@@ -355,10 +349,6 @@ func (c *controller) reconcile(ctx context.Context, rawKey string) error {
 	// fields this controller owns, so an existing ClusterCachedResource keeps
 	// whatever others put on it -- the clustercachedresources controller
 	// defaults spec.identity in place, and that must survive this write.
-	//
-	// References that did resolve are applied even while others have not: an
-	// APIExport that mixes a settled reference with a brand-new one should not
-	// have the settled one held hostage.
 	for _, want := range wanted {
 		if err := c.applyResource(ctx, cluster, want); err != nil {
 			return err
@@ -366,12 +356,6 @@ func (c *controller) reconcile(ctx context.Context, rawKey string) error {
 	}
 
 	if len(unresolved) > 0 {
-		// Requeue with backoff. The rate limiter starts at milliseconds, so the
-		// ordinary case -- a CRD applied moments before the APIExport that names
-		// it -- converges about as fast as an event would have delivered it. A
-		// reference to a kind that genuinely does not exist settles into a slow
-		// retry, which is the right price for a misconfiguration that would
-		// otherwise leave no trace anywhere.
 		return fmt.Errorf("APIExport %s|%s references %s: not resolvable (yet)", cluster, export.Name, unresolved)
 	}
 
@@ -381,14 +365,6 @@ func (c *controller) reconcile(ctx context.Context, rawKey string) error {
 // wantedFor resolves an APIExport's references to the ClusterCachedResources
 // that should exist for them, as apply configurations keyed by name. It also
 // reports the references that could not be resolved.
-//
-// An unresolved reference is neither an error nor an absence. The RESTMapper
-// behind restMappingFor is per-replica, in-memory state fed asynchronously by
-// its own controller -- and one that deliberately withholds a CRD until it is
-// Established. A no-match from it means "this replica does not know that kind
-// yet", which is true of every kind for a short while after it is created, and
-// stays true forever for a kind that was never created. The two are
-// indistinguishable here, so this returns them and lets the caller retry.
 func (c *controller) wantedFor(export *apisv1alpha2.APIExport) (map[string]*cachev1alpha1apply.ClusterCachedResourceApplyConfiguration, []reference, error) {
 	if !export.DeletionTimestamp.IsZero() {
 		// On its way out. The garbage collector handles what it owns.

--- a/pkg/reconciler/cache/apiexportreference/apiexportreference_controller.go
+++ b/pkg/reconciler/cache/apiexportreference/apiexportreference_controller.go
@@ -148,6 +148,11 @@ type reference struct {
 	name  string
 }
 
+// String renders a reference in human readable form, for logging and error messages. It is not a legal object name.
+func (r reference) String() string {
+	return fmt.Sprintf("%s.%s/%s", strings.ToLower(r.kind), r.group, r.name)
+}
+
 // resolved is a reference once its kind has been turned into a resource.
 type resolved struct {
 	gvr  schema.GroupVersionResource
@@ -311,7 +316,7 @@ func (c *controller) reconcile(ctx context.Context, rawKey string) error {
 		return err
 	}
 
-	wanted, err := c.wantedFor(export)
+	wanted, unresolved, err := c.wantedFor(export)
 	if err != nil {
 		return err
 	}
@@ -324,17 +329,25 @@ func (c *controller) reconcile(ctx context.Context, rawKey string) error {
 	// Anything this APIExport owns but no longer asks for goes. Deleting the
 	// ClusterCachedResource is what removes the copies: its finalizer drains
 	// them while the kind is still served.
-	for _, ccr := range existing {
-		if _, keep := wanted[ccr.Name]; keep {
-			continue
-		}
-		if !ccr.DeletionTimestamp.IsZero() {
-			continue
-		}
-		klog.FromContext(ctx).V(2).Info("dropping a ClusterCachedResource nothing references anymore",
-			"clusterCachedResource", ccr.Name)
-		if err := c.deleteResource(ctx, cluster, ccr.Name); err != nil && !apierrors.IsNotFound(err) {
-			return err
+	//
+	// Only when every reference resolved, though. With one still unresolved the
+	// wanted set is a partial answer, and pruning against it would delete a
+	// ClusterCachedResource the APIExport does in fact still ask for -- then
+	// recreate it on the next pass, draining and refilling the cache for a kind
+	// that never stopped being referenced.
+	if len(unresolved) == 0 {
+		for _, ccr := range existing {
+			if _, keep := wanted[ccr.Name]; keep {
+				continue
+			}
+			if !ccr.DeletionTimestamp.IsZero() {
+				continue
+			}
+			klog.FromContext(ctx).V(2).Info("dropping a ClusterCachedResource nothing references anymore",
+				"clusterCachedResource", ccr.Name)
+			if err := c.deleteResource(ctx, cluster, ccr.Name); err != nil && !apierrors.IsNotFound(err) {
+				return err
+			}
 		}
 	}
 
@@ -342,37 +355,59 @@ func (c *controller) reconcile(ctx context.Context, rawKey string) error {
 	// fields this controller owns, so an existing ClusterCachedResource keeps
 	// whatever others put on it -- the clustercachedresources controller
 	// defaults spec.identity in place, and that must survive this write.
+	//
+	// References that did resolve are applied even while others have not: an
+	// APIExport that mixes a settled reference with a brand-new one should not
+	// have the settled one held hostage.
 	for _, want := range wanted {
 		if err := c.applyResource(ctx, cluster, want); err != nil {
 			return err
 		}
 	}
 
+	if len(unresolved) > 0 {
+		// Requeue with backoff. The rate limiter starts at milliseconds, so the
+		// ordinary case -- a CRD applied moments before the APIExport that names
+		// it -- converges about as fast as an event would have delivered it. A
+		// reference to a kind that genuinely does not exist settles into a slow
+		// retry, which is the right price for a misconfiguration that would
+		// otherwise leave no trace anywhere.
+		return fmt.Errorf("APIExport %s|%s references %s: not resolvable (yet)", cluster, export.Name, unresolved)
+	}
+
 	return nil
 }
 
 // wantedFor resolves an APIExport's references to the ClusterCachedResources
-// that should exist for them, as apply configurations keyed by name.
-func (c *controller) wantedFor(export *apisv1alpha2.APIExport) (map[string]*cachev1alpha1apply.ClusterCachedResourceApplyConfiguration, error) {
+// that should exist for them, as apply configurations keyed by name. It also
+// reports the references that could not be resolved.
+//
+// An unresolved reference is neither an error nor an absence. The RESTMapper
+// behind restMappingFor is per-replica, in-memory state fed asynchronously by
+// its own controller -- and one that deliberately withholds a CRD until it is
+// Established. A no-match from it means "this replica does not know that kind
+// yet", which is true of every kind for a short while after it is created, and
+// stays true forever for a kind that was never created. The two are
+// indistinguishable here, so this returns them and lets the caller retry.
+func (c *controller) wantedFor(export *apisv1alpha2.APIExport) (map[string]*cachev1alpha1apply.ClusterCachedResourceApplyConfiguration, []reference, error) {
 	if !export.DeletionTimestamp.IsZero() {
 		// On its way out. The garbage collector handles what it owns.
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	cluster := logicalcluster.From(export)
 	wanted := map[string]*cachev1alpha1apply.ClusterCachedResourceApplyConfiguration{}
 	seen := sets.New[resolved]()
+	var unresolved []reference
 
 	for _, ref := range referencesFrom(export) {
 		mapping, err := c.restMappingFor(cluster, schema.GroupKind{Group: ref.group, Kind: ref.kind})
 		if err != nil {
 			if meta.IsNoMatchError(err) {
-				// The kind is not served in that workspace. Nothing to cache,
-				// and nothing this controller can do about it: the APIExport is
-				// pointing at something that does not exist.
+				unresolved = append(unresolved, ref)
 				continue
 			}
-			return nil, err
+			return nil, nil, err
 		}
 
 		r := resolved{gvr: mapping.Resource, name: ref.name}
@@ -384,5 +419,5 @@ func (c *controller) wantedFor(export *apisv1alpha2.APIExport) (map[string]*cach
 		wanted[nameFor(export.Name, r)] = desired(export, r)
 	}
 
-	return wanted, nil
+	return wanted, unresolved, nil
 }

--- a/pkg/reconciler/cache/apiexportreference/apiexportreference_controller_test.go
+++ b/pkg/reconciler/cache/apiexportreference/apiexportreference_controller_test.go
@@ -373,11 +373,6 @@ func TestReconcile(t *testing.T) {
 		require.Empty(t, deleted)
 	})
 
-	// The bootstrap race: a CRD and the APIExport naming its kind applied in the
-	// same breath. The RESTMapper has not caught up, and if reconcile calls that
-	// a finished job the APIExport is wedged until something else touches it --
-	// no ClusterCachedResource, no replication, and discovery of the virtual
-	// resource fails on every shard from then on.
 	t.Run("an unresolved reference requeues instead of settling for nothing", func(t *testing.T) {
 		t.Parallel()
 

--- a/pkg/reconciler/cache/apiexportreference/apiexportreference_controller_test.go
+++ b/pkg/reconciler/cache/apiexportreference/apiexportreference_controller_test.go
@@ -68,6 +68,17 @@ func sheriffRef(name string) corev1.TypedLocalObjectReference {
 	}
 }
 
+// ghostRef names a kind sheriffMapper does not know, which is what a CRD that
+// has not been created -- or has not been Established yet -- looks like from
+// here.
+func ghostRef(name string) corev1.TypedLocalObjectReference {
+	return corev1.TypedLocalObjectReference{
+		APIGroup: ptr.To("nowhere.dev"),
+		Kind:     "Ghost",
+		Name:     name,
+	}
+}
+
 func sheriffMapper(t *testing.T) func(cluster logicalcluster.Name, gk schema.GroupKind) (*meta.RESTMapping, error) {
 	return func(cluster logicalcluster.Name, gk schema.GroupKind) (*meta.RESTMapping, error) {
 		require.Equal(t, logicalcluster.Name(testCluster), cluster, "references must resolve in the APIExport's own cluster")
@@ -180,9 +191,10 @@ func TestWantedFor(t *testing.T) {
 		e := export("wildwest-provider", sheriffRef("one"))
 		e.DeletionTimestamp = ptr.To(metav1.Now())
 
-		wanted, err := c.wantedFor(e)
+		wanted, unresolved, err := c.wantedFor(e)
 		require.NoError(t, err)
 		require.Empty(t, wanted)
+		require.Empty(t, unresolved)
 	})
 
 	t.Run("no references, nothing wanted", func(t *testing.T) {
@@ -190,9 +202,10 @@ func TestWantedFor(t *testing.T) {
 
 		c := &controller{restMappingFor: sheriffMapper(t)}
 
-		wanted, err := c.wantedFor(export("wildwest-provider"))
+		wanted, unresolved, err := c.wantedFor(export("wildwest-provider"))
 		require.NoError(t, err)
 		require.Empty(t, wanted)
+		require.Empty(t, unresolved)
 	})
 
 	t.Run("a reference resolves to one ClusterCachedResource", func(t *testing.T) {
@@ -200,8 +213,9 @@ func TestWantedFor(t *testing.T) {
 
 		c := &controller{restMappingFor: sheriffMapper(t)}
 
-		wanted, err := c.wantedFor(export("wildwest-provider", sheriffRef("one")))
+		wanted, unresolved, err := c.wantedFor(export("wildwest-provider", sheriffRef("one")))
 		require.NoError(t, err)
+		require.Empty(t, unresolved)
 		require.Len(t, wanted, 1)
 		want := wanted[nameFor("wildwest-provider", resolved{
 			gvr:  schema.GroupVersionResource{Group: "wildwest.dev", Version: "v1alpha1", Resource: "sheriffs"},
@@ -216,23 +230,33 @@ func TestWantedFor(t *testing.T) {
 
 		c := &controller{restMappingFor: sheriffMapper(t)}
 
-		wanted, err := c.wantedFor(export("wildwest-provider", sheriffRef("one"), sheriffRef("one")))
+		wanted, unresolved, err := c.wantedFor(export("wildwest-provider", sheriffRef("one"), sheriffRef("one")))
 		require.NoError(t, err)
+		require.Empty(t, unresolved)
 		require.Len(t, wanted, 1)
 	})
 
-	t.Run("a kind that is not served is skipped", func(t *testing.T) {
+	t.Run("a kind that is not served is reported, not dropped", func(t *testing.T) {
 		t.Parallel()
 
 		c := &controller{restMappingFor: sheriffMapper(t)}
 
-		wanted, err := c.wantedFor(export("wildwest-provider", corev1.TypedLocalObjectReference{
-			APIGroup: ptr.To("nowhere.dev"),
-			Kind:     "Ghost",
-			Name:     "one",
-		}))
+		wanted, unresolved, err := c.wantedFor(export("wildwest-provider", ghostRef("one")))
 		require.NoError(t, err)
 		require.Empty(t, wanted)
+		require.Equal(t, []reference{{group: "nowhere.dev", kind: "Ghost", name: "one"}}, unresolved,
+			"a no-match is 'not yet', and the caller has to hear about it to retry")
+	})
+
+	t.Run("a reference that resolves is kept while another does not", func(t *testing.T) {
+		t.Parallel()
+
+		c := &controller{restMappingFor: sheriffMapper(t)}
+
+		wanted, unresolved, err := c.wantedFor(export("wildwest-provider", sheriffRef("one"), ghostRef("two")))
+		require.NoError(t, err)
+		require.Len(t, wanted, 1, "a settled reference is not held hostage by an unsettled one")
+		require.Len(t, unresolved, 1)
 	})
 
 	t.Run("other mapper errors propagate", func(t *testing.T) {
@@ -243,7 +267,7 @@ func TestWantedFor(t *testing.T) {
 			return nil, boom
 		}}
 
-		_, err := c.wantedFor(export("wildwest-provider", sheriffRef("one")))
+		_, _, err := c.wantedFor(export("wildwest-provider", sheriffRef("one")))
 		require.ErrorIs(t, err, boom)
 	})
 }
@@ -347,5 +371,50 @@ func TestReconcile(t *testing.T) {
 
 		require.NoError(t, c.reconcile(context.Background(), key))
 		require.Empty(t, deleted)
+	})
+
+	// The bootstrap race: a CRD and the APIExport naming its kind applied in the
+	// same breath. The RESTMapper has not caught up, and if reconcile calls that
+	// a finished job the APIExport is wedged until something else touches it --
+	// no ClusterCachedResource, no replication, and discovery of the virtual
+	// resource fails on every shard from then on.
+	t.Run("an unresolved reference requeues instead of settling for nothing", func(t *testing.T) {
+		t.Parallel()
+
+		var applied, deleted []string
+		c := newController(
+			export("wildwest-provider", ghostRef("one")),
+			nil, &applied, &deleted)
+
+		err := c.reconcile(context.Background(), key)
+		require.Error(t, err, "returning nil here is what makes the race permanent")
+		require.Contains(t, err.Error(), "ghost.nowhere.dev/one")
+		require.Empty(t, applied)
+	})
+
+	t.Run("nothing is pruned while a reference is unresolved", func(t *testing.T) {
+		t.Parallel()
+
+		var applied, deleted []string
+		c := newController(
+			export("wildwest-provider", ghostRef("one")),
+			[]*cachev1alpha1.ClusterCachedResource{owned("not-actually-stale")},
+			&applied, &deleted)
+
+		require.Error(t, c.reconcile(context.Background(), key))
+		require.Empty(t, deleted,
+			"a partial wanted set is not evidence that a ClusterCachedResource is unreferenced")
+	})
+
+	t.Run("references that did resolve are applied even while others have not", func(t *testing.T) {
+		t.Parallel()
+
+		var applied, deleted []string
+		c := newController(
+			export("wildwest-provider", sheriffRef("one"), ghostRef("two")),
+			nil, &applied, &deleted)
+
+		require.Error(t, c.reconcile(context.Background(), key))
+		require.Equal(t, []string{wantedName}, applied)
 	})
 }


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Stay with me on this.... Wasted half day on this :D  

The apiexport-reference controller resolved `storage.virtual.reference`
through the `DynamicRESTMapper` and treated a no-match as a settled answer:
it skipped the reference, returned nil, and forgot the key. Nothing
re-enqueues it -- the controller watches APIExports and
`ClusterCachedResources`, not CRDs -- so the APIExport stayed without its
`ClusterCachedResource` until something happened to touch it again.
    
That mapper is per-replica in-memory state, fed asynchronously by its own
controller, and since #4322 (fixing another issue) it withholds a CRD until it is Established.
A no-match therefore means "this replica does not know that kind yet",
which is true of every kind for a few seconds after it is created. An
APIExport applied in the same breath as the CRD it references loses,
permanently: no `ClusterCachedResource`, so the referenced object never
reaches the cache server, so every shard fails discovery of the virtual
resource with "failed to retrieve virtual workspace URL" from then on.
    
`wantedFor` now reports unresolved references instead of dropping them, and
reconcile returns an error for them so the key requeues. The rate limiter
starts at milliseconds, so the bootstrap case converges about as fast as
an event would have delivered it, while a reference to a kind that really
does not exist settles into a slow retry -- and says so, where before it
left no trace anywhere.
    
Pruning is now skipped while any reference is unresolved. The wanted set
is partial in that state, and deleting against it would drop a
`ClusterCachedResource` the APIExport still asks for, draining and
refilling the cache for a kind that never stopped being referenced.
References that did resolve are still applied, so one unsettled reference
not hold up the rest.

## What Type of PR Is This?
/kind bug

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Retry APIExport references that are not resolvable yet
```
