### PR TITLE
Add --shard-replica-count

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -771,7 +771,7 @@ func NewConfig(ctx context.Context, opts kcpserveroptions.CompletedOptions) (*Co
 		informerfactoryhack.Wrap(c.KubeSharedInformerFactory),
 		admissionPluginInitializers,
 		opts.GenericControlPlane,
-		3,
+		opts.Extra.ShardReplicaCount,
 		conversionFactory)
 	if err != nil {
 		return nil, fmt.Errorf("error configuring api extensions: %w", err)

--- a/pkg/server/options/options.go
+++ b/pkg/server/options/options.go
@@ -72,6 +72,7 @@ type ExtraOptions struct {
 	// front-proxy trust the forwarded identity headers instead of clearing them.
 	MountProxyClientCertFile              string
 	MountProxyClientKeyFile               string
+	ShardReplicaCount                     int
 	DiscoveryPollInterval                 time.Duration
 	ExperimentalBindFreePort              bool
 	LogicalClusterTotalObjectLimit        int64
@@ -127,6 +128,7 @@ func NewOptions(rootDir string) *Options {
 			ShardBaseURL:                       "",
 			ShardExternalURL:                   "",
 			ShardName:                          "root",
+			ShardReplicaCount:                  1,
 			DiscoveryPollInterval:              60 * time.Second,
 			ExperimentalBindFreePort:           false,
 			ConversionCELTransformationTimeout: time.Second,
@@ -183,6 +185,10 @@ func (o *Options) AddFlags(fss *cliflag.NamedFlagSets) {
 	fs.StringVar(&o.Extra.ShardBaseURL, "shard-base-url", o.Extra.ShardBaseURL, "Base URL to this kcp shard. Defaults to external address.")
 	fs.StringVar(&o.Extra.ShardExternalURL, "shard-external-url", o.Extra.ShardExternalURL, "URL used by outside clients to talk to this kcp shard. Defaults to external address.")
 	fs.StringVar(&o.Extra.ShardName, "shard-name", o.Extra.ShardName, "A name of this kcp shard. Defaults to the \"root\" name.")
+	// https://github.com/kubernetes/kubernetes/blob/f28b4c9efbca5c5c0af716d9f2d5702667ee8a45/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go#L491-L495
+	// The --shard-replica-count is passed along and lands as
+	// masterCount in upstream which then causes a 5s delay on startup.
+	fs.IntVar(&o.Extra.ShardReplicaCount, "shard-replica-count", o.Extra.ShardReplicaCount, "Number of kcp server replicas serving this shard. Values greater than 1 delay CRD establishment by 5 seconds so all replicas can warm their caches before the CRD is served.")
 	fs.StringVar(&o.Extra.ShardVirtualWorkspaceCAFile, "shard-virtual-workspace-ca-file", o.Extra.ShardVirtualWorkspaceCAFile, "Path to a CA certificate file that is valid for the virtual workspace server.")
 	fs.StringVar(&o.Extra.ShardVirtualWorkspaceURL, "shard-virtual-workspace-url", o.Extra.ShardVirtualWorkspaceURL, "An external URL address of a virtual workspace server associated with this shard. Defaults to shard's base address.")
 	fs.StringVar(&o.Extra.ShardClientCertFile, "shard-client-cert-file", o.Extra.ShardClientCertFile, "Path to a client certificate file the shard uses to communicate with other system components.")
@@ -242,6 +248,10 @@ func (o *CompletedOptions) Validate() []error {
 
 	if o.Extra.ShardName != corev1alpha1.RootShard && len(o.Cache.Client.KubeconfigFile) == 0 {
 		errs = append(errs, fmt.Errorf("--cache-kubeconfig is required for non-root shards"))
+	}
+
+	if o.Extra.ShardReplicaCount < 1 {
+		errs = append(errs, fmt.Errorf("--shard-replica-count must be at least 1"))
 	}
 
 	differential := false


### PR DESCRIPTION

<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

A value higher than 1 adds a 5s startup delay for CRDs to be established.

```text
kcp/. [main] 30%>./hack/measure-boot.bash 10
run 1: 13.9s
run 2: 11.9s
run 3: 12.2s
run 4: 13.6s
run 5: 13.5s
run 6: 12.2s
run 7: 12.7s
run 8: 11.8s
run 9: 12.2s
run 10: 12.3s
min 11.8s  median 12.2s  max 13.9s
kcp/. [main] 32%>g co faster-bootup
Switched to branch 'faster-bootup'
kcp/. [main] 32%>make build
# ....
kcp/. [faster-bootup] 30%>./hack/measure-boot.bash 10
run 1: 11.5s
run 2: 6.8s
run 3: 6.8s
run 4: 7.2s
run 5: 7.2s
run 6: 7.1s
run 7: 7.9s
run 8: 8.5s
run 9: 7.0s
run 10: 7.6s
min 6.8s  median 7.2s  max 11.5s
```

## What Type of PR Is This?

/kind cleanup

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
