### PR TITLE
[DRAFT] Make the mapping file in front-proxy optional

### DIFF
--- a/cmd/sharded-test-server/frontproxy.go
+++ b/cmd/sharded-test-server/frontproxy.go
@@ -77,14 +77,6 @@ func startFrontProxy(
 			ProxyClientCert: filepath.Join(workDirPath, ".kcp-front-proxy", "requestheader.crt"),
 			ProxyClientKey:  filepath.Join(workDirPath, ".kcp-front-proxy", "requestheader.key"),
 		},
-		{
-			Path: "/clusters/",
-			// this path is not actually used, since shard URLs are determined based on the Shard
-			Backend:         "https://localhost:6444",
-			BackendServerCA: filepath.Join(workDirPath, ".kcp", "serving-ca.crt"),
-			ProxyClientCert: filepath.Join(workDirPath, ".kcp-front-proxy", "requestheader.crt"),
-			ProxyClientKey:  filepath.Join(workDirPath, ".kcp-front-proxy", "requestheader.key"),
-		},
 	}
 
 	mappingsYAML, err := yaml.Marshal(mappings)

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/emicklei/go-restful/v3 v3.13.0
 	github.com/evanphx/json-patch v5.6.0+incompatible
 	github.com/fatih/color v1.18.0
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-logr/logr v1.4.3
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/go-cmp v0.7.0
@@ -122,7 +123,6 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/egymgmbh/go-prefix-writer v0.0.0-20180609083313-7326ea162eca // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.1 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.5 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/pkg/proxy/lookup/lookup.go
+++ b/pkg/proxy/lookup/lookup.go
@@ -32,48 +32,18 @@ import (
 	kcpauthorization "github.com/kcp-dev/kcp/pkg/authorization"
 	"github.com/kcp-dev/kcp/pkg/index"
 	proxyindex "github.com/kcp-dev/kcp/pkg/proxy/index"
-	"github.com/kcp-dev/kcp/pkg/server/proxy/types"
 )
 
-func WithClusterResolver(delegate http.Handler, mappings []types.PathMapping, index proxyindex.Index) http.Handler {
+// WithClusterResolver resolves the logical cluster targeted by the request path and stores cluster name, shard name and shard URL in the request context.
+// Requests without a /clusters/<name> path segment pass through unchanged.
+func WithClusterResolver(delegate http.Handler, index proxyindex.Index) http.Handler {
 	mux := http.NewServeMux()
 
-	// fallback for all unrecognized URLs
-	mux.Handle("/", delegate)
+	mux.Handle("/", newPathResolveHandler(delegate, index))
 
-	// Use the extra path mappings as an additional source of cluster names in URLs;
-	// it's okay for a virtual workspace URL to not match here or to not have a
-	// cluster placeholder in its URL pattern, since the default handler will simply
-	// forward the request unchanged (and most likely, unauthenticated).
-
-	// We can use the same handler for all mappings, since the actual muxing to
-	// the destinations happens later in proxy.HttpHandler; here we only care about
-	// detecting the cluster name.
-	mappingHandler := newMappingHandler(delegate, index)
-
-	for _, mapping := range mappings {
-		p := strings.TrimRight(mapping.Path, "/")
-
-		// Even though we know how to handle the "special" core clusters path,
-		// the mapping provides additional PKI configuration that is not available
-		// by just looking up the cluster in the index and figuring out the
-		// target shard. That's why it's required to configure /clusters/ in the
-		// front-proxy mappings and since admins could choose not to include it,
-		// we only enable the built-in clusterResolveHandler if we actually find
-		// an appropriate mapping.
-		if p == "/clusters" {
-			// we know how to parse cluster URLs
-			resolveHandler := newClusterResolveHandler(delegate, index)
-			mux.HandleFunc("/clusters/{cluster}", resolveHandler)
-			mux.HandleFunc("/clusters/{cluster}/{trail...}", resolveHandler)
-		} else {
-			// mappings are configured with *prefixes*; in order to match both exact matches
-			// and prefix matches (i.e. if "/foo" is configured, both "/foo" and "/foo/bar"
-			// must match), each mapping is added twice to the mux.
-			mux.HandleFunc(p, mappingHandler)
-			mux.HandleFunc(p+"/{trail...}", mappingHandler)
-		}
-	}
+	resolveHandler := newClusterResolveHandler(delegate, index)
+	mux.HandleFunc("/clusters/{cluster}", resolveHandler)
+	mux.HandleFunc("/clusters/{cluster}/{trail...}", resolveHandler)
 
 	return mux
 }
@@ -111,25 +81,10 @@ func newClusterResolveHandler(delegate http.Handler, index proxyindex.Index) htt
 	}
 }
 
