### PR TITLE
hack: don't let artifact tar warnings fail otherwise-green CI runs

### DIFF
--- a/cmd/test-server/main.go
+++ b/cmd/test-server/main.go
@@ -150,5 +150,13 @@ func start(shardFlags []string, workDirPath, logDirPath string, quiet bool) erro
 
 	s.GatherMetrics(metricsCtx)
 
+	// Stop the shard and wait for its process to actually exit before we
+	// return, instead of relying on the deferred cancel() above, which
+	// only asynchronously triggers termination. Without this, main() can
+	// return - and the process running it can exit - while the shard is
+	// still shutting down and flushing its log/audit files.
+	cancel()
+	<-errCh
+
 	return nil
 }

--- a/hack/run-with-prow.sh
+++ b/hack/run-with-prow.sh
@@ -34,7 +34,18 @@ echo "Command terminated with ${EXIT_CODE}"
 
 echo 'Compressing build artifacts...'
 cd "$ARTIFACTS"
+set +o errexit
 tar cjf artifacts.tar.bz2 --remove-files *
+TAR_EXIT_CODE=${?}
+set -o errexit
+if [[ "${TAR_EXIT_CODE}" -ne 0 ]]; then
+	# Processes started by the test run (e.g. kcp servers) can still be
+	# shutting down and writing to their log/audit files when we get here,
+	# which makes tar report a non-fatal "file changed as we read it"
+	# warning (or a failed rmdir of the directory it lives in) as a fatal
+	# error. Don't let that mask the actual test result.
+	echo "warning: compressing artifacts exited with code ${TAR_EXIT_CODE}, some files may still be present uncompressed in ${ARTIFACTS}"
+fi
 echo 'Done compressing files.'
 
 exit "${EXIT_CODE}"

--- a/hack/run-with-prow.sh
+++ b/hack/run-with-prow.sh
@@ -34,18 +34,7 @@ echo "Command terminated with ${EXIT_CODE}"
 
 echo 'Compressing build artifacts...'
 cd "$ARTIFACTS"
-set +o errexit
 tar cjf artifacts.tar.bz2 --remove-files *
-TAR_EXIT_CODE=${?}
-set -o errexit
-if [[ "${TAR_EXIT_CODE}" -ne 0 ]]; then
-	# Processes started by the test run (e.g. kcp servers) can still be
-	# shutting down and writing to their log/audit files when we get here,
-	# which makes tar report a non-fatal "file changed as we read it"
-	# warning (or a failed rmdir of the directory it lives in) as a fatal
-	# error. Don't let that mask the actual test result.
-	echo "warning: compressing artifacts exited with code ${TAR_EXIT_CODE}, some files may still be present uncompressed in ${ARTIFACTS}"
-fi
 echo 'Done compressing files.'
 
 exit "${EXIT_CODE}"


### PR DESCRIPTION
## Summary

CI post-steps in `hack/run-with-prow.sh` sometimes fail while compressing
artifacts (`tar: kcp/audit.log: file changed as we read it`), even though the
test run itself passed. This happens because `cmd/test-server`'s `start()`
returned as soon as it saw the shutdown signal, relying on a deferred
`cancel()` to stop the shard asynchronously — so the wrapping process (and
the artifact-compression step) could exit before the shard had actually
terminated and flushed its log/audit files.

This PR fixes that at the root: `start()` now explicitly cancels the shard
and blocks on its termination channel before returning, so the process is
confirmed exited first. An earlier version of this PR worked around the
symptom in `hack/run-with-prow.sh` instead; that's been reverted in favor of
this fix.

The equivalent change for `cmd/sharded-test-server` is bigger (it needs
`startFrontProxy` to expose its own termination channel) and is left for a
follow-up PR.

## What Type of PR Is This?

/kind bug

## Related Issue(s)

Fixes #4343

## Release Notes

```release-note
NONE
```
