### PR TITLE
add glightbox to enlarge pics in documentation

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -95,6 +95,8 @@ plugins:
   # Configure multi-version plugin
   - mike:
       alias_type: redirect
+  # Click images to enlarge them in a lightbox
+  - glightbox
 
 markdown_extensions:
   # Code block highlighting

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
 mike==2.1.3
 mkdocs==1.5.3
 mkdocs-awesome-pages-plugin==2.9.2
+mkdocs-glightbox==0.4.0
 mkdocs-macros-plugin==1.3.7
 mkdocs-material==9.5.17
 mkdocs-material-extensions==1.3.1


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Allows one to click on images in our documentation to make them fullscreen


click on the image here
<img width="848" height="836" alt="grafik" src="https://github.com/user-attachments/assets/eac46b1a-cc7d-4f34-89e0-296772401ab3" />

and then it becomes fullscreen in a lightbox
<img width="2249" height="1368" alt="grafik" src="https://github.com/user-attachments/assets/f882b755-e172-4087-be38-2a44b7fd5020" />


## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind chore
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind documentation

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
