### PR TITLE
[release-0.31] Fix permission claim defaultSelector hiding claimed resources

### DIFF
--- a/staging/src/github.com/kcp-dev/sdk/apis/apis/v1alpha2/permissionclaims/labels.go
+++ b/staging/src/github.com/kcp-dev/sdk/apis/apis/v1alpha2/permissionclaims/labels.go
@@ -36,6 +36,17 @@ func ToLabelKeyAndValue(exportClusterName logicalcluster.Name, exportName string
 	// (identification) key as that would require (some sort of) migration.
 	permissionClaim.Verbs = nil
 
+	// DefaultSelector and the binding-time Selector scope down which objects are
+	// claimed; they are not part of a claim's identity. They must not contribute
+	// to the hash: the APIExport reconciler hashes the APIExport's claim (which may
+	// carry a defaultSelector) to build the virtual workspace LIST/WATCH filter,
+	// while the permissionclaim labeler hashes the APIBinding's accepted claim
+	// (which never carries a defaultSelector) to label the claimed objects. If
+	// defaultSelector contributed to the hash the two would diverge and claimed
+	// resources would be invisible through the APIExport endpoint. See
+	// https://github.com/kcp-dev/kcp/issues/4198.
+	permissionClaim.DefaultSelector = nil
+
 	bytes, err := json.Marshal(permissionClaim)
 	if err != nil {
 		return "", "", err

--- a/staging/src/github.com/kcp-dev/sdk/apis/apis/v1alpha2/permissionclaims/labels_test.go
+++ b/staging/src/github.com/kcp-dev/sdk/apis/apis/v1alpha2/permissionclaims/labels_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package permissionclaims
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
+)
+
+// TestToLabelKeyAndValue ensures that TestToLabelKeyAndValue stays stable.
+func TestToLabelKeyAndValue(t *testing.T) {
+	t.Parallel()
+	cases := map[string]struct {
+		exportCluster logicalcluster.Name
+		exportName    string
+		claim         apisv1alpha2.PermissionClaim
+		wantKey       string
+		wantValue     string
+	}{
+		"simple group/resource": {
+			exportCluster: "root",
+			exportName:    "tenancy.kcp.io",
+			claim: apisv1alpha2.PermissionClaim{
+				GroupResource: apisv1alpha2.GroupResource{
+					Group:    "",
+					Resource: "configmaps",
+				},
+				Verbs: []string{"get", "list"},
+			},
+			wantKey:   "claimed.internal.apis.kcp.io/bmCdly9xXiUpEHe3ypvDwvXMTfoVZUE92mqAQf",
+			wantValue: "3QVjs6pfBjMpLEVYYhysJnroYGsQGlWm05E4qe",
+		},
+		"with identity hash": {
+			exportCluster: "abcd1234",
+			exportName:    "my-export",
+			claim: apisv1alpha2.PermissionClaim{
+				GroupResource: apisv1alpha2.GroupResource{
+					Group:    "apps",
+					Resource: "deployments",
+				},
+				Verbs:        []string{"get"},
+				IdentityHash: "deadbeef",
+			},
+			wantKey:   "claimed.internal.apis.kcp.io/phGj1BkmdNY3LKTrtFc1KGLYTBs8Nt50p8PIU",
+			wantValue: "4CpOMiJ5JL9ZC4cG8ne7nGNQbSOEUiwZ89KHal",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			key, value, err := ToLabelKeyAndValue(tc.exportCluster, tc.exportName, tc.claim)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantKey, key)
+			assert.Equal(t, tc.wantValue, value)
+		})
+	}
+}
+
+// TestToReflexiveAPIBindingLabelKeyAndValue ensures that ToReflexiveAPIBindingLabelKeyAndValue stays stable.
+func TestToLabelKeyAndValueIgnoresVerbs(t *testing.T) {
+	t.Parallel()
+	base := apisv1alpha2.PermissionClaim{
+		GroupResource: apisv1alpha2.GroupResource{Group: "apps", Resource: "deployments"},
+		Verbs:         []string{"get"},
+	}
+	withMoreVerbs := base
+	withMoreVerbs.Verbs = []string{"get", "list", "watch", "create"}
+
+	keyA, valueA, err := ToLabelKeyAndValue("root", "tenancy.kcp.io", base)
+	require.NoError(t, err)
+	keyB, valueB, err := ToLabelKeyAndValue("root", "tenancy.kcp.io", withMoreVerbs)
+	require.NoError(t, err)
+
+	assert.Equal(t, keyA, keyB)
+	assert.Equal(t, valueA, valueB)
+}
+
+// TestToLabelKeyAndValueIgnoresDefaultSelector is a regression test for
+// https://github.com/kcp-dev/kcp/issues/4198. The APIExport reconciler hashes
+// the APIExport's claim (which may carry a defaultSelector) to build the virtual
+// workspace LIST/WATCH filter, while the permissionclaim labeler hashes the
+// APIBinding's accepted claim (which never carries a defaultSelector) to label
+// the claimed objects. If defaultSelector contributed to the hash, the two would
+// diverge and claimed resources (e.g. workspacetypes) would be invisible through
+// the APIExport endpoint.
+func TestToLabelKeyAndValueIgnoresDefaultSelector(t *testing.T) {
+	t.Parallel()
+	base := apisv1alpha2.PermissionClaim{
+		GroupResource: apisv1alpha2.GroupResource{Group: "tenancy.kcp.io", Resource: "workspacetypes"},
+		IdentityHash:  "a83e47a180b6e88edde2f42a9f2cd5740ea0bdc3d271d926374f0ce7204e5c17",
+		Verbs:         []string{"*"},
+	}
+	withDefaultSelector := base
+	withDefaultSelector.DefaultSelector = &apisv1alpha2.PermissionClaimSelector{MatchAll: true}
+
+	keyA, valueA, err := ToLabelKeyAndValue("root", "workspaces", base)
+	require.NoError(t, err)
+	keyB, valueB, err := ToLabelKeyAndValue("root", "workspaces", withDefaultSelector)
+	require.NoError(t, err)
+
+	assert.Equal(t, keyA, keyB)
+	assert.Equal(t, valueA, valueB, "defaultSelector must not change the claim hash (issue #4198)")
+}
+
+// TestToReflexiveAPIBindingLabelKeyAndValue ensures that ToReflexiveAPIBindingLabelKeyAndValue stays stable.
+func TestToReflexiveAPIBindingLabelKeyAndValue(t *testing.T) {
+	t.Parallel()
+	key, value := ToReflexiveAPIBindingLabelKeyAndValue("root", "tenancy.kcp.io")
+	assert.Equal(t, "claimed.internal.apis.kcp.io/bmCdly9xXiUpEHe3ypvDwvXMTfoVZUE92mqAQf", key)
+	assert.Equal(t, "LstvmbbzVDDOn90ZbhzSQO5U3DMCf88h1pZ", value)
+}
+
+// TestToAPIBindingExportLabelValue ensures that ToAPIBindingExportLabelValue stays stable.
+func TestToAPIBindingExportLabelValue(t *testing.T) {
+	t.Parallel()
+	cases := map[string]struct {
+		cluster    logicalcluster.Name
+		exportName string
+		want       string
+	}{
+		"root tenancy":   {"root", "tenancy.kcp.io", "bmCdly9xXiUpEHe3ypvDwvXMTfoVZUE92mqAQf"},
+		"foreign export": {"abcd1234", "my-export", "phGj1BkmdNY3LKTrtFc1KGLYTBs8Nt50p8PIU"},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, ToAPIBindingExportLabelValue(tc.cluster, tc.exportName))
+		})
+	}
+}
+
+// TestExportHashIsConsistent ensures that ToLabelKeyAndValue and ToReflexiveAPIBindingLabelKeyAndValue produce equivalent output.
+func TestExportHashIsConsistent(t *testing.T) {
+	t.Parallel()
+	cluster := logicalcluster.Name("root")
+	exportName := "tenancy.kcp.io"
+
+	keyFromLabel, _, err := ToLabelKeyAndValue(cluster, exportName, apisv1alpha2.PermissionClaim{
+		GroupResource: apisv1alpha2.GroupResource{Resource: "configmaps"},
+		Verbs:         []string{"get"},
+	})
+	require.NoError(t, err)
+	keyFromReflexive, _ := ToReflexiveAPIBindingLabelKeyAndValue(cluster, exportName)
+	valueFromBinding := ToAPIBindingExportLabelValue(cluster, exportName)
+
+	assert.Equal(t, keyFromLabel, keyFromReflexive)
+	assert.Equal(t, apisv1alpha2.APIExportPermissionClaimLabelPrefix+valueFromBinding, keyFromLabel)
+}

