### PR TITLE
pkg/server: disable the openapi endpoint for system:bound-crds

### DIFF
--- a/pkg/admission/mutatingadmissionpolicy/mutating_admission_policy.go
+++ b/pkg/admission/mutatingadmissionpolicy/mutating_admission_policy.go
@@ -61,6 +61,8 @@ import (
 
 const PluginName = "KCPMutatingAdmissionPolicy"
 
+const systemBoundCRDsClusterName = logicalcluster.Name("system:bound-crds")
+
 func Register(plugins *admission.Plugins) {
 	plugins.Register(PluginName,
 		func(config io.Reader) (admission.Interface, error) {
@@ -205,6 +207,10 @@ func (k *KubeMutatingAdmissionPolicy) Admit(ctx context.Context, a admission.Att
 	cluster, err := genericapirequest.ValidClusterFrom(ctx)
 	if err != nil {
 		return err
+	}
+
+	if cluster.Name == systemBoundCRDsClusterName {
+		return nil
 	}
 
 	sourceCluster, err := k.getSourceClusterForGroupResource(cluster.Name, a.GetResource().GroupResource())

--- a/pkg/server/openapiv3/servicecache.go
+++ b/pkg/server/openapiv3/servicecache.go
@@ -56,6 +56,8 @@ const (
 
 	// TODO(sttts): move to central place in kube.
 	BoundAnnotationKey = "apis.kcp.io/bound-crd"
+
+	systemBoundCRDsClusterName = logicalcluster.Name("system:bound-crds")
 )
 
 // WithOpenAPIv3 returns a handler that serves OpenAPI v3 specs for CRDs, not
@@ -129,12 +131,27 @@ func (c *ServiceCache) RegisterStaticAPIs(cont *restful.Container) error {
 	return nil
 }
 
+func (c *ServiceCache) serveEmpty(w http.ResponseWriter, r *http.Request) {
+	m := mux.NewPathRecorderMux("cluster-aware-openapi-v3-empty")
+	service := handler3.NewOpenAPIService()
+	if err := service.RegisterOpenAPIV3VersionedService("/openapi/v3", m); err != nil {
+		responsewriters.InternalError(w, r, err)
+		return
+	}
+	m.ServeHTTP(w, r)
+}
+
 func (c *ServiceCache) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	clusterName, err := request.ClusterNameFrom(r.Context())
 	if err != nil {
 		http.NotFound(w, r)
+		return
+	}
+
+	if clusterName == systemBoundCRDsClusterName {
+		c.serveEmpty(w, r)
 		return
 	}
 

--- a/pkg/server/openapiv3/servicecache_test.go
+++ b/pkg/server/openapiv3/servicecache_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openapiv3
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apiextensions-apiserver/pkg/kcp"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+)
+
+type erroringCRDClusterLister struct{}
+
+func (erroringCRDClusterLister) Cluster(logicalcluster.Name) kcp.ClusterAwareCRDLister {
+	return erroringCRDLister{}
+}
+
+type erroringCRDLister struct{}
+
+func (erroringCRDLister) List(context.Context, labels.Selector) ([]*apiextensionsv1.CustomResourceDefinition, error) {
+	return nil, errors.New("lister must not be reached for system:bound-crds")
+}
+
+func (erroringCRDLister) Get(context.Context, string) (*apiextensionsv1.CustomResourceDefinition, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (erroringCRDLister) Refresh(crd *apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1.CustomResourceDefinition, error) {
+	return crd, nil
+}
+
+func TestServeHTTPSkipsSystemBoundCRDs(t *testing.T) {
+	t.Parallel()
+
+	c := NewServiceCache(nil, erroringCRDClusterLister{}, nil, DefaultServiceCacheSize)
+
+	for _, tc := range []struct {
+		name     string
+		cluster  logicalcluster.Name
+		wantCode int
+	}{
+		{name: "system:bound-crds serves an empty doc without listing CRDs", cluster: systemBoundCRDsClusterName, wantCode: http.StatusOK},
+		{name: "regular workspace goes through the normal path", cluster: logicalcluster.Name("root:some-workspace"), wantCode: http.StatusInternalServerError},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := request.WithCluster(context.Background(), request.Cluster{Name: tc.cluster})
+			req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/openapi/v3", http.NoBody)
+
+			rec := httptest.NewRecorder()
+			c.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantCode {
+				t.Errorf("cluster %q: got status %d, want %d", tc.cluster, rec.Code, tc.wantCode)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

This system WS holds all bound CRDs across the shard, so merging their openapi fails on duplicate GVKs. The schema diff doens't matter as the upstream ext apisever "merger" just errors on matching GVK keys. Serve an empty openapi doc from this WS to avoid merge errors.

Also in MAP admission, skip this WS so no callers even trigger an openapi fetch on this WS. It seems MAP admission is the only internal kcp mechanism that does it (?). External admin users could have a use case for this but if there are duplicates they will just get an error and no actual merged schemas.

If you think there are better ways to solve this, LMK, i didn't want to patch upstream to relax the merge

## What Type of PR Is This?

/kind bug

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #4332

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
bug: stop serving OpenAPI v3 from the `system:bound-crds` workspace as it may contain duplicated GVKs sourced from different consumers.
```