-func newMappingHandler(delegate http.Handler, index proxyindex.Index) http.HandlerFunc {
+func newPathResolveHandler(delegate http.Handler, index proxyindex.Index) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		// Not every virtual workspace and/or every mapping has a {cluster} in its URL;
-		// also wildcard requests have to be passed without lookup.
-		//
-		// For /clusters paths, the mux pattern is /clusters/{cluster}/{trail...}, so
-		// req.PathValue("cluster") returns the cluster name directly.
-		//
-		// For /services/... paths, the mux pattern is /services/<name>/{trail...} - there's
-		// no {cluster} placeholder. The entire "clusters/root:orgs:bob/apis/..." is captured
-		// as {trail...}, so req.PathValue("cluster") returns empty. In this case, we need to
-		// parse the cluster from the URL path using extractClusterFromPath.
-		clusterName := req.PathValue("cluster")
-
-		// If no cluster from path pattern, try to extract from URL path.
-		// Virtual workspace URLs often have the pattern: /services/<name>/clusters/<cluster>/...
-		if clusterName == "" {
-			clusterName = extractClusterFromPath(req.URL.Path)
-		}
+		// covers virtual workspace URLs like /services/<name>/clusters/<cluster>/...
+		clusterName := extractClusterFromPath(req.URL.Path)
 
 		if clusterName == "" || clusterName == "*" {
 			delegate.ServeHTTP(w, req)

--- a/pkg/proxy/mapping.go
+++ b/pkg/proxy/mapping.go
@@ -33,8 +33,17 @@ import (
 	"github.com/kcp-dev/kcp/pkg/server/proxy/types"
 )
 
+// loadMappings reads path mappings from filename.
+// Empty filename or a missing file yields nil mappings.
 func loadMappings(filename string) ([]types.PathMapping, error) {
+	if filename == "" {
+		return nil, nil
+	}
+
 	mappingData, err := os.ReadFile(filename)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -47,10 +56,7 @@ func loadMappings(filename string) ([]types.PathMapping, error) {
 	return mapping, nil
 }
 
-func isShardMapping(m types.PathMapping) bool {
-	return m.Path == "/clusters/"
-}
-
+// NewHandler builds the additional-routes proxy handler from the configured mappings.
 func NewHandler(ctx context.Context, mappings []types.PathMapping) (http.Handler, error) {
 	handlers := proxy.HttpHandler{
 		Mappings: types.HttpHandlerMappings{},
@@ -70,19 +76,10 @@ func NewHandler(ctx context.Context, mappings []types.PathMapping) (http.Handler
 			return nil, fmt.Errorf("failed to create path mapping for path %q: %w", m.Path, err)
 		}
 
-		var handler http.Handler
-		if isShardMapping(m) {
-			clusterProxy := newShardReverseProxy()
-			clusterProxy.Transport = transport
-			clusterProxy.ErrorHandler = metrics.NewProxyErrorHandler()
-			handler = clusterProxy
-		} else {
-			// TODO: handle virtual workspace apiservers per shard
-			proxy := httputil.NewSingleHostReverseProxy(u)
-			proxy.Transport = transport
-			proxy.ErrorHandler = metrics.NewProxyErrorHandler()
-			handler = proxy
-		}
+		reverseProxy := httputil.NewSingleHostReverseProxy(u)
+		reverseProxy.Transport = transport
+		reverseProxy.ErrorHandler = metrics.NewProxyErrorHandler()
+		var handler http.Handler = reverseProxy
 
 		userHeader := "X-Remote-User"
 		groupHeader := "X-Remote-Group"

--- a/pkg/proxy/mapping.go
+++ b/pkg/proxy/mapping.go
@@ -23,6 +23,10 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"path/filepath"
+	"sync/atomic"
+
+	"github.com/fsnotify/fsnotify"
 
 	"sigs.k8s.io/yaml"
 
@@ -111,4 +115,62 @@ func NewHandler(ctx context.Context, mappings []types.PathMapping) (http.Handler
 	handlers.Mappings.Sort()
 
 	return &handlers, nil
+}
+
+// reloadableHandler delegates to an atomically swappable handler.
+type reloadableHandler struct {
+	handler atomic.Pointer[http.Handler]
+}
+
+func (h *reloadableHandler) store(handler http.Handler) {
+	h.handler.Store(&handler)
+}
+
+func (h *reloadableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	(*h.handler.Load()).ServeHTTP(w, r)
+}
+
+// watchMappingFile calls reload when filename is created or written until ctx is done.
+// The parent directory is watched to catch late creation, deletion and atomic updates.
+// Reload errors are logged and the previous state is kept.
+func watchMappingFile(ctx context.Context, filename string, reload func() error) error {
+	logger := klog.FromContext(ctx).WithValues("file", filename)
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("failed to create mapping file watcher: %w", err)
+	}
+	defer watcher.Close()
+
+	if err := watcher.Add(filepath.Dir(filename)); err != nil {
+		return fmt.Errorf("failed to watch mapping file directory: %w", err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return nil
+			}
+			logger.Error(err, "mapping file watch error")
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return nil
+			}
+			if event.Name != filename || !event.Op.Has(fsnotify.Create) && !event.Op.Has(fsnotify.Write) {
+				continue
+			}
+			// file may be gone mid atomic-swap; the create of the new file follows
+			if _, err := os.Stat(filename); err != nil {
+				continue
+			}
+			if err := reload(); err != nil {
+				logger.Error(err, "failed to reload mapping file, keeping previous mappings")
+				continue
+			}
+			logger.V(2).Info("reloaded mapping file")
+		}
+	}
 }

--- a/pkg/proxy/mapping_test.go
+++ b/pkg/proxy/mapping_test.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2026 The kcp Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/client-go/util/cert"
+
+	serverproxy "github.com/kcp-dev/kcp/pkg/server/proxy"
+	"github.com/kcp-dev/kcp/pkg/server/proxy/types"
+)
+
+// writeMappingFile writes content to a mapping file in a temp dir and returns its path.
+func writeMappingFile(t *testing.T, content string) string {
+	t.Helper()
+
+	file := filepath.Join(t.TempDir(), "mappings.yaml")
+	require.NoError(t, os.WriteFile(file, []byte(content), 0o600))
+	return file
+}
+
+// writeSelfSignedCert writes a self-signed cert and key to a temp dir and returns their paths.
+func writeSelfSignedCert(t *testing.T) (string, string) {
+	t.Helper()
+
+	certPEM, keyPEM, err := cert.GenerateSelfSignedCertKey("localhost", nil, nil)
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "tls.crt")
+	keyFile := filepath.Join(dir, "tls.key")
+	require.NoError(t, os.WriteFile(certFile, certPEM, 0o600))
+	require.NoError(t, os.WriteFile(keyFile, keyPEM, 0o600))
+	return certFile, keyFile
+}
+
+func TestLoadMappings(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		file    func(t *testing.T) string
+		want    []types.PathMapping
+		wantErr bool
+	}{
+		"empty filename yields nil mappings": {
+			file: func(t *testing.T) string { return "" },
+		},
+		"missing file yields nil mappings": {
+			file: func(t *testing.T) string { return filepath.Join(t.TempDir(), "missing.yaml") },
+		},
+		"valid file yields mappings": {
+			file: func(t *testing.T) string {
+				return writeMappingFile(t, "- path: /services/\n  backend: https://localhost:7443\n")
+			},
+			want: []types.PathMapping{
+				{
+					Path:    "/services/",
+					Backend: "https://localhost:7443",
+				},
+			},
+		},
+		"invalid YAML fails": {
+			file:    func(t *testing.T) string { return writeMappingFile(t, "{invalid") },
+			wantErr: true,
+		},
+	}
+
+	for title, cas := range cases {
+		t.Run(title, func(t *testing.T) {
+			t.Parallel()
+
+			mappings, err := loadMappings(cas.file(t))
+			if cas.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, cas.want, mappings)
+		})
+	}
+}
+
+func TestNewHandler_noMappings(t *testing.T) {
+	t.Parallel()
+
+	handler, err := NewHandler(t.Context(), nil)
+	require.NoError(t, err)
+
+	httpHandler, ok := handler.(*serverproxy.HttpHandler)
+	require.Truef(t, ok, "expected *proxy.HttpHandler, got %T", handler)
+
+	assert.Nil(t, httpHandler.DefaultHandler, "no mappings must not install a default handler")
+	assert.Empty(t, httpHandler.Mappings, "no mappings must not install routes")
+}
+
+func TestNewHandler_buildsConfiguredMappings(t *testing.T) {
+	t.Parallel()
+
+	certFile, keyFile := writeSelfSignedCert(t)
+	mappings := []types.PathMapping{
+		{
+			Path:            "/services/",
+			Backend:         "https://localhost:7443",
+			BackendServerCA: certFile,
+			ProxyClientCert: certFile,
+			ProxyClientKey:  keyFile,
+		},
+		{
+			Path:            "/",
+			Backend:         "https://localhost:8443",
+			BackendServerCA: certFile,
+			ProxyClientCert: certFile,
+			ProxyClientKey:  keyFile,
+		},
+	}
+
+	handler, err := NewHandler(t.Context(), mappings)
+	require.NoError(t, err)
+
+	httpHandler, ok := handler.(*serverproxy.HttpHandler)
+	require.Truef(t, ok, "expected *proxy.HttpHandler, got %T", handler)
+
+	require.Len(t, httpHandler.Mappings, 1, "the / mapping must become the default handler, not a route")
+	assert.Equal(t, "/services/", httpHandler.Mappings[0].Path)
+	assert.NotNil(t, httpHandler.DefaultHandler, "the / mapping must become the default handler")
+}