--- a/test/e2e/virtual/apiexport/virtualworkspace_test.go
+++ b/test/e2e/virtual/apiexport/virtualworkspace_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	authorizationv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	extensionsapiserver "k8s.io/apiextensions-apiserver/pkg/apiserver"
@@ -837,6 +838,98 @@ func TestAPIExportPermissionClaims(t *testing.T) {
 	}
 	_, err = kubeVWClusterClient.Cluster(logicalcluster.NewPath(consumer1.Spec.Cluster)).AuthorizationV1().LocalSubjectAccessReviews("default").Create(t.Context(), lsar, metav1.CreateOptions{})
 	require.NoError(t, err)
+}
+
+// TestAPIExportPermissionClaimsDefaultSelector is a regression test for
+// https://github.com/kcp-dev/kcp/issues/4198. When an APIExport's permission
+// claim carries a defaultSelector, the claimed resources used to become invisible
+// through the APIExport virtual workspace, because the virtual workspace LIST
+// filter hashed the APIExport's claim (with defaultSelector) while the
+// permissionclaim labeler hashed the APIBinding's accepted claim (without
+// defaultSelector). The two hashes diverged, so the filter never matched the
+// labeled objects. Dropping defaultSelector "fixed" it for the reporter; this
+// test ensures a defaultSelector no longer hides claimed resources.
+func TestAPIExportPermissionClaimsDefaultSelector(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "control-plane")
+
+	server := kcptesting.SharedKcpServer(t)
+
+	orgPath, _ := kcptesting.NewWorkspaceFixture(t, server, core.RootCluster.Path(), kcptesting.WithType(core.RootCluster.Path(), "organization"))
+	claimerPath, _ := kcptesting.NewWorkspaceFixture(t, server, orgPath, kcptesting.WithName("claimer"))
+	consumerPath, consumer := kcptesting.NewWorkspaceFixture(t, server, orgPath, kcptesting.WithName("consumer"))
+
+	cfg := server.BaseConfig(t)
+	kcpClusterClient, err := kcpclientset.NewForConfig(cfg)
+	require.NoError(t, err, "failed to construct kcp cluster client for server")
+	dynamicClusterClient, err := kcpdynamic.NewForConfig(cfg)
+	require.NoError(t, err, "failed to construct dynamic cluster client for server")
+	kubeClusterClient, err := kcpkubernetesclientset.NewForConfig(cfg)
+	require.NoError(t, err, "failed to construct kube cluster client for server")
+
+	t.Logf("Create cowboys APIExport in %v claiming configmaps WITH a defaultSelector", claimerPath)
+	claims := []apisv1alpha2.PermissionClaim{
+		{
+			GroupResource: apisv1alpha2.GroupResource{Group: "", Resource: "configmaps"},
+			Verbs:         []string{"*"},
+			// This defaultSelector is the trigger for issue #4198.
+			DefaultSelector: &apisv1alpha2.PermissionClaimSelector{MatchAll: true},
+		},
+	}
+	setUpServiceProvider(t, dynamicClusterClient, kcpClusterClient, false, claimerPath, cfg, claims)
+
+	t.Logf("Bind cowboys from %v to %v, accepting the configmaps claim WITHOUT a defaultSelector (as a user-authored APIBinding would)", claimerPath, consumerPath)
+	bindConsumerToProvider(t, consumerPath, claimerPath, kcpClusterClient, cfg, apisv1alpha2.AcceptablePermissionClaim{
+		ScopedPermissionClaim: apisv1alpha2.ScopedPermissionClaim{
+			PermissionClaim: apisv1alpha2.PermissionClaim{
+				GroupResource: apisv1alpha2.GroupResource{Group: "", Resource: "configmaps"},
+				Verbs:         []string{"*"},
+			},
+			Selector: apisv1alpha2.PermissionClaimSelector{MatchAll: true},
+		},
+		State: apisv1alpha2.ClaimAccepted,
+	})
+
+	t.Logf("Create a configmap in consumer workspace %v", consumerPath)
+	const configMapName = "claimed-cm"
+	_, err = kubeClusterClient.Cluster(consumerPath).CoreV1().ConfigMaps("default").Create(t.Context(), &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: configMapName},
+		Data:       map[string]string{"hello": "world"},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err, "failed to create configmap in consumer workspace")
+
+	t.Logf("Waiting for the cowboys APIExport to have a virtual workspace URL for %q", consumerPath)
+	consumerVWCfg := rest.CopyConfig(cfg)
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		apiExportEndpointSlice, err := kcpClusterClient.Cluster(claimerPath).ApisV1alpha1().APIExportEndpointSlices().Get(t.Context(), "today-cowboys", metav1.GetOptions{})
+		require.NoError(t, err)
+		var found bool
+		consumerVWCfg.Host, found, err = framework.VirtualWorkspaceURL(t.Context(), kcpClusterClient, consumer, framework.ExportVirtualWorkspaceURLs(apiExportEndpointSlice))
+		require.NoError(t, err)
+		return found, fmt.Sprintf("waiting for virtual workspace URLs to be available: %v", apiExportEndpointSlice.Status.APIExportEndpoints)
+	}, wait.ForeverTestTimeout, time.Millisecond*100)
+
+	dynamicVWClusterClient, err := kcpdynamic.NewForConfig(consumerVWCfg)
+	require.NoError(t, err)
+	configMapsGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+
+	t.Logf("Verify the claimed configmap is visible through the APIExport virtual workspace despite the defaultSelector")
+	kcptestinghelpers.Eventually(t, func() (bool, string) {
+		list, err := dynamicVWClusterClient.Resource(configMapsGVR).List(t.Context(), metav1.ListOptions{})
+		if err != nil {
+			return false, fmt.Sprintf("error listing configmaps through virtual workspace: %v", err)
+		}
+		for _, item := range list.Items {
+			if item.GetName() == configMapName {
+				return true, ""
+			}
+		}
+		var names []string
+		for _, item := range list.Items {
+			names = append(names, item.GetName())
+		}
+		return false, fmt.Sprintf("claimed configmap %q not yet visible through virtual workspace; saw %v", configMapName, names)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "claimed configmap never became visible through the APIExport virtual workspace (issue #4198)")
 }
 
 func TestAPIExportClaimableBuiltInAPIsDrift(t *testing.T) {


### PR DESCRIPTION
## Summary

Manual cherry-pick of #4200 to `release-0.31`.

The cherry-pick had one modify/delete conflict because `labels_test.go` does not exist on this branch. I kept the upstream version of that test file. The resulting commit preserves the original author and the full upstream regression coverage.

Validation:

- `(cd staging/src/github.com/kcp-dev/sdk && go test ./... -count=1)`
- `go test ./test/e2e/virtual/apiexport -run '^TestAPIExportPermissionClaimsDefaultSelector$' -count=1 -v`
- `git diff --check`

## What Type of PR Is This?

/kind bug

## Related Issue(s)

Backports #4200.

## Release Notes

```release-note
Fix watch request via VirtualWorkspace when selectors are used.
```
