### PR TITLE
apiexportreference: Add a hardcoded list of refs to ignore

### DIFF
--- a/pkg/reconciler/cache/apiexportreference/apiexportreference_controller.go
+++ b/pkg/reconciler/cache/apiexportreference/apiexportreference_controller.go
@@ -68,6 +68,14 @@ const (
 	ControllerName = "kcp-apiexport-reference-controller"
 )
 
+// Don't create CCRs for builtin endpoint slice kinds that we are already replicating.
+var ignoreBuiltinEndpointSlices = sets.New[schema.GroupKind](
+	schema.GroupKind{
+		Group: "cache.kcp.io",
+		Kind:  "ClusterCachedResourceEndpointSlice",
+	},
+)
+
 // NewController returns a controller that keeps a ClusterCachedResource for
 // every object an APIExport references.
 func NewController(
@@ -153,6 +161,13 @@ func (r reference) String() string {
 	return fmt.Sprintf("%s.%s/%s", strings.ToLower(r.kind), r.group, r.name)
 }
 
+func (r reference) GroupKind() schema.GroupKind {
+	return schema.GroupKind{
+		Group: r.group,
+		Kind:  r.kind,
+	}
+}
+
 // resolved is a reference once its kind has been turned into a resource.
 type resolved struct {
 	gvr  schema.GroupVersionResource
@@ -168,15 +183,19 @@ func referencesFrom(export *apisv1alpha2.APIExport) []reference {
 		if resource.Storage.Virtual == nil {
 			continue
 		}
-		ref := resource.Storage.Virtual.Reference
-		if ref.Kind == "" || ref.Name == "" {
+		objRef := resource.Storage.Virtual.Reference
+		if objRef.Kind == "" || objRef.Name == "" {
 			continue
 		}
-		refs = append(refs, reference{
-			group: ptr.Deref(ref.APIGroup, ""),
-			kind:  ref.Kind,
-			name:  ref.Name,
-		})
+		ref := reference{
+			group: ptr.Deref(objRef.APIGroup, ""),
+			kind:  objRef.Kind,
+			name:  objRef.Name,
+		}
+		if ignoreBuiltinEndpointSlices.Has(ref.GroupKind()) {
+			continue
+		}
+		refs = append(refs, ref)
 	}
 	return refs
 }

--- a/pkg/reconciler/cache/apiexportreference/apiexportreference_controller_test.go
+++ b/pkg/reconciler/cache/apiexportreference/apiexportreference_controller_test.go
@@ -96,22 +96,40 @@ func sheriffMapper(t *testing.T) func(cluster logicalcluster.Name, gk schema.Gro
 func TestReferencesFrom(t *testing.T) {
 	t.Parallel()
 
-	e := export("wildwest-provider", sheriffRef("one"))
-	e.Spec.Resources = append(e.Spec.Resources,
-		// Regular storage: not a reference.
-		apisv1alpha2.ResourceSchema{Group: "wildwest.dev", Name: "cowboys", Schema: "today.cowboys.wildwest.dev"},
-		// Virtual storage without kind or name: not a usable reference.
-		apisv1alpha2.ResourceSchema{
-			Group:   "wildwest.dev",
-			Name:    "cowboys",
-			Schema:  "today.cowboys.wildwest.dev",
-			Storage: apisv1alpha2.ResourceSchemaStorage{Virtual: &apisv1alpha2.ResourceSchemaStorageVirtual{}},
-		},
-	)
+	t.Run("consider only non-empty VR refs", func(t *testing.T) {
+		t.Parallel()
 
-	require.Equal(t,
-		[]reference{{group: "wildwest.dev", kind: "Sheriff", name: "one"}},
-		referencesFrom(e))
+		e := export("wildwest-provider", sheriffRef("one"))
+		e.Spec.Resources = append(e.Spec.Resources,
+			// Regular storage: not a reference.
+			apisv1alpha2.ResourceSchema{Group: "wildwest.dev", Name: "cowboys", Schema: "today.cowboys.wildwest.dev"},
+			// Virtual storage without kind or name: not a usable reference.
+			apisv1alpha2.ResourceSchema{
+				Group:   "wildwest.dev",
+				Name:    "cowboys",
+				Schema:  "today.cowboys.wildwest.dev",
+				Storage: apisv1alpha2.ResourceSchemaStorage{Virtual: &apisv1alpha2.ResourceSchemaStorageVirtual{}},
+			},
+		)
+
+		require.Equal(t,
+			[]reference{{group: "wildwest.dev", kind: "Sheriff", name: "one"}},
+			referencesFrom(e))
+	})
+
+	t.Run("ignore VR refs from ignoreBuiltinEndpointSlices", func(t *testing.T) {
+		t.Parallel()
+
+		e := export("wildwest-provider", corev1.TypedLocalObjectReference{
+			APIGroup: ptr.To("cache.kcp.io"),
+			Kind:     "ClusterCachedResourceEndpointSlice",
+			Name:     "instances",
+		})
+
+		require.Equal(t,
+			[]reference(nil),
+			referencesFrom(e))
+	})
 }
 
 func TestNameFor(t *testing.T) {


### PR DESCRIPTION
## Summary

ClusterCachedResourceEndpointSlice is already replicated, but apiexportreference creates a CCR for it anyway. 

This PR adds a hardcoded list of refs to ignore and not create CCRs for.

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind bug

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