--- a/pkg/proxy/mapping_test.go
+++ b/pkg/proxy/mapping_test.go
@@ -17,13 +17,18 @@ limitations under the License.
 package proxy
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/cert"
 
 	serverproxy "github.com/kcp-dev/kcp/pkg/server/proxy"
@@ -143,4 +148,83 @@ func TestNewHandler_buildsConfiguredMappings(t *testing.T) {
 	require.Len(t, httpHandler.Mappings, 1, "the / mapping must become the default handler, not a route")
 	assert.Equal(t, "/services/", httpHandler.Mappings[0].Path)
 	assert.NotNil(t, httpHandler.DefaultHandler, "the / mapping must become the default handler")
+}
+
+func TestReloadableHandler(t *testing.T) {
+	t.Parallel()
+
+	handler := &reloadableHandler{}
+	handler.store(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	}))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", http.NoBody))
+	require.Equal(t, http.StatusTeapot, rec.Code)
+
+	handler.store(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", http.NoBody))
+	assert.Equal(t, http.StatusOK, rec.Code, "swapped handler must serve subsequent requests")
+}
+
+func TestWatchMappingFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "mappings.yaml")
+
+	reloads := make(chan struct{}, 16)
+	reload := func() error {
+		reloads <- struct{}{}
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		done <- watchMappingFile(ctx, file, reload)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		require.NoError(t, <-done)
+	})
+
+	expectReload := func(t *testing.T, msg string) {
+		t.Helper()
+		select {
+		case <-reloads:
+		case <-time.After(wait.ForeverTestTimeout):
+			t.Fatal(msg)
+		}
+	}
+	expectNoReload := func(t *testing.T, msg string) {
+		t.Helper()
+		select {
+		case <-reloads:
+			t.Fatal(msg)
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+
+	// watcher needs to be established before the first write
+	time.Sleep(100 * time.Millisecond)
+
+	require.NoError(t, os.WriteFile(file, []byte("[]"), 0o600))
+	expectReload(t, "late create must trigger a reload")
+
+	require.NoError(t, os.WriteFile(file, []byte("[]"), 0o600))
+	expectReload(t, "write must trigger a reload")
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "other.yaml"), []byte("[]"), 0o600))
+	expectNoReload(t, "unrelated file must not trigger a reload")
+
+	require.NoError(t, os.Remove(file))
+	expectNoReload(t, "delete must not trigger a reload")
+
+	require.NoError(t, os.WriteFile(file, []byte("[]"), 0o600))
+	expectReload(t, "re-create must trigger a reload")
 }

--- a/pkg/proxy/options/options.go
+++ b/pkg/proxy/options/options.go
@@ -56,7 +56,7 @@ func (o *Options) AddFlags(fss *cliflag.NamedFlagSets) {
 	o.Authentication.AddFlags(fss.FlagSet("authentication"))
 
 	fs := fss.FlagSet("proxy")
-	fs.StringVar(&o.MappingFile, "mapping-file", o.MappingFile, "Config file mapping paths to backends")
+	fs.StringVar(&o.MappingFile, "mapping-file", o.MappingFile, "Optional config file mapping additional paths to backends. /clusters/ requests are always routed to the shards and cannot be remapped.")
 	fs.StringVar(&o.RootDirectory, "root-directory", o.RootDirectory, "Root directory.")
 	fs.StringVar(&o.RootKubeconfig, "root-kubeconfig", o.RootKubeconfig, "The path to the kubeconfig of the root shard.")
 	fs.StringVar(&o.ShardsKubeconfig, "shards-kubeconfig", o.ShardsKubeconfig, "The path to the kubeconfig used for communication with all shards. The server name if provided is replaced with a shard's hostname.")
@@ -86,9 +86,6 @@ func (o *Options) Complete() error {
 func (o *Options) Validate() []error {
 	var errs []error
 
-	if o.MappingFile == "" {
-		errs = append(errs, fmt.Errorf("--mapping-file is required"))
-	}
 	if len(o.ShardsKubeconfig) == 0 {
 		errs = append(errs, fmt.Errorf("--shards-kubeconfig is required"))
 	}

--- a/pkg/proxy/options/options.go
+++ b/pkg/proxy/options/options.go
@@ -56,7 +56,7 @@ func (o *Options) AddFlags(fss *cliflag.NamedFlagSets) {
 	o.Authentication.AddFlags(fss.FlagSet("authentication"))
 
 	fs := fss.FlagSet("proxy")
-	fs.StringVar(&o.MappingFile, "mapping-file", o.MappingFile, "Optional config file mapping additional paths to backends. /clusters/ requests are always routed to the shards and cannot be remapped.")
+	fs.StringVar(&o.MappingFile, "mapping-file", o.MappingFile, "Optional config file mapping additional paths to backends, changes are applied without a restart. /clusters/ requests are always routed to the shards and cannot be remapped.")
 	fs.StringVar(&o.RootDirectory, "root-directory", o.RootDirectory, "Root directory.")
 	fs.StringVar(&o.RootKubeconfig, "root-kubeconfig", o.RootKubeconfig, "The path to the kubeconfig of the root shard.")
 	fs.StringVar(&o.ShardsKubeconfig, "shards-kubeconfig", o.ShardsKubeconfig, "The path to the kubeconfig used for communication with all shards. The server name if provided is replaced with a shard's hostname.")

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -23,13 +23,36 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"os"
+	"strings"
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/client-go/rest"
 
 	"github.com/kcp-dev/kcp/pkg/proxy/authheaders"
 	"github.com/kcp-dev/kcp/pkg/proxy/lookup"
+	"github.com/kcp-dev/kcp/pkg/proxy/metrics"
 )
+
+// clustersPathPrefix is the built-in shard route.
+const clustersPathPrefix = "/clusters/"
+
+// WithShardRouting serves /clusters/ requests via the shard reverse proxy using shardsTransport and delegates everything else.
+func WithShardRouting(delegate http.Handler, shardsTransport http.RoundTripper) http.HandlerFunc {
+	clusterProxy := newShardReverseProxy()
+	clusterProxy.Transport = shardsTransport
+	clusterProxy.ErrorHandler = metrics.NewProxyErrorHandler()
+	shardHandler := WithProxyAuthHeaders(clusterProxy, "X-Remote-User", "X-Remote-Group", "X-Remote-Extra-")
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, clustersPathPrefix) {
+			shardHandler.ServeHTTP(w, r)
+			return
+		}
+
+		delegate.ServeHTTP(w, r)
+	}
+}
 
 func newTransport(clientCert, clientKeyFile, caFile string) (*http.Transport, error) {
 	caCert, err := os.ReadFile(caFile)
@@ -50,6 +73,19 @@ func newTransport(clientCert, clientKeyFile, caFile string) (*http.Transport, er
 		Certificates: []tls.Certificate{cert},
 		RootCAs:      caCertPool,
 	}
+
+	return transport, nil
+}
+
+// newShardsTransport builds a transport with only the TLS material from the shards rest.Config, deliberately without identity or token wrappers that would conflict with the X-Remote-* requestheader authentication.
+func newShardsTransport(config *rest.Config) (*http.Transport, error) {
+	tlsConfig, err := rest.TLSConfigFor(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create TLS config for shards: %w", err)
+	}
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = tlsConfig
 
 	return transport, nil
 }

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -35,6 +35,47 @@ const (
 	clusterNameEncodedK = "authentication.kcp.io/cluster-name"
 )
 
+// roundTripperFunc adapts a function to http.RoundTripper.
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// TestWithShardRouting ensures /clusters/ requests hit the built-in shard
+// route and everything else falls through to the delegate.
+func TestWithShardRouting(t *testing.T) {
+	t.Parallel()
+
+	var shardHit, delegateHit bool
+	transport := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		shardHit = true
+		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: http.Header{}}, nil
+	})
+	delegate := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		delegateHit = true
+	})
+
+	handler := WithShardRouting(delegate, transport)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://front-proxy/clusters/root/api/v1/secrets", http.NoBody)
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+	if !shardHit {
+		t.Error("expected /clusters/ request to hit the shard route")
+	}
+	if delegateHit {
+		t.Error("expected /clusters/ request not to hit the delegate")
+	}
+
+	shardHit = false
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://front-proxy/services/foo", http.NoBody)
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+	if shardHit {
+		t.Error("expected non-/clusters/ request not to hit the shard route")
+	}
+	if !delegateHit {
+		t.Error("expected non-/clusters/ request to hit the delegate")
+	}
+}
+
 // forwardThroughProxy runs WithProxyAuthHeaders with the given authenticated
 // user (or none, if user is nil) over a request carrying the given inbound
 // client headers, and returns the headers as they would be forwarded to the

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"slices"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -75,15 +74,10 @@ func NewServer(ctx context.Context, c CompletedConfig) (*Server, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to load mappings from %q: %w", c.Options.MappingFile, err)
 	}
-	hasShardMapping := slices.ContainsFunc(mappings, isShardMapping)
 
-	// When a mapping for shards is configured, we need to build up an index of which shard hosts
-	// which workspaces and logicalclusters. Ideally we'd start the index controller only if there
-	// is a shard mapping (i.e. a "/clusters/" entry in the mapping list), but there are other places
-	// in the general server package that always lookup the shard, so making the index optional would
-	// require deeper refactoring to make everything rely on the lookup middleware.
-	// If so, there will be also another middleware injected into the handler chain, which is responsible
-	// for resolving the incoming request and store the found cluster name in a context variable.
+	// Built an index of which shard hosts which workspaces and logicalclusters, so
+	// that the cluster resolver middleware can resolve incoming requests to a shard and
+	// store the found cluster name in a context variable.
 	rootShardConfigInformerClient, err := kcpclientset.NewForConfig(s.CompletedConfig.RootShardConfig)
 	if err != nil {
 		return s, fmt.Errorf("failed to create client for informers: %w", err)
@@ -123,9 +117,7 @@ func NewServer(ctx context.Context, c CompletedConfig) (*Server, error) {
 
 	// Make the per-workspace authenticator available to the previous middleware
 	// by hooking up a handler and a runtime index.
-	hasWorkspaceAuth := hasShardMapping && kcpfeatures.DefaultFeatureGate.Enabled(kcpfeatures.WorkspaceAuthentication)
-
-	if hasWorkspaceAuth {
+	if kcpfeatures.DefaultFeatureGate.Enabled(kcpfeatures.WorkspaceAuthentication) {
 		// This controller is similar to the index controller, but keeps track of the per-workspace authenticators.
 		ctrl, err := authentication.NewController(ctx, s.KcpSharedInformerFactory.Core().V1alpha1().Shards(), getClientFunc, nil)
 		if err != nil {
@@ -141,10 +133,8 @@ func NewServer(ctx context.Context, c CompletedConfig) (*Server, error) {
 		handler = authentication.WithWorkspaceAuthResolver(handler, s.AuthController)
 	}
 
-	if hasShardMapping {
-		// This middleware must happen before the authentication.
-		handler = lookup.WithClusterResolver(handler, mappings, s.IndexController)
-	}
+	// This middleware must happen before the authentication.
+	handler = lookup.WithClusterResolver(handler, s.IndexController)
 
 	requestInfoFactory := requestinfo.NewFactory()
 	handler = kcpfilters.WithInClusterServiceAccountRequestRewrite(handler)

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -99,10 +99,18 @@ func NewServer(ctx context.Context, c CompletedConfig) (*Server, error) {
 	// interface.
 	s.IndexController = index.NewController(ctx, s.KcpSharedInformerFactory.Core().V1alpha1().Shards(), getClientFunc)
 
+	shardsTransport, err := newShardsTransport(c.ShardsConfig)
+	if err != nil {
+		return s, fmt.Errorf("failed to create shards transport: %w", err)
+	}
+
 	handler, err := NewHandler(ctx, mappings)
 	if err != nil {
 		return s, err
 	}
+
+	// /clusters/ requests are always routed to the shards, before any mapping.
+	handler = WithShardRouting(handler, shardsTransport)
 
 	// The optional auth handler will call the underlying authenticator only if
 	// auth methods are configured directly on the front-proxy *or* if there is

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -62,17 +62,12 @@ type Server struct {
 	IndexController          *index.Controller
 	AuthController           *authentication.Controller
 	KcpSharedInformerFactory kcpinformers.SharedScopedInformerFactory
+	reloadMappings           func() error
 }
 
 func NewServer(ctx context.Context, c CompletedConfig) (*Server, error) {
 	s := &Server{
 		CompletedConfig: c,
-	}
-
-	// load the configured path mappings
-	mappings, err := loadMappings(c.Options.MappingFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load mappings from %q: %w", c.Options.MappingFile, err)
 	}
 
 	// Built an index of which shard hosts which workspaces and logicalclusters, so
@@ -104,13 +99,29 @@ func NewServer(ctx context.Context, c CompletedConfig) (*Server, error) {
 		return s, fmt.Errorf("failed to create shards transport: %w", err)
 	}
 
-	handler, err := NewHandler(ctx, mappings)
-	if err != nil {
+	mappingHandler := &reloadableHandler{}
+	s.reloadMappings = func() error {
+		mappings, err := loadMappings(c.Options.MappingFile)
+		if err != nil {
+			return fmt.Errorf("failed to load mappings from %q: %w", c.Options.MappingFile, err)
+		}
+
+		handler, err := NewHandler(ctx, mappings)
+		if err != nil {
+			return err
+		}
+
+		mappingHandler.store(handler)
+		return nil
+	}
+
+	// fail fast on an invalid mapping file at startup, a missing file is fine
+	if err := s.reloadMappings(); err != nil {
 		return s, err
 	}
 
 	// /clusters/ requests are always routed to the shards, before any mapping.
-	handler = WithShardRouting(handler, shardsTransport)
+	var handler http.Handler = WithShardRouting(mappingHandler, shardsTransport)
 
 	// The optional auth handler will call the underlying authenticator only if
 	// auth methods are configured directly on the front-proxy *or* if there is
@@ -231,6 +242,14 @@ func (s preparedServer) Run(ctx context.Context) error {
 
 	// start indexes
 	go s.IndexController.Start(ctx, 2)
+
+	if s.CompletedConfig.Options.MappingFile != "" {
+		go func() {
+			if err := watchMappingFile(ctx, s.CompletedConfig.Options.MappingFile, s.reloadMappings); err != nil {
+				logger.Error(err, "failed to watch mapping file")
+			}
+		}()
+	}
 
 	if s.AuthController != nil {
 		go s.AuthController.Start(ctx, 2)


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

`/clusters/` is always resolved first, then mapping file.
mapping file is optional and hot-reloadable.

## What Type of PR Is This?

/kind feature

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
The mapping file for the front-proxy is now optional and is reloaded when it changes
```
